### PR TITLE
Move bash argv opt to end of ags line in scripts

### DIFF
--- a/bin/ada-petstore.sh
+++ b/bin/ada-petstore.sh
@@ -28,7 +28,7 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 model="modules/openapi-generator/src/test/resources/2_0/petstore.yaml"
-ags="$@ generate --template-dir modules/openapi-generator/src/main/resources/Ada -l ada"
+ags="generate --template-dir modules/openapi-generator/src/main/resources/Ada -l ada $@"
 ags="$ags -i $model -t modules/openapi-generator/src/main/resources/Ada -o samples/client/petstore/ada"
 ags="$ags -DprojectName=Petstore --model-package Samples.Petstore"
 

--- a/bin/android-petstore-httpclient.sh
+++ b/bin/android-petstore-httpclient.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/android -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l android -Dlibrary=httpclient -o samples/client/petstore/android/httpclient"
+ags="generate -t modules/openapi-generator/src/main/resources/android -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l android -Dlibrary=httpclient -o samples/client/petstore/android/httpclient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/android-petstore-volley.sh
+++ b/bin/android-petstore-volley.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l android -c bin/android-petstore-volley.json -o samples/client/petstore/android/volley"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l android -c bin/android-petstore-volley.json -o samples/client/petstore/android/volley $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/apache2-petstore-config.sh
+++ b/bin/apache2-petstore-config.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -l apache2 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/config/petstore/apache2"
+ags="generate -l apache2 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/config/petstore/apache2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/apex-petstore.sh
+++ b/bin/apex-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/apex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l apex -o samples/client/petstore/apex"
+ags="generate -t modules/openapi-generator/src/main/resources/apex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l apex -o samples/client/petstore/apex $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/aspnetcore-petstore-server.sh
+++ b/bin/aspnetcore-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -l aspnetcore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/aspnetcore --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5}"
+ags="generate -l aspnetcore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/aspnetcore --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5} $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/bash-petstore.sh
+++ b/bin/bash-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-args="$@ generate -t modules/openapi-generator/src/main/resources/bash -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l bash -o samples/client/petstore/bash -c modules/openapi-generator/src/test/resources/2_0/bash-config.json --additional-properties hideGenerationTimestamp=true"
+args="generate -t modules/openapi-generator/src/main/resources/bash -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l bash -o samples/client/petstore/bash -c modules/openapi-generator/src/test/resources/2_0/bash-config.json --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/clojure-petstore.sh
+++ b/bin/clojure-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.json -l clojure -o samples/client/petstore/clojure"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.json -l clojure -o samples/client/petstore/clojure $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-net-35.sh
+++ b/bin/csharp-petstore-net-35.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNet35 --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-35.json"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNet35 --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-35.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-net-40.sh
+++ b/bin/csharp-petstore-net-40.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNet40 --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-40.json"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNet40 --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-40.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-net-standard.sh
+++ b/bin/csharp-petstore-net-standard.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNetStandard --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-standard.json"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNetStandard --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-standard.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-netcore-project.sh
+++ b/bin/csharp-petstore-netcore-project.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNetCoreProject --additional-properties packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true -c ./bin/csharp-petstore-net-standard.json"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientNetCoreProject --additional-properties packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true -c ./bin/csharp-petstore-net-standard.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore.sh
+++ b/bin/csharp-petstore.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C}"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} $@"
 
 # restore csproj file
 echo "restore csproject file: CI/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj"

--- a/bin/csharp-property-changed-petstore.sh
+++ b/bin/csharp-property-changed-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientWithPropertyChanged --additional-properties generatePropertyChanged=true --additional-properties packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5}"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l csharp -o samples/client/petstore/csharp/OpenAPIClientWithPropertyChanged --additional-properties generatePropertyChanged=true --additional-properties packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5} $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cwiki-petstore.sh
+++ b/bin/cwiki-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l cwiki -o samples/documentation/cwiki"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l cwiki -o samples/documentation/cwiki $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/dart-flutter-petstore.sh
+++ b/bin/dart-flutter-petstore.sh
@@ -28,18 +28,18 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 ## Generate non-browserClient
-#ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/swagger -DhideGenerationTimestamp=true -DbrowserClient=false"
+#ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/swagger -DhideGenerationTimestamp=true -DbrowserClient=false $@"
 #
 ## then options to generate the library for vm would be:
-##ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/swagger_vm -DbrowserClient=false -DpubName=swagger_vm"
+##ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/swagger_vm -DbrowserClient=false -DpubName=swagger_vm $@"
 #java $JAVA_OPTS -jar $executable $ags
 #
 ## Generate browserClient
-#ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/swagger-browser-client -DhideGenerationTimestamp=true -DbrowserClient=true"
+#ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/swagger-browser-client -DhideGenerationTimestamp=true -DbrowserClient=true $@"
 #java $JAVA_OPTS -jar $executable $ags
 
 # Generate non-browserClient and put it to the flutter sample app
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/flutter_petstore/swagger -DhideGenerationTimestamp=true -DbrowserClient=false"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/flutter_petstore/swagger -DhideGenerationTimestamp=true -DbrowserClient=false $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # There is a proposal to allow importing different libraries depending on the environment:

--- a/bin/dart-petstore.sh
+++ b/bin/dart-petstore.sh
@@ -29,18 +29,18 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate non-browserClient
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi -DhideGenerationTimestamp=true -DbrowserClient=false"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi -DhideGenerationTimestamp=true -DbrowserClient=false $@"
 
 # then options to generate the library for vm would be:
-#ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi_vm -DbrowserClient=false -DpubName=openapi_vm"
+#ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi_vm -DbrowserClient=false -DpubName=openapi_vm $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # Generate browserClient
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi-browser-client -DhideGenerationTimestamp=true -DbrowserClient=true"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi-browser-client -DhideGenerationTimestamp=true -DbrowserClient=true $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # Generate non-browserClient and put it to the flutter sample app
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/flutter_petstore/openapi -DhideGenerationTimestamp=true -DbrowserClient=false"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dart -o samples/client/petstore/dart/flutter_petstore/openapi -DhideGenerationTimestamp=true -DbrowserClient=false $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # There is a proposal to allow importing different libraries depending on the environment:

--- a/bin/dynamic-html.sh
+++ b/bin/dynamic-html.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dynamic-html  -o samples/dynamic-html"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l dynamic-html  -o samples/dynamic-html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/eiffel-petstore.sh
+++ b/bin/eiffel-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-args="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l eiffel -o samples/client/petstore/eiffel/"
+args="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l eiffel -o samples/client/petstore/eiffel/ $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/erlang-petstore-client.sh
+++ b/bin/erlang-petstore-client.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/erlang-client -DpackageName=petstore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l erlang-client -o samples/client/petstore/erlang-client"
+ags="generate -t modules/openapi-generator/src/main/resources/erlang-client -DpackageName=petstore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l erlang-client -o samples/client/petstore/erlang-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/finch-petstore-server.sh
+++ b/bin/finch-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -t modules/openapi-generator/src/main/resources/finch -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-finch -o samples/server/petstore/finch"
+ags="generate -t modules/openapi-generator/src/main/resources/finch -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-finch -o samples/server/petstore/finch $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/flash-petstore.sh
+++ b/bin/flash-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/flash -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l flash -o samples/client/petstore/flash -c bin/flash-petstore.json"
+ags="generate -t modules/openapi-generator/src/main/resources/flash -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l flash -o samples/client/petstore/flash -c bin/flash-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/go-petstore-server.sh
+++ b/bin/go-petstore-server.sh
@@ -28,6 +28,6 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
-ags="$@ generate -t modules/openapi-generator/src/main/resources/go-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver  --additional-properties hideGenerationTimestamp=true -Dservice"
+ags="generate -t modules/openapi-generator/src/main/resources/go-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver  --additional-properties hideGenerationTimestamp=true -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/go-petstore-withxml.sh
+++ b/bin/go-petstore-withxml.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/go -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l go -o samples/client/petstore/go/go-petstore-withXml -DpackageName=petstore,withXml=true "
+ags="generate -t modules/openapi-generator/src/main/resources/go -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l go -o samples/client/petstore/go/go-petstore-withXml -DpackageName=petstore,withXml=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/groovy-petstore.sh
+++ b/bin/groovy-petstore.sh
@@ -27,5 +27,5 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l groovy -o samples/client/petstore/groovy -DhideGenerationTimestamp=true" 
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l groovy -o samples/client/petstore/groovy -DhideGenerationTimestamp=true $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/haskell-http-client-petstore.sh
+++ b/bin/haskell-http-client-petstore.sh
@@ -28,7 +28,7 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
-args="$@ generate -t modules/openapi-generator/src/main/resources/haskell-http-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l haskell-http-client -o samples/client/petstore/haskell-http-client"
+args="generate -t modules/openapi-generator/src/main/resources/haskell-http-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l haskell-http-client -o samples/client/petstore/haskell-http-client $@"
 
 echo "java ${JAVA_OPTS} -jar ${executable} ${args}"
 java $JAVA_OPTS -jar $executable $args

