### PR TITLE
Fix Swift4 and Swift3 template comment

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift3/api.mustache
@@ -94,36 +94,36 @@ open class {{classname}}: APIBase {
 
     /**
      {{#summary}}
-     {{{summary}}}
+///  {{{summary}}}
      {{/summary}}
-     - {{httpMethod}} {{{path}}}
+///  - {{httpMethod}} {{{path}}}
      {{#notes}}
-     - {{{notes}}}
+///  - {{{notes}}}
      {{/notes}}
      {{#subresourceOperation}}
-     - subresourceOperation: {{subresourceOperation}}
+///  - subresourceOperation: {{subresourceOperation}}
      {{/subresourceOperation}}
      {{#defaultResponse}}
-     - defaultResponse: {{defaultResponse}}
+///  - defaultResponse: {{defaultResponse}}
      {{/defaultResponse}}
      {{#authMethods}}
-     - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
-       - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
-       - name: {{name}}
+///  - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
+///    - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
+///    - name: {{name}}
      {{/authMethods}}
      {{#hasResponseHeaders}}
-     - responseHeaders: [{{#responseHeaders}}{{{baseName}}}({{{datatype}}}){{^-last}}, {{/-last}}{{/responseHeaders}}]
+///  - responseHeaders: [{{#responseHeaders}}{{{baseName}}}({{{datatype}}}){{^-last}}, {{/-last}}{{/responseHeaders}}]
      {{/hasResponseHeaders}}
      {{#examples}}
-     - examples: {{{examples}}}
+///  - examples: {{{examples}}}
      {{/examples}}
      {{#externalDocs}}
-     - externalDocs: {{externalDocs}}
+///  - externalDocs: {{externalDocs}}
      {{/externalDocs}}
      {{#allParams}}
-     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+///  - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}
-     - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
+///  - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
      */
     open class func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{{path}}}"{{#pathParams}}

