### PR TITLE
jaxrs-resteasy: fix outer enum case

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumOuterClass.mustache
@@ -1,3 +1,3 @@
 public enum {{classname}} {
-    {{#allowableValues}}{{.}}{{^-last}}, {{/-last}}{{/allowableValues}}
+    {{#allowableValues}}{{#enumVars}}{{{name}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}
 }


### PR DESCRIPTION
With the `jaxrs-resteasy` generator, this PR fixes the outer-class enum case. 

Example OAS3:

```yaml
openapi: 3.0.1
info:
  title: ping test
  version: '1.0'
servers:
  - url: 'http://localhost:8000/'
paths:
  /ping:
    get:
      operationId: pingGet
      responses:
        '200':
          description: Ok
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ObjWithEnums'

components:
  schemas:
    ObjWithEnums:
      type: object
      properties:
        SProp:
            $ref: "#/components/schemas/StringEnum"

    StringEnum:
      type: string
      enum:
        - "c"
        - "b"
        - "a"
```