--- a/bin/haskell-servant-petstore.sh
+++ b/bin/haskell-servant-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/haskell-servant -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l haskell -o samples/server/petstore/haskell-servant"
+ags="generate -t modules/openapi-generator/src/main/resources/haskell-servant -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l haskell -o samples/server/petstore/haskell-servant $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/html-markdown.sh
+++ b/bin/html-markdown.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/markdown.yaml -l html  -o samples/html.md"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/markdown.yaml -l html  -o samples/html.md $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/html-petstore.sh
+++ b/bin/html-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l html  -o samples/html"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l html  -o samples/html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/html2-petstore.sh
+++ b/bin/html2-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l html2  -o samples/html2 --additional-properties hideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l html2  -o samples/html2 --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-inflector-petstore-server.sh
+++ b/bin/java-inflector-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaInflector -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java-inflector -o samples/server/petstore/java-inflector -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaInflector -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java-inflector -o samples/server/petstore/java-inflector -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-msf4j-petstore-server.sh
+++ b/bin/java-msf4j-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/MSF4J -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java-msf4j -o samples/server/petstore/java-msf4j/ -DhideGenerationTimestamp=true --additional-properties artifactId=swagger-msf4j-server"
+ags="generate -t modules/openapi-generator/src/main/resources/MSF4J -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java-msf4j -o samples/server/petstore/java-msf4j/ -DhideGenerationTimestamp=true --additional-properties artifactId=swagger-msf4j-server $@"
 
 echo "Removing files and folders under samples/server/petstore/java-msf4j/src/main"
 rm -rf samples/server/petstore/java-msf4j/src/main

--- a/bin/java-petstore-feign.sh
+++ b/bin/java-petstore-feign.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/feign -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-feign.json -o samples/client/petstore/java/feign -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/feign -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-feign.json -o samples/client/petstore/java/feign -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/feign/src/main"
 rm -rf samples/client/petstore/java/feign/src/main

--- a/bin/java-petstore-google-api-client.sh
+++ b/bin/java-petstore-google-api-client.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/google-api-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-google-api-client.json -o samples/client/petstore/java/google-api-client -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/google-api-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-google-api-client.json -o samples/client/petstore/java/google-api-client -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/google-api-client/src/main"
 rm -rf samples/client/petstore/java/google-api-client/src/main

--- a/bin/java-petstore-jersey1.sh
+++ b/bin/java-petstore-jersey1.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id petstore-java-client-jersey1 -t modules/openapi-generator/src/main/resources/Java -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -o samples/client/petstore/java/jersey1 -DhideGenerationTimestamp=true --library=jersey1"
+ags="generate --artifact-id petstore-java-client-jersey1 -t modules/openapi-generator/src/main/resources/Java -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -o samples/client/petstore/java/jersey1 -DhideGenerationTimestamp=true --library=jersey1 $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey1/src/main"
 rm -rf samples/client/petstore/java/jersey1/src/main

--- a/bin/java-petstore-jersey2-java6.sh
+++ b/bin/java-petstore-jersey2-java6.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id petstore-jersey2-java6 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java6 -DhideGenerationTimestamp=true,supportJava6=true"
+ags="generate --artifact-id petstore-jersey2-java6 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java6 -DhideGenerationTimestamp=true,supportJava6=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2/src/main"
 rm -rf samples/client/petstore/java/jersey2-java6/src/main

--- a/bin/java-petstore-jersey2.sh
+++ b/bin/java-petstore-jersey2.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2 -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2/src/main"
 rm -rf samples/client/petstore/java/jersey2/src/main

--- a/bin/java-petstore-okhttp-gson-parcelable.sh
+++ b/bin/java-petstore-okhttp-gson-parcelable.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id petstore-okhttp-gson-parcelableModel -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore/java/okhttp-gson-parcelableModel -DhideGenerationTimestamp=true,parcelableModel=true"
+ags="generate --artifact-id petstore-okhttp-gson-parcelableModel -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore/java/okhttp-gson-parcelableModel -DhideGenerationTimestamp=true,parcelableModel=true $@"
 
 rm -rf samples/client/petstore/java/okhttp-gson-parcelableModel/src/main
 find samples/client/petstore/java/okhttp-gson-parcelableModel -maxdepth 1 -type f ! -name "README.md" -exec rm {} +

--- a/bin/java-petstore-okhttp-gson.sh
+++ b/bin/java-petstore-okhttp-gson.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore/java/okhttp-gson -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore/java/okhttp-gson -DhideGenerationTimestamp=true $@"
 
 rm -rf samples/client/petstore/java/okhttp-gson/src/main
 find samples/client/petstore/java/okhttp-gson -maxdepth 1 -type f ! -name "README.md" -exec rm {} +

--- a/bin/java-petstore-rest-assured.sh
+++ b/bin/java-petstore-rest-assured.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/rest-assured -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-rest-assured.json -o samples/client/petstore/java/rest-assured -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/rest-assured -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-rest-assured.json -o samples/client/petstore/java/rest-assured -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/rest-assured/src/main"
 rm -rf samples/client/petstore/java/rest-assured/src/main

--- a/bin/java-petstore-resteasy.sh
+++ b/bin/java-petstore-resteasy.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-resteasy.json -o samples/client/petstore/java/resteasy -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-resteasy.json -o samples/client/petstore/java/resteasy -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/resteasy/src/main"
 rm -rf samples/client/petstore/java/resteasy/src/main

--- a/bin/java-petstore-resttemplate-withxml.sh
+++ b/bin/java-petstore-resttemplate-withxml.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml --artifact-id pestore-resttemplate-withxml -l java -c bin/java-petstore-resttemplate.json -o samples/client/petstore/java/resttemplate-withXml -DhideGenerationTimestamp=true,withXml=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml --artifact-id pestore-resttemplate-withxml -l java -c bin/java-petstore-resttemplate.json -o samples/client/petstore/java/resttemplate-withXml -DhideGenerationTimestamp=true,withXml=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/resttemplate/src/main"
 rm -rf samples/client/petstore/java/resttemplate-withXml/src/main

--- a/bin/java-petstore-resttemplate.sh
+++ b/bin/java-petstore-resttemplate.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-resttemplate.json -o samples/client/petstore/java/resttemplate -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-resttemplate.json -o samples/client/petstore/java/resttemplate -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/resttemplate/src/main"
 rm -rf samples/client/petstore/java/resttemplate/src/main

--- a/bin/java-petstore-retrofit.sh
+++ b/bin/java-petstore-retrofit.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit.json -o samples/client/petstore/java/retrofit -DhideGenerationTimestamp=true,dateLibrary=joda"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit.json -o samples/client/petstore/java/retrofit -DhideGenerationTimestamp=true,dateLibrary=joda $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit/src/main"
 rm -rf samples/client/petstore/java/retrofit/src/main

--- a/bin/java-petstore-retrofit2-play24.sh
+++ b/bin/java-petstore-retrofit2-play24.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id petstore-java-client-retrofit2-play24 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2-play24.json -o samples/client/petstore/java/retrofit2-play24 -DhideGenerationTimestamp=true"
+ags="generate --artifact-id petstore-java-client-retrofit2-play24 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2-play24.json -o samples/client/petstore/java/retrofit2-play24 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2-play24/src/main"
 rm -rf samples/client/petstore/java/retrofit2-play24/src/main

