### PR TITLE
Code clean-up: remove DefaultCodegen#getSimpleRef(String)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1470,7 +1470,7 @@ public class DefaultCodegen implements CodegenConfig {
                         continue;
                     }
                     Schema refSchema = null;
-                    String ref = getSimpleRef(interfaceSchema.get$ref());
+                    String ref = ModelUtils.getSimpleRef(interfaceSchema.get$ref());
                     if (allDefinitions != null) {
                         refSchema = allDefinitions.get(ref);
                     }
@@ -1591,7 +1591,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         if (StringUtils.isNotBlank(schema.get$ref())) {
-            Schema interfaceSchema = allSchemas.get(getSimpleRef(schema.get$ref()));
+            Schema interfaceSchema = allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref()));
             addProperties(properties, required, interfaceSchema, allSchemas);
             return;
         }
@@ -2223,9 +2223,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             } else {
                 // process body parameter
-                if (StringUtils.isNotBlank(requestBody.get$ref())) {
-                    requestBody = openAPI.getComponents().getRequestBodies().get(getSimpleRef(requestBody.get$ref()));
-                }
+                requestBody = ModelUtils.getReferencedRequestBody(openAPI, requestBody);
 
                 String bodyParameterName = "";
                 if (op.vendorExtensions != null && op.vendorExtensions.containsKey("x-codegen-request-body-name")) {
@@ -3999,7 +3997,7 @@ public class DefaultCodegen implements CodegenConfig {
             if (StringUtils.isBlank(ref)) {
                 return null;
             }
-            ref = getSimpleRef(ref);
+            ref = ModelUtils.getSimpleRef(ref);
             return allSchemas.get(ref);
         }
         return null;
@@ -4012,14 +4010,9 @@ public class DefaultCodegen implements CodegenConfig {
             if (StringUtils.isBlank(ref)) {
                 return null;
             }
-            return getSimpleRef(ref);
+            return ModelUtils.getSimpleRef(ref);
         }
         return null;
-    }
-
-    // TODO decommission this function and replace it with ModelUtils.getSimpleRef() directly
-    protected String getSimpleRef(String ref) {
-        return ModelUtils.getSimpleRef(ref);
     }
 
     protected String getCollectionFormat(Parameter parameter) {
@@ -4064,7 +4057,7 @@ public class DefaultCodegen implements CodegenConfig {
         LOGGER.debug("debugging fromRequestBodyToFormParameters= " + body);
         Schema schema = ModelUtils.getSchemaFromRequestBody(body);
         if (StringUtils.isNotBlank(schema.get$ref())) {
-            schema = schemas.get(getSimpleRef(schema.get$ref()));
+            schema = schemas.get(ModelUtils.getSimpleRef(schema.get$ref()));
         }
         if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
             Map<String, Schema> properties = schema.getProperties();
@@ -4219,7 +4212,7 @@ public class DefaultCodegen implements CodegenConfig {
         LOGGER.debug("Request body = " + body);
         Schema schema = ModelUtils.getSchemaFromRequestBody(body);
         if (StringUtils.isNotBlank(schema.get$ref())) {
-            name = getSimpleRef(schema.get$ref());
+            name = ModelUtils.getSimpleRef(schema.get$ref());
             schema = schemas.get(name);
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -331,7 +331,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
             }
             return "std::vector<" + inner + ">()";
         } else if (!StringUtils.isEmpty(p.get$ref())) { // model
-            return "new " + toModelName(getSimpleRef(p.get$ref())) + "()";
+            return "new " + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         } else if (ModelUtils.isStringSchema(p)) {
             return "\"\"";
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
@@ -344,7 +344,7 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
         } else if (ModelUtils.isStringSchema(p)) {
             return "new QString(\"\")";
         } else if (!StringUtils.isEmpty(p.get$ref())) {
-            return "new " + toModelName(getSimpleRef(p.get$ref())) + "()";
+            return "new " + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         }
         return "NULL";
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestClientCodegen.java
@@ -337,7 +337,7 @@ public class CppRestClientCodegen extends AbstractCppCodegen {
             }
             return "std::vector<" + inner + ">()";
         } else if (!StringUtils.isEmpty(p.get$ref())) {
-            return "new " + toModelName(getSimpleRef(p.get$ref())) + "()";
+            return "new " + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         } else if (ModelUtils.isStringSchema(p)) {
             return "utility::conversions::to_string_t(\"\")";
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestbedServerCodegen.java
@@ -324,7 +324,7 @@ public class CppRestbedServerCodegen extends AbstractCppCodegen {
             }
             return "std::vector<" + inner + ">()";
         } else if (!StringUtils.isEmpty(p.get$ref())) {
-            return "new " + toModelName(getSimpleRef(p.get$ref())) + "()";
+            return "new " + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         }
         return "nullptr";
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppTizenClientCodegen.java
@@ -225,7 +225,7 @@ public class CppTizenClientCodegen extends DefaultCodegen implements CodegenConf
         } else if (ModelUtils.isArraySchema(p)) {
             return "new std::list()";
         } else if (!StringUtils.isEmpty(p.get$ref())) {
-            return "new " + toModelName(getSimpleRef(p.get$ref())) + "()";
+            return "new " + toModelName(ModelUtils.getSimpleRef(p.get$ref())) + "()";
         } else if (ModelUtils.isDateSchema(p) || ModelUtils.isDateTimeSchema(p)) {
             return "null";
         } else if (ModelUtils.isStringSchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -688,7 +688,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
                 Schema response = (Schema) rsp.schema;
                 // Check whether we're returning an object with a defined XML namespace.
                 if (response != null && (!StringUtils.isEmpty(response.get$ref()))) {
-                    Schema model = definitions.get(getSimpleRef(response.get$ref()));
+                    Schema model = definitions.get(ModelUtils.getSimpleRef(response.get$ref()));
                     if ((model != null)) {
                         XML xml = model.getXml();
                         if ((xml != null) && (xml.getNamespace() != null)) {
@@ -826,7 +826,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         CodegenModel mdl = super.fromModel(name, model, allDefinitions);
         mdl.vendorExtensions.put("upperCaseName", name.toUpperCase());
         if (!StringUtils.isEmpty(model.get$ref())) {
-            Schema schema = allDefinitions.get(getSimpleRef(model.get$ref()));
+            Schema schema = allDefinitions.get(ModelUtils.getSimpleRef(model.get$ref()));
             mdl.dataType = typeMapping.get(schema.getType());
         }
         if (ModelUtils.isArraySchema(model)) {
@@ -1051,7 +1051,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
 
         if ((refName != null) && (refName instanceof String)) {
             String name = (String) refName;
-            Schema model = definitions.get(getSimpleRef(name));
+            Schema model = definitions.get(ModelUtils.getSimpleRef(name));
 
             if (model != null) {
                 XML xml = model.getXml();


### PR DESCRIPTION
Remove `DefaultCodegen#getSimpleRef(String)` (was marked as TODO):

> decommission this function and replace it with ModelUtils.getSimpleRef() directly

Use `ModelUtils#getSimpleRef(String)` instead.
