### PR TITLE
Fix an issue with example generator when array is too large

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -202,17 +202,11 @@ public class ExampleGenerator {
                 }
                 return objectProperties;
             }
-        } else if (ModelUtils.isDateSchema(property))
-
-        {
+        } else if (ModelUtils.isDateSchema(property)) {
             return "2000-01-23";
-        } else if (ModelUtils.isDateTimeSchema(property))
-
-        {
+        } else if (ModelUtils.isDateTimeSchema(property)) {
             return "2000-01-23T04:56:07.000+00:00";
-        } else if (ModelUtils.isNumberSchema(property))
-
-        {
+        } else if (ModelUtils.isNumberSchema(property)) {
             Double min = property.getMinimum() == null ? null : property.getMinimum().doubleValue();
             Double max = property.getMaximum() == null ? null : property.getMaximum().doubleValue();
             if (ModelUtils.isFloatSchema(property)) { // float
@@ -222,23 +216,17 @@ public class ExampleGenerator {
             } else { // no format defined
                 return randomNumber(min, max);
             }
-        } else if (ModelUtils.isFileSchema(property))
-
-        {
+        } else if (ModelUtils.isFileSchema(property)) {
             return "";  // TODO
 
-        } else if (ModelUtils.isIntegerSchema(property))
-
-        {
+        } else if (ModelUtils.isIntegerSchema(property)) {
             Double min = property.getMinimum() == null ? null : property.getMinimum().doubleValue();
             Double max = property.getMaximum() == null ? null : property.getMaximum().doubleValue();
             if (ModelUtils.isLongSchema(property)) {
                 return (long) randomNumber(min, max);
             }
             return (int) randomNumber(min, max);
-        } else if (ModelUtils.isMapSchema(property))
-
-        {
+        } else if (ModelUtils.isMapSchema(property)) {
             Map<String, Object> mp = new HashMap<String, Object>();
             if (property.getName() != null) {
                 mp.put(property.getName(),
@@ -248,13 +236,9 @@ public class ExampleGenerator {
                         resolvePropertyToExample(propertyName, mediaType, (Schema) property.getAdditionalProperties(), processedModels));
             }
             return mp;
-        } else if (ModelUtils.isUUIDSchema(property))
-
-        {
+        } else if (ModelUtils.isUUIDSchema(property)) {
             return "046b6c7f-0b8a-43b9-b35d-6489e6daee91";
-        } else if (ModelUtils.isStringSchema(property))
-
-        {
+        } else if (ModelUtils.isStringSchema(property)) {
             LOGGER.debug("String property");
             String defaultValue = (String) property.getDefault();
             if (defaultValue != null && !defaultValue.isEmpty()) {
@@ -273,9 +257,7 @@ public class ExampleGenerator {
             }
             LOGGER.debug("No values found, using property name " + propertyName + " as example");
             return propertyName;
-        } else if (!StringUtils.isEmpty(property.get$ref()))
-
-        { // model
+        } else if (!StringUtils.isEmpty(property.get$ref())) { // model
             String simpleName = ModelUtils.getSimpleRef(property.get$ref());
             Schema schema = ModelUtils.getSchema(openAPI, simpleName);
             if (schema == null) { // couldn't find the model/schema
@@ -283,9 +265,7 @@ public class ExampleGenerator {
             }
             return resolveModelToExample(simpleName, mediaType, schema, processedModels);
 
-        } else if (ModelUtils.isObjectSchema(property))
-
-        {
+        } else if (ModelUtils.isObjectSchema(property)) {
             return "{}";
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -17,10 +17,10 @@
 
 package org.openapitools.codegen.examples;
 
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.core.util.Json;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -191,6 +191,10 @@ public class ExampleGenerator {
             Schema innerType = ((ArraySchema) property).getItems();
             if (innerType != null) {
                 int arrayLength = null == ((ArraySchema) property).getMaxItems() ? 2 : ((ArraySchema) property).getMaxItems();
+                if (arrayLength > 1024) {
+                    LOGGER.warn("The max items allowed in property {} is too large ({} items), restricting it to 1024 items", property, arrayLength);
+                    arrayLength = 1024;
+                }
                 Object[] objectProperties = new Object[arrayLength];
                 Object objProperty = resolvePropertyToExample(propertyName, mediaType, innerType, processedModels);
                 for (int i = 0; i < arrayLength; i++) {
@@ -198,11 +202,17 @@ public class ExampleGenerator {
                 }
                 return objectProperties;
             }
-        } else if (ModelUtils.isDateSchema(property)) {
+        } else if (ModelUtils.isDateSchema(property))
+
+        {
             return "2000-01-23";
-        } else if (ModelUtils.isDateTimeSchema(property)) {
+        } else if (ModelUtils.isDateTimeSchema(property))
+
+        {
             return "2000-01-23T04:56:07.000+00:00";
-        } else if (ModelUtils.isNumberSchema(property)) {
+        } else if (ModelUtils.isNumberSchema(property))
+
+        {
             Double min = property.getMinimum() == null ? null : property.getMinimum().doubleValue();
             Double max = property.getMaximum() == null ? null : property.getMaximum().doubleValue();
             if (ModelUtils.isFloatSchema(property)) { // float
@@ -212,17 +222,23 @@ public class ExampleGenerator {
             } else { // no format defined
                 return randomNumber(min, max);
             }
-        } else if (ModelUtils.isFileSchema(property)) {
+        } else if (ModelUtils.isFileSchema(property))
+
+        {
             return "";  // TODO
 
-        } else if (ModelUtils.isIntegerSchema(property)) {
+        } else if (ModelUtils.isIntegerSchema(property))
+
+        {
             Double min = property.getMinimum() == null ? null : property.getMinimum().doubleValue();
             Double max = property.getMaximum() == null ? null : property.getMaximum().doubleValue();
             if (ModelUtils.isLongSchema(property)) {
                 return (long) randomNumber(min, max);
             }
             return (int) randomNumber(min, max);
-        } else if (ModelUtils.isMapSchema(property)) {
+        } else if (ModelUtils.isMapSchema(property))
+
+        {
             Map<String, Object> mp = new HashMap<String, Object>();
             if (property.getName() != null) {
                 mp.put(property.getName(),
@@ -232,9 +248,13 @@ public class ExampleGenerator {
                         resolvePropertyToExample(propertyName, mediaType, (Schema) property.getAdditionalProperties(), processedModels));
             }
             return mp;
-        } else if (ModelUtils.isUUIDSchema(property)) {
+        } else if (ModelUtils.isUUIDSchema(property))
+
+        {
             return "046b6c7f-0b8a-43b9-b35d-6489e6daee91";
-        } else if (ModelUtils.isStringSchema(property)) {
+        } else if (ModelUtils.isStringSchema(property))
+
+        {
             LOGGER.debug("String property");
             String defaultValue = (String) property.getDefault();
             if (defaultValue != null && !defaultValue.isEmpty()) {
@@ -253,7 +273,9 @@ public class ExampleGenerator {
             }
             LOGGER.debug("No values found, using property name " + propertyName + " as example");
             return propertyName;
-        } else if (!StringUtils.isEmpty(property.get$ref())) { // model
+        } else if (!StringUtils.isEmpty(property.get$ref()))
+
+        { // model
             String simpleName = ModelUtils.getSimpleRef(property.get$ref());
             Schema schema = ModelUtils.getSchema(openAPI, simpleName);
             if (schema == null) { // couldn't find the model/schema
@@ -261,7 +283,9 @@ public class ExampleGenerator {
             }
             return resolveModelToExample(simpleName, mediaType, schema, processedModels);
 
-        } else if (ModelUtils.isObjectSchema(property)) {
+        } else if (ModelUtils.isObjectSchema(property))
+
+        {
             return "{}";
         }
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

