### PR TITLE
Reduce CI logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ script:
   # fail if generators contain tab '\t'
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
-  - mvn clean install
-  - mvn -q --batch-mode verify -Psamples
+  - mvn --quiet clean install
+  - mvn --quiet verify -Psamples
 after_success:
   # push a snapshot version to maven repo
   - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_BRANCH" = "master" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
   - nuget restore samples\client\petstore\csharp\OpenAPIClientNetStandard\Org.OpenAPITools.sln
   - msbuild samples\client\petstore\csharp\OpenAPIClientNetStandard\Org.OpenAPITools.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   # install openapi-generator locally
-  - mvn clean install --batch-mode
+  - mvn clean install --quiet
 test_script:
   # test c# API client
   - nunit-console samples\client\petstore\csharp\OpenAPIClient\src\Org.OpenAPITools.Test\bin\Debug\Org.OpenAPITools.Test.dll --result=myresults.xml;format=AppVeyor

--- a/circle.yml
+++ b/circle.yml
@@ -35,16 +35,16 @@ test:
   override:
     ## test with jdk8
     - java -version
-    - mvn clean install
-    - mvn -q verify -Psamples
+    - mvn --quiet clean install
+    - mvn --quiet verify -Psamples
     # skip the rest if previous mvn task fails
     - if [ $? -ne 0 ]; then exit 1; fi
     ## test with jdk7
     - sudo update-java-alternatives -s java-1.7.0-openjdk-amd64
     - java -version
     - cp CI/pom.xml.circleci.java7 pom.xml # use jdk7 pom
-    - mvn clean install
-    - mvn -q verify -Psamples
+    - mvn --quiet clean install
+    - mvn --quiet verify -Psamples
     # skip the rest if previous mvn task fails
     - if [ $? -ne 0 ]; then exit 1; fi
     ## docker push done in Travis instead

--- a/shippable.yml
+++ b/shippable.yml
@@ -28,8 +28,8 @@ build:
     - mix --version
     # test samples defined in pom.xml
     - cp CI/pom.xml.shippable pom.xml
-    - mvn clean install
-    - mvn verify -P samples
+    - mvn --quiet clean install
+    - mvn --quiet verify -P samples
     # generate all petstore sampless (client, servers, doc)
     - ./bin/run-all-petstore 2>&1 > run-all-petstore.log
   post_ci:


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Following on from #70 , run CI builds with `mvn --quiet` to reduce log size.
Rationale: some of the build scripts already used `mvn --quiet` (or `-q`), some used `mvn --batch-mode` (or `-B`), so I've made the used of `--quiet` consistent, for smallest log size.