### PR TITLE
[Spring] Create a default implementation of delegate if none could be autowired

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -63,7 +63,10 @@ public interface {{classname}} {
         {{/reactive}}
     {{/isDelegate}}
     {{#isDelegate}}
-    {{classname}}Delegate getDelegate();
+
+    default {{classname}}Delegate getDelegate() {
+        return new {{classname}}Delegate() {};
+    }
     {{/isDelegate}}
 {{/jdk8}}
 {{#operation}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -27,14 +27,9 @@ import javax.validation.constraints.*;
 import javax.validation.Valid;
     {{/useBeanValidation}}
 {{/jdk8}}
-{{#jdk8-no-delegate}}
+{{#jdk8}}
 import java.util.Optional;
-{{/jdk8-no-delegate}}
-{{^jdk8-no-delegate}}
-    {{#useOptional}}
-import java.util.Optional;
-    {{/useOptional}}
-{{/jdk8-no-delegate}}
+{{/jdk8}}
 {{^jdk8}}
 import java.util.List;
 import java.util.Map;
@@ -46,24 +41,28 @@ import java.util.concurrent.Callable;
 @Controller
 {{#operations}}
 public class {{classname}}Controller implements {{classname}} {
-
 {{#isDelegate}}
+
     private final {{classname}}Delegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public {{classname}}Controller({{classname}}Delegate delegate) {
-        this.delegate = delegate;
-    }
+    public {{classname}}Controller(@org.springframework.beans.factory.annotation.Autowired(required = false) {{classname}}Delegate delegate) {
     {{#jdk8}}
+        this.delegate = Optional.ofNullable(delegate).orElse(new {{classname}}Delegate() {});
+    }
 
     @Override
     public {{classname}}Delegate getDelegate() {
         return delegate;
     }
     {{/jdk8}}
+    {{^jdk8}}
+        this.delegate = delegate;
+    }
+    {{/jdk8}}
 {{/isDelegate}}
 {{^isDelegate}}
-{{^reactive}}
+    {{^reactive}}
+
     private final NativeWebRequest request;
 
     @org.springframework.beans.factory.annotation.Autowired
@@ -77,9 +76,9 @@ public class {{classname}}Controller implements {{classname}} {
         return Optional.ofNullable(request);
     }
     {{/jdk8}}
-{{/reactive}}
-
+    {{/reactive}}
 {{/isDelegate}}
+
 {{^jdk8}}
 {{#operation}}
     public {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -24,7 +24,10 @@ import java.util.Map;
 
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {
-    AnotherFakeApiDelegate getDelegate();
+
+    default AnotherFakeApiDelegate getDelegate() {
+        return new AnotherFakeApiDelegate() {};
+    }
 
     @ApiOperation(value = "To test special tags", nickname = "testSpecialTags", notes = "To test special tags", response = Client.class, tags={ "$another-fake?", })
     @ApiResponses(value = { 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,19 +1,20 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final AnotherFakeApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(AnotherFakeApiDelegate delegate) {
-        this.delegate = delegate;
+    public AnotherFakeApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) AnotherFakeApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new AnotherFakeApiDelegate() {});
     }
 
     @Override
     public AnotherFakeApiDelegate getDelegate() {
         return delegate;
     }
+
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApi.java
@@ -31,7 +31,10 @@ import java.util.Map;
 
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {
-    FakeApiDelegate getDelegate();
+
+    default FakeApiDelegate getDelegate() {
+        return new FakeApiDelegate() {};
+    }
 
     @ApiOperation(value = "", nickname = "fakeOuterBooleanSerialize", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @ApiResponses(value = { 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,19 +1,20 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public class FakeApiController implements FakeApi {
 
     private final FakeApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(FakeApiDelegate delegate) {
-        this.delegate = delegate;
+    public FakeApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) FakeApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new FakeApiDelegate() {});
     }
 
     @Override
     public FakeApiDelegate getDelegate() {
         return delegate;
     }
+
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -24,7 +24,10 @@ import java.util.Map;
 
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {
-    FakeClassnameTestApiDelegate getDelegate();
+
+    default FakeClassnameTestApiDelegate getDelegate() {
+        return new FakeClassnameTestApiDelegate() {};
+    }
 
     @ApiOperation(value = "To test class name in snake case", nickname = "testClassname", notes = "To test class name in snake case", response = Client.class, authorizations = {
         @Authorization(value = "api_key_query")

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,19 +1,20 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final FakeClassnameTestApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(FakeClassnameTestApiDelegate delegate) {
-        this.delegate = delegate;
+    public FakeClassnameTestApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) FakeClassnameTestApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new FakeClassnameTestApiDelegate() {});
     }
 
     @Override
     public FakeClassnameTestApiDelegate getDelegate() {
         return delegate;
     }
+
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApi.java
@@ -26,7 +26,10 @@ import java.util.Map;
 
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {
-    PetApiDelegate getDelegate();
+
+    default PetApiDelegate getDelegate() {
+        return new PetApiDelegate() {};
+    }
 
     @ApiOperation(value = "Add a new pet to the store", nickname = "addPet", notes = "", authorizations = {
         @Authorization(value = "petstore_auth", scopes = {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,19 +1,20 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public class PetApiController implements PetApi {
 
     private final PetApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(PetApiDelegate delegate) {
-        this.delegate = delegate;
+    public PetApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) PetApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new PetApiDelegate() {});
     }
 
     @Override
     public PetApiDelegate getDelegate() {
         return delegate;
     }
+
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApi.java
@@ -25,7 +25,10 @@ import java.util.Map;
 
 @Api(value = "store", description = "the store API")
 public interface StoreApi {
-    StoreApiDelegate getDelegate();
+
+    default StoreApiDelegate getDelegate() {
+        return new StoreApiDelegate() {};
+    }
 
     @ApiOperation(value = "Delete purchase order by ID", nickname = "deleteOrder", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", tags={ "store", })
     @ApiResponses(value = { 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,19 +1,20 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public class StoreApiController implements StoreApi {
 
     private final StoreApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(StoreApiDelegate delegate) {
-        this.delegate = delegate;
+    public StoreApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) StoreApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new StoreApiDelegate() {});
     }
 
     @Override
     public StoreApiDelegate getDelegate() {
         return delegate;
     }
+
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApi.java
@@ -25,7 +25,10 @@ import java.util.Map;
 
 @Api(value = "user", description = "the user API")
 public interface UserApi {
-    UserApiDelegate getDelegate();
+
+    default UserApiDelegate getDelegate() {
+        return new UserApiDelegate() {};
+    }
 
     @ApiOperation(value = "Create user", nickname = "createUser", notes = "This can only be done by the logged in user.", tags={ "user", })
     @ApiResponses(value = { 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,19 +1,20 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public class UserApiController implements UserApi {
 
     private final UserApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(UserApiDelegate delegate) {
-        this.delegate = delegate;
+    public UserApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) UserApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new UserApiDelegate() {});
     }
 
     @Override
     public UserApiDelegate getDelegate() {
         return delegate;
     }
+
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -23,10 +23,10 @@ public class AnotherFakeApiController implements AnotherFakeApi {
 
     private final AnotherFakeApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public AnotherFakeApiController(AnotherFakeApiDelegate delegate) {
+    public AnotherFakeApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) AnotherFakeApiDelegate delegate) {
         this.delegate = delegate;
     }
+
     public ResponseEntity<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client client) {
         return delegate.testSpecialTags(client);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiController.java
@@ -30,10 +30,10 @@ public class FakeApiController implements FakeApi {
 
     private final FakeApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public FakeApiController(FakeApiDelegate delegate) {
+    public FakeApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) FakeApiDelegate delegate) {
         this.delegate = delegate;
     }
+
     public ResponseEntity<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Boolean body) {
         return delegate.fakeOuterBooleanSerialize(body);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -23,10 +23,10 @@ public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 
     private final FakeClassnameTestApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public FakeClassnameTestApiController(FakeClassnameTestApiDelegate delegate) {
+    public FakeClassnameTestApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) FakeClassnameTestApiDelegate delegate) {
         this.delegate = delegate;
     }
+
     public ResponseEntity<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Client client) {
         return delegate.testClassname(client);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApiController.java
@@ -25,10 +25,10 @@ public class PetApiController implements PetApi {
 
     private final PetApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public PetApiController(PetApiDelegate delegate) {
+    public PetApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) PetApiDelegate delegate) {
         this.delegate = delegate;
     }
+
     public ResponseEntity<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Pet pet) {
         return delegate.addPet(pet);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApiController.java
@@ -24,10 +24,10 @@ public class StoreApiController implements StoreApi {
 
     private final StoreApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public StoreApiController(StoreApiDelegate delegate) {
+    public StoreApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) StoreApiDelegate delegate) {
         this.delegate = delegate;
     }
+
     public ResponseEntity<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId) {
         return delegate.deleteOrder(orderId);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiController.java
@@ -24,10 +24,10 @@ public class UserApiController implements UserApi {
 
     private final UserApiDelegate delegate;
 
-    @org.springframework.beans.factory.annotation.Autowired
-    public UserApiController(UserApiDelegate delegate) {
+    public UserApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) UserApiDelegate delegate) {
         this.delegate = delegate;
     }
+
     public ResponseEntity<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody User user) {
         return delegate.createUser(user);
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

Currently the server with `delegatePattern` doesn't start as-is as it tries to autowire implementations of the delegate interfaces which don't exist.
This PR sets the autowiring as non required and creates a default implementation of a delegate if none could be autowired.
Note : on spring-boot, I could have used `@ConditionalOnMissingBean` but that would not work with raw spring.

