### PR TITLE
DefaultGenerator: fix NullPointerException

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -294,7 +294,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             return;
         }
 
-        final Map<String, Schema> schemas = this.openAPI.getComponents().getSchemas();
+        final Map<String, Schema> schemas = ModelUtils.getSchemas(this.openAPI);
         if (schemas == null) {
             return;
         }


### PR DESCRIPTION
Fix this null pointer:
```
Exception in thread "main" java.lang.NullPointerException
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:297)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:783)
```

When the generator is started on a OAS3 without any components section like [ping.yaml](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/test/resources/3_0/ping.yaml)

This PR also activate one test case that was ignored and add a new one.