### PR TITLE
[Java][Rest-assured] Changed Rest-assured params

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -17,8 +17,6 @@
 
 package org.openapitools.codegen.languages;
 
-import static java.util.Collections.sort;
-
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
@@ -32,6 +30,7 @@ import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.GzipFeatures;
 import org.openapitools.codegen.languages.features.PerformBeanValidationFeatures;
+import org.openapitools.codegen.mustache.CaseFormatLambda;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +44,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
+import static java.util.Collections.sort;
 
 public class JavaClientCodegen extends AbstractJavaCodegen
         implements BeanValidationFeatures, PerformBeanValidationFeatures,
@@ -283,6 +286,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
         } else if (REST_ASSURED.equals(getLibrary())) {
             additionalProperties.put("gson", "true");
+            additionalProperties.put("convert", new CaseFormatLambda(LOWER_CAMEL, UPPER_UNDERSCORE));
             apiTemplateFiles.put("api.mustache", ".java");
             supportingFiles.add(new SupportingFile("ResponseSpecBuilders.mustache", invokerFolder, "ResponseSpecBuilders.java"));
             supportingFiles.add(new SupportingFile("JSON.mustache", invokerFolder, "JSON.java"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/mustache/CaseFormatLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/mustache/CaseFormatLambda.java
@@ -1,0 +1,48 @@
+package org.openapitools.codegen.mustache;
+
+import com.google.common.base.CaseFormat;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.openapitools.codegen.CodegenConfig;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Converts text from CaseFormat to another CaseFormat
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("convert", new CaseFormatLambda(LOWER_CAMEL, UPPER_UNDERSCORE));
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#convert}}{{name}}{{/convert}}
+ * </pre>
+ */
+public class CaseFormatLambda implements Mustache.Lambda {
+    private CodegenConfig generator = null;
+
+    private CaseFormat initialFormat;
+    private CaseFormat targetFormat;
+
+    public CaseFormatLambda(CaseFormat target, CaseFormat targetFormat) {
+        this.initialFormat = target;
+        this.targetFormat = targetFormat;
+    }
+
+    public CaseFormatLambda generator(final CodegenConfig generator) {
+        this.generator = generator;
+        return this;
+    }
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String text = initialFormat.converterTo(targetFormat).convert(fragment.execute());
+        if (generator != null && generator.reservedWords().contains(text)) {
+            text = generator.escapeReservedWord(text);
+        }
+        writer.write(text);
+    }
+}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -151,46 +151,54 @@ public class {{classname}} {
         {{/bodyParams}}
         {{#headerParams}}
 
+        public static final String {{#convert}}{{paramName}}{{/convert}}_HEADER = "{{baseName}}";
+
         /**
          * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Header(String {{paramName}}) {
-            reqSpec.addHeader("{{baseName}}", {{paramName}});
+            reqSpec.addHeader({{#convert}}{{paramName}}{{/convert}}_HEADER, {{paramName}});
             return this;
         }
         {{/headerParams}}
         {{#pathParams}}
+
+        public static final String {{#convert}}{{paramName}}{{/convert}}_PATH = "{{baseName}}";
 
         /**
          * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Path(Object {{paramName}}) {
-            reqSpec.addPathParam("{{baseName}}", {{paramName}});
+            reqSpec.addPathParam({{#convert}}{{paramName}}{{/convert}}_PATH, {{paramName}});
             return this;
         }
         {{/pathParams}}
         {{#queryParams}}
+
+        public static final String {{#convert}}{{paramName}}{{/convert}}_QUERY = "{{baseName}}";
 
         /**
          * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Query(Object... {{paramName}}) {
-            reqSpec.addQueryParam("{{baseName}}", {{paramName}});
+            reqSpec.addQueryParam({{#convert}}{{paramName}}{{/convert}}_QUERY, {{paramName}});
             return this;
         }
         {{/queryParams}}
         {{#formParams}}
         {{^isFile}}
 
+         public static final String {{#convert}}{{paramName}}{{/convert}}_FORM = "{{baseName}}";
+
          /**
          * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
          * @return operation
          */
          public {{operationIdCamelCase}}Oper {{paramName}}Form(Object... {{paramName}}) {
-            reqSpec.addFormParam("{{baseName}}", {{paramName}});
+            reqSpec.addFormParam({{#convert}}{{paramName}}{{/convert}}_FORM, {{paramName}});
             return this;
          }
         {{/isFile}}

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -463,12 +463,14 @@ public class FakeApi {
             return this;
         }
 
+        public static final String QUERY_QUERY = "query";
+
         /**
          * @param query (String)  (required)
          * @return operation
          */
         public TestBodyWithQueryParamsOper queryQuery(Object... query) {
-            reqSpec.addQueryParam("query", query);
+            reqSpec.addQueryParam(QUERY_QUERY, query);
             return this;
         }
 
@@ -621,120 +623,146 @@ public class FakeApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(POST, REQ_URI));
         }
 
+         public static final String INTEGER_FORM = "integer";
+
          /**
          * @param integer (Integer) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper integerForm(Object... integer) {
-            reqSpec.addFormParam("integer", integer);
+            reqSpec.addFormParam(INTEGER_FORM, integer);
             return this;
          }
+
+         public static final String INT32_FORM = "int32";
 
          /**
          * @param int32 (Integer) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper int32Form(Object... int32) {
-            reqSpec.addFormParam("int32", int32);
+            reqSpec.addFormParam(INT32_FORM, int32);
             return this;
          }
+
+         public static final String INT64_FORM = "int64";
 
          /**
          * @param int64 (Long) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper int64Form(Object... int64) {
-            reqSpec.addFormParam("int64", int64);
+            reqSpec.addFormParam(INT64_FORM, int64);
             return this;
          }
+
+         public static final String NUMBER_FORM = "number";
 
          /**
          * @param number (BigDecimal) None (required)
          * @return operation
          */
          public TestEndpointParametersOper numberForm(Object... number) {
-            reqSpec.addFormParam("number", number);
+            reqSpec.addFormParam(NUMBER_FORM, number);
             return this;
          }
+
+         public static final String _FLOAT_FORM = "float";
 
          /**
          * @param _float (Float) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper _floatForm(Object... _float) {
-            reqSpec.addFormParam("float", _float);
+            reqSpec.addFormParam(_FLOAT_FORM, _float);
             return this;
          }
+
+         public static final String _DOUBLE_FORM = "double";
 
          /**
          * @param _double (Double) None (required)
          * @return operation
          */
          public TestEndpointParametersOper _doubleForm(Object... _double) {
-            reqSpec.addFormParam("double", _double);
+            reqSpec.addFormParam(_DOUBLE_FORM, _double);
             return this;
          }
+
+         public static final String STRING_FORM = "string";
 
          /**
          * @param string (String) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper stringForm(Object... string) {
-            reqSpec.addFormParam("string", string);
+            reqSpec.addFormParam(STRING_FORM, string);
             return this;
          }
+
+         public static final String PATTERN_WITHOUT_DELIMITER_FORM = "pattern_without_delimiter";
 
          /**
          * @param patternWithoutDelimiter (String) None (required)
          * @return operation
          */
          public TestEndpointParametersOper patternWithoutDelimiterForm(Object... patternWithoutDelimiter) {
-            reqSpec.addFormParam("pattern_without_delimiter", patternWithoutDelimiter);
+            reqSpec.addFormParam(PATTERN_WITHOUT_DELIMITER_FORM, patternWithoutDelimiter);
             return this;
          }
+
+         public static final String _BYTE_FORM = "byte";
 
          /**
          * @param _byte (byte[]) None (required)
          * @return operation
          */
          public TestEndpointParametersOper _byteForm(Object... _byte) {
-            reqSpec.addFormParam("byte", _byte);
+            reqSpec.addFormParam(_BYTE_FORM, _byte);
             return this;
          }
+
+         public static final String DATE_FORM = "date";
 
          /**
          * @param date (LocalDate) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper dateForm(Object... date) {
-            reqSpec.addFormParam("date", date);
+            reqSpec.addFormParam(DATE_FORM, date);
             return this;
          }
+
+         public static final String DATE_TIME_FORM = "dateTime";
 
          /**
          * @param dateTime (OffsetDateTime) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper dateTimeForm(Object... dateTime) {
-            reqSpec.addFormParam("dateTime", dateTime);
+            reqSpec.addFormParam(DATE_TIME_FORM, dateTime);
             return this;
          }
+
+         public static final String PASSWORD_FORM = "password";
 
          /**
          * @param password (String) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper passwordForm(Object... password) {
-            reqSpec.addFormParam("password", password);
+            reqSpec.addFormParam(PASSWORD_FORM, password);
             return this;
          }
+
+         public static final String PARAM_CALLBACK_FORM = "callback";
 
          /**
          * @param paramCallback (String) None (optional, default to null)
          * @return operation
          */
          public TestEndpointParametersOper paramCallbackForm(Object... paramCallback) {
-            reqSpec.addFormParam("callback", paramCallback);
+            reqSpec.addFormParam(PARAM_CALLBACK_FORM, paramCallback);
             return this;
          }
 
@@ -814,75 +842,91 @@ public class FakeApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(GET, REQ_URI));
         }
 
+        public static final String ENUM_HEADER_STRING_ARRAY_HEADER = "enum_header_string_array";
+
         /**
          * @param enumHeaderStringArray (List&lt;String&gt;) Header parameter enum test (string array) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumHeaderStringArrayHeader(String enumHeaderStringArray) {
-            reqSpec.addHeader("enum_header_string_array", enumHeaderStringArray);
+            reqSpec.addHeader(ENUM_HEADER_STRING_ARRAY_HEADER, enumHeaderStringArray);
             return this;
         }
+
+        public static final String ENUM_HEADER_STRING_HEADER = "enum_header_string";
 
         /**
          * @param enumHeaderString (String) Header parameter enum test (string) (optional, default to -efg)
          * @return operation
          */
         public TestEnumParametersOper enumHeaderStringHeader(String enumHeaderString) {
-            reqSpec.addHeader("enum_header_string", enumHeaderString);
+            reqSpec.addHeader(ENUM_HEADER_STRING_HEADER, enumHeaderString);
             return this;
         }
+
+        public static final String ENUM_QUERY_STRING_ARRAY_QUERY = "enum_query_string_array";
 
         /**
          * @param enumQueryStringArray (List&lt;String&gt;) Query parameter enum test (string array) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumQueryStringArrayQuery(Object... enumQueryStringArray) {
-            reqSpec.addQueryParam("enum_query_string_array", enumQueryStringArray);
+            reqSpec.addQueryParam(ENUM_QUERY_STRING_ARRAY_QUERY, enumQueryStringArray);
             return this;
         }
+
+        public static final String ENUM_QUERY_STRING_QUERY = "enum_query_string";
 
         /**
          * @param enumQueryString (String) Query parameter enum test (string) (optional, default to -efg)
          * @return operation
          */
         public TestEnumParametersOper enumQueryStringQuery(Object... enumQueryString) {
-            reqSpec.addQueryParam("enum_query_string", enumQueryString);
+            reqSpec.addQueryParam(ENUM_QUERY_STRING_QUERY, enumQueryString);
             return this;
         }
+
+        public static final String ENUM_QUERY_INTEGER_QUERY = "enum_query_integer";
 
         /**
          * @param enumQueryInteger (Integer) Query parameter enum test (double) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumQueryIntegerQuery(Object... enumQueryInteger) {
-            reqSpec.addQueryParam("enum_query_integer", enumQueryInteger);
+            reqSpec.addQueryParam(ENUM_QUERY_INTEGER_QUERY, enumQueryInteger);
             return this;
         }
+
+        public static final String ENUM_QUERY_DOUBLE_QUERY = "enum_query_double";
 
         /**
          * @param enumQueryDouble (Double) Query parameter enum test (double) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumQueryDoubleQuery(Object... enumQueryDouble) {
-            reqSpec.addQueryParam("enum_query_double", enumQueryDouble);
+            reqSpec.addQueryParam(ENUM_QUERY_DOUBLE_QUERY, enumQueryDouble);
             return this;
         }
+
+         public static final String ENUM_FORM_STRING_ARRAY_FORM = "enum_form_string_array";
 
          /**
          * @param enumFormStringArray (List&lt;String&gt;) Form parameter enum test (string array) (optional, default to $)
          * @return operation
          */
          public TestEnumParametersOper enumFormStringArrayForm(Object... enumFormStringArray) {
-            reqSpec.addFormParam("enum_form_string_array", enumFormStringArray);
+            reqSpec.addFormParam(ENUM_FORM_STRING_ARRAY_FORM, enumFormStringArray);
             return this;
          }
+
+         public static final String ENUM_FORM_STRING_FORM = "enum_form_string";
 
          /**
          * @param enumFormString (String) Form parameter enum test (string) (optional, default to -efg)
          * @return operation
          */
          public TestEnumParametersOper enumFormStringForm(Object... enumFormString) {
-            reqSpec.addFormParam("enum_form_string", enumFormString);
+            reqSpec.addFormParam(ENUM_FORM_STRING_FORM, enumFormString);
             return this;
          }
 
@@ -1012,21 +1056,25 @@ public class FakeApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(GET, REQ_URI));
         }
 
+         public static final String PARAM_FORM = "param";
+
          /**
          * @param param (String) field1 (required)
          * @return operation
          */
          public TestJsonFormDataOper paramForm(Object... param) {
-            reqSpec.addFormParam("param", param);
+            reqSpec.addFormParam(PARAM_FORM, param);
             return this;
          }
+
+         public static final String PARAM2_FORM = "param2";
 
          /**
          * @param param2 (String) field2 (required)
          * @return operation
          */
          public TestJsonFormDataOper param2Form(Object... param2) {
-            reqSpec.addFormParam("param2", param2);
+            reqSpec.addFormParam(PARAM2_FORM, param2);
             return this;
          }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
@@ -196,21 +196,25 @@ public class PetApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(DELETE, REQ_URI));
         }
 
+        public static final String API_KEY_HEADER = "api_key";
+
         /**
          * @param apiKey (String)  (optional)
          * @return operation
          */
         public DeletePetOper apiKeyHeader(String apiKey) {
-            reqSpec.addHeader("api_key", apiKey);
+            reqSpec.addHeader(API_KEY_HEADER, apiKey);
             return this;
         }
+
+        public static final String PET_ID_PATH = "petId";
 
         /**
          * @param petId (Long) Pet id to delete (required)
          * @return operation
          */
         public DeletePetOper petIdPath(Object petId) {
-            reqSpec.addPathParam("petId", petId);
+            reqSpec.addPathParam(PET_ID_PATH, petId);
             return this;
         }
 
@@ -281,12 +285,14 @@ public class PetApi {
             return execute(handler).as(type);
         }
 
+        public static final String STATUS_QUERY = "status";
+
         /**
          * @param status (List&lt;String&gt;) Status values that need to be considered for filter (required)
          * @return operation
          */
         public FindPetsByStatusOper statusQuery(Object... status) {
-            reqSpec.addQueryParam("status", status);
+            reqSpec.addQueryParam(STATUS_QUERY, status);
             return this;
         }
 
@@ -359,12 +365,14 @@ public class PetApi {
             return execute(handler).as(type);
         }
 
+        public static final String TAGS_QUERY = "tags";
+
         /**
          * @param tags (List&lt;String&gt;) Tags to filter by (required)
          * @return operation
          */
         public FindPetsByTagsOper tagsQuery(Object... tags) {
-            reqSpec.addQueryParam("tags", tags);
+            reqSpec.addQueryParam(TAGS_QUERY, tags);
             return this;
         }
 
@@ -435,12 +443,14 @@ public class PetApi {
             return execute(handler).as(type);
         }
 
+        public static final String PET_ID_PATH = "petId";
+
         /**
          * @param petId (Long) ID of pet to return (required)
          * @return operation
          */
         public GetPetByIdOper petIdPath(Object petId) {
-            reqSpec.addPathParam("petId", petId);
+            reqSpec.addPathParam(PET_ID_PATH, petId);
             return this;
         }
 
@@ -571,30 +581,36 @@ public class PetApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(POST, REQ_URI));
         }
 
