### PR TITLE
[finch] Allow finch server to compile for CI checks

### DIFF
--- a/modules/openapi-generator/src/main/resources/finch/DataAccessor.mustache
+++ b/modules/openapi-generator/src/main/resources/finch/DataAccessor.mustache
@@ -4,13 +4,15 @@ package {{packageName}}
 import java.io._
 import java.util.UUID
 import java.time._
-
+import com.twitter.finagle.http.exp.Multipart.{FileUpload, InMemoryFileUpload, OnDiskFileUpload}
 
 import {{modelPackage}}._
 
 trait DataAccessor {
-    // TODO: apiInfo -> apis -> operations = ???
-    // NOTE: ??? throws a not implemented exception
+    // TODO: apiInfo -> apis -> operations = TODO error
+    private object TODO extends CommonError("Not implemented") {
+        def message = "Not implemented"
+    }
 
 {{#apiInfo}}
     {{#apis}}
@@ -20,7 +22,7 @@ trait DataAccessor {
         * {{{description}}}
         * @return A {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}}
         */
-        def {{baseName}}_{{operationId}}({{{vendorExtensions.x-codegen-typedParams}}}): Either[CommonError,{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}}] = ???
+        def {{baseName}}_{{operationId}}({{{vendorExtensions.x-codegen-typedParams}}}): Either[CommonError,{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}}] = Left(TODO)
 
     {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/finch/api.mustache
+++ b/modules/openapi-generator/src/main/resources/finch/api.mustache
@@ -58,7 +58,7 @@ object {{classname}} {
         * @return An endpoint representing a {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}}
         */
         private def {{operationId}}(da: DataAccessor): Endpoint[{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}}] =
-        {{httpMethod}}({{{vendorExtensions.x-codegen-paths}}}) { {{#hasParams}}({{{vendorExtensions.x-codegen-typedParams}}}) => {{/hasParams}}
+        {{httpMethod}}({{{vendorExtensions.x-codegen-paths}}}) { {{#vendorExtensions.x-codegen-typedParams}}({{{vendorExtensions.x-codegen-typedParams}}}) =>{{/vendorExtensions.x-codegen-typedParams}}
           da.{{baseName}}_{{operationId}}({{{vendorExtensions.x-codegen-params}}}) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)

--- a/modules/openapi-generator/src/main/resources/finch/build.sbt
+++ b/modules/openapi-generator/src/main/resources/finch/build.sbt
@@ -6,7 +6,7 @@ name := "finch-sample"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.3"
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 

--- a/samples/server/petstore/finch/build.sbt
+++ b/samples/server/petstore/finch/build.sbt
@@ -6,7 +6,7 @@ name := "finch-sample"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.3"
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 

--- a/samples/server/petstore/finch/src/main/scala/DataAccessor.scala
+++ b/samples/server/petstore/finch/src/main/scala/DataAccessor.scala
@@ -4,132 +4,134 @@ package org.openapitools
 import java.io._
 import java.util.UUID
 import java.time._
-
+import com.twitter.finagle.http.exp.Multipart.{FileUpload, InMemoryFileUpload, OnDiskFileUpload}
 
 import org.openapitools.models._
 
 trait DataAccessor {
-    // TODO: apiInfo -> apis -> operations = ???
-    // NOTE: ??? throws a not implemented exception
+    // TODO: apiInfo -> apis -> operations = TODO error
+    private object TODO extends CommonError("Not implemented") {
+        def message = "Not implemented"
+    }
 
         /**
         * 
         * @return A Unit
         */
-        def Pet_addPet(pet: Pet): Either[CommonError,Unit] = ???
+        def Pet_addPet(pet: Pet): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def Pet_deletePet(petId: Long, apiKey: Option[String]): Either[CommonError,Unit] = ???
+        def Pet_deletePet(petId: Long, apiKey: Option[String]): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Seq[Pet]
         */
-        def Pet_findPetsByStatus(status: Seq[String]): Either[CommonError,Seq[Pet]] = ???
+        def Pet_findPetsByStatus(status: Seq[String]): Either[CommonError,Seq[Pet]] = Left(TODO)
 
         /**
         * 
         * @return A Seq[Pet]
         */
-        def Pet_findPetsByTags(tags: Seq[String]): Either[CommonError,Seq[Pet]] = ???
+        def Pet_findPetsByTags(tags: Seq[String]): Either[CommonError,Seq[Pet]] = Left(TODO)
 
         /**
         * 
         * @return A Pet
         */
-        def Pet_getPetById(petId: Long, authParamapi_key: String): Either[CommonError,Pet] = ???
+        def Pet_getPetById(petId: Long, authParamapi_key: String): Either[CommonError,Pet] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def Pet_updatePet(pet: Pet): Either[CommonError,Unit] = ???
+        def Pet_updatePet(pet: Pet): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def Pet_updatePetWithForm(petId: Long, name: Option[String], status: Option[String]): Either[CommonError,Unit] = ???
+        def Pet_updatePetWithForm(petId: Long, name: Option[String], status: Option[String]): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A ApiResponse
         */
-        def Pet_uploadFile(petId: Long, additionalMetadata: Option[String], file: FileUpload): Either[CommonError,ApiResponse] = ???
+        def Pet_uploadFile(petId: Long, additionalMetadata: Option[String], file: FileUpload): Either[CommonError,ApiResponse] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def Store_deleteOrder(orderId: String): Either[CommonError,Unit] = ???
+        def Store_deleteOrder(orderId: String): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Map[String, Int]
         */
-        def Store_getInventory(authParamapi_key: String): Either[CommonError,Map[String, Int]] = ???
+        def Store_getInventory(authParamapi_key: String): Either[CommonError,Map[String, Int]] = Left(TODO)
 
         /**
         * 
         * @return A Order
         */
-        def Store_getOrderById(orderId: Long): Either[CommonError,Order] = ???
+        def Store_getOrderById(orderId: Long): Either[CommonError,Order] = Left(TODO)
 
         /**
         * 
         * @return A Order
         */
-        def Store_placeOrder(order: Order): Either[CommonError,Order] = ???
+        def Store_placeOrder(order: Order): Either[CommonError,Order] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def User_createUser(user: User): Either[CommonError,Unit] = ???
+        def User_createUser(user: User): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def User_createUsersWithArrayInput(user: Seq[User]): Either[CommonError,Unit] = ???
+        def User_createUsersWithArrayInput(user: Seq[User]): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def User_createUsersWithListInput(user: Seq[User]): Either[CommonError,Unit] = ???
+        def User_createUsersWithListInput(user: Seq[User]): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def User_deleteUser(username: String): Either[CommonError,Unit] = ???
+        def User_deleteUser(username: String): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A User
         */
-        def User_getUserByName(username: String): Either[CommonError,User] = ???
+        def User_getUserByName(username: String): Either[CommonError,User] = Left(TODO)
 
         /**
         * 
         * @return A String
         */
-        def User_loginUser(username: String, password: String): Either[CommonError,String] = ???
+        def User_loginUser(username: String, password: String): Either[CommonError,String] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def User_logoutUser(): Either[CommonError,Unit] = ???
+        def User_logoutUser(): Either[CommonError,Unit] = Left(TODO)
 
         /**
         * 
         * @return A Unit
         */
-        def User_updateUser(username: String, user: User): Either[CommonError,Unit] = ???
+        def User_updateUser(username: String, user: User): Either[CommonError,Unit] = Left(TODO)
 
 }

--- a/samples/server/petstore/finch/src/main/scala/org/openapitools/apis/PetApi.scala
+++ b/samples/server/petstore/finch/src/main/scala/org/openapitools/apis/PetApi.scala
@@ -60,7 +60,7 @@ object PetApi {
         * @return An endpoint representing a Unit
         */
         private def addPet(da: DataAccessor): Endpoint[Unit] =
-        post("pet" :: jsonBody[Pet]) { (pet: Pet) => 
+        post("pet" :: jsonBody[Pet]) { (pet: Pet) =>
           da.Pet_addPet(pet) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -74,7 +74,7 @@ object PetApi {
         * @return An endpoint representing a Unit
         */
         private def deletePet(da: DataAccessor): Endpoint[Unit] =
-        delete("pet" :: long :: headerOption("api_key")) { (petId: Long, apiKey: Option[String]) => 
+        delete("pet" :: long :: headerOption("api_key")) { (petId: Long, apiKey: Option[String]) =>
           da.Pet_deletePet(petId, apiKey) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -88,7 +88,7 @@ object PetApi {
         * @return An endpoint representing a Seq[Pet]
         */
         private def findPetsByStatus(da: DataAccessor): Endpoint[Seq[Pet]] =
-        get("pet" :: "findByStatus" :: params("status")) { (status: Seq[String]) => 
+        get("pet" :: "findByStatus" :: params("status")) { (status: Seq[String]) =>
           da.Pet_findPetsByStatus(status) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -102,7 +102,7 @@ object PetApi {
         * @return An endpoint representing a Seq[Pet]
         */
         private def findPetsByTags(da: DataAccessor): Endpoint[Seq[Pet]] =
-        get("pet" :: "findByTags" :: params("tags")) { (tags: Seq[String]) => 
+        get("pet" :: "findByTags" :: params("tags")) { (tags: Seq[String]) =>
           da.Pet_findPetsByTags(tags) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -116,7 +116,7 @@ object PetApi {
         * @return An endpoint representing a Pet
         */
         private def getPetById(da: DataAccessor): Endpoint[Pet] =
-        get("pet" :: long :: header("api_key")) { (petId: Long, authParamapi_key: String) => 
+        get("pet" :: long :: header("api_key")) { (petId: Long, authParamapi_key: String) =>
           da.Pet_getPetById(petId, authParamapi_key) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -130,7 +130,7 @@ object PetApi {
         * @return An endpoint representing a Unit
         */
         private def updatePet(da: DataAccessor): Endpoint[Unit] =
-        put("pet" :: jsonBody[Pet]) { (pet: Pet) => 
+        put("pet" :: jsonBody[Pet]) { (pet: Pet) =>
           da.Pet_updatePet(pet) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -144,7 +144,7 @@ object PetApi {
         * @return An endpoint representing a Unit
         */
         private def updatePetWithForm(da: DataAccessor): Endpoint[Unit] =
-        post("pet" :: long :: string :: string) { (petId: Long, name: Option[String], status: Option[String]) => 
+        post("pet" :: long :: paramOption("name") :: paramOption("status")) { (petId: Long, name: Option[String], status: Option[String]) =>
           da.Pet_updatePetWithForm(petId, name, status) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -158,7 +158,7 @@ object PetApi {
         * @return An endpoint representing a ApiResponse
         */
         private def uploadFile(da: DataAccessor): Endpoint[ApiResponse] =
-        post("pet" :: long :: "uploadImage" :: string :: fileUpload("file")) { (petId: Long, additionalMetadata: Option[String], file: FileUpload) => 
+        post("pet" :: long :: "uploadImage" :: paramOption("additionalMetadata") :: fileUpload("file")) { (petId: Long, additionalMetadata: Option[String], file: FileUpload) =>
           da.Pet_uploadFile(petId, additionalMetadata, file) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)

--- a/samples/server/petstore/finch/src/main/scala/org/openapitools/apis/StoreApi.scala
+++ b/samples/server/petstore/finch/src/main/scala/org/openapitools/apis/StoreApi.scala
@@ -54,7 +54,7 @@ object StoreApi {
         * @return An endpoint representing a Unit
         */
         private def deleteOrder(da: DataAccessor): Endpoint[Unit] =
-        delete("store" :: "order" :: string) { (orderId: String) => 
+        delete("store" :: "order" :: string) { (orderId: String) =>
           da.Store_deleteOrder(orderId) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -68,7 +68,7 @@ object StoreApi {
         * @return An endpoint representing a Map[String, Int]
         */
         private def getInventory(da: DataAccessor): Endpoint[Map[String, Int]] =
-        get("store" :: "inventory" :: header("api_key")) { 
+        get("store" :: "inventory" :: header("api_key")) { (authParamapi_key: String) =>
           da.Store_getInventory(authParamapi_key) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -82,7 +82,7 @@ object StoreApi {
         * @return An endpoint representing a Order
         */
         private def getOrderById(da: DataAccessor): Endpoint[Order] =
-        get("store" :: "order" :: long) { (orderId: Long) => 
+        get("store" :: "order" :: long) { (orderId: Long) =>
           da.Store_getOrderById(orderId) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -96,7 +96,7 @@ object StoreApi {
         * @return An endpoint representing a Order
         */
         private def placeOrder(da: DataAccessor): Endpoint[Order] =
-        post("store" :: "order" :: jsonBody[Order]) { (order: Order) => 
+        post("store" :: "order" :: jsonBody[Order]) { (order: Order) =>
           da.Store_placeOrder(order) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)

--- a/samples/server/petstore/finch/src/main/scala/org/openapitools/apis/UserApi.scala
+++ b/samples/server/petstore/finch/src/main/scala/org/openapitools/apis/UserApi.scala
@@ -59,7 +59,7 @@ object UserApi {
         * @return An endpoint representing a Unit
         */
         private def createUser(da: DataAccessor): Endpoint[Unit] =
-        post("user" :: jsonBody[User]) { (user: User) => 
+        post("user" :: jsonBody[User]) { (user: User) =>
           da.User_createUser(user) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -73,7 +73,7 @@ object UserApi {
         * @return An endpoint representing a Unit
         */
         private def createUsersWithArrayInput(da: DataAccessor): Endpoint[Unit] =
-        post("user" :: "createWithArray" :: jsonBody[Seq[User]]) { (user: Seq[User]) => 
+        post("user" :: "createWithArray" :: jsonBody[Seq[User]]) { (user: Seq[User]) =>
           da.User_createUsersWithArrayInput(user) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -87,7 +87,7 @@ object UserApi {
         * @return An endpoint representing a Unit
         */
         private def createUsersWithListInput(da: DataAccessor): Endpoint[Unit] =
-        post("user" :: "createWithList" :: jsonBody[Seq[User]]) { (user: Seq[User]) => 
+        post("user" :: "createWithList" :: jsonBody[Seq[User]]) { (user: Seq[User]) =>
           da.User_createUsersWithListInput(user) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -101,7 +101,7 @@ object UserApi {
         * @return An endpoint representing a Unit
         */
         private def deleteUser(da: DataAccessor): Endpoint[Unit] =
-        delete("user" :: string) { (username: String) => 
+        delete("user" :: string) { (username: String) =>
           da.User_deleteUser(username) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -115,7 +115,7 @@ object UserApi {
         * @return An endpoint representing a User
         */
         private def getUserByName(da: DataAccessor): Endpoint[User] =
-        get("user" :: string) { (username: String) => 
+        get("user" :: string) { (username: String) =>
           da.User_getUserByName(username) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -129,7 +129,7 @@ object UserApi {
         * @return An endpoint representing a String
         */
         private def loginUser(da: DataAccessor): Endpoint[String] =
-        get("user" :: "login" :: param("username") :: param("password")) { (username: String, password: String) => 
+        get("user" :: "login" :: param("username") :: param("password")) { (username: String, password: String) =>
           da.User_loginUser(username, password) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -143,7 +143,7 @@ object UserApi {
         * @return An endpoint representing a Unit
         */
         private def logoutUser(da: DataAccessor): Endpoint[Unit] =
-        get("user" :: "logout") { 
+        get("user" :: "logout") { () =>
           da.User_logoutUser() match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)
@@ -157,7 +157,7 @@ object UserApi {
         * @return An endpoint representing a Unit
         */
         private def updateUser(da: DataAccessor): Endpoint[Unit] =
-        put("user" :: string :: jsonBody[User]) { (username: String, user: User) => 
+        put("user" :: string :: jsonBody[User]) { (username: String, user: User) =>
           da.User_updateUser(username, user) match {
             case Left(error) => checkError(error)
             case Right(data) => Ok(data)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Previous error handling implementation had types returning
`Either[CommonError, UserType]`, but implemented with the scala shortcut
`???` which throws an exception instead. This causes compilation to fail
with a message that the expected CommonError is of type Any. This is
often fixable with generic upper bounds constraints, but this is
overkill for a placeholder implementation. Returning a temporary 'TODO'
type solves the compile error, and should allow CI to check for valid
compilation on changes.

Included in this is also a fix to support optional query parameter
types. The spec used to generate the finch server has optional query
parameters, but the version of finch in the template doesn't support
options on query parameters. Finch does, however, aggregate everything
(headers, query string, path parameters, etc) under "param" with
"paramOption" for those which are optional types.