--- a/modules/openapi-generator/src/main/resources/swift4/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/api.mustache
@@ -100,30 +100,30 @@ open class {{classname}} {
 
     /**
      {{#summary}}
-     {{{summary}}}
+///  {{{summary}}}
      {{/summary}}
-     - {{httpMethod}} {{{path}}}{{#notes}}
-     - {{{notes}}}{{/notes}}{{#subresourceOperation}}
-     - subresourceOperation: {{subresourceOperation}}{{/subresourceOperation}}{{#defaultResponse}}
-     - defaultResponse: {{defaultResponse}}{{/defaultResponse}}
+///  - {{httpMethod}} {{{path}}}{{#notes}}
+///  - {{{notes}}}{{/notes}}{{#subresourceOperation}}
+///  - subresourceOperation: {{subresourceOperation}}{{/subresourceOperation}}{{#defaultResponse}}
+///  - defaultResponse: {{defaultResponse}}{{/defaultResponse}}
      {{#authMethods}}
-     - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
-       - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
-       - name: {{name}}
+///  - {{#isBasic}}BASIC{{/isBasic}}{{#isOAuth}}OAuth{{/isOAuth}}{{#isApiKey}}API Key{{/isApiKey}}:
+///    - type: {{type}}{{#keyParamName}} {{keyParamName}} {{#isKeyInQuery}}(QUERY){{/isKeyInQuery}}{{#isKeyInHeaer}}(HEADER){{/isKeyInHeaer}}{{/keyParamName}}
+///    - name: {{name}}
        {{/authMethods}}
      {{#hasResponseHeaders}}
-     - responseHeaders: [{{#responseHeaders}}{{{baseName}}}({{{datatype}}}){{^-last}}, {{/-last}}{{/responseHeaders}}]
+///  - responseHeaders: [{{#responseHeaders}}{{{baseName}}}({{{datatype}}}){{^-last}}, {{/-last}}{{/responseHeaders}}]
      {{/hasResponseHeaders}}
      {{#hasExamples}}
-     - examples: {{{examples}}}
+///  - examples: {{{examples}}}
      {{/hasExamples}}
      {{#externalDocs}}
-     - externalDocs: {{externalDocs}}
+///  - externalDocs: {{externalDocs}}
      {{/externalDocs}}
      {{#allParams}}
-     - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
+///  - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
      {{/allParams}}
-     - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
+///  - returns: RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{description}}
      */
     open class func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{{path}}}"{{#pathParams}}

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -23,14 +23,14 @@ open class AnotherFakeAPI: APIBase {
 
 
     /**
-     To test special tags
-     - PATCH /another-fake/dummy
-     - To test special tags
-     - examples: [{contentType=application/json, example={
+///  To test special tags
+///  - PATCH /another-fake/dummy
+///  - To test special tags
+///  - examples: [{contentType=application/json, example={
   "client" : "client"
 }}]
-     - parameter client: (body) client model 
-     - returns: RequestBuilder<Client> 
+///  - parameter client: (body) client model 
+///  - returns: RequestBuilder<Client> 
      */
     open class func testSpecialTagsWithRequestBuilder(client: Client) -> RequestBuilder<Client> {
         let path = "/another-fake/dummy"

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -22,11 +22,11 @@ open class FakeAPI: APIBase {
 
 
     /**
-     - POST /fake/outer/boolean
-     - Test serialization of outer boolean types
-     - examples: [{contentType=*/*, example=null}]
-     - parameter body: (body) Input boolean as post body (optional)
-     - returns: RequestBuilder<Bool> 
+///  - POST /fake/outer/boolean
+///  - Test serialization of outer boolean types
+///  - examples: [{contentType=*/*, example=null}]
+///  - parameter body: (body) Input boolean as post body (optional)
+///  - returns: RequestBuilder<Bool> 
      */
     open class func fakeOuterBooleanSerializeWithRequestBuilder(body: Bool? = nil) -> RequestBuilder<Bool> {
         let path = "/fake/outer/boolean"
@@ -52,11 +52,11 @@ open class FakeAPI: APIBase {
 
 
     /**
-     - POST /fake/outer/composite
-     - Test serialization of object with outer number type
-     - examples: [{contentType=*/*, example={ }}]
-     - parameter outerComposite: (body) Input composite as post body (optional)
-     - returns: RequestBuilder<OuterComposite> 
+///  - POST /fake/outer/composite
+///  - Test serialization of object with outer number type
+///  - examples: [{contentType=*/*, example={ }}]
+///  - parameter outerComposite: (body) Input composite as post body (optional)
+///  - returns: RequestBuilder<OuterComposite> 
      */
     open class func fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: OuterComposite? = nil) -> RequestBuilder<OuterComposite> {
         let path = "/fake/outer/composite"
@@ -82,11 +82,11 @@ open class FakeAPI: APIBase {
 
 
     /**
-     - POST /fake/outer/number
-     - Test serialization of outer number types
-     - examples: [{contentType=*/*, example=null}]
-     - parameter body: (body) Input number as post body (optional)
-     - returns: RequestBuilder<Double> 
+///  - POST /fake/outer/number
+///  - Test serialization of outer number types
+///  - examples: [{contentType=*/*, example=null}]
+///  - parameter body: (body) Input number as post body (optional)
+///  - returns: RequestBuilder<Double> 
      */
     open class func fakeOuterNumberSerializeWithRequestBuilder(body: Double? = nil) -> RequestBuilder<Double> {
         let path = "/fake/outer/number"
@@ -112,11 +112,11 @@ open class FakeAPI: APIBase {
 
 
     /**
-     - POST /fake/outer/string
-     - Test serialization of outer string types
-     - examples: [{contentType=*/*, example=null}]
-     - parameter body: (body) Input string as post body (optional)
-     - returns: RequestBuilder<String> 
+///  - POST /fake/outer/string
+///  - Test serialization of outer string types
+///  - examples: [{contentType=*/*, example=null}]
+///  - parameter body: (body) Input string as post body (optional)
+///  - returns: RequestBuilder<String> 
      */
     open class func fakeOuterStringSerializeWithRequestBuilder(body: String? = nil) -> RequestBuilder<String> {
         let path = "/fake/outer/string"
@@ -143,14 +143,14 @@ open class FakeAPI: APIBase {
 
 
     /**
-     To test \"client\" model
-     - PATCH /fake
-     - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+///  To test \"client\" model
+///  - PATCH /fake
+///  - To test \"client\" model
+///  - examples: [{contentType=application/json, example={
   "client" : "client"
 }}]
-     - parameter client: (body) client model 
-     - returns: RequestBuilder<Client> 
+///  - parameter client: (body) client model 
+///  - returns: RequestBuilder<Client> 
      */
     open class func testClientModelWithRequestBuilder(client: Client) -> RequestBuilder<Client> {
         let path = "/fake"
@@ -190,27 +190,27 @@ open class FakeAPI: APIBase {
 
 
     /**
-     Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-     - POST /fake
-     - Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-     - BASIC:
-       - type: http
-       - name: http_basic_test
-     - parameter number: (form) None 
-     - parameter double: (form) None 
-     - parameter patternWithoutDelimiter: (form) None 
-     - parameter byte: (form) None 
-     - parameter integer: (form) None (optional)
-     - parameter int32: (form) None (optional)
-     - parameter int64: (form) None (optional)
-     - parameter float: (form) None (optional)
-     - parameter string: (form) None (optional)
-     - parameter binary: (form) None (optional)
-     - parameter date: (form) None (optional)
-     - parameter dateTime: (form) None (optional)
-     - parameter password: (form) None (optional)
-     - parameter callback: (form) None (optional)
-     - returns: RequestBuilder<Void> 
+///  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+///  - POST /fake
+///  - Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+///  - BASIC:
+///    - type: http
+///    - name: http_basic_test
+///  - parameter number: (form) None 
+///  - parameter double: (form) None 
+///  - parameter patternWithoutDelimiter: (form) None 
+///  - parameter byte: (form) None 
+///  - parameter integer: (form) None (optional)
+///  - parameter int32: (form) None (optional)
+///  - parameter int64: (form) None (optional)
+///  - parameter float: (form) None (optional)
+///  - parameter string: (form) None (optional)
+///  - parameter binary: (form) None (optional)
+///  - parameter date: (form) None (optional)
+///  - parameter dateTime: (form) None (optional)
+///  - parameter password: (form) None (optional)
+///  - parameter callback: (form) None (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func testEndpointParametersWithRequestBuilder(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int32? = nil, int32: Int32? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: ISOFullDate? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) -> RequestBuilder<Void> {
         let path = "/fake"
@@ -329,18 +329,18 @@ open class FakeAPI: APIBase {
 
 
     /**
-     To test enum parameters
-     - GET /fake
-     - To test enum parameters
-     - parameter enumHeaderStringArray: (header) Header parameter enum test (string array) (optional)
-     - parameter enumHeaderString: (header) Header parameter enum test (string) (optional)
-     - parameter enumQueryStringArray: (query) Query parameter enum test (string array) (optional)
-     - parameter enumQueryString: (query) Query parameter enum test (string) (optional)
-     - parameter enumQueryInteger: (query) Query parameter enum test (double) (optional)
-     - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional)
-     - parameter enumFormString: (form) Form parameter enum test (string) (optional)
-     - parameter enumQueryDouble: (form) Query parameter enum test (double) (optional)
-     - returns: RequestBuilder<Void> 
+///  To test enum parameters
+///  - GET /fake
+///  - To test enum parameters
+///  - parameter enumHeaderStringArray: (header) Header parameter enum test (string array) (optional)
+///  - parameter enumHeaderString: (header) Header parameter enum test (string) (optional)
+///  - parameter enumQueryStringArray: (query) Query parameter enum test (string array) (optional)
+///  - parameter enumQueryString: (query) Query parameter enum test (string) (optional)
+///  - parameter enumQueryInteger: (query) Query parameter enum test (double) (optional)
+///  - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional)
+///  - parameter enumFormString: (form) Form parameter enum test (string) (optional)
+///  - parameter enumQueryDouble: (form) Query parameter enum test (double) (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func testEnumParametersWithRequestBuilder(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil) -> RequestBuilder<Void> {
         let path = "/fake"
@@ -385,11 +385,11 @@ open class FakeAPI: APIBase {
 
 
     /**
-     test json serialization of form data
-     - GET /fake/jsonFormData
-     - parameter param: (form) field1 
-     - parameter param2: (form) field2 
-     - returns: RequestBuilder<Void> 
+///  test json serialization of form data
+///  - GET /fake/jsonFormData
+///  - parameter param: (form) field1 
+///  - parameter param2: (form) field2 
+///  - returns: RequestBuilder<Void> 
      */
     open class func testJsonFormDataWithRequestBuilder(param: String, param2: String) -> RequestBuilder<Void> {
         let path = "/fake/jsonFormData"

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -23,16 +23,16 @@ open class FakeClassnameTags123API: APIBase {
 
 
     /**
-     To test class name in snake case
-     - PATCH /fake_classname_test
-     - API Key:
-       - type: apiKey api_key_query (QUERY)
-       - name: api_key_query
-     - examples: [{contentType=application/json, example={
+///  To test class name in snake case
+///  - PATCH /fake_classname_test
+///  - API Key:
+///    - type: apiKey api_key_query (QUERY)
+///    - name: api_key_query
+///  - examples: [{contentType=application/json, example={
   "client" : "client"
 }}]
-     - parameter client: (body) client model 
-     - returns: RequestBuilder<Client> 
+///  - parameter client: (body) client model 
+///  - returns: RequestBuilder<Client> 
      */
     open class func testClassnameWithRequestBuilder(client: Client) -> RequestBuilder<Client> {
         let path = "/fake_classname_test"

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -23,13 +23,13 @@ open class PetAPI: APIBase {
 
 
     /**
-     Add a new pet to the store
-     - POST /pet
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter pet: (body) Pet object that needs to be added to the store 
-     - returns: RequestBuilder<Void> 
+///  Add a new pet to the store
+///  - POST /pet
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter pet: (body) Pet object that needs to be added to the store 
+///  - returns: RequestBuilder<Void> 
      */
     open class func addPetWithRequestBuilder(pet: Pet) -> RequestBuilder<Void> {
         let path = "/pet"
@@ -57,14 +57,14 @@ open class PetAPI: APIBase {
 
 
     /**
-     Deletes a pet
-     - DELETE /pet/{petId}
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter petId: (path) Pet id to delete 
-     - parameter apiKey: (header)  (optional)
-     - returns: RequestBuilder<Void> 
+///  Deletes a pet
+///  - DELETE /pet/{petId}
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter petId: (path) Pet id to delete 
+///  - parameter apiKey: (header)  (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
@@ -107,13 +107,13 @@ open class PetAPI: APIBase {
 
 
     /**
-     Finds Pets by status
-     - GET /pet/findByStatus
-     - Multiple status values can be provided with comma separated strings
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+///  Finds Pets by status
+///  - GET /pet/findByStatus
+///  - Multiple status values can be provided with comma separated strings
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -139,7 +139,7 @@ open class PetAPI: APIBase {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - examples: [{contentType=application/json, example={
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -165,8 +165,8 @@ open class PetAPI: APIBase {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - parameter status: (query) Status values that need to be considered for filter 
-     - returns: RequestBuilder<[Pet]> 
+///  - parameter status: (query) Status values that need to be considered for filter 
+///  - returns: RequestBuilder<[Pet]> 
      */
     open class func findPetsByStatusWithRequestBuilder(status: [String]) -> RequestBuilder<[Pet]> {
         let path = "/pet/findByStatus"
@@ -196,13 +196,13 @@ open class PetAPI: APIBase {
 
 
     /**
-     Finds Pets by tags
-     - GET /pet/findByTags
-     - Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+///  Finds Pets by tags
+///  - GET /pet/findByTags
+///  - Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -228,7 +228,7 @@ open class PetAPI: APIBase {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - examples: [{contentType=application/json, example={
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -254,8 +254,8 @@ open class PetAPI: APIBase {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - parameter tags: (query) Tags to filter by 
-     - returns: RequestBuilder<[Pet]> 
+///  - parameter tags: (query) Tags to filter by 
+///  - returns: RequestBuilder<[Pet]> 
      */
     open class func findPetsByTagsWithRequestBuilder(tags: [String]) -> RequestBuilder<[Pet]> {
         let path = "/pet/findByTags"
@@ -285,13 +285,13 @@ open class PetAPI: APIBase {
 
 
     /**
-     Find pet by ID
-     - GET /pet/{petId}
-     - Returns a single pet
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
-     - examples: [{contentType=application/json, example={
+///  Find pet by ID
+///  - GET /pet/{petId}
+///  - Returns a single pet
+///  - API Key:
+///    - type: apiKey api_key 
+///    - name: api_key
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -317,7 +317,7 @@ open class PetAPI: APIBase {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - examples: [{contentType=application/json, example={
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -343,8 +343,8 @@ open class PetAPI: APIBase {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - parameter petId: (path) ID of pet to return 
-     - returns: RequestBuilder<Pet> 
+///  - parameter petId: (path) ID of pet to return 
+///  - returns: RequestBuilder<Pet> 
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var path = "/pet/{petId}"
@@ -374,13 +374,13 @@ open class PetAPI: APIBase {
 
 
     /**
-     Update an existing pet
-     - PUT /pet
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter pet: (body) Pet object that needs to be added to the store 
-     - returns: RequestBuilder<Void> 
+///  Update an existing pet
+///  - PUT /pet
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter pet: (body) Pet object that needs to be added to the store 
+///  - returns: RequestBuilder<Void> 
      */
     open class func updatePetWithRequestBuilder(pet: Pet) -> RequestBuilder<Void> {
         let path = "/pet"
@@ -409,15 +409,15 @@ open class PetAPI: APIBase {
 
 
     /**
-     Updates a pet in the store with form data
-     - POST /pet/{petId}
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter petId: (path) ID of pet that needs to be updated 
-     - parameter name: (form) Updated name of the pet (optional)
-     - parameter status: (form) Updated status of the pet (optional)
-     - returns: RequestBuilder<Void> 
+///  Updates a pet in the store with form data
+///  - POST /pet/{petId}
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter petId: (path) ID of pet that needs to be updated 
+///  - parameter name: (form) Updated name of the pet (optional)
+///  - parameter status: (form) Updated status of the pet (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
@@ -455,20 +455,20 @@ open class PetAPI: APIBase {
 
 
     /**
-     uploads an image
-     - POST /pet/{petId}/uploadImage
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+///  uploads an image
+///  - POST /pet/{petId}/uploadImage
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - examples: [{contentType=application/json, example={
   "code" : 0,
   "type" : "type",
   "message" : "message"
 }}]
-     - parameter petId: (path) ID of pet to update 
-     - parameter additionalMetadata: (form) Additional data to pass to server (optional)
-     - parameter file: (form) file to upload (optional)
-     - returns: RequestBuilder<ApiResponse> 
+///  - parameter petId: (path) ID of pet to update 
+///  - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+///  - parameter file: (form) file to upload (optional)
+///  - returns: RequestBuilder<ApiResponse> 
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var path = "/pet/{petId}/uploadImage"

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -23,11 +23,11 @@ open class StoreAPI: APIBase {
 
 
     /**
-     Delete purchase order by ID
-     - DELETE /store/order/{order_id}
-     - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-     - parameter orderId: (path) ID of the order that needs to be deleted 
-     - returns: RequestBuilder<Void> 
+///  Delete purchase order by ID
+///  - DELETE /store/order/{order_id}
+///  - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+///  - parameter orderId: (path) ID of the order that needs to be deleted 
+///  - returns: RequestBuilder<Void> 
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var path = "/store/order/{order_id}"
@@ -56,13 +56,13 @@ open class StoreAPI: APIBase {
 
 
     /**
-     Returns pet inventories by status
-     - GET /store/inventory
-     - Returns a map of status codes to quantities
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
-     - returns: RequestBuilder<[String:Int32]> 
+///  Returns pet inventories by status
+///  - GET /store/inventory
+///  - Returns a map of status codes to quantities
+///  - API Key:
+///    - type: apiKey api_key 
+///    - name: api_key
+///  - returns: RequestBuilder<[String:Int32]> 
      */
     open class func getInventoryWithRequestBuilder() -> RequestBuilder<[String:Int32]> {
         let path = "/store/inventory"
@@ -89,10 +89,10 @@ open class StoreAPI: APIBase {
 
 
     /**
-     Find purchase order by ID
-     - GET /store/order/{order_id}
-     - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/json, example={
+///  Find purchase order by ID
+///  - GET /store/order/{order_id}
+///  - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+///  - examples: [{contentType=application/json, example={
   "petId" : 6,
   "quantity" : 1,
   "id" : 0,
@@ -107,7 +107,7 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}]
-     - examples: [{contentType=application/json, example={
+///  - examples: [{contentType=application/json, example={
   "petId" : 6,
   "quantity" : 1,
   "id" : 0,
@@ -122,8 +122,8 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}]
-     - parameter orderId: (path) ID of pet that needs to be fetched 
-     - returns: RequestBuilder<Order> 
+///  - parameter orderId: (path) ID of pet that needs to be fetched 
+///  - returns: RequestBuilder<Order> 
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var path = "/store/order/{order_id}"
@@ -153,9 +153,9 @@ open class StoreAPI: APIBase {
 
 
     /**
-     Place an order for a pet
-     - POST /store/order
-     - examples: [{contentType=application/json, example={
+///  Place an order for a pet
+///  - POST /store/order
+///  - examples: [{contentType=application/json, example={
   "petId" : 6,
   "quantity" : 1,
   "id" : 0,
@@ -170,7 +170,7 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}]
-     - examples: [{contentType=application/json, example={
+///  - examples: [{contentType=application/json, example={
   "petId" : 6,
   "quantity" : 1,
   "id" : 0,
@@ -185,8 +185,8 @@ open class StoreAPI: APIBase {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}]
-     - parameter order: (body) order placed for purchasing the pet 
-     - returns: RequestBuilder<Order> 
+///  - parameter order: (body) order placed for purchasing the pet 
+///  - returns: RequestBuilder<Order> 
      */
     open class func placeOrderWithRequestBuilder(order: Order) -> RequestBuilder<Order> {
         let path = "/store/order"

--- a/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift3/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -23,11 +23,11 @@ open class UserAPI: APIBase {
 
 
     /**
-     Create user
-     - POST /user
-     - This can only be done by the logged in user.
-     - parameter user: (body) Created user object 
-     - returns: RequestBuilder<Void> 
+///  Create user
+///  - POST /user
+///  - This can only be done by the logged in user.
+///  - parameter user: (body) Created user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func createUserWithRequestBuilder(user: User) -> RequestBuilder<Void> {
         let path = "/user"
@@ -54,10 +54,10 @@ open class UserAPI: APIBase {
 
 
     /**
-     Creates list of users with given input array
-     - POST /user/createWithArray
-     - parameter user: (body) List of user object 
-     - returns: RequestBuilder<Void> 
+///  Creates list of users with given input array
+///  - POST /user/createWithArray
+///  - parameter user: (body) List of user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func createUsersWithArrayInputWithRequestBuilder(user: [User]) -> RequestBuilder<Void> {
         let path = "/user/createWithArray"
@@ -84,10 +84,10 @@ open class UserAPI: APIBase {
 
 
     /**
-     Creates list of users with given input array
-     - POST /user/createWithList
-     - parameter user: (body) List of user object 
-     - returns: RequestBuilder<Void> 
+///  Creates list of users with given input array
+///  - POST /user/createWithList
+///  - parameter user: (body) List of user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func createUsersWithListInputWithRequestBuilder(user: [User]) -> RequestBuilder<Void> {
         let path = "/user/createWithList"
@@ -114,11 +114,11 @@ open class UserAPI: APIBase {
 
 
     /**
-     Delete user
-     - DELETE /user/{username}
-     - This can only be done by the logged in user.
-     - parameter username: (path) The name that needs to be deleted 
-     - returns: RequestBuilder<Void> 
+///  Delete user
+///  - DELETE /user/{username}
+///  - This can only be done by the logged in user.
+///  - parameter username: (path) The name that needs to be deleted 
+///  - returns: RequestBuilder<Void> 
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var path = "/user/{username}"
@@ -148,9 +148,9 @@ open class UserAPI: APIBase {
 
 
     /**
-     Get user by user name
-     - GET /user/{username}
-     - examples: [{contentType=application/json, example={
+///  Get user by user name
+///  - GET /user/{username}
+///  - examples: [{contentType=application/json, example={
   "firstName" : "firstName",
   "lastName" : "lastName",
   "password" : "password",
@@ -169,7 +169,7 @@ open class UserAPI: APIBase {
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
 </User>}]
-     - examples: [{contentType=application/json, example={
+///  - examples: [{contentType=application/json, example={
   "firstName" : "firstName",
   "lastName" : "lastName",
   "password" : "password",
@@ -188,8 +188,8 @@ open class UserAPI: APIBase {
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
 </User>}]
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
-     - returns: RequestBuilder<User> 
+///  - parameter username: (path) The name that needs to be fetched. Use user1 for testing.  
+///  - returns: RequestBuilder<User> 
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var path = "/user/{username}"
@@ -220,12 +220,12 @@ open class UserAPI: APIBase {
 
 
     /**
-     Logs user into the system
-     - GET /user/login
-     - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
-     - parameter username: (query) The user name for login 
-     - parameter password: (query) The password for login in clear text 
-     - returns: RequestBuilder<String> 
+///  Logs user into the system
+///  - GET /user/login
+///  - responseHeaders: [X-Rate-Limit(Int32), X-Expires-After(Date)]
+///  - parameter username: (query) The user name for login 
+///  - parameter password: (query) The password for login in clear text 
+///  - returns: RequestBuilder<String> 
      */
     open class func loginUserWithRequestBuilder(username: String, password: String) -> RequestBuilder<String> {
         let path = "/user/login"
@@ -255,9 +255,9 @@ open class UserAPI: APIBase {
 
 
     /**
-     Logs out current logged in user session
-     - GET /user/logout
-     - returns: RequestBuilder<Void> 
+///  Logs out current logged in user session
+///  - GET /user/logout
+///  - returns: RequestBuilder<Void> 
      */
     open class func logoutUserWithRequestBuilder() -> RequestBuilder<Void> {
         let path = "/user/logout"
@@ -285,12 +285,12 @@ open class UserAPI: APIBase {
 
 
     /**
-     Updated user
-     - PUT /user/{username}
-     - This can only be done by the logged in user.
-     - parameter username: (path) name that need to be deleted 
-     - parameter user: (body) Updated user object 
-     - returns: RequestBuilder<Void> 
+///  Updated user
+///  - PUT /user/{username}
+///  - This can only be done by the logged in user.
+///  - parameter username: (path) name that need to be deleted 
+///  - parameter user: (body) Updated user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func updateUserWithRequestBuilder(username: String, user: User) -> RequestBuilder<Void> {
         var path = "/user/{username}"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -25,14 +25,14 @@ open class AnotherFakeAPI {
 
 
     /**
-     To test special tags
-     - PATCH /another-fake/dummy
-     - To test special tags
-     - examples: [{contentType=application/json, example={
+///  To test special tags
+///  - PATCH /another-fake/dummy
+///  - To test special tags
+///  - examples: [{contentType=application/json, example={
   "client" : "client"
 }}]
-     - parameter client: (body) client model 
-     - returns: RequestBuilder<Client> 
+///  - parameter client: (body) client model 
+///  - returns: RequestBuilder<Client> 
      */
     open class func testSpecialTagsWithRequestBuilder(client: Client) -> RequestBuilder<Client> {
         let path = "/another-fake/dummy"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -24,11 +24,11 @@ open class FakeAPI {
 
 
     /**
-     - POST /fake/outer/boolean
-     - Test serialization of outer boolean types
-     - examples: [{contentType=*/*, example=null}]
-     - parameter body: (body) Input boolean as post body (optional)
-     - returns: RequestBuilder<Bool> 
+///  - POST /fake/outer/boolean
+///  - Test serialization of outer boolean types
+///  - examples: [{contentType=*/*, example=null}]
+///  - parameter body: (body) Input boolean as post body (optional)
+///  - returns: RequestBuilder<Bool> 
      */
     open class func fakeOuterBooleanSerializeWithRequestBuilder(body: Bool? = nil) -> RequestBuilder<Bool> {
         let path = "/fake/outer/boolean"
@@ -55,11 +55,11 @@ open class FakeAPI {
 
 
     /**
-     - POST /fake/outer/composite
-     - Test serialization of object with outer number type
-     - examples: [{contentType=*/*, example={ }}]
-     - parameter outerComposite: (body) Input composite as post body (optional)
-     - returns: RequestBuilder<OuterComposite> 
+///  - POST /fake/outer/composite
+///  - Test serialization of object with outer number type
+///  - examples: [{contentType=*/*, example={ }}]
+///  - parameter outerComposite: (body) Input composite as post body (optional)
+///  - returns: RequestBuilder<OuterComposite> 
      */
     open class func fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: OuterComposite? = nil) -> RequestBuilder<OuterComposite> {
         let path = "/fake/outer/composite"
@@ -86,11 +86,11 @@ open class FakeAPI {
 
 
     /**
-     - POST /fake/outer/number
-     - Test serialization of outer number types
-     - examples: [{contentType=*/*, example=null}]
-     - parameter body: (body) Input number as post body (optional)
-     - returns: RequestBuilder<Double> 
+///  - POST /fake/outer/number
+///  - Test serialization of outer number types
+///  - examples: [{contentType=*/*, example=null}]
+///  - parameter body: (body) Input number as post body (optional)
+///  - returns: RequestBuilder<Double> 
      */
     open class func fakeOuterNumberSerializeWithRequestBuilder(body: Double? = nil) -> RequestBuilder<Double> {
         let path = "/fake/outer/number"
@@ -117,11 +117,11 @@ open class FakeAPI {
 
 
     /**
-     - POST /fake/outer/string
-     - Test serialization of outer string types
-     - examples: [{contentType=*/*, example=null}]
-     - parameter body: (body) Input string as post body (optional)
-     - returns: RequestBuilder<String> 
+///  - POST /fake/outer/string
+///  - Test serialization of outer string types
+///  - examples: [{contentType=*/*, example=null}]
+///  - parameter body: (body) Input string as post body (optional)
+///  - returns: RequestBuilder<String> 
      */
     open class func fakeOuterStringSerializeWithRequestBuilder(body: String? = nil) -> RequestBuilder<String> {
         let path = "/fake/outer/string"
@@ -153,10 +153,10 @@ open class FakeAPI {
 
 
     /**
-     - PUT /fake/body-with-query-params
-     - parameter query: (query)  
-     - parameter user: (body)  
-     - returns: RequestBuilder<Void> 
+///  - PUT /fake/body-with-query-params
+///  - parameter query: (query)  
+///  - parameter user: (body)  
+///  - returns: RequestBuilder<Void> 
      */
     open class func testBodyWithQueryParamsWithRequestBuilder(query: String, user: User) -> RequestBuilder<Void> {
         let path = "/fake/body-with-query-params"
@@ -187,14 +187,14 @@ open class FakeAPI {
 
 
     /**
-     To test \"client\" model
-     - PATCH /fake
-     - To test \"client\" model
-     - examples: [{contentType=application/json, example={
+///  To test \"client\" model
+///  - PATCH /fake
+///  - To test \"client\" model
+///  - examples: [{contentType=application/json, example={
   "client" : "client"
 }}]
-     - parameter client: (body) client model 
-     - returns: RequestBuilder<Client> 
+///  - parameter client: (body) client model 
+///  - returns: RequestBuilder<Client> 
      */
     open class func testClientModelWithRequestBuilder(client: Client) -> RequestBuilder<Client> {
         let path = "/fake"
@@ -239,27 +239,27 @@ open class FakeAPI {
 
 
     /**
-     Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-     - POST /fake
-     - Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-     - BASIC:
-       - type: http
-       - name: http_basic_test
-     - parameter number: (form) None 
-     - parameter double: (form) None 
-     - parameter patternWithoutDelimiter: (form) None 
-     - parameter byte: (form) None 
-     - parameter integer: (form) None (optional)
-     - parameter int32: (form) None (optional)
-     - parameter int64: (form) None (optional)
-     - parameter float: (form) None (optional)
-     - parameter string: (form) None (optional)
-     - parameter binary: (form) None (optional)
-     - parameter date: (form) None (optional)
-     - parameter dateTime: (form) None (optional)
-     - parameter password: (form) None (optional)
-     - parameter callback: (form) None (optional)
-     - returns: RequestBuilder<Void> 
+///  Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+///  - POST /fake
+///  - Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+///  - BASIC:
+///    - type: http
+///    - name: http_basic_test
+///  - parameter number: (form) None 
+///  - parameter double: (form) None 
+///  - parameter patternWithoutDelimiter: (form) None 
+///  - parameter byte: (form) None 
+///  - parameter integer: (form) None (optional)
+///  - parameter int32: (form) None (optional)
+///  - parameter int64: (form) None (optional)
+///  - parameter float: (form) None (optional)
+///  - parameter string: (form) None (optional)
+///  - parameter binary: (form) None (optional)
+///  - parameter date: (form) None (optional)
+///  - parameter dateTime: (form) None (optional)
+///  - parameter password: (form) None (optional)
+///  - parameter callback: (form) None (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func testEndpointParametersWithRequestBuilder(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) -> RequestBuilder<Void> {
         let path = "/fake"
@@ -383,18 +383,18 @@ open class FakeAPI {
 
 
     /**
-     To test enum parameters
-     - GET /fake
-     - To test enum parameters
-     - parameter enumHeaderStringArray: (header) Header parameter enum test (string array) (optional)
-     - parameter enumHeaderString: (header) Header parameter enum test (string) (optional, default to "-efg")
-     - parameter enumQueryStringArray: (query) Query parameter enum test (string array) (optional)
-     - parameter enumQueryString: (query) Query parameter enum test (string) (optional, default to "-efg")
-     - parameter enumQueryInteger: (query) Query parameter enum test (double) (optional)
-     - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
-     - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to "$")
-     - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to "-efg")
-     - returns: RequestBuilder<Void> 
+///  To test enum parameters
+///  - GET /fake
+///  - To test enum parameters
+///  - parameter enumHeaderStringArray: (header) Header parameter enum test (string array) (optional)
+///  - parameter enumHeaderString: (header) Header parameter enum test (string) (optional, default to "-efg")
+///  - parameter enumQueryStringArray: (query) Query parameter enum test (string array) (optional)
+///  - parameter enumQueryString: (query) Query parameter enum test (string) (optional, default to "-efg")
+///  - parameter enumQueryInteger: (query) Query parameter enum test (double) (optional)
+///  - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
+///  - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to "$")
+///  - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to "-efg")
+///  - returns: RequestBuilder<Void> 
      */
     open class func testEnumParametersWithRequestBuilder(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) -> RequestBuilder<Void> {
         let path = "/fake"
@@ -443,10 +443,10 @@ open class FakeAPI {
 
 
     /**
-     test inline additionalProperties
-     - POST /fake/inline-additionalProperties
-     - parameter requestBody: (body) request body 
-     - returns: RequestBuilder<Void> 
+///  test inline additionalProperties
+///  - POST /fake/inline-additionalProperties
+///  - parameter requestBody: (body) request body 
+///  - returns: RequestBuilder<Void> 
      */
     open class func testInlineAdditionalPropertiesWithRequestBuilder(requestBody: [String:String]) -> RequestBuilder<Void> {
         let path = "/fake/inline-additionalProperties"
@@ -479,11 +479,11 @@ open class FakeAPI {
 
 
     /**
-     test json serialization of form data
-     - GET /fake/jsonFormData
-     - parameter param: (form) field1 
-     - parameter param2: (form) field2 
-     - returns: RequestBuilder<Void> 
+///  test json serialization of form data
+///  - GET /fake/jsonFormData
+///  - parameter param: (form) field1 
+///  - parameter param2: (form) field2 
+///  - returns: RequestBuilder<Void> 
      */
     open class func testJsonFormDataWithRequestBuilder(param: String, param2: String) -> RequestBuilder<Void> {
         let path = "/fake/jsonFormData"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -25,17 +25,17 @@ open class FakeClassnameTags123API {
 
 
     /**
-     To test class name in snake case
-     - PATCH /fake_classname_test
-     - To test class name in snake case
-     - API Key:
-       - type: apiKey api_key_query (QUERY)
-       - name: api_key_query
-     - examples: [{contentType=application/json, example={
+///  To test class name in snake case
+///  - PATCH /fake_classname_test
+///  - To test class name in snake case
+///  - API Key:
+///    - type: apiKey api_key_query (QUERY)
+///    - name: api_key_query
+///  - examples: [{contentType=application/json, example={
   "client" : "client"
 }}]
-     - parameter client: (body) client model 
-     - returns: RequestBuilder<Client> 
+///  - parameter client: (body) client model 
+///  - returns: RequestBuilder<Client> 
      */
     open class func testClassnameWithRequestBuilder(client: Client) -> RequestBuilder<Client> {
         let path = "/fake_classname_test"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -29,13 +29,13 @@ open class PetAPI {
 
 
     /**
-     Add a new pet to the store
-     - POST /pet
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter pet: (body) Pet object that needs to be added to the store 
-     - returns: RequestBuilder<Void> 
+///  Add a new pet to the store
+///  - POST /pet
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter pet: (body) Pet object that needs to be added to the store 
+///  - returns: RequestBuilder<Void> 
      */
     open class func addPetWithRequestBuilder(pet: Pet) -> RequestBuilder<Void> {
         let path = "/pet"
@@ -68,14 +68,14 @@ open class PetAPI {
 
 
     /**
-     Deletes a pet
-     - DELETE /pet/{petId}
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter petId: (path) Pet id to delete 
-     - parameter apiKey: (header)  (optional)
-     - returns: RequestBuilder<Void> 
+///  Deletes a pet
+///  - DELETE /pet/{petId}
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter petId: (path) Pet id to delete 
+///  - parameter apiKey: (header)  (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func deletePetWithRequestBuilder(petId: Int64, apiKey: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
@@ -119,13 +119,13 @@ open class PetAPI {
 
 
     /**
-     Finds Pets by status
-     - GET /pet/findByStatus
-     - Multiple status values can be provided with comma separated strings
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+///  Finds Pets by status
+///  - GET /pet/findByStatus
+///  - Multiple status values can be provided with comma separated strings
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -151,8 +151,8 @@ open class PetAPI {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - parameter status: (query) Status values that need to be considered for filter 
-     - returns: RequestBuilder<[Pet]> 
+///  - parameter status: (query) Status values that need to be considered for filter 
+///  - returns: RequestBuilder<[Pet]> 
      */
     open class func findPetsByStatusWithRequestBuilder(status: [String]) -> RequestBuilder<[Pet]> {
         let path = "/pet/findByStatus"
@@ -183,13 +183,13 @@ open class PetAPI {
 
 
     /**
-     Finds Pets by tags
-     - GET /pet/findByTags
-     - Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+///  Finds Pets by tags
+///  - GET /pet/findByTags
+///  - Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -215,8 +215,8 @@ open class PetAPI {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - parameter tags: (query) Tags to filter by 
-     - returns: RequestBuilder<[Pet]> 
+///  - parameter tags: (query) Tags to filter by 
+///  - returns: RequestBuilder<[Pet]> 
      */
     open class func findPetsByTagsWithRequestBuilder(tags: [String]) -> RequestBuilder<[Pet]> {
         let path = "/pet/findByTags"
@@ -247,13 +247,13 @@ open class PetAPI {
 
 
     /**
-     Find pet by ID
-     - GET /pet/{petId}
-     - Returns a single pet
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
-     - examples: [{contentType=application/json, example={
+///  Find pet by ID
+///  - GET /pet/{petId}
+///  - Returns a single pet
+///  - API Key:
+///    - type: apiKey api_key 
+///    - name: api_key
+///  - examples: [{contentType=application/json, example={
   "photoUrls" : [ "photoUrls", "photoUrls" ],
   "name" : "doggie",
   "id" : 0,
@@ -279,8 +279,8 @@ open class PetAPI {
   </tags>
   <status>aeiou</status>
 </Pet>}]
-     - parameter petId: (path) ID of pet to return 
-     - returns: RequestBuilder<Pet> 
+///  - parameter petId: (path) ID of pet to return 
+///  - returns: RequestBuilder<Pet> 
      */
     open class func getPetByIdWithRequestBuilder(petId: Int64) -> RequestBuilder<Pet> {
         var path = "/pet/{petId}"
@@ -315,13 +315,13 @@ open class PetAPI {
 
 
     /**
-     Update an existing pet
-     - PUT /pet
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter pet: (body) Pet object that needs to be added to the store 
-     - returns: RequestBuilder<Void> 
+///  Update an existing pet
+///  - PUT /pet
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter pet: (body) Pet object that needs to be added to the store 
+///  - returns: RequestBuilder<Void> 
      */
     open class func updatePetWithRequestBuilder(pet: Pet) -> RequestBuilder<Void> {
         let path = "/pet"
@@ -355,15 +355,15 @@ open class PetAPI {
 
 
     /**
-     Updates a pet in the store with form data
-     - POST /pet/{petId}
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - parameter petId: (path) ID of pet that needs to be updated 
-     - parameter name: (form) Updated name of the pet (optional)
-     - parameter status: (form) Updated status of the pet (optional)
-     - returns: RequestBuilder<Void> 
+///  Updates a pet in the store with form data
+///  - POST /pet/{petId}
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - parameter petId: (path) ID of pet that needs to be updated 
+///  - parameter name: (form) Updated name of the pet (optional)
+///  - parameter status: (form) Updated status of the pet (optional)
+///  - returns: RequestBuilder<Void> 
      */
     open class func updatePetWithFormWithRequestBuilder(petId: Int64, name: String? = nil, status: String? = nil) -> RequestBuilder<Void> {
         var path = "/pet/{petId}"
@@ -402,20 +402,20 @@ open class PetAPI {
 
 
     /**
-     uploads an image
-     - POST /pet/{petId}/uploadImage
-     - OAuth:
-       - type: oauth2
-       - name: petstore_auth
-     - examples: [{contentType=application/json, example={
+///  uploads an image
+///  - POST /pet/{petId}/uploadImage
+///  - OAuth:
+///    - type: oauth2
+///    - name: petstore_auth
+///  - examples: [{contentType=application/json, example={
   "code" : 0,
   "type" : "type",
   "message" : "message"
 }}]
-     - parameter petId: (path) ID of pet to update 
-     - parameter additionalMetadata: (form) Additional data to pass to server (optional)
-     - parameter file: (form) file to upload (optional)
-     - returns: RequestBuilder<ApiResponse> 
+///  - parameter petId: (path) ID of pet to update 
+///  - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+///  - parameter file: (form) file to upload (optional)
+///  - returns: RequestBuilder<ApiResponse> 
      */
     open class func uploadFileWithRequestBuilder(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> RequestBuilder<ApiResponse> {
         var path = "/pet/{petId}/uploadImage"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -29,11 +29,11 @@ open class StoreAPI {
 
 
     /**
-     Delete purchase order by ID
-     - DELETE /store/order/{order_id}
-     - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-     - parameter orderId: (path) ID of the order that needs to be deleted 
-     - returns: RequestBuilder<Void> 
+///  Delete purchase order by ID
+///  - DELETE /store/order/{order_id}
+///  - For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+///  - parameter orderId: (path) ID of the order that needs to be deleted 
+///  - returns: RequestBuilder<Void> 
      */
     open class func deleteOrderWithRequestBuilder(orderId: String) -> RequestBuilder<Void> {
         var path = "/store/order/{order_id}"
@@ -63,13 +63,13 @@ open class StoreAPI {
 
 
     /**
-     Returns pet inventories by status
-     - GET /store/inventory
-     - Returns a map of status codes to quantities
-     - API Key:
-       - type: apiKey api_key 
-       - name: api_key
-     - returns: RequestBuilder<[String:Int]> 
+///  Returns pet inventories by status
+///  - GET /store/inventory
+///  - Returns a map of status codes to quantities
+///  - API Key:
+///    - type: apiKey api_key 
+///    - name: api_key
+///  - returns: RequestBuilder<[String:Int]> 
      */
     open class func getInventoryWithRequestBuilder() -> RequestBuilder<[String:Int]> {
         let path = "/store/inventory"
@@ -97,10 +97,10 @@ open class StoreAPI {
 
 
     /**
-     Find purchase order by ID
-     - GET /store/order/{order_id}
-     - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     - examples: [{contentType=application/json, example={
+///  Find purchase order by ID
+///  - GET /store/order/{order_id}
+///  - For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+///  - examples: [{contentType=application/json, example={
   "petId" : 6,
   "quantity" : 1,
   "id" : 0,
@@ -115,8 +115,8 @@ open class StoreAPI {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}]
-     - parameter orderId: (path) ID of pet that needs to be fetched 
-     - returns: RequestBuilder<Order> 
+///  - parameter orderId: (path) ID of pet that needs to be fetched 
+///  - returns: RequestBuilder<Order> 
      */
     open class func getOrderByIdWithRequestBuilder(orderId: Int64) -> RequestBuilder<Order> {
         var path = "/store/order/{order_id}"
@@ -147,9 +147,9 @@ open class StoreAPI {
 
 
     /**
-     Place an order for a pet
-     - POST /store/order
-     - examples: [{contentType=application/json, example={
+///  Place an order for a pet
+///  - POST /store/order
+///  - examples: [{contentType=application/json, example={
   "petId" : 6,
   "quantity" : 1,
   "id" : 0,
@@ -164,8 +164,8 @@ open class StoreAPI {
   <status>aeiou</status>
   <complete>true</complete>
 </Order>}]
-     - parameter order: (body) order placed for purchasing the pet 
-     - returns: RequestBuilder<Order> 
+///  - parameter order: (body) order placed for purchasing the pet 
+///  - returns: RequestBuilder<Order> 
      */
     open class func placeOrderWithRequestBuilder(order: Order) -> RequestBuilder<Order> {
         let path = "/store/order"

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -29,11 +29,11 @@ open class UserAPI {
 
 
     /**
-     Create user
-     - POST /user
-     - This can only be done by the logged in user.
-     - parameter user: (body) Created user object 
-     - returns: RequestBuilder<Void> 
+///  Create user
+///  - POST /user
+///  - This can only be done by the logged in user.
+///  - parameter user: (body) Created user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func createUserWithRequestBuilder(user: User) -> RequestBuilder<Void> {
         let path = "/user"
@@ -65,10 +65,10 @@ open class UserAPI {
 
 
     /**
-     Creates list of users with given input array
-     - POST /user/createWithArray
-     - parameter user: (body) List of user object 
-     - returns: RequestBuilder<Void> 
+///  Creates list of users with given input array
+///  - POST /user/createWithArray
+///  - parameter user: (body) List of user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func createUsersWithArrayInputWithRequestBuilder(user: [User]) -> RequestBuilder<Void> {
         let path = "/user/createWithArray"
@@ -100,10 +100,10 @@ open class UserAPI {
 
 
     /**
-     Creates list of users with given input array
-     - POST /user/createWithList
-     - parameter user: (body) List of user object 
-     - returns: RequestBuilder<Void> 
+///  Creates list of users with given input array
+///  - POST /user/createWithList
+///  - parameter user: (body) List of user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func createUsersWithListInputWithRequestBuilder(user: [User]) -> RequestBuilder<Void> {
         let path = "/user/createWithList"
@@ -135,11 +135,11 @@ open class UserAPI {
 
 
     /**
-     Delete user
-     - DELETE /user/{username}
-     - This can only be done by the logged in user.
-     - parameter username: (path) The name that needs to be deleted 
-     - returns: RequestBuilder<Void> 
+///  Delete user
+///  - DELETE /user/{username}
+///  - This can only be done by the logged in user.
+///  - parameter username: (path) The name that needs to be deleted 
+///  - returns: RequestBuilder<Void> 
      */
     open class func deleteUserWithRequestBuilder(username: String) -> RequestBuilder<Void> {
         var path = "/user/{username}"
@@ -170,9 +170,9 @@ open class UserAPI {
 
 
     /**
-     Get user by user name
-     - GET /user/{username}
-     - examples: [{contentType=application/json, example={
+///  Get user by user name
+///  - GET /user/{username}
+///  - examples: [{contentType=application/json, example={
   "firstName" : "firstName",
   "lastName" : "lastName",
   "password" : "password",
@@ -191,8 +191,8 @@ open class UserAPI {
   <phone>aeiou</phone>
   <userStatus>123</userStatus>
 </User>}]
-     - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
-     - returns: RequestBuilder<User> 
+///  - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+///  - returns: RequestBuilder<User> 
      */
     open class func getUserByNameWithRequestBuilder(username: String) -> RequestBuilder<User> {
         var path = "/user/{username}"
@@ -224,12 +224,12 @@ open class UserAPI {
 
 
     /**
-     Logs user into the system
-     - GET /user/login
-     - responseHeaders: [X-Rate-Limit(Int), X-Expires-After(Date)]
-     - parameter username: (query) The user name for login 
-     - parameter password: (query) The password for login in clear text 
-     - returns: RequestBuilder<String> 
+///  Logs user into the system
+///  - GET /user/login
+///  - responseHeaders: [X-Rate-Limit(Int), X-Expires-After(Date)]
+///  - parameter username: (query) The user name for login 
+///  - parameter password: (query) The password for login in clear text 
+///  - returns: RequestBuilder<String> 
      */
     open class func loginUserWithRequestBuilder(username: String, password: String) -> RequestBuilder<String> {
         let path = "/user/login"
@@ -264,9 +264,9 @@ open class UserAPI {
 
 
     /**
-     Logs out current logged in user session
-     - GET /user/logout
-     - returns: RequestBuilder<Void> 
+///  Logs out current logged in user session
+///  - GET /user/logout
+///  - returns: RequestBuilder<Void> 
      */
     open class func logoutUserWithRequestBuilder() -> RequestBuilder<Void> {
         let path = "/user/logout"
@@ -299,12 +299,12 @@ open class UserAPI {
 
 
     /**
-     Updated user
-     - PUT /user/{username}
-     - This can only be done by the logged in user.
-     - parameter username: (path) name that need to be deleted 
-     - parameter user: (body) Updated user object 
-     - returns: RequestBuilder<Void> 
+///  Updated user
+///  - PUT /user/{username}
+///  - This can only be done by the logged in user.
+///  - parameter username: (path) name that need to be deleted 
+///  - parameter user: (body) Updated user object 
+///  - returns: RequestBuilder<Void> 
      */
     open class func updateUserWithRequestBuilder(username: String, user: User) -> RequestBuilder<Void> {
         var path = "/user/{username}"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Swift4 and Swift3 client has error when examples `contentType=*/*` 

```swift
    /**
     - POST /fake/outer/string
     - Test serialization of outer string types
     - examples: [{contentType=*/*, example=null}]
     - parameter body: (body) Input string as post body (optional)
     - returns: RequestBuilder<String> 
     */
    open class func fakeOuterStringSerializeWithRequestBuilder(body: String? = nil) -> RequestBuilder<String> {
        let path = "/fake/outer/string"
        let URLString = PetstoreClientAPI.basePath + path
        let parameters = body?.encodeToJSON()

        let url = URLComponents(string: URLString)

        let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()

        return requestBuilder.init(method: "POST", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
    }
```

Add Comment `///`

```swift
    /**
///  - POST /fake/outer/string
///  - Test serialization of outer string types
///  - examples: [{contentType=*/*, example=null}]
///  - parameter body: (body) Input string as post body (optional)
///  - returns: RequestBuilder<String> 
     */
    open class func fakeOuterStringSerializeWithRequestBuilder(body: String? = nil) -> RequestBuilder<String> {
        let path = "/fake/outer/string"
        let URLString = PetstoreClientAPI.basePath + path
        let parameters = body?.encodeToJSON()

        let url = URLComponents(string: URLString)

        let requestBuilder: RequestBuilder<String>.Type = PetstoreClientAPI.requestBuilderFactory.getBuilder()

        return requestBuilder.init(method: "POST", URLString: (url?.string ?? URLString), parameters: parameters, isBody: true)
    }
```