+        public static final String PET_ID_PATH = "petId";
+
         /**
          * @param petId (Long) ID of pet that needs to be updated (required)
          * @return operation
          */
         public UpdatePetWithFormOper petIdPath(Object petId) {
-            reqSpec.addPathParam("petId", petId);
+            reqSpec.addPathParam(PET_ID_PATH, petId);
             return this;
         }
+
+         public static final String NAME_FORM = "name";
 
          /**
          * @param name (String) Updated name of the pet (optional, default to null)
          * @return operation
          */
          public UpdatePetWithFormOper nameForm(Object... name) {
-            reqSpec.addFormParam("name", name);
+            reqSpec.addFormParam(NAME_FORM, name);
             return this;
          }
+
+         public static final String STATUS_FORM = "status";
 
          /**
          * @param status (String) Updated status of the pet (optional, default to null)
          * @return operation
          */
          public UpdatePetWithFormOper statusForm(Object... status) {
-            reqSpec.addFormParam("status", status);
+            reqSpec.addFormParam(STATUS_FORM, status);
             return this;
          }
 
@@ -669,21 +685,25 @@ public class PetApi {
             return execute(handler).as(type);
         }
 
+        public static final String PET_ID_PATH = "petId";
+
         /**
          * @param petId (Long) ID of pet to update (required)
          * @return operation
          */
         public UploadFileOper petIdPath(Object petId) {
-            reqSpec.addPathParam("petId", petId);
+            reqSpec.addPathParam(PET_ID_PATH, petId);
             return this;
         }
