### PR TITLE
[elm] Download dependencies without prompting user

### DIFF
--- a/samples/client/petstore/elm/elm-compile-test
+++ b/samples/client/petstore/elm/elm-compile-test
@@ -4,7 +4,7 @@
 for ELM in `find src -name "*.elm"`
 do
     echo "Compiling $ELM"
-    elm make $ELM --output /dev/null
+    elm make $ELM --output /dev/null --yes
     rc=$?
     if [[ $rc != 0 ]]
     then


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The user does not get prompted anymore for compiling the Elm test.
This should possibly also fix the Travis CI build?!