--- a/bin/java-petstore-retrofit2-play25.sh
+++ b/bin/java-petstore-retrofit2-play25.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id petstore-java-client-retrofit2-play25 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2-play25.json -o samples/client/petstore/java/retrofit2-play25 -DhideGenerationTimestamp=true"
+ags="generate --artifact-id petstore-java-client-retrofit2-play25 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2-play25.json -o samples/client/petstore/java/retrofit2-play25 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2-play25/src/main"
 rm -rf samples/client/petstore/java/retrofit2-play25/src/main

--- a/bin/java-petstore-retrofit2.sh
+++ b/bin/java-petstore-retrofit2.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2.json -o samples/client/petstore/java/retrofit2 -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2.json -o samples/client/petstore/java/retrofit2 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2/src/main"
 rm -rf samples/client/petstore/java/retrofit2/src/main

--- a/bin/java-petstore-retrofit2rx.sh
+++ b/bin/java-petstore-retrofit2rx.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2rx.json -o samples/client/petstore/java/retrofit2rx -DuseRxJava=true,hideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2rx.json -o samples/client/petstore/java/retrofit2rx -DuseRxJava=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2rx/src/main"
 rm -rf samples/client/petstore/java/retrofit2rx/src/main

--- a/bin/java-petstore-retrofit2rx2.sh
+++ b/bin/java-petstore-retrofit2rx2.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2rx2.json -o samples/client/petstore/java/retrofit2rx2 -DuseRxJava2=true,hideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-retrofit2rx2.json -o samples/client/petstore/java/retrofit2rx2 -DuseRxJava2=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2rx2/src/main"
 rm -rf samples/client/petstore/java/retrofit2rx2/src/main

--- a/bin/java-petstore-vertx.sh
+++ b/bin/java-petstore-vertx.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/vertx -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-vertx.json -o samples/client/petstore/java/vertx -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/vertx -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java-petstore-vertx.json -o samples/client/petstore/java/vertx -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/vertx/src/main"
 rm -rf samples/client/petstore/java/vertx/src/main

--- a/bin/java-pkmst-petstore-server.sh
+++ b/bin/java-pkmst-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/java-pkmst -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-pkmst -o samples/server/petstore/java-pkmst/ -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/java-pkmst -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-pkmst -o samples/server/petstore/java-pkmst/ -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/java-pkmst/src/main"
 rm -rf samples/server/petstore/java-pkmst/src/main

--- a/bin/java-play-framework-petstore-server-api-package-override.sh
+++ b/bin/java-play-framework-petstore-server-api-package-override.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-api-package-override -DhideGenerationTimestamp=true,apiPackage=com.puppies.store.apis"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-api-package-override -DhideGenerationTimestamp=true,apiPackage=com.puppies.store.apis $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-play-framework-petstore-server-async.sh
+++ b/bin/java-play-framework-petstore-server-async.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -c bin/java-play-framework-petstore-server-async.json -o samples/server/petstore/java-play-framework-async -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -c bin/java-play-framework-petstore-server-async.json -o samples/server/petstore/java-play-framework-async -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-controller-only.sh
+++ b/bin/java-play-framework-petstore-server-controller-only.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-controller-only -DhideGenerationTimestamp=true,controllerOnly=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-controller-only -DhideGenerationTimestamp=true,controllerOnly=true $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-play-framework-petstore-server-no-bean-validation.sh
+++ b/bin/java-play-framework-petstore-server-no-bean-validation.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-bean-validation -DhideGenerationTimestamp=true,useBeanValidation=false"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-bean-validation -DhideGenerationTimestamp=true,useBeanValidation=false $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-play-framework-petstore-server-no-exception-handling.sh
+++ b/bin/java-play-framework-petstore-server-no-exception-handling.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-exception-handling -DhideGenerationTimestamp=true,handleExceptions=false"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-exception-handling -DhideGenerationTimestamp=true,handleExceptions=false $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-play-framework-petstore-server-no-interface.sh
+++ b/bin/java-play-framework-petstore-server-no-interface.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-interface -DhideGenerationTimestamp=true,useInterfaces=false"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-interface -DhideGenerationTimestamp=true,useInterfaces=false $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-play-framework-petstore-server-no-swagger-ui.sh
+++ b/bin/java-play-framework-petstore-server-no-swagger-ui.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-swagger-ui -DhideGenerationTimestamp=true,useSwaggerUI=false"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-swagger-ui -DhideGenerationTimestamp=true,useSwaggerUI=false $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-play-framework-petstore-server-no-wrap-calls.sh
+++ b/bin/java-play-framework-petstore-server-no-wrap-calls.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-wrap-calls -DhideGenerationTimestamp=true,wrapCalls=false"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-play-framework -o samples/server/petstore/java-play-framework-no-wrap-calls -DhideGenerationTimestamp=true,wrapCalls=false $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/java-undertow-petstore-server.sh
+++ b/bin/java-undertow-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/undertow -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-undertow-server -o samples/server/petstore/undertow --additional-properties hideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/undertow -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-undertow-server -o samples/server/petstore/undertow --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-vertx-async-petstore-server.sh
+++ b/bin/java-vertx-async-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-vertx -o samples/server/petstore/java-vertx/async -DvertxSwaggerRouterVersion=1.4.0 -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-vertx -o samples/server/petstore/java-vertx/async -DvertxSwaggerRouterVersion=1.4.0 -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-vertx-rx-petstore-server.sh
+++ b/bin/java-vertx-rx-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-vertx --artifact-id java-vertx-rx-server -o samples/server/petstore/java-vertx/rx -DvertxSwaggerRouterVersion=1.4.0,rxInterface=true -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l java-vertx --artifact-id java-vertx-rx-server -o samples/server/petstore/java-vertx/rx -DvertxSwaggerRouterVersion=1.4.0,rxInterface=true -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java8-petstore-jersey2.sh
+++ b/bin/java8-petstore-jersey2.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id petstore-jersey2-java8 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java8-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java8 -DhideGenerationTimestamp=true --additional-properties serverPort=8082"
+ags="generate --artifact-id petstore-jersey2-java8 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l java -c bin/java8-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java8 -DhideGenerationTimestamp=true --additional-properties serverPort=8082 $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2-java8/src/main"
 rm -rf samples/client/petstore/java/jersey2-java8/src/main

--- a/bin/jaxrs-cxf-cdi-petstore-server.sh
+++ b/bin/jaxrs-cxf-cdi-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true"
+="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-client-petstore.sh
+++ b/bin/jaxrs-cxf-client-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id "jaxrs-cxf-petstore-client" -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/ -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-client -o samples/client/petstore/jaxrs-cxf-client"
+ags="generate --artifact-id "jaxrs-cxf-petstore-client" -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/ -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-client -o samples/client/petstore/jaxrs-cxf-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server-annotated-base-path.sh
+++ b/bin/jaxrs-cxf-petstore-server-annotated-base-path.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id cxf-annotated-basepath -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf -o samples/server/petstore/jaxrs-cxf-annotated-base-path -DhideGenerationTimestamp=true,useAnnotatedBasePath=true --additional-properties serverPort=8082"
+ags="generate --artifact-id cxf-annotated-basepath -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf -o samples/server/petstore/jaxrs-cxf-annotated-base-path -DhideGenerationTimestamp=true,useAnnotatedBasePath=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server-non-spring-application.sh
+++ b/bin/jaxrs-cxf-petstore-server-non-spring-application.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id cxf-server-non-spring -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf -o samples/server/petstore/jaxrs-cxf-non-spring-app -DhideGenerationTimestamp=true,generateNonSpringApplication=true --additional-properties serverPort=8082"
+ags="generate --artifact-id cxf-server-non-spring -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf -o samples/server/petstore/jaxrs-cxf-non-spring-app -DhideGenerationTimestamp=true,generateNonSpringApplication=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server.sh
+++ b/bin/jaxrs-cxf-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-cxf -o samples/server/petstore/jaxrs-cxf -DhideGenerationTimestamp=true --additional-properties serverPort=8082"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-cxf -o samples/server/petstore/jaxrs-cxf -DhideGenerationTimestamp=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-jersey1-petstore-server.sh
+++ b/bin/jaxrs-jersey1-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8082 --library=jersey1 --artifact-id=jaxrs-jersey1-server"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8082 --library=jersey1 --artifact-id=jaxrs-jersey1-server $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey1/src/main