+
+         public static final String ADDITIONAL_METADATA_FORM = "additionalMetadata";
 
          /**
          * @param additionalMetadata (String) Additional data to pass to server (optional, default to null)
          * @return operation
          */
          public UploadFileOper additionalMetadataForm(Object... additionalMetadata) {
-            reqSpec.addFormParam("additionalMetadata", additionalMetadata);
+            reqSpec.addFormParam(ADDITIONAL_METADATA_FORM, additionalMetadata);
             return this;
          }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -109,12 +109,14 @@ public class StoreApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(DELETE, REQ_URI));
         }
 
+        public static final String ORDER_ID_PATH = "order_id";
+
         /**
          * @param orderId (String) ID of the order that needs to be deleted (required)
          * @return operation
          */
         public DeleteOrderOper orderIdPath(Object orderId) {
-            reqSpec.addPathParam("order_id", orderId);
+            reqSpec.addPathParam(ORDER_ID_PATH, orderId);
             return this;
         }
 
@@ -251,12 +253,14 @@ public class StoreApi {
             return execute(handler).as(type);
         }
 
+        public static final String ORDER_ID_PATH = "order_id";
+
         /**
          * @param orderId (Long) ID of pet that needs to be fetched (required)
          * @return operation
          */
         public GetOrderByIdOper orderIdPath(Object orderId) {
-            reqSpec.addPathParam("order_id", orderId);
+            reqSpec.addPathParam(ORDER_ID_PATH, orderId);
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -326,12 +326,14 @@ public class UserApi {
             return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(DELETE, REQ_URI));
         }
 
