### PR TITLE
[aspnetcore] Fix openapi.json location rename

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/Startup.mustache
@@ -93,7 +93,10 @@ namespace {{packageName}}
                 .UseMvc()
                 .UseDefaultFiles()
                 .UseStaticFiles()
-                .UseSwagger()
+                .UseSwagger(c =>
+                {
+                    c.RouteTemplate = "swagger/{documentName}/openapi.json";
+                })
                 .UseSwaggerUI(c =>
                 {
                     //TODO: Either use the SwaggerGen generated Swagger contract (generated from C# classes)

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Startup.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Startup.cs
@@ -100,7 +100,10 @@ namespace Org.OpenAPITools
                 .UseMvc()
                 .UseDefaultFiles()
                 .UseStaticFiles()
-                .UseSwagger()
+                .UseSwagger(c =>
+                {
+                    c.RouteTemplate = "swagger/{documentName}/openapi.json";
+                })
                 .UseSwaggerUI(c =>
                 {
                     //TODO: Either use the SwaggerGen generated Swagger contract (generated from C# classes)


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Swashbuckle generation was missing the configuration to rename from
default swagger.json to openapi.json (expected by change in SwaggerUI's
configuration for the endpoint).

This generates to the appropriate location and updates the sample to
load the Swagger UI properly on run.

Fixes an issue I found while evaluating #53.

NOTE: `{documentName}` is not a mustache variable. It is a templated placeholder for Swashbuckle to replace with the version pulled from the generated document.
