### PR TITLE
Fix javadoc issues in "openapi-generator" module

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3973,7 +3973,7 @@ public class DefaultCodegen implements CodegenConfig {
     /**
      * returns the list of MIME types the APIs can produce
      *
-     * @param openAPI
+     * @param openAPI current specification instance
      * @param operation Operation
      * @return a set of MIME types
      */

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -235,7 +235,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     /**
      * Sets the naming convention for Kotlin enum properties
      *
-     * @param enumPropertyNamingType The string representation of the naming convention, as defined by {@link CodegenConstants.ENUM_PROPERTY_NAMING_TYPE}
+     * @param enumPropertyNamingType The string representation of the naming convention, as defined by {@link org.openapitools.codegen.CodegenConstants.ENUM_PROPERTY_NAMING_TYPE}
      */
     public void setEnumPropertyNaming(final String enumPropertyNamingType) {
         try {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
@@ -195,7 +195,6 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
      * Parse Markdown to HTML for the main "Description" attribute
      *
      * @param openAPI The base object containing the global description through "Info" class
-     * @return Void
      */
     private void preparHtmlForGlobalDescription(OpenAPI openAPI) {
         if (openAPI.getInfo() == null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -72,9 +72,9 @@ public class URLPathUtils {
 
     /**
      * Return the port, example value <code>8080</code>
-     * @param url
+     * @param url server url
      * @param defaultPort if the port is not set
-     * @return
+     * @return port
      */
     public static String getPort(URL url, int defaultPort) {
         return getPort(url, String.valueOf(defaultPort));
@@ -82,9 +82,9 @@ public class URLPathUtils {
 
     /**
      * Return the port, example value <code>8080</code>
-     * @param url
+     * @param url server url
      * @param defaultPort if the port is not set
-     * @return
+     * @return port
      */
     public static String getPort(URL url, String defaultPort) {
         if (url == null || url.getPort() == -1) {
@@ -96,7 +96,7 @@ public class URLPathUtils {
 
     /**
      * Return the path, example value <code>/abcdef/xyz</code>
-     * @param url
+     * @param url server url
      * @param defaultPath if the path is not empty
      * @return path
      */
@@ -110,7 +110,7 @@ public class URLPathUtils {
 
     /**
      * Get the protocol and the host, example value <code>https://www.abcdef.xyz</code>
-     * @param url
+     * @param url server url
      * @return protocolAndHost
      */
     public static String getProtocolAndHost(URL url) {
@@ -124,7 +124,7 @@ public class URLPathUtils {
 
     /**
      * Return the first complete URL from the OpenAPI specification
-     * @param openAPI
+     * @param openAPI current OpenAPI specification
      * @return host
      */
     public static String getHost(OpenAPI openAPI) {


### PR DESCRIPTION
See #63 for the `openapi-generator`. I did not changed `ModelUtils` because the warnings are fixed with #74 