--- a/bin/jaxrs-jersey1-usetags-petstore-server.sh
+++ b/bin/jaxrs-jersey1-usetags-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1-useTags -DhideGenerationTimestamp=true,serverPort=8082 --library=jersey1 --artifact-id=jaxrs-jersey1-useTags --additional-properties useTags=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1-useTags -DhideGenerationTimestamp=true,serverPort=8082 --library=jersey1 --artifact-id=jaxrs-jersey1-useTags --additional-properties useTags=true $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1-useTags/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey1-useTags/src/main

--- a/bin/jaxrs-petstore-server-datelib-j8.sh
+++ b/bin/jaxrs-petstore-server-datelib-j8.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs-datelib-j8/ -c ./bin/jaxrs-datelib-j8.json -DhideGenerationTimestamp=true --additional-properties serverPort=8082"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs-datelib-j8/ -c ./bin/jaxrs-datelib-j8.json -DhideGenerationTimestamp=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-petstore-server.sh
+++ b/bin/jaxrs-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-jersey-petstore-server -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8082"
+ags="generate --artifact-id jaxrs-jersey-petstore-server -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8082 $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey2/src/main

--- a/bin/jaxrs-resteasy-eap-java8-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-java8-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-resteasy-eap-java8-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-java8 -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-java8-petstore-server.json"
+ags="generate --artifact-id jaxrs-resteasy-eap-java8-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-java8 -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-java8-petstore-server.json $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap-java8/src/main"
 rm -rf samples/server/petstore/jaxrs-resteasy/eap-java8/src/main

--- a/bin/jaxrs-resteasy-eap-joda-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-joda-petstore-server.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-resteasy-eap-joda-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-joda-petstore-server.json"
+ags="generate --artifact-id jaxrs-resteasy-eap-joda-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-joda-petstore-server.json $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap-joda/src/main"
 rm -rf samples/server/petstore/jaxrs-resteasy/eap-joda/src/main

--- a/bin/jaxrs-resteasy-eap-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap/src/main"
 rm -rf samples/server/petstore/jaxrs-resteasy/eap/src/main

--- a/bin/jaxrs-resteasy-joda-petstore-server.sh
+++ b/bin/jaxrs-resteasy-joda-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-resteasy-joda-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy -o samples/server/petstore/jaxrs-resteasy/joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-joda-petstore-server.json"
+ags="generate --artifact-id jaxrs-resteasy-joda-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy -o samples/server/petstore/jaxrs-resteasy/joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-joda-petstore-server.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-resteasy-petstore-server.sh
+++ b/bin/jaxrs-resteasy-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy -o samples/server/petstore/jaxrs-resteasy/default -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-resteasy -o samples/server/petstore/jaxrs-resteasy/default -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-spec-petstore-server-interface-returning-response.sh
+++ b/bin/jaxrs-spec-petstore-server-interface-returning-response.sh
@@ -27,10 +27,10 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-spec-interface-response-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-spec -o samples/server/petstore/jaxrs-spec-interface-response
+ags="generate --artifact-id jaxrs-spec-interface-response-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-spec -o samples/server/petstore/jaxrs-spec-interface-response
 -DhideGenerationTimestamp=true
 -DserializableModel=true
 -DinterfaceOnly=true
--DreturnResponse=true"
+-DreturnResponse=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-spec-petstore-server-interface.sh
+++ b/bin/jaxrs-spec-petstore-server-interface.sh
@@ -27,9 +27,9 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-spec-interface-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-spec -o samples/server/petstore/jaxrs-spec-interface
+ags="generate --artifact-id jaxrs-spec-interface-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-spec -o samples/server/petstore/jaxrs-spec-interface
 -DhideGenerationTimestamp=true
 -DserializableModel=true
--DinterfaceOnly=true"
+-DinterfaceOnly=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-spec-petstore-server.sh
+++ b/bin/jaxrs-spec-petstore-server.sh
@@ -27,8 +27,8 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id jaxrs-spec-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-spec -o samples/server/petstore/jaxrs-spec 
+ags="generate --artifact-id jaxrs-spec-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-spec -o samples/server/petstore/jaxrs-spec
 -DhideGenerationTimestamp=true
--DserializableModel=true"
+-DserializableModel=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-usetags-petstore-server.sh
+++ b/bin/jaxrs-usetags-petstore-server.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2-useTags -DhideGenerationTimestamp=true,serverPort=8082 --artifact-id=jaxrs-jersey2-useTags --additional-properties useTags=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2-useTags -DhideGenerationTimestamp=true,serverPort=8082 --artifact-id=jaxrs-jersey2-useTags --additional-properties useTags=true $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2-useTags/src/main"
 rm -rf samples/server/petstore/jaxrs/jersey2-useTags/src/main

--- a/bin/jmeter-petstore.sh
+++ b/bin/jmeter-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jmeter -o samples/client/petstore/jmeter/"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jmeter -o samples/client/petstore/jmeter/ $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/lumen-petstore-server.sh
+++ b/bin/lumen-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/lumen -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-lumen -o samples/server/petstore/lumen"
+ags="generate -t modules/openapi-generator/src/main/resources/lumen -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-lumen -o samples/server/petstore/lumen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nancyfx-petstore-server-async.sh
+++ b/bin/nancyfx-petstore-server-async.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -t modules/openapi-generator/src/main/resources/csharp-nancyfx -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l csharp-nancyfx -o samples/server/petstore/nancyfx-async --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4},asyncServer=true"
+ags="generate -t modules/openapi-generator/src/main/resources/csharp-nancyfx -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l csharp-nancyfx -o samples/server/petstore/nancyfx-async --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4},asyncServer=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nancyfx-petstore-server.sh
+++ b/bin/nancyfx-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate $@ -t modules/openapi-generator/src/main/resources/csharp-nancyfx -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l csharp-nancyfx -o samples/server/petstore/nancyfx --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4},asyncServer=false"
+ags="generate -t modules/openapi-generator/src/main/resources/csharp-nancyfx -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l csharp-nancyfx -o samples/server/petstore/nancyfx --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4},asyncServer=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nodejs-petstore-google-cloud-functions.sh
+++ b/bin/nodejs-petstore-google-cloud-functions.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nodejs-petstore-server.sh
+++ b/bin/nodejs-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/nodejs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l nodejs-server -o samples/server/petstore/nodejs -Dservice"
+ags="generate -t modules/openapi-generator/src/main/resources/nodejs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l nodejs-server -o samples/server/petstore/nodejs -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/objc-petstore-coredata.sh
+++ b/bin/objc-petstore-coredata.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/2_0/petstore.json -l objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -c bin/objc-petstore.json"
+ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/2_0/petstore.json -l objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -c bin/objc-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/android-petstore-volley.sh
+++ b/bin/openapi3/android-petstore-volley.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l android -c bin/android-petstore-volley.json -o samples/client/petstore/android/volley"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l android -c bin/android-petstore-volley.json -o samples/client/petstore/android/volley $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/bash-petstore.sh
+++ b/bin/openapi3/bash-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-args="$@ generate -t modules/openapi-generator/src/main/resources/bash -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l bash -o samples/client/petstore/bash -c modules/openapi-generator/src/test/resources/3_0/bash-config.json --additional-properties hideGenerationTimestamp=true"
+args="generate -t modules/openapi-generator/src/main/resources/bash -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l bash -o samples/client/petstore/bash -c modules/openapi-generator/src/test/resources/3_0/bash-config.json --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/openapi3/clojure-petstore.sh
+++ b/bin/openapi3/clojure-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.json -l clojure -o samples/client/petstore/clojure"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.json -l clojure -o samples/client/petstore/clojure $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/dart-petstore.sh
+++ b/bin/openapi3/dart-petstore.sh
@@ -29,18 +29,18 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate non-browserClient
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi -DhideGenerationTimestamp=true -DbrowserClient=false"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi -DhideGenerationTimestamp=true -DbrowserClient=false $@"
 
 # then options to generate the library for vm would be:
-#ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi_vm -DbrowserClient=false -DpubName=openapi_vm"
+#ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi_vm -DbrowserClient=false -DpubName=openapi_vm $@"
 #java $JAVA_OPTS -jar $executable $ags
 
 # Generate browserClient
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi-browser-client -DhideGenerationTimestamp=true -DbrowserClient=true"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/openapi-browser-client -DhideGenerationTimestamp=true -DbrowserClient=true $@"
 #java $JAVA_OPTS -jar $executable $ags
 
 # Generate non-browserClient and put it to the flutter sample app
