### PR TITLE
Meta: set version for "build-helper-maven-plugin"

### DIFF
--- a/modules/openapi-generator/src/main/resources/codegen/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/pom.mustache
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>

--- a/samples/meta-codegen/lib/pom.xml
+++ b/samples/meta-codegen/lib/pom.xml
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add_sources</id>


### PR DESCRIPTION
This PR removes those warnings

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openapitools:myClientCodegen-openapi-generator:jar:1.0.0
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 65, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

That are created when this command is executed:

```
mvn verify -f samples/meta-codegen/lib/pom.xml
```

---

Corresponding script: `bin/meta-codegen.sh`