### PR TITLE
[Kotlin] Sanitize enum varname

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -421,8 +421,8 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         if (reservedWords.contains(modified)) {
             return escapeReservedWord(modified);
         }
-
-        return modified;
+        // NOTE: another sanitize because camelize can create an invalid name
+        return sanitizeKotlinSpecificNames(modified);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -1,0 +1,69 @@
+package org.openapitools.codegen.kotlin;
+
+import org.openapitools.codegen.CodegenType;
+import org.openapitools.codegen.languages.AbstractKotlinCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.openapitools.codegen.CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.*;
+
+public class AbstractKotlinCodegenTest {
+
+    private final AbstractKotlinCodegen codegen = new P_AbstractKotlinCodegen();
+
+    @Test
+    public void camlCaseEnumConverter() {
+        codegen.setEnumPropertyNaming(camelCase.name());
+        Assert.assertEquals(codegen.toEnumVarName("long Name", null), "longName");
+        Assert.assertEquals(codegen.toEnumVarName("1long Name", null), "_1longName");
+        Assert.assertEquals(codegen.toEnumVarName("not1long Name", null), "not1longName");
+    }
+
+    @Test
+    public void uppercasEnumConverter() {
+        codegen.setEnumPropertyNaming(UPPERCASE.name());
+        Assert.assertEquals(codegen.toEnumVarName("long Name", null), "LONG_NAME");
+        Assert.assertEquals(codegen.toEnumVarName("1long Name", null), "_1LONG_NAME");
+        Assert.assertEquals(codegen.toEnumVarName("not1long Name", null), "NOT1LONG_NAME");
+    }
+    @Test
+    public void snake_caseEnumConverter() {
+        codegen.setEnumPropertyNaming(snake_case.name());
+        Assert.assertEquals(codegen.toEnumVarName("long Name", null), "long_name");
+        Assert.assertEquals(codegen.toEnumVarName("1long Name", null), "_1long_name");
+        Assert.assertEquals(codegen.toEnumVarName("not1long Name", null), "not1long_name");
+    }
+
+    @Test
+    public void originalEnumConverter() {
+        codegen.setEnumPropertyNaming(original.name());
+        Assert.assertEquals(codegen.toEnumVarName("long Name", null), "long_Name");
+        Assert.assertEquals(codegen.toEnumVarName("1long Name", null), "_1long_Name");
+        Assert.assertEquals(codegen.toEnumVarName("not1long Name", null), "not1long_Name");
+    }
+    @Test
+    public void pascalCaseEnumConverter() {
+        codegen.setEnumPropertyNaming(PascalCase.name());
+        Assert.assertEquals(codegen.toEnumVarName("long Name", null), "LongName");
+        Assert.assertEquals(codegen.toEnumVarName("1long Name", null), "_1longName");
+        Assert.assertEquals(codegen.toEnumVarName("not1long Name", null), "Not1longName");
+    }
+
+
+    private class P_AbstractKotlinCodegen extends AbstractKotlinCodegen {
+        @Override
+        public CodegenType getTag() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getHelp() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Sanitize enumeration name for adding underscore when it's required.

Must fix #76

Technical committee member: @jimschubert