-ags="$@ generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/flutter_petstore/openapi -DhideGenerationTimestamp=true -DbrowserClient=false"
+ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dart -o samples/client/petstore/dart/flutter_petstore/openapi -DhideGenerationTimestamp=true -DbrowserClient=false $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # There is a proposal to allow importing different libraries depending on the environment:

--- a/bin/openapi3/dynamic-html.sh
+++ b/bin/openapi3/dynamic-html.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dynamic-html  -o samples/dynamic-html"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l dynamic-html  -o samples/dynamic-html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/erlang-petstore-client.sh
+++ b/bin/openapi3/erlang-petstore-client.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/erlang-client -DpackageName=petstore -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l erlang-client -o samples/client/petstore/erlang-client"
+ags="generate -t modules/openapi-generator/src/main/resources/erlang-client -DpackageName=petstore -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l erlang-client -o samples/client/petstore/erlang-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/flash-petstore.sh
+++ b/bin/openapi3/flash-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/flash -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l flash -o samples/client/petstore/flash -c bin/flash-petstore.json"
+ags="generate -t modules/openapi-generator/src/main/resources/flash -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l flash -o samples/client/petstore/flash -c bin/flash-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/go-petstore-server.sh
+++ b/bin/openapi3/go-petstore-server.sh
@@ -28,6 +28,6 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
-ags="$@ generate -t modules/openapi-generator/src/main/resources/go-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver  --additional-properties hideGenerationTimestamp=true -Dservice"
+ags="generate -t modules/openapi-generator/src/main/resources/go-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l go-server -o samples/server/petstore/go-api-server -DpackageName=petstoreserver  --additional-properties hideGenerationTimestamp=true -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/groovy-petstore.sh
+++ b/bin/openapi3/groovy-petstore.sh
@@ -27,5 +27,5 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l groovy -o samples/client/petstore/groovy -DhideGenerationTimestamp=true" 
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l groovy -o samples/client/petstore/groovy -DhideGenerationTimestamp=true $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/haskell-http-client-petstore.sh
+++ b/bin/openapi3/haskell-http-client-petstore.sh
@@ -28,7 +28,7 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
-args="$@ generate -t modules/openapi-generator/src/main/resources/haskell-http-client -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l haskell-http-client -o samples/client/petstore/haskell-http-client"
+args="generate -t modules/openapi-generator/src/main/resources/haskell-http-client -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l haskell-http-client -o samples/client/petstore/haskell-http-client $@"
 
 echo "java ${JAVA_OPTS} -jar ${executable} ${args}"
 java $JAVA_OPTS -jar $executable $args

