### PR TITLE
[TypeScript] Make OpenAPI Generator serialize subclasses properly

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api.mustache
@@ -83,8 +83,8 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
-			
-			// Get the actual type of this object
+            
+            // Get the actual type of this object
             type = this.findCorrectType(data, type);
 
             // get the map for the correct type.

--- a/modules/openapi-generator/src/main/resources/typescript-node/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api.mustache
@@ -47,7 +47,12 @@ class ObjectSerializer {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
-                    return data[discriminatorProperty]; // use the type given in the discriminator
+                    var discriminatorType = data[discriminatorProperty];
+                    if(typeMap[discriminatorType]){
+                        return discriminatorType; // use the type given in the discriminator
+                    } else {
+                        return expectedType; // discriminator did not map to a type
+                    }
                 } else {
                     return expectedType; // discriminator was not present (or an empty string)
                 }
@@ -78,6 +83,9 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
+			
+			// Get the actual type of this object
+            type = this.findCorrectType(data, type);
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -92,8 +92,8 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
-			
-			// Get the actual type of this object
+            
+            // Get the actual type of this object
             type = this.findCorrectType(data, type);
 
             // get the map for the correct type.

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -56,7 +56,12 @@ class ObjectSerializer {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
-                    return data[discriminatorProperty]; // use the type given in the discriminator
+                    var discriminatorType = data[discriminatorProperty];
+                    if(typeMap[discriminatorType]){
+                        return discriminatorType; // use the type given in the discriminator
+                    } else {
+                        return expectedType; // discriminator did not map to a type
+                    }
                 } else {
                     return expectedType; // discriminator was not present (or an empty string)
                 }
@@ -87,6 +92,9 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
+			
+			// Get the actual type of this object
+            type = this.findCorrectType(data, type);
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();
@@ -144,7 +152,7 @@ export class ApiResponse {
     'type'?: string;
     'message'?: string;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -175,7 +183,7 @@ export class Category {
     'id'?: number;
     'name'?: string;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -208,7 +216,7 @@ export class Order {
     'status'?: Order.StatusEnum;
     'complete'?: boolean;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -268,7 +276,7 @@ export class Pet {
     */
     'status'?: Pet.StatusEnum;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -321,7 +329,7 @@ export class Tag {
     'id'?: number;
     'name'?: string;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -356,7 +364,7 @@ export class User {
     */
     'userStatus'?: number;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Motivation
----
Previously, when serializing as subclass of a property, generated swagger clients would only serialize properties of the parent class causing some values to not be pass through

Modifications
----
Before serializing attributes of a given type, we check to see if there is a specific type to be serialized so that we don't miss any properties.

Issue: https://github.com/OpenAPITools/openapi-generator/issues/100

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx  @macjohnny @wing328 
