### PR TITLE
[Clojure] Add util method to set the api-context globally

### DIFF
--- a/modules/openapi-generator/src/main/resources/clojure/core.mustache
+++ b/modules/openapi-generator/src/main/resources/clojure/core.mustache
@@ -24,6 +24,11 @@
   "Dynamic API context to be applied in API calls."
   default-api-context)
 
+(defn set-api-context
+  "Set the *api-context* globally"
+  [new-context]
+  (alter-var-root #'*api-context* (constantly (merge *api-context* new-context))))
+
 (defmacro with-api-context
   "A helper macro to wrap *api-context* with default values."
   [api-context & body]

--- a/samples/client/petstore/clojure/src/open_api_petstore/core.clj
+++ b/samples/client/petstore/clojure/src/open_api_petstore/core.clj
@@ -24,6 +24,11 @@
   "Dynamic API context to be applied in API calls."
   default-api-context)
 
+(defn set-api-context
+  "Set the *api-context* globally"
+  [new-context]
+  (alter-var-root #'*api-context* (constantly (merge *api-context* new-context))))
+
 (defmacro with-api-context
   "A helper macro to wrap *api-context* with default values."
   [api-context & body]


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Before the change, to update the api-context (e.g. the URL of the API) it was necessary to wrap all the calls in `(with-api-context new-context api-call-here)`.
Since in some cases the new context needs to be shared globally in the app (e.g. we have a different URL for services in dev/test/production), it is useful to have a method to change the `api-context` once and for all.

Example usage:
```clojure
(set-api-context {:base-url "https://new-url-here"})
```

/cc @wing328 