### PR TITLE
Code clean-up: remove field declaration hiding existing fields

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -19,9 +19,6 @@ package org.openapitools.codegen.languages;
 
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
-import org.openapitools.codegen.languages.features.JbossFeature;
-import org.openapitools.codegen.languages.features.SwaggerFeatures;
-import io.swagger.v3.oas.models.*;
 
 import java.io.File;
 
@@ -34,8 +31,6 @@ import java.io.File;
  */
 public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen implements BeanValidationFeatures {
 
-    protected boolean useBeanValidation = true;
-
     /**
      * Default constructor
      */
@@ -43,6 +38,7 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen imp
         outputFolder = "generated-code/JavaJaxRS-CXF-CDI";
         artifactId = "openapi-jaxrs-cxf-cdi-server";
         sourceFolder = "src" + File.separator + "gen" + File.separator + "java";
+        useBeanValidation = true;
 
         // Three API templates to support CDI injection
         apiTemplateFiles.put("apiService.mustache", ".java");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
@@ -31,9 +31,9 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     protected static final String LIBRARY_JERSEY2 = "jersey2";
 
     /**
-     * Default library template to use. (Default:{@value #DEFAULT_LIBRARY})
+     * Default library template to use. (Default:{@value #DEFAULT_JERSEY_LIBRARY})
      */
-    public static final String DEFAULT_LIBRARY = LIBRARY_JERSEY2;
+    public static final String DEFAULT_JERSEY_LIBRARY = LIBRARY_JERSEY2;
     public static final String USE_TAGS = "useTags";
 
     protected boolean useTags = false;
@@ -61,7 +61,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
         supportedLibraries.put(LIBRARY_JERSEY1, "Jersey core 1.x");
         supportedLibraries.put(LIBRARY_JERSEY2, "Jersey core 2.x");
         library.setEnum(supportedLibraries);
-        library.setDefault(DEFAULT_LIBRARY);
+        library.setDefault(DEFAULT_JERSEY_LIBRARY);
 
         cliOptions.add(library);
         cliOptions.add(CliOption.newBoolean(SUPPORT_JAVA6, "Whether to support Java6 with the Jersey1/2 library."));
@@ -101,7 +101,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         // use default library if unset
         if (StringUtils.isEmpty(library)) {
-            setLibrary(DEFAULT_LIBRARY);
+            setLibrary(DEFAULT_JERSEY_LIBRARY);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.IMPL_FOLDER)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMSF4JServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaMSF4JServerCodegen.java
@@ -36,7 +36,7 @@ public class JavaMSF4JServerCodegen extends AbstractJavaJAXRSServerCodegen {
     protected static final String LIBRARY_JERSEY2 = "jersey2";
 
 
-    public static final String DEFAULT_LIBRARY = LIBRARY_JERSEY2;
+    public static final String DEFAULT_MSF4J_LIBRARY = LIBRARY_JERSEY2;
 
     public JavaMSF4JServerCodegen() {
         super();
@@ -52,7 +52,7 @@ public class JavaMSF4JServerCodegen extends AbstractJavaJAXRSServerCodegen {
         supportedLibraries.put(LIBRARY_JERSEY1, "Jersey core 1.x");
         supportedLibraries.put(LIBRARY_JERSEY2, "Jersey core 2.x");
         library.setEnum(supportedLibraries);
-        library.setDefault(DEFAULT_LIBRARY);
+        library.setDefault(DEFAULT_MSF4J_LIBRARY);
         cliOptions.add(library);
 
     }
@@ -90,7 +90,7 @@ public class JavaMSF4JServerCodegen extends AbstractJavaJAXRSServerCodegen {
 
         // use default library if unset
         if (StringUtils.isEmpty(library)) {
-            setLibrary(DEFAULT_LIBRARY);
+            setLibrary(DEFAULT_MSF4J_LIBRARY);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.IMPL_FOLDER)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaPKMSTServerCodegen.java
@@ -46,29 +46,16 @@ import java.util.Map;
  */
 public class JavaPKMSTServerCodegen extends AbstractJavaCodegen {
 
-    public static final String FULL_JAVA_UTIL = "fullJavaUtil";
-    public static final String SUPPORT_JAVA6 = "supportJava6";
     public static final String CONFIG_PACKAGE = "configPackage";
     public static final String BASE_PACKAGE = "basePackage";
     public static final String TITLE = "title";
-    public static final String WITH_XML = "withXml";
     public static final String EUREKA_URI = "eurekaUri";
     public static final String ZIPKIN_URI = "zipkinUri";
     public static final String SPRINGADMIN_URI = "springBootAdminUri";
-    protected String projectFolder;
-    protected String projectTestFolder;
-    protected String sourceFolder;
-    protected String testFolder;
     protected String basePackage = "com.prokarma.pkmst";
     protected String serviceName = "Pkmst";
     protected String configPackage = "com.prokarma.pkmst.config";
     protected boolean implicitHeaders = false;
-    protected boolean serializeBigDecimalAsString = false;
-    protected boolean withXml = false;
-    protected boolean fullJavaUtil;
-    protected String javaUtilPrefix = "";
-    protected Boolean serializableModel = false;
-    protected String invokerPackage;
     protected String title;
     protected String eurekaUri;
     protected String zipkinUri;
@@ -88,6 +75,10 @@ public class JavaPKMSTServerCodegen extends AbstractJavaCodegen {
         modelPackage = "com.prokarma.pkmst.model";
         invokerPackage = "com.prokarma.pkmst.controller";
         additionalProperties.put("jackson", "true");
+        serializeBigDecimalAsString = false;
+        withXml = false;
+        javaUtilPrefix = "";
+        serializableModel = false;
         this.cliOptions.add(new CliOption("groupId", "groupId in generated pom.xml"));
         this.cliOptions.add(new CliOption("artifactId", "artifactId in generated pom.xml"));
         this.cliOptions.add(new CliOption("artifactVersion", "artifact version in generated pom.xml"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaResteasyEapServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaResteasyEapServerCodegen.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen
         implements JbossFeature, BeanValidationFeatures, SwaggerFeatures {
 
-    protected boolean useBeanValidation = true;
     protected boolean generateJbossDeploymentDescriptor = true;
     protected boolean useSwaggerFeature = false;
 
@@ -43,6 +42,7 @@ public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen
         super();
 
         artifactId = "openapi-jaxrs-resteasy-eap-server";
+        useBeanValidation = true;
 
         outputFolder = "generated-code/JavaJaxRS-Resteasy-eap";
         apiTemplateFiles.put("apiServiceImpl.mustache", ".java");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -31,7 +31,6 @@ import java.util.Map;
 public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
     public static final String DATE_LIBRARY = "dateLibrary";
-    protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
     private static final Logger LOGGER = LoggerFactory.getLogger(KotlinClientCodegen.class);
 
     protected String dateLibrary = DateLibrary.JAVA8.value;
@@ -65,6 +64,8 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         embeddedTemplateDir = templateDir = "kotlin-client";
         apiPackage = packageName + ".apis";
         modelPackage = packageName + ".models";
+
+        enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use");
         Map<String, String> dateOptions = new HashMap<>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaGatlingCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaGatlingCodegen.java
@@ -38,7 +38,6 @@ public class ScalaGatlingCodegen extends AbstractScalaCodegen implements Codegen
     private static final Logger LOGGER = LoggerFactory.getLogger(ScalaGatlingCodegen.class);
 
     // source folder where to write the files
-    protected String sourceFolder = "src" + File.separator + "gatling" + File.separator + "scala";
     protected String resourceFolder = "src" + File.separator + "gatling" + File.separator + "resources";
     protected String confFolder = resourceFolder + File.separator + "conf";
     protected String dataFolder = resourceFolder + File.separator + "data";
@@ -75,6 +74,8 @@ public class ScalaGatlingCodegen extends AbstractScalaCodegen implements Codegen
 
     public ScalaGatlingCodegen() {
         super();
+
+        sourceFolder = "src" + File.separator + "gatling" + File.separator + "scala";
 
         // set the output folder here
         outputFolder = "generated-code/gatling";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -55,7 +55,6 @@ public class SpringCodegen extends AbstractJavaCodegen
         implements BeanValidationFeatures, OptionalFeatures {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringCodegen.class);
 
-    public static final String DEFAULT_LIBRARY = "spring-boot";
     public static final String TITLE = "title";
     public static final String SERVER_PORT = "serverPort";
     public static final String CONFIG_PACKAGE = "configPackage";
@@ -69,6 +68,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String RESPONSE_WRAPPER = "responseWrapper";
     public static final String USE_TAGS = "useTags";
     public static final String SPRING_MVC_LIBRARY = "spring-mvc";
+    public static final String SPRING_BOOT = "spring-boot";
     public static final String SPRING_CLOUD_LIBRARY = "spring-cloud";
     public static final String IMPLICIT_HEADERS = "implicitHeaders";
     public static final String SWAGGER_DOCKET_CONFIG = "swaggerDocketConfig";
@@ -120,15 +120,14 @@ public class SpringCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_OPTIONAL,
                 "Use Optional container for optional parameters"));
 
-        supportedLibraries.put(DEFAULT_LIBRARY, "Spring-boot Server application using the SpringFox integration.");
+        supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application using the SpringFox integration.");
         supportedLibraries.put(SPRING_MVC_LIBRARY, "Spring-MVC Server application using the SpringFox integration.");
         supportedLibraries.put(SPRING_CLOUD_LIBRARY, "Spring-Cloud-Feign client with Spring-Boot auto-configured settings.");
-        setLibrary(DEFAULT_LIBRARY);
+        setLibrary(SPRING_BOOT);
 
         CliOption library = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use");
-        library.setDefault(DEFAULT_LIBRARY);
+        library.setDefault(SPRING_BOOT);
         library.setEnum(supportedLibraries);
-        library.setDefault(DEFAULT_LIBRARY);
         cliOptions.add(library);
     }
 
@@ -206,7 +205,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         }
 
         if (additionalProperties.containsKey(REACTIVE)) {
-            if (!library.equals(DEFAULT_LIBRARY)) {
+            if (!library.equals(SPRING_BOOT)) {
                 throw new IllegalArgumentException("Currently, reactive option is only supported with Spring-boot");
             }
             this.setReactive(Boolean.valueOf(additionalProperties.get(REACTIVE).toString()));
@@ -262,7 +261,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
 
         if (!this.interfaceOnly) {
-            if (library.equals(DEFAULT_LIBRARY)) {
+            if (library.equals(SPRING_BOOT)) {
                 if (!this.reactive) {
                     supportingFiles.add(new SupportingFile("homeController.mustache",
                             (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator), "HomeController.java"));
@@ -324,7 +323,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         if ("threetenbp".equals(dateLibrary)) {
             supportingFiles.add(new SupportingFile("customInstantDeserializer.mustache",
                     (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator), "CustomInstantDeserializer.java"));
-            if (library.equals(DEFAULT_LIBRARY) || library.equals(SPRING_CLOUD_LIBRARY)) {
+            if (library.equals(SPRING_BOOT) || library.equals(SPRING_CLOUD_LIBRARY)) {
                 supportingFiles.add(new SupportingFile("jacksonConfiguration.mustache",
                         (sourceFolder + File.separator + configPackage).replace(".", java.io.File.separator), "JacksonConfiguration.java"));
             }
@@ -395,7 +394,7 @@ public class SpringCodegen extends AbstractJavaCodegen
 
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
-        if((library.equals(DEFAULT_LIBRARY) || library.equals(SPRING_MVC_LIBRARY)) && !useTags) {
+        if((library.equals(SPRING_BOOT) || library.equals(SPRING_MVC_LIBRARY)) && !useTags) {
             String basePath = resourcePath;
             if (basePath.startsWith("/")) {
                 basePath = basePath.substring(1);


### PR DESCRIPTION
This code cleanup removes field declaration that hides existing field.

> Having field declarations that hides another field or variable is in my opinion a bad practice in java. Name shadowing can cause subtle errors and should be avoided.