--- a/bin/openapi3/haskell-servant-petstore.sh
+++ b/bin/openapi3/haskell-servant-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/haskell-servant -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l haskell -o samples/server/petstore/haskell-servant"
+ags="generate -t modules/openapi-generator/src/main/resources/haskell-servant -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l haskell -o samples/server/petstore/haskell-servant $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/html-petstore.sh
+++ b/bin/openapi3/html-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l html  -o samples/html"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l html  -o samples/html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/html2-petstore.sh
+++ b/bin/openapi3/html2-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l html2  -o samples/html2 --additional-properties hideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l html2  -o samples/html2 --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/jaxrs-cxf-client-petstore.sh
+++ b/bin/openapi3/jaxrs-cxf-client-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id "jaxrs-cxf-petstore-client" -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/ -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l jaxrs-cxf-client -o samples/client/petstore/jaxrs-cxf-client"
+ags="generate --artifact-id "jaxrs-cxf-petstore-client" -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/ -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l jaxrs-cxf-client -o samples/client/petstore/jaxrs-cxf-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/lumen-petstore-server.sh
+++ b/bin/openapi3/lumen-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/lumen -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-lumen -o samples/server/petstore/lumen"
+ags="generate -t modules/openapi-generator/src/main/resources/lumen -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-lumen -o samples/server/petstore/lumen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/nodejs-petstore-google-cloud-functions.sh
+++ b/bin/openapi3/nodejs-petstore-google-cloud-functions.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/nodejs-petstore-server.sh
+++ b/bin/openapi3/nodejs-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/nodejs -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l nodejs-server -o samples/server/petstore/nodejs -Dservice"
+ags="generate -t modules/openapi-generator/src/main/resources/nodejs -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l nodejs-server -o samples/server/petstore/nodejs -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/objc-petstore-coredata.sh
+++ b/bin/openapi3/objc-petstore-coredata.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/3_0/petstore.json -l objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -D appName=PetstoreClient"
+ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/3_0/petstore.json -l objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -D appName=PetstoreClient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/perl-petstore.sh
+++ b/bin/openapi3/perl-petstore.sh
@@ -28,6 +28,6 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml  -l perl -o samples/client/petstore/perl -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml  -l perl -o samples/client/petstore/perl -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-silex-petstore-server.sh
+++ b/bin/openapi3/php-silex-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l php-silex -o samples/server/petstore/php-silex"
+ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l php-silex -o samples/server/petstore/php-silex $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/python-flask-petstore-python2.sh
+++ b/bin/openapi3/python-flask-petstore-python2.sh
@@ -27,8 +27,8 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-#ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -DsupportPython2=true"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/flaskConnexion -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -c bin/supportPython2.json -D service"
+#ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -DsupportPython2=true $@"
+ags="generate -t modules/openapi-generator/src/main/resources/flaskConnexion -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -c bin/supportPython2.json -D service $@"
 
 rm -rf samples/server/petstore/flaskConnexion-python2/*
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/qt5-petstore.sh
+++ b/bin/openapi3/qt5-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/qt5cpp -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l cpp-qt5 -o samples/client/petstore/qt5cpp"
+ags="generate -t modules/openapi-generator/src/main/resources/qt5cpp -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l cpp-qt5 -o samples/client/petstore/qt5cpp $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/rails5-petstore-server.sh
+++ b/bin/openapi3/rails5-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/rails5 -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l ruby-on-rails -o samples/server/petstore/rails5"
+ags="generate -t modules/openapi-generator/src/main/resources/rails5 -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l ruby-on-rails -o samples/server/petstore/rails5 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/restbed-petstore-server.sh
+++ b/bin/openapi3/restbed-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -l cpp-restbed-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o samples/server/petstore/restbed"
+ags="generate -l cpp-restbed-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o samples/server/petstore/restbed $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/scala-petstore.sh
+++ b/bin/openapi3/scala-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scala -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l scala -o samples/client/petstore/scala"
+ags="generate -t modules/openapi-generator/src/main/resources/scala -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l scala -o samples/client/petstore/scala $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/scalatra-petstore-server.sh
+++ b/bin/openapi3/scalatra-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scalatra -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l scalatra -o samples/server/petstore/scalatra"
+ags="generate -t modules/openapi-generator/src/main/resources/scalatra -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l scalatra -o samples/server/petstore/scalatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/scalaz-petstore.sh
+++ b/bin/openapi3/scalaz-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scalaz -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l scalaz -o samples/client/petstore/scalaz"
+ags="generate -t modules/openapi-generator/src/main/resources/scalaz -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l scalaz -o samples/client/petstore/scalaz $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/security/php-petstore.sh
+++ b/bin/openapi3/security/php-petstore.sh
@@ -33,6 +33,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/php -i modules/openapi-generator/src/test/resources/3_0/petstore-security-test.yaml -l php -o samples/client/petstore-security-test/php"
+ags="generate -t modules/openapi-generator/src/main/resources/php -i modules/openapi-generator/src/test/resources/3_0/petstore-security-test.yaml -l php -o samples/client/petstore-security-test/php $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/sinatra-petstore-server.sh
+++ b/bin/openapi3/sinatra-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/sinatra -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l ruby-sinatra -o samples/server/petstore/sinatra"
+ags="generate -t modules/openapi-generator/src/main/resources/sinatra -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l ruby-sinatra -o samples/server/petstore/sinatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/slim-petstore-server.sh
+++ b/bin/openapi3/slim-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/slim -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l php-slim -o samples/server/petstore/slim"
+ags="generate -t modules/openapi-generator/src/main/resources/slim -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l php-slim -o samples/server/petstore/slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/tizen-petstore.sh
+++ b/bin/openapi3/tizen-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/tizen -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l cpp-tizen -o samples/client/petstore/tizen"
+ags="generate -t modules/openapi-generator/src/main/resources/tizen -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l cpp-tizen -o samples/client/petstore/tizen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-petstore-all.sh
+++ b/bin/openapi3/typescript-angular-petstore-all.sh
@@ -29,21 +29,21 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript Petstore API client (default)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/default --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/default --additional-properties ngVersion=2 $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (npm setting)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2 $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (with interfaces generated)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2 $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (v4 { Adding InjectionToken Over OpaqueToken })"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4 $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (v4.3 { Adding HttpClientModule over HttpModule })"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3 $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v2-petstore-interfaces.sh
+++ b/bin/openapi3/typescript-angular-v2-petstore-interfaces.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v2-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-angular-v2-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v4-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-angular-v4-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v4.3-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-angular-v4.3-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angularjs-petstore.sh
+++ b/bin/openapi3/typescript-angularjs-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angularjs -o samples/client/petstore/typescript-angularjs"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-angularjs -o samples/client/petstore/typescript-angularjs $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-aurelia-petstore.sh
+++ b/bin/openapi3/typescript-aurelia-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-aurelia -o samples/client/petstore/typescript-aurelia/default"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-aurelia -o samples/client/petstore/typescript-aurelia/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore-interfaces.sh
+++ b/bin/openapi3/typescript-fetch-petstore-interfaces.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/with-interfaces -D withInterfaces=true"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/with-interfaces -D withInterfaces=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore-target-es6.sh
+++ b/bin/openapi3/typescript-fetch-petstore-target-es6.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-target-es6.json -o samples/client/petstore/typescript-fetch/builds/es6-target"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-target-es6.json -o samples/client/petstore/typescript-fetch/builds/es6-target $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore-with-npm-version.sh
+++ b/bin/openapi3/typescript-fetch-petstore-with-npm-version.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-with-npm-version.json -o samples/client/petstore/typescript-fetch/builds/with-npm-version"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-with-npm-version.json -o samples/client/petstore/typescript-fetch/builds/with-npm-version $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore.sh
+++ b/bin/openapi3/typescript-fetch-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-inversify-petstore.sh
+++ b/bin/openapi3/typescript-inversify-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-inversify -o samples/client/petstore/typescript-inversify"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-inversify -o samples/client/petstore/typescript-inversify $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-jquery-petstore-all.sh
+++ b/bin/openapi3/typescript-jquery-petstore-all.sh
@@ -29,9 +29,9 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript Petstore API client (default)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -o samples/client/petstore/typescript-jquery/default"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -o samples/client/petstore/typescript-jquery/default $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript Petstore API client (npm setting)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-jquery-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-jquery-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-jquery-petstore.sh
+++ b/bin/openapi3/typescript-jquery-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -o samples/client/petstore/typescript-jquery/default"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-jquery -o samples/client/petstore/typescript-jquery/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-node-petstore-all.sh
+++ b/bin/openapi3/typescript-node-petstore-all.sh
@@ -29,9 +29,9 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript node Petstore API client (default setting)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -o samples/client/petstore/typescript-node/default"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -o samples/client/petstore/typescript-node/default $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript node Petstore API client with npm setting"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-node-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-node-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-node-petstore.sh
+++ b/bin/openapi3/typescript-node-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -o samples/client/petstore/typescript-node/default"
+ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -l typescript-node -o samples/client/petstore/typescript-node/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/ze-ph-petstore-server.sh
+++ b/bin/openapi3/ze-ph-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/ze-ph -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-ze-ph -o samples/server/petstore/ze-ph"
+ags="generate -t modules/openapi-generator/src/main/resources/ze-ph -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-ze-ph -o samples/server/petstore/ze-ph $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/perl-deep-module-petstore.sh
+++ b/bin/perl-deep-module-petstore.sh
@@ -27,6 +27,6 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml  -l perl -o samples/client/petstore/perl/deep_module_test -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml  -l perl -o samples/client/petstore/perl/deep_module_test -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags --additional-properties moduleName=Something::Deep -o samples/client/petstore/perl/deep_module_test

--- a/bin/perl-petstore.sh
+++ b/bin/perl-petstore.sh
@@ -28,6 +28,6 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml  -l perl -o samples/client/petstore/perl -DhideGenerationTimestamp=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml  -l perl -o samples/client/petstore/perl -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-silex-petstore-server.sh
+++ b/bin/php-silex-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l php-silex -o samples/server/petstore/php-silex"
+ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l php-silex -o samples/server/petstore/php-silex $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/python-flask-petstore-python2.sh
+++ b/bin/python-flask-petstore-python2.sh
@@ -27,8 +27,8 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-#ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -DsupportPython2=true"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/flaskConnexion -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -c bin/supportPython2.json -D service"
+#ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -DsupportPython2=true $@"
+ags="generate -t modules/openapi-generator/src/main/resources/flaskConnexion -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l python-flask -o samples/server/petstore/flaskConnexion-python2 -c bin/supportPython2.json -D service $@"
 
 rm -rf samples/server/petstore/flaskConnexion-python2/*
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/qt5-petstore.sh
+++ b/bin/qt5-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/qt5cpp -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l cpp-qt5 -o samples/client/petstore/qt5cpp"
+ags="generate -t modules/openapi-generator/src/main/resources/qt5cpp -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l cpp-qt5 -o samples/client/petstore/qt5cpp $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/rails5-petstore-server.sh
+++ b/bin/rails5-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/rails5 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l ruby-on-rails -o samples/server/petstore/rails5"
+ags="generate -t modules/openapi-generator/src/main/resources/rails5 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l ruby-on-rails -o samples/server/petstore/rails5 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/restbed-petstore-server.sh
+++ b/bin/restbed-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -l cpp-restbed-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/restbed"
+ags="generate -l cpp-restbed-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/restbed $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/rust-server-petstore.sh
+++ b/bin/rust-server-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/rust-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l rust-server -o samples/server/petstore/rust-server -DpackageName=petstore_api"
+ags="generate -t modules/openapi-generator/src/main/resources/rust-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l rust-server -o samples/server/petstore/rust-server -DpackageName=petstore_api $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-gatling-petstore.sh
+++ b/bin/scala-gatling-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scala-gatling -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-gatling -o samples/client/petstore/scala-gatling"
+ags="generate -t modules/openapi-generator/src/main/resources/scala-gatling -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-gatling -o samples/client/petstore/scala-gatling $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-lagom-server-petstore.sh
+++ b/bin/scala-lagom-server-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scala-lagom-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-lagom-server -o samples/server/petstore/scala-lagom-server"
+ags="generate -t modules/openapi-generator/src/main/resources/scala-lagom-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-lagom-server -o samples/server/petstore/scala-lagom-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-petstore.sh
+++ b/bin/scala-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scala -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-httpclient -o samples/client/petstore/scala"
+ags="generate -t modules/openapi-generator/src/main/resources/scala -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scala-httpclient -o samples/client/petstore/scala $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scalatra-petstore-server.sh
+++ b/bin/scalatra-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scalatra -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scalatra -o samples/server/petstore/scalatra"
+ags="generate -t modules/openapi-generator/src/main/resources/scalatra -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scalatra -o samples/server/petstore/scalatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scalaz-petstore.sh
+++ b/bin/scalaz-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scalaz -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scalaz -o samples/client/petstore/scalaz"
+ags="generate -t modules/openapi-generator/src/main/resources/scalaz -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l scalaz -o samples/client/petstore/scalaz $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/csharp-petstore.sh
+++ b/bin/security/csharp-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l csharp -o samples/client/petstore-security-test/csharp/SwaggerClient --additional-properties packageGuid={8CE139DF-64BC-4591-85F8-8506C2B67514}"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l csharp -o samples/client/petstore-security-test/csharp/SwaggerClient --additional-properties packageGuid={8CE139DF-64BC-4591-85F8-8506C2B67514} $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/go-petstore.sh
+++ b/bin/security/go-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/go -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l go -o samples/client/petstore-security-test/go"
+ags="generate -t modules/openapi-generator/src/main/resources/go -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l go -o samples/client/petstore-security-test/go $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/java-petstore-okhttp-gson.sh
+++ b/bin/security/java-petstore-okhttp-gson.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore-security-test/java/okhttp-gson -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore-security-test/java/okhttp-gson -DhideGenerationTimestamp=true $@"
 
 rm -rf samples/client/petstore-security-test/java/okhttp-gson/src/main
 find samples/client/petstore-security-test/java/okhttp-gson -maxdepth 1 -type f ! -name "README.md" -exec rm {} +

--- a/bin/security/javascript-closure-angular.sh
+++ b/bin/security/javascript-closure-angular.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l javascript-closure-angular -o samples/client/petstore-security-test/javascript-closure-angular"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l javascript-closure-angular -o samples/client/petstore-security-test/javascript-closure-angular $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/javascript-petstore.sh
+++ b/bin/security/javascript-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/Javascript -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l javascript -o samples/client/petstore-security-test/javascript  -DappName=PetstoreClient"
+ags="generate -t modules/openapi-generator/src/main/resources/Javascript -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l javascript -o samples/client/petstore-security-test/javascript  -DappName=PetstoreClient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/lumen-petstore-server.sh
+++ b/bin/security/lumen-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/lumen -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php-lumen -o samples/server/petstore-security-test/lumen"
+ags="generate -t modules/openapi-generator/src/main/resources/lumen -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php-lumen -o samples/server/petstore-security-test/lumen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/objc-petstore.sh
+++ b/bin/security/objc-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l objc -o samples/client/petstore-security-test/objc"
+ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l objc -o samples/client/petstore-security-test/objc $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/perl-petstore.sh
+++ b/bin/security/perl-petstore.sh
@@ -28,7 +28,7 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml  -l perl -o samples/client/petstore-security-test/perl"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml  -l perl -o samples/client/petstore-security-test/perl $@"
 
 java $JAVA_OPTS -jar $executable $ags
 

--- a/bin/security/php-petstore.sh
+++ b/bin/security/php-petstore.sh
@@ -33,6 +33,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/php -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php -o samples/client/petstore-security-test/php"
+ags="generate -t modules/openapi-generator/src/main/resources/php -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php -o samples/client/petstore-security-test/php $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/python-petstore.sh
+++ b/bin/security/python-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l python -o samples/client/petstore-security-test/python -DpackageName=petstore_api"
+ags="generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l python -o samples/client/petstore-security-test/python -DpackageName=petstore_api $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/qt5cpp-petstore.sh
+++ b/bin/security/qt5cpp-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/qt5cpp -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l cpp-qt5 -o samples/client/petstore-security-test/qt5cpp"
+ags="generate -t modules/openapi-generator/src/main/resources/qt5cpp -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l cpp-qt5 -o samples/client/petstore-security-test/qt5cpp $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/ruby-petstore.sh
+++ b/bin/security/ruby-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/ruby -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l ruby -c bin/ruby-petstore.json -o samples/client/petstore-security-test/ruby"
+ags="generate -t modules/openapi-generator/src/main/resources/ruby -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l ruby -c bin/ruby-petstore.json -o samples/client/petstore-security-test/ruby $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/scala-petstore.sh
+++ b/bin/security/scala-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/scala -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l scala-httpclient -o samples/client/petstore-security-test/scala"
+ags="generate -t modules/openapi-generator/src/main/resources/scala -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l scala-httpclient -o samples/client/petstore-security-test/scala $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/silex-petstore-server.sh
+++ b/bin/security/silex-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php-silex -o samples/server/petstore-security-test/silex"
+ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php-silex -o samples/server/petstore-security-test/silex $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/slim-petstore-server.sh
+++ b/bin/security/slim-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/slim -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php-slim -o samples/server/petstore-security-test/slim"
+ags="generate -t modules/openapi-generator/src/main/resources/slim -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l php-slim -o samples/server/petstore-security-test/slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/swift-petstore.sh
+++ b/bin/security/swift-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/swift -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l swift2-deprecated -o samples/client/petstore-security-test/swift"
+ags="generate -t modules/openapi-generator/src/main/resources/swift -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l swift2-deprecated -o samples/client/petstore-security-test/swift $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/typescript-angular.sh
+++ b/bin/security/typescript-angular.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/typescript-angular -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-angular -o samples/client/petstore-security-test/typescript-angular"
+ags="generate -t modules/openapi-generator/src/main/resources/typescript-angular -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-angular -o samples/client/petstore-security-test/typescript-angular $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/typescript-angular2.sh
+++ b/bin/security/typescript-angular2.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-angular -o samples/client/petstore-security-test/typescript-angular2"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-angular -o samples/client/petstore-security-test/typescript-angular2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/typescript-fetch-petstore.sh
+++ b/bin/security/typescript-fetch-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/typescript-fetch -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-fetch -o samples/client/petstore-security-test/typescript-fetch"
+ags="generate -t modules/openapi-generator/src/main/resources/typescript-fetch -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-fetch -o samples/client/petstore-security-test/typescript-fetch $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/typescript-inversify.sh
+++ b/bin/security/typescript-inversify.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/typescript-inversify -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-inversify -o samples/client/petstore-security-test/typescript-inversify"
+ags="generate -t modules/openapi-generator/src/main/resources/typescript-inversify -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-inversify -o samples/client/petstore-security-test/typescript-inversify $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/typescript-jquery-all.sh
+++ b/bin/security/typescript-jquery-all.sh
@@ -29,9 +29,9 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript jquery Petstore API client (default setting)"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-jquery -o samples/client/petstore-security-test/typescript-jquery/default"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-jquery -o samples/client/petstore-security-test/typescript-jquery/default $@"
 java $JAVA_OPTS -jar $executable $ags
 
 echo "Typescript jquery Petstore API client with npm setting"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-jquery -c bin/typescript-petstore-npm.json -o samples/client/petstore-security-test/typescript-jquery/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-jquery -c bin/typescript-petstore-npm.json -o samples/client/petstore-security-test/typescript-jquery/npm $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/security/typescript-node.sh
+++ b/bin/security/typescript-node.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/typescript-node -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-node -o samples/client/petstore-security-test/typescript-node"
+ags="generate -t modules/openapi-generator/src/main/resources/typescript-node -i modules/openapi-generator/src/test/resources/2_0/petstore-security-test.yaml -l typescript-node -o samples/client/petstore-security-test/typescript-node $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/sinatra-petstore-server.sh
+++ b/bin/sinatra-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/sinatra -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l ruby-sinatra -o samples/server/petstore/sinatra"
+ags="generate -t modules/openapi-generator/src/main/resources/sinatra -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l ruby-sinatra -o samples/server/petstore/sinatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/slim-petstore-server.sh
+++ b/bin/slim-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/slim -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l php-slim -o samples/server/petstore/slim"
+ags="generate -t modules/openapi-generator/src/main/resources/slim -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l php-slim -o samples/server/petstore/slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-cloud-feign-petstore.sh
+++ b/bin/spring-cloud-feign-petstore.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l spring -c bin/spring-cloud-feign-petstore.json -o samples/client/petstore/spring-cloud -DhideGenerationTimestamp=true,responseWrapper=HystrixCommand"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l spring -c bin/spring-cloud-feign-petstore.json -o samples/client/petstore/spring-cloud -DhideGenerationTimestamp=true,responseWrapper=HystrixCommand $@"
 
 echo "Removing files and folders under samples/client/petstore/spring-cloud/src/main"
 rm -rf samples/client/petstore/spring-cloud/src/main

--- a/bin/spring-delegate-j8.sh
+++ b/bin/spring-delegate-j8.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id springboot-delegate-j8 -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-delegate-j8 -DdelegatePattern=true,hideGenerationTimestamp=true"
+ags="generate --artifact-id springboot-delegate-j8 -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-delegate-j8 -DdelegatePattern=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-delegate-j8/src/main"
 rm -rf samples/server/petstore/springboot-delegate-j8/src/main

--- a/bin/spring-delegate.sh
+++ b/bin/spring-delegate.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id springboot-delegate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-delegate -DdelegatePattern=true,hideGenerationTimestamp=true,java8=false"
+ags="generate --artifact-id springboot-delegate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-delegate -DdelegatePattern=true,hideGenerationTimestamp=true,java8=false $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-delegate/src/main"
 rm -rf samples/server/petstore/springboot-delegate/src/main

--- a/bin/spring-mvc-petstore-j8-async-server.sh
+++ b/bin/spring-mvc-petstore-j8-async-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/spring-mvc-j8-async -c bin/spring-mvc-petstore-j8-async.json -DhideGenerationTimestamp=true,async=true --additional-properties serverPort=8002"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/spring-mvc-j8-async -c bin/spring-mvc-petstore-j8-async.json -DhideGenerationTimestamp=true,async=true --additional-properties serverPort=8002 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-mvc-petstore-j8-localdatetime.sh
+++ b/bin/spring-mvc-petstore-j8-localdatetime.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/spring-mvc-petstore-j8-localdatetime.json -o samples/server/petstore/spring-mvc-j8-localdatetime -DhideGenerationTimestamp=true --additional-properties serverPort=8002"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/spring-mvc-petstore-j8-localdatetime.json -o samples/server/petstore/spring-mvc-j8-localdatetime -DhideGenerationTimestamp=true --additional-properties serverPort=8002 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-mvc-petstore-server.sh
+++ b/bin/spring-mvc-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/spring-mvc-petstore-server.json -o samples/server/petstore/spring-mvc -DhideGenerationTimestamp=true,java8=false --additional-properties serverPort=8002"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/spring-mvc-petstore-server.json -o samples/server/petstore/spring-mvc -DhideGenerationTimestamp=true,java8=false --additional-properties serverPort=8002 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-stubs.sh
+++ b/bin/spring-stubs.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id spring-stubs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l spring -o samples/client/petstore/spring-stubs -DinterfaceOnly=true,singleContentTypes=true,hideGenerationTimestamp=true"
+ags="generate --artifact-id spring-stubs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l spring -o samples/client/petstore/spring-stubs -DinterfaceOnly=true,singleContentTypes=true,hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/springboot-petstore-server-beanvalidation.sh
+++ b/bin/springboot-petstore-server-beanvalidation.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-beanvalidation -c bin/springboot-petstore-server-beanvalidation.json -DhideGenerationTimestamp=true,java8=false"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -o samples/server/petstore/springboot-beanvalidation -c bin/springboot-petstore-server-beanvalidation.json -DhideGenerationTimestamp=true,java8=false $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-beanvalidation/src/main"
 rm -rf samples/server/petstore/springboot-beanvalidation/src/main

--- a/bin/springboot-petstore-server-implicitHeaders.sh
+++ b/bin/springboot-petstore-server-implicitHeaders.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate --artifact-id springboot-implicitHeaders -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/springboot-petstore-server-implicitHeaders.json -o samples/server/petstore/springboot-implicitHeaders -DhideGenerationTimestamp=true"
+ags="generate --artifact-id springboot-implicitHeaders -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/springboot-petstore-server-implicitHeaders.json -o samples/server/petstore/springboot-implicitHeaders -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-implicitHeaders/src/main"
 rm -rf samples/server/petstore/springboot-implicitHeaders/src/main

--- a/bin/springboot-petstore-server-useOptional.sh
+++ b/bin/springboot-petstore-server-useOptional.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/springboot-petstore-server-useOptional.json -o samples/server/petstore/springboot-useoptional -DhideGenerationTimestamp=true"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l spring -c bin/springboot-petstore-server-useOptional.json -o samples/server/petstore/springboot-useoptional -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-useoptional/src/main"
 rm -rf samples/server/petstore/springboot-useoptional/src/main

--- a/bin/swift3-petstore-unwraprequired.sh
+++ b/bin/swift3-petstore-unwraprequired.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c ./bin/swift3-petstore-unwraprequired.json -o samples/client/petstore/swift3/unwraprequired"
+ags="generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -l swift3 -c ./bin/swift3-petstore-unwraprequired.json -o samples/client/petstore/swift3/unwraprequired $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-objcCompatible.sh
+++ b/bin/swift4-petstore-objcCompatible.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift4 -c ./bin/swift4-petstore-objcCompatible.json -o samples/client/petstore/swift4/objcCompatible"
+ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift4 -c ./bin/swift4-petstore-objcCompatible.json -o samples/client/petstore/swift4/objcCompatible $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-promisekit.sh
+++ b/bin/swift4-petstore-promisekit.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift4 -c ./bin/swift4-petstore-promisekit.json -o samples/client/petstore/swift4/promisekit"
+ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift4 -c ./bin/swift4-petstore-promisekit.json -o samples/client/petstore/swift4/promisekit $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-rxswift.sh
+++ b/bin/swift4-petstore-rxswift.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift4 -c ./bin/swift4-petstore-rxswift.json -o samples/client/petstore/swift4/rxswift"
+ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l swift4 -c ./bin/swift4-petstore-rxswift.json -o samples/client/petstore/swift4/rxswift $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-test.sh
+++ b/bin/swift4-test.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift4Test.json -l swift4 -c ./bin/swift4-test.json -o samples/client/test/swift4/default"
+ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift4Test.json -l swift4 -c ./bin/swift4-test.json -o samples/client/test/swift4/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v2-petstore-interfaces.sh
+++ b/bin/typescript-angular-v2-petstore-interfaces.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v2-petstore-with-npm.sh
+++ b/bin/typescript-angular-v2-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v4-petstore-with-npm.sh
+++ b/bin/typescript-angular-v4-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v4.3-petstore-with-npm.sh
+++ b/bin/typescript-angular-v4.3-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angularjs-petstore.sh
+++ b/bin/typescript-angularjs-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angularjs -o samples/client/petstore/typescript-angularjs"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-angularjs -o samples/client/petstore/typescript-angularjs $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-aurelia-petstore.sh
+++ b/bin/typescript-aurelia-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-aurelia -o samples/client/petstore/typescript-aurelia/default"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-aurelia -o samples/client/petstore/typescript-aurelia/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore-interfaces.sh
+++ b/bin/typescript-fetch-petstore-interfaces.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/with-interfaces -D withInterfaces=true"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/with-interfaces -D withInterfaces=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore-target-es6.sh
+++ b/bin/typescript-fetch-petstore-target-es6.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-target-es6.json -o samples/client/petstore/typescript-fetch/builds/es6-target"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-target-es6.json -o samples/client/petstore/typescript-fetch/builds/es6-target $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore-with-npm-version.sh
+++ b/bin/typescript-fetch-petstore-with-npm-version.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-with-npm-version.json -o samples/client/petstore/typescript-fetch/builds/with-npm-version"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -c bin/typescript-fetch-petstore-with-npm-version.json -o samples/client/petstore/typescript-fetch/builds/with-npm-version $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore.sh
+++ b/bin/typescript-fetch-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-inversify-petstore.sh
+++ b/bin/typescript-inversify-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-inversify -o samples/client/petstore/typescript-inversify"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-inversify -o samples/client/petstore/typescript-inversify $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-jquery-petstore-with-npm.sh
+++ b/bin/typescript-jquery-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-jquery-petstore.sh
+++ b/bin/typescript-jquery-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-jquery -o samples/client/petstore/typescript-jquery/default"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-jquery -o samples/client/petstore/typescript-jquery/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-node-petstore-with-npm.sh
+++ b/bin/typescript-node-petstore-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-node-petstore.sh
+++ b/bin/typescript-node-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-node -o samples/client/petstore/typescript-node/default"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l typescript-node -o samples/client/petstore/typescript-node/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/ze-ph-petstore-server.sh
+++ b/bin/ze-ph-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="$@ generate -t modules/openapi-generator/src/main/resources/ze-ph -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-ze-ph -o samples/server/petstore/ze-ph"
+ags="generate -t modules/openapi-generator/src/main/resources/ze-ph -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -l php-ze-ph -o samples/server/petstore/ze-ph $@"
 
 java $JAVA_OPTS -jar $executable $ags


### PR DESCRIPTION
see #113

The $@ option in bash doesn't make sense to come before `generate`
because the only option we can pass before generate cli usage is `help`.

System properties can be passed via JAVA_OPTS, so there's not really a
need for any intermediaries in the command line construction.

Having $@ at the end of the arguments list allows maintainers and users
inspecting options to quickly pass new options to a script. For example,

```
./bin/aspnetcore-petstore.sh --additional-properties sourceFolder=asdf
```

For command line arguments that may appear more than once in the
arguments list, this change doesn't provide any rules about overwriting
values that may exist (hard-coded) in the script. That is, in the
example above, if aspnetcore-petstore.sh already includes the
sourceFolder set to a different value, the "winning" value is up to the
options parser and openapi-generator-cli implementation.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
