### PR TITLE
Update Docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ openapi-generator generate -i https://raw.githubusercontent.com/openapitools/ope
 
 #### Public Pre-built Docker images
 
- - [https://hub.docker.com/r/openapitools/openapi-generator-online/](https://hub.docker.com/r/openapitools/openapi-generator-online/) (official web service)
  - [https://hub.docker.com/r/openapitools/openapi-generator-cli/](https://hub.docker.com/r/openapitools/openapi-generator-cli/) (official CLI)
+ - [https://hub.docker.com/r/openapitools/openapi-generator-online/](https://hub.docker.com/r/openapitools/openapi-generator-online/) (official web service)
+
 
 #### OpenAPI Generator CLI Docker Image
 

--- a/docs/migration-from-swagger-codegen.md
+++ b/docs/migration-from-swagger-codegen.md
@@ -4,6 +4,27 @@ OpenAPI Generator is a fork of `swagger-codegen` between version `2.3.1` and `2.
 This community-driven version called "OpenAPI Generator" provides similar functionalities and can be used as drop-in replacement.
 This guide explains the major differences in order to help you with the migration.
 
+### New docker images
+
+The docker images are available on DockerHub: https://hub.docker.com/u/openapitools/
+
+**CLI for OpenAPI Generator**
+
+Image to run OpenAPI Generator in the command line (see [OpenAPI Generator CLI Docker Image](../README.md#openapi-generator-cli-docker-image))
+
+Old: `swaggerapi/swagger-codegen-cli`
+
+New: `openapitools/openapi-generator-cli`
+
+**OpenAPI Generator as web service**
+
+Image to run OpenAPI Generator as a web service (see [OpenAPI Generator Online Docker Image](../README.md#openapi-generator-online-docker-image))
+
+Old: `swaggerapi/swagger-generator`
+
+New: `openapitools/openapi-generator-online`
+
+
 ### New maven coordinates
 
 You can find our released artefact on maven central:


### PR DESCRIPTION
* Mention Docker image correspondence swagger-codegen/openapi-generator in Migration Guide
* Change order in README to match the sections