### PR TITLE
[JaxRS-Java] issue with implFolder on windows, and required fields generation for containers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -240,11 +241,11 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         String result = super.apiFilename(templateName, tag);
 
         if (templateName.endsWith("Impl.mustache")) {
-            int ix = result.lastIndexOf('/');
+            int ix = result.lastIndexOf(File.separator);
             result = result.substring(0, ix) + "/impl" + result.substring(ix, result.length() - 5) + "ServiceImpl.java";
             result = result.replace(apiFileFolder(), implFileFolder(implFolder));
         } else if (templateName.endsWith("Factory.mustache")) {
-            int ix = result.lastIndexOf('/');
+            int ix = result.lastIndexOf(File.separator);
             result = result.substring(0, ix) + "/factories" + result.substring(ix, result.length() - 5) + "ServiceFactory.java";
             result = result.replace(apiFileFolder(), implFileFolder(implFolder));
         } else if (templateName.endsWith("Service.mustache")) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -11,7 +11,12 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 {{>enumClass}}{{/isEnum}}{{#items.isEnum}}{{#items}}
 
 {{>enumClass}}{{/items}}{{/items.isEnum}}
-  private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};{{/vars}}
+{{#isContainer}}
+  private {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
+{{/isContainer}}
+{{^isContainer}}
+  private {{{datatypeWithEnum}}} {{name}} = {{{defaultValue}}};
+{{/isContainer}}{{/vars}}
 
   {{#vars}}
   /**
@@ -33,12 +38,37 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
   }
+  {{#isListContainer}}
+
+  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{^required}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}};
+    }
+    {{/required}}
+    this.{{name}}.add({{name}}Item);
+    return this;
+  }
+  {{/isListContainer}}
+
+  {{#isMapContainer}}
+
+  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{^required}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}};
+    }
+    {{/required}}
+    this.{{name}}.put(key, {{name}}Item);
+    return this;
+  }
+  {{/isMapContainer}}
 
   {{/vars}}
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pojo.mustache
@@ -38,7 +38,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{#isBoolean}}is{{/isBoolean}}{{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Category.java
@@ -19,7 +19,9 @@ import javax.xml.bind.annotation.*;
 public class Category   {
   
   private Long id = null;
+
   private String name = null;
+
 
   /**
    **/
@@ -38,6 +40,7 @@ public class Category   {
     this.id = id;
   }
 
+
   /**
    **/
   public Category name(String name) {
@@ -54,6 +57,7 @@ public class Category   {
   public void setName(String name) {
     this.name = name;
   }
+
 
 
   @Override

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,8 +19,11 @@ import javax.xml.bind.annotation.*;
 public class ModelApiResponse   {
   
   private Integer code = null;
+
   private String type = null;
+
   private String message = null;
+
 
   /**
    **/
@@ -39,6 +42,7 @@ public class ModelApiResponse   {
     this.code = code;
   }
 
+
   /**
    **/
   public ModelApiResponse type(String type) {
@@ -56,6 +60,7 @@ public class ModelApiResponse   {
     this.type = type;
   }
 
+
   /**
    **/
   public ModelApiResponse message(String message) {
@@ -72,6 +77,7 @@ public class ModelApiResponse   {
   public void setMessage(String message) {
     this.message = message;
   }
+
 
 
   @Override

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
@@ -19,9 +19,13 @@ import javax.xml.bind.annotation.*;
 public class Order   {
   
   private Long id = null;
+
   private Long petId = null;
+
   private Integer quantity = null;
+
   private java.util.Date shipDate = null;
+
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -56,7 +60,9 @@ public enum StatusEnum {
 }
 
   private StatusEnum status = null;
+
   private Boolean complete = false;
+
 
   /**
    **/
@@ -75,6 +81,7 @@ public enum StatusEnum {
     this.id = id;
   }
 
+
   /**
    **/
   public Order petId(Long petId) {
@@ -91,6 +98,7 @@ public enum StatusEnum {
   public void setPetId(Long petId) {
     this.petId = petId;
   }
+
 
   /**
    **/
@@ -109,6 +117,7 @@ public enum StatusEnum {
     this.quantity = quantity;
   }
 
+
   /**
    **/
   public Order shipDate(java.util.Date shipDate) {
@@ -125,6 +134,7 @@ public enum StatusEnum {
   public void setShipDate(java.util.Date shipDate) {
     this.shipDate = shipDate;
   }
+
 
   /**
    * Order Status
@@ -144,6 +154,7 @@ public enum StatusEnum {
     this.status = status;
   }
 
+
   /**
    **/
   public Order complete(Boolean complete) {
@@ -160,6 +171,7 @@ public enum StatusEnum {
   public void setComplete(Boolean complete) {
     this.complete = complete;
   }
+
 
 
   @Override

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
@@ -23,10 +23,15 @@ import javax.xml.bind.annotation.*;
 public class Pet   {
   
   private Long id = null;
+
   private Category category = null;
+
   private String name = null;
+
   private List<String> photoUrls = new ArrayList<String>();
-  private List<Tag> tags = new ArrayList<Tag>();
+
+  private List<Tag> tags = null;
+
 
 @XmlType(name="StatusEnum")
 @XmlEnum(String.class)
@@ -62,6 +67,7 @@ public enum StatusEnum {
 
   private StatusEnum status = null;
 
+
   /**
    **/
   public Pet id(Long id) {
@@ -79,6 +85,7 @@ public enum StatusEnum {
     this.id = id;
   }
 
+
   /**
    **/
   public Pet category(Category category) {
@@ -95,6 +102,7 @@ public enum StatusEnum {
   public void setCategory(Category category) {
     this.category = category;
   }
+
 
   /**
    **/
@@ -114,6 +122,7 @@ public enum StatusEnum {
     this.name = name;
   }
 
+
   /**
    **/
   public Pet photoUrls(List<String> photoUrls) {
@@ -132,6 +141,12 @@ public enum StatusEnum {
     this.photoUrls = photoUrls;
   }
 
+  public Pet addPhotoUrlsItem(String photoUrlsItem) {
+    this.photoUrls.add(photoUrlsItem);
+    return this;
+  }
+
+
   /**
    **/
   public Pet tags(List<Tag> tags) {
@@ -148,6 +163,15 @@ public enum StatusEnum {
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
+
+  public Pet addTagsItem(Tag tagsItem) {
+    if (this.tags == null) {
+      this.tags = new ArrayList<Tag>();
+    }
+    this.tags.add(tagsItem);
+    return this;
+  }
+
 
   /**
    * pet status in the store
@@ -166,6 +190,7 @@ public enum StatusEnum {
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
+
 
 
   @Override

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Tag.java
@@ -19,7 +19,9 @@ import javax.xml.bind.annotation.*;
 public class Tag   {
   
   private Long id = null;
+
   private String name = null;
+
 
   /**
    **/
@@ -38,6 +40,7 @@ public class Tag   {
     this.id = id;
   }
 
+
   /**
    **/
   public Tag name(String name) {
@@ -54,6 +57,7 @@ public class Tag   {
   public void setName(String name) {
     this.name = name;
   }
+
 
 
   @Override

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/User.java
@@ -19,13 +19,21 @@ import javax.xml.bind.annotation.*;
 public class User   {
   
   private Long id = null;
+
   private String username = null;
+
   private String firstName = null;
+
   private String lastName = null;
+
   private String email = null;
+
   private String password = null;
+
   private String phone = null;
+
   private Integer userStatus = null;
+
 
   /**
    **/
@@ -44,6 +52,7 @@ public class User   {
     this.id = id;
   }
 
+
   /**
    **/
   public User username(String username) {
@@ -60,6 +69,7 @@ public class User   {
   public void setUsername(String username) {
     this.username = username;
   }
+
 
   /**
    **/
@@ -78,6 +88,7 @@ public class User   {
     this.firstName = firstName;
   }
 
+
   /**
    **/
   public User lastName(String lastName) {
@@ -94,6 +105,7 @@ public class User   {
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
+
 
   /**
    **/
@@ -112,6 +124,7 @@ public class User   {
     this.email = email;
   }
 
+
   /**
    **/
   public User password(String password) {
@@ -128,6 +141,7 @@ public class User   {
   public void setPassword(String password) {
     this.password = password;
   }
+
 
   /**
    **/
@@ -146,6 +160,7 @@ public class User   {
     this.phone = phone;
   }
 
+
   /**
    * User Status
    **/
@@ -163,6 +178,7 @@ public class User   {
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;
   }
+
 
 
   @Override


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Fix implFolder issue with jaxrs-cxf-cdi generator
  This fix is for the issue: swagger-api/swagger-codegen#8113
  When using jaxrs-cxf-cdi and other JaxRS generators, the implFolder
  config is not honored by the generator on windows.
- jaxrs-cxf-cdi: containers with no default init
  Change similar to https://github.com/swagger-api/swagger-codegen/pull/5363/files for jax-rs-cdi generator.
  When a property that is a contained is not declared as required, it is initialized to `null`, and not to the empty container.
  This makes api much more easy to use, since one can differentiate when an input list in json has been set to the empty array or simply not set.