### PR TITLE
Fix Elm generator for polymorphism

### DIFF
--- a/modules/openapi-generator/src/main/resources/elm/aliasDecoder.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/aliasDecoder.mustache
@@ -1,5 +1,5 @@
 {{classVarName}}Decoder : Decoder {{classname}}
 {{classVarName}}Decoder =
-    {{#parent}}Decode.list {{vendorExtensions.x-decoder}}{{/parent}}{{^parent}}decode {{classname}}
+    decode {{classname}}
 {{#allVars}}{{^discriminatorValue}}        |> {{>fieldDecoder}}
-{{/discriminatorValue}}{{/allVars}}{{/parent}}
+{{/discriminatorValue}}{{/allVars}}

--- a/modules/openapi-generator/src/main/resources/elm/aliasEncoder.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/aliasEncoder.mustache
@@ -1,7 +1,7 @@
 {{classVarName}}Encoder : {{classname}} -> Encode.Value
 {{classVarName}}Encoder model =
-    {{#parent}}Encode.list (List.map {{vendorExtensions.x-encoder}} model){{/parent}}{{^parent}}Encode.object
+    Encode.object
 {{#allVars}}
         {{#-first}}[{{/-first}}{{^-first}},{{/-first}} {{>fieldEncoder}}
 {{/allVars}}
-        ]{{/parent}}
+        ]

--- a/modules/openapi-generator/src/main/resources/elm/model.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/model.mustache
@@ -15,7 +15,7 @@ import Maybe exposing (map, withDefault)
    {{{description}}}
 -}
 {{/description}}
-{{#isEnum}}{{>modelTypeUnion}}{{/isEnum}}{{^isEnum}}{{#hasChildren}}{{>modelTypeDiscriminator}}{{/hasChildren}}{{^hasChildren}}{{#isAlias}}{{>modelTypePrimitive}}{{/isAlias}}{{^isAlias}}{{>modelTypeAlias}}{{/isAlias}}{{/hasChildren}}{{/isEnum}}
+{{#isEnum}}{{>modelTypeUnion}}{{/isEnum}}{{^isEnum}}{{#hasChildren}}{{>modelTypeDiscriminator}}{{/hasChildren}}{{^hasChildren}}{{#isAlias}}{{>modelTypePrimitive}}{{/isAlias}}{{^isAlias}}{{#isArrayModel}}{{>modelTypeArray}}{{/isArrayModel}}{{^isArrayModel}}{{>modelTypeAlias}}{{/isArrayModel}}{{/isAlias}}{{/hasChildren}}{{/isEnum}}
 {{/model}}
 {{^-last}}
 

--- a/modules/openapi-generator/src/main/resources/elm/modelTypeAlias.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/modelTypeAlias.mustache
@@ -1,6 +1,6 @@
 
 
-type alias {{classname}} ={{#parent}} {{parent}}{{/parent}}{{^parent}}
+type alias {{classname}} =
     { {{#vars}}{{^-first}}    , {{/-first}}{{name}} : {{^required}}Maybe {{/required}}{{#isContainer}}(List {{/isContainer}}{{#isEnum}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{datatype}}{{/isEnum}}{{#isContainer}}){{/isContainer}}
 {{/vars}}    }
 {{#vars}}
@@ -10,7 +10,6 @@ type alias {{classname}} ={{#parent}} {{parent}}{{/parent}}{{^parent}}
 {{>union}}
 {{/isEnum}}
 {{/vars}}
-{{/parent}}
 
 
 {{>aliasDecoder}}

--- a/modules/openapi-generator/src/main/resources/elm/modelTypeArray.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/modelTypeArray.mustache
@@ -1,0 +1,12 @@
+type alias {{classname}} =
+    {{parent}}
+
+
+{{classVarName}}Decoder : Decoder {{classname}}
+{{classVarName}}Decoder =
+    Decode.list {{vendorExtensions.x-decoder}}
+
+
+{{classVarName}}Encoder : {{classname}} -> Encode.Value
+{{classVarName}}Encoder model =
+    Encode.list (List.map {{vendorExtensions.x-encoder}} model)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- ~[ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.~ Apparently something is broken, the pet's `category` is named `object` instead, see #79. This PR does not alter the examples any further.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The support for polymorphism/discriminators was accidentally dropped by adding support for array schemas. This PR fixes correctly re-adds the array schemas support.