### PR TITLE
Consider minLength, maxLength and pattern in referenced schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1519,7 +1519,7 @@ public class DefaultCodegen implements CodegenConfig {
                     addProperties(allProperties, allRequired, child, allDefinitions);
                 }
             }
-            addVars(m, properties, required, allProperties, allRequired);
+            addVars(m, properties, required, allProperties, allRequired, allDefinitions);
             // TODO
             //} else if (schema instanceof RefModel) {
         } else {
@@ -1533,7 +1533,7 @@ public class DefaultCodegen implements CodegenConfig {
             if (ModelUtils.isMapSchema(schema)) {
                 addAdditionPropertiesToCodeGenModel(m, schema);
             }
-            addVars(m, schema.getProperties(), schema.getRequired());
+            addVars(m, schema.getProperties(), schema.getRequired(), allDefinitions);
         }
 
         if (m.vars != null) {
@@ -3095,12 +3095,12 @@ public class DefaultCodegen implements CodegenConfig {
         }
     }
 
-    private void addVars(CodegenModel model, Map<String, Schema> properties, List<String> required) {
-        addVars(model, properties, required, null, null);
+    private void addVars(CodegenModel model, Map<String, Schema> properties, List<String> required, Map<String, Schema> allDefinitions) {
+        addVars(model, properties, required, null, null, allDefinitions);
     }
 
     private void addVars(CodegenModel m, Map<String, Schema> properties, List<String> required,
-                         Map<String, Schema> allProperties, List<String> allRequired) {
+                         Map<String, Schema> allProperties, List<String> allRequired, Map<String, Schema> allDefinitions) {
 
         m.hasRequired = false;
         if (properties != null && !properties.isEmpty()) {
@@ -3109,7 +3109,7 @@ public class DefaultCodegen implements CodegenConfig {
 
             Set<String> mandatory = required == null ? Collections.<String>emptySet()
                     : new TreeSet<String>(required);
-            addVars(m, m.vars, properties, mandatory);
+            addVars(m, m.vars, properties, mandatory, allDefinitions);
             m.allMandatory = m.mandatory = mandatory;
         } else {
             m.emptyVars = true;
@@ -3120,12 +3120,12 @@ public class DefaultCodegen implements CodegenConfig {
         if (allProperties != null) {
             Set<String> allMandatory = allRequired == null ? Collections.<String>emptySet()
                     : new TreeSet<String>(allRequired);
-            addVars(m, m.allVars, allProperties, allMandatory);
+            addVars(m, m.allVars, allProperties, allMandatory, allDefinitions);
             m.allMandatory = allMandatory;
         }
     }
 
-    private void addVars(CodegenModel m, List<CodegenProperty> vars, Map<String, Schema> properties, Set<String> mandatory) {
+    private void addVars(CodegenModel m, List<CodegenProperty> vars, Map<String, Schema> properties, Set<String> mandatory, Map<String, Schema> allDefinitions) {
         // convert set to list so that we can access the next entry in the loop
         List<Map.Entry<String, Schema>> propertyList = new ArrayList<Map.Entry<String, Schema>>(properties.entrySet());
         final int totalCount = propertyList.size();
@@ -3133,7 +3133,11 @@ public class DefaultCodegen implements CodegenConfig {
             Map.Entry<String, Schema> entry = propertyList.get(i);
 
             final String key = entry.getKey();
-            final Schema prop = entry.getValue();
+            Schema prop = entry.getValue();
+            if (allDefinitions != null && prop != null && StringUtils.isNotEmpty(prop.get$ref())) {
+                String refName = ModelUtils.getSimpleRef(prop.get$ref());
+                prop = allDefinitions.get(refName);
+            }
 
             if (prop == null) {
                 LOGGER.warn("null property for " + key);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -58,6 +58,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -864,6 +865,83 @@ public class JavaModelTest {
         Assert.assertEquals(cp2.name, "long2");
         Assert.assertEquals(cp2.baseType, "Long");
         Assert.assertEquals(cp2.getter, "getLong2");
+    }
+
+    @Test(description = "convert string property")
+    public void stringPropertyTest() {
+        final Schema property = new StringSchema().maxLength(10).minLength(3).pattern("^[A-Z]+$");
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        final CodegenProperty cp = codegen.fromProperty("somePropertyWithMinMaxAndPattern", property);
+
+        Assert.assertEquals(cp.baseName, "somePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.nameInCamelCase, "SomePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.nameInSnakeCase, "SOME_PROPERTY_WITH_MIN_MAX_AND_PATTERN");
+        Assert.assertEquals(cp.datatype, "String");
+        Assert.assertEquals(cp.name, "somePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.baseType, "String");
+        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isLong);
+        Assert.assertFalse(cp.isInteger);
+        Assert.assertTrue(cp.isString);
+        Assert.assertEquals(cp.getter, "getSomePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.minLength, Integer.valueOf(3));
+        Assert.assertEquals(cp.maxLength, Integer.valueOf(10));
+        Assert.assertEquals(cp.pattern, "^[A-Z]+$");
+    }
+
+    @Test(description = "convert string property in an object")
+    public void stringPropertyInObjectTest() {
+        final Schema property = new StringSchema().maxLength(10).minLength(3).pattern("^[A-Z]+$");
+        final Schema myObject = new ObjectSchema().addProperties("somePropertyWithMinMaxAndPattern", property);
+
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        CodegenModel cm = codegen.fromModel("myObject", myObject, Collections.singletonMap("myObject", myObject));
+
+        Assert.assertEquals(cm.getVars().size(), 1);
+        CodegenProperty cp = cm.getVars().get(0);
+        Assert.assertEquals(cp.baseName, "somePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.nameInCamelCase, "SomePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.nameInSnakeCase, "SOME_PROPERTY_WITH_MIN_MAX_AND_PATTERN");
+        Assert.assertEquals(cp.datatype, "String");
+        Assert.assertEquals(cp.name, "somePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.baseType, "String");
+        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isLong);
+        Assert.assertFalse(cp.isInteger);
+        Assert.assertTrue(cp.isString);
+        Assert.assertEquals(cp.getter, "getSomePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.minLength, Integer.valueOf(3));
+        Assert.assertEquals(cp.maxLength, Integer.valueOf(10));
+        Assert.assertEquals(cp.pattern, "^[A-Z]+$");
+    }
+
+    @Test(description = "convert referenced string property in an object")
+    public void stringPropertyReferencedInObjectTest() {
+        final Schema property = new StringSchema().maxLength(10).minLength(3).pattern("^[A-Z]+$");
+        final Schema myObject = new ObjectSchema().addProperties("somePropertyWithMinMaxAndPattern", new ObjectSchema().$ref("refObj"));
+
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        Map<String, Schema> schemaMap = new HashMap<>();
+        schemaMap.put("myObject", myObject);
+        schemaMap.put("refObj", property);
+        CodegenModel cm = codegen.fromModel("myObject", myObject, schemaMap);
+
+        Assert.assertEquals(cm.getVars().size(), 1);
+        CodegenProperty cp = cm.getVars().get(0);
+        Assert.assertEquals(cp.baseName, "somePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.nameInCamelCase, "SomePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.nameInSnakeCase, "SOME_PROPERTY_WITH_MIN_MAX_AND_PATTERN");
+        Assert.assertEquals(cp.datatype, "String");
+        Assert.assertEquals(cp.name, "somePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.baseType, "String");
+        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isLong);
+        Assert.assertFalse(cp.isInteger);
+        Assert.assertTrue(cp.isString);
+        Assert.assertEquals(cp.getter, "getSomePropertyWithMinMaxAndPattern");
+        Assert.assertEquals(cp.minLength, Integer.valueOf(3));
+        Assert.assertEquals(cp.maxLength, Integer.valueOf(10));
+        Assert.assertEquals(cp.pattern, "^[A-Z]+$");
     }
 
     @Test(description = "convert an array schema")


### PR DESCRIPTION
Reported by @FatCash on https://github.com/swagger-api/swagger-codegen/issues/8001

OAS2 example:

```
definitions:
  SomeObj:
    type: object
    properties:
      nick:
        $ref: "#/definitions/NickName"
  NickName:
    type: string
    minLength: 1
    maxLength: 3
    pattern: "^[A-Z]+$"
```

---

The solution proposed here is really temporary. When we will work on #20, I think that a lot of the method will be refactored. For example the OpenAPI instance will be propagated instead of `Map<String, Schema>` everywhere and use `ModelUtils` to resolve referenced Schema.
