### PR TITLE
Fix version for "spring-boot-maven-plugin"

### DIFF
--- a/CI/pom.xml.bash
+++ b/CI/pom.xml.bash
@@ -936,5 +936,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
     </properties>
 </project>

--- a/CI/pom.xml.bash
+++ b/CI/pom.xml.bash
@@ -936,6 +936,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
-        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
+        <spring-boot-version>2.0.2.RELEASE</spring-boot-version>
     </properties>
 </project>

--- a/CI/pom.xml.circleci
+++ b/CI/pom.xml.circleci
@@ -985,6 +985,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
-        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
+        <spring-boot-version>2.0.2.RELEASE</spring-boot-version>
     </properties>
 </project>

--- a/CI/pom.xml.circleci
+++ b/CI/pom.xml.circleci
@@ -985,5 +985,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
     </properties>
 </project>

--- a/CI/pom.xml.circleci.java7
+++ b/CI/pom.xml.circleci.java7
@@ -966,6 +966,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
-        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
+        <spring-boot-version>2.0.2.RELEASE</spring-boot-version>
     </properties>
 </project>

--- a/CI/pom.xml.circleci.java7
+++ b/CI/pom.xml.circleci.java7
@@ -966,5 +966,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
     </properties>
 </project>

--- a/CI/pom.xml.ios
+++ b/CI/pom.xml.ios
@@ -944,5 +944,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
     </properties>
 </project>

--- a/CI/pom.xml.ios
+++ b/CI/pom.xml.ios
@@ -944,6 +944,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
-        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
+        <spring-boot-version>2.0.2.RELEASE</spring-boot-version>
     </properties>
 </project>

--- a/CI/pom.xml.shippable
+++ b/CI/pom.xml.shippable
@@ -941,6 +941,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
-        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
+        <spring-boot-version>2.0.2.RELEASE</spring-boot-version>
     </properties>
 </project>

--- a/CI/pom.xml.shippable
+++ b/CI/pom.xml.shippable
@@ -941,5 +941,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
     </properties>
 </project>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot-maven-plugin-version}</version>
+                <version>${spring-boot-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot-maven-plugin-version}</version>
+                <version>${spring-boot-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.0.2.RELEASE</version>
+                <version>${spring-boot-maven-plugin-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -33,6 +33,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-maven-plugin-version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
-        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
+        <spring-boot-version>2.0.2.RELEASE</spring-boot-version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -964,5 +964,6 @@
         <surefire-version>2.19.1</surefire-version>
         <jmockit-version>1.25</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
+        <spring-boot-maven-plugin-version>2.0.2.RELEASE</spring-boot-maven-plugin-version>
     </properties>
 </project>


### PR DESCRIPTION
This should fix the warnings we see at the beginning of the maven build:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openapitools:openapi-generator-online:jar:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 33, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
@cbornet can you have a look?