+        public static final String USERNAME_PATH = "username";
+
         /**
          * @param username (String) The name that needs to be deleted (required)
          * @return operation
          */
         public DeleteUserOper usernamePath(Object username) {
-            reqSpec.addPathParam("username", username);
+            reqSpec.addPathParam(USERNAME_PATH, username);
             return this;
         }
 
@@ -402,12 +404,14 @@ public class UserApi {
             return execute(handler).as(type);
         }
 
+        public static final String USERNAME_PATH = "username";
+
         /**
          * @param username (String) The name that needs to be fetched. Use user1 for testing. (required)
          * @return operation
          */
         public GetUserByNameOper usernamePath(Object username) {
-            reqSpec.addPathParam("username", username);
+            reqSpec.addPathParam(USERNAME_PATH, username);
             return this;
         }
 
@@ -479,21 +483,25 @@ public class UserApi {
             return execute(handler).as(type);
         }
 
+        public static final String USERNAME_QUERY = "username";
+
         /**
          * @param username (String) The user name for login (required)
          * @return operation
          */
         public LoginUserOper usernameQuery(Object... username) {
-            reqSpec.addQueryParam("username", username);
+            reqSpec.addQueryParam(USERNAME_QUERY, username);
             return this;
         }
+
+        public static final String PASSWORD_QUERY = "password";
 
         /**
          * @param password (String) The password for login in clear text (required)
          * @return operation
          */
         public LoginUserOper passwordQuery(Object... password) {
-            reqSpec.addQueryParam("password", password);
+            reqSpec.addQueryParam(PASSWORD_QUERY, password);
             return this;
         }
 
@@ -620,12 +628,14 @@ public class UserApi {
             return this;
         }
 
+        public static final String USERNAME_PATH = "username";
+
         /**
          * @param username (String) name that need to be deleted (required)
          * @return operation
          */
         public UpdateUserOper usernamePath(Object username) {
-            reqSpec.addPathParam("username", username);
+            reqSpec.addPathParam(USERNAME_PATH, username);
             return this;
         }
 


### PR DESCRIPTION
…een refactored

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Added constants for Rest-assured params.
Made params as constants for Rest-assured.
See [issue](https://github.com/OpenAPITools/openapi-generator/issues/25).

