### PR TITLE
Update swagger-parser to 2.0.1

### DIFF
--- a/CI/pom.xml.bash
+++ b/CI/pom.xml.bash
@@ -919,7 +919,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.0</swagger-parser-version>
+        <swagger-parser-version>2.0.1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.circleci
+++ b/CI/pom.xml.circleci
@@ -968,7 +968,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.0</swagger-parser-version>
+        <swagger-parser-version>2.0.1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.circleci.java7
+++ b/CI/pom.xml.circleci.java7
@@ -949,7 +949,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.0</swagger-parser-version>
+        <swagger-parser-version>2.0.1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.ios
+++ b/CI/pom.xml.ios
@@ -927,7 +927,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.0</swagger-parser-version>
+        <swagger-parser-version>2.0.1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.shippable
+++ b/CI/pom.xml.shippable
@@ -924,7 +924,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.0</swagger-parser-version>
+        <swagger-parser-version>2.0.1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/pom.xml
+++ b/pom.xml
@@ -947,7 +947,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.0</swagger-parser-version>
+        <swagger-parser-version>2.0.1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>


### PR DESCRIPTION
Because `2.0.1` version of swagger-parser will be published soon (see https://github.com/swagger-api/swagger-parser/issues/717) this PR give us a chance to test it in OpenAPI Generator before it is released.
