### PR TITLE
jaxrs-cxf-cdi: fix outer enum

### DIFF
--- a/bin/jaxrs-cxf-cdi-petstore-server.sh
+++ b/bin/jaxrs-cxf-cdi-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true $@"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -l jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumClass.mustache
@@ -1,6 +1,6 @@
 @XmlType(name="{{datatypeWithEnum}}")
 @XmlEnum({{dataType}}.class)
-public enum {{datatypeWithEnum}} {
+public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
 
     {{#allowableValues}}
     {{#enumVars}}@XmlEnumValue({{{value}}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
@@ -9,7 +9,7 @@ public enum {{datatypeWithEnum}} {
 
     private {{dataType}} value;
 
-    {{datatypeWithEnum}} ({{dataType}} v) {
+    {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{dataType}} v) {
         value = v;
     }
 
@@ -22,7 +22,7 @@ public enum {{datatypeWithEnum}} {
         return String.valueOf(value);
     }
 
-    public static {{datatypeWithEnum}} fromValue(String v) {
+    public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String v) {
         for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
             if (String.valueOf(b.value).equals(v)) {
                 return b;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumOuterClass.mustache
@@ -1,0 +1,5 @@
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+{{>enumClass}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/model.mustache
@@ -10,7 +10,7 @@ import javax.validation.constraints.*;
 /**
  * {{description}}
  **/{{/description}}
-{{#isEnum}}{{>enumClass}}{{/isEnum}}
+{{#isEnum}}{{>enumOuterClass}}{{/isEnum}}
 {{^isEnum}}{{>pojo}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
@@ -36,7 +36,7 @@ public enum StatusEnum {
 
     private String value;
 
-    StatusEnum (String v) {
+    StatusEnum(String v) {
         value = v;
     }
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
@@ -42,7 +42,7 @@ public enum StatusEnum {
 
     private String value;
 
-    StatusEnum (String v) {
+    StatusEnum(String v) {
         value = v;
     }
 


### PR DESCRIPTION
With the `jaxrs-cxf-cdi` generator, this PR fixes the outer-class enum case. 
This is similar to other JaxRS generators.

Example OAS3:

```yaml
openapi: 3.0.1
info:
  title: ping test
  version: '1.0'
servers:
  - url: 'http://localhost:8000/'
paths:
  /ping:
    get:
      operationId: pingGet
      responses:
        '200':
          description: Ok
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ObjWithEnums'

components:
  schemas:
    ObjWithEnums:
      type: object
      properties:
        SProp:
            $ref: "#/components/schemas/StringEnum"

    StringEnum:
      type: string
      enum:
        - "c"
        - "b"
        - "a"
```


