### PR TITLE
Fixes javadoc warnings in GenApiDelegate

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/api/GenApiDelegate.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/api/GenApiDelegate.java
@@ -43,6 +43,7 @@ public interface GenApiDelegate {
 
     /**
      * @see GenApi#clientOptions
+     * @return A {@link ResponseEntity} listing options for the target client generator.
      */
     default ResponseEntity<List<String>> clientOptions() {
         getRequest().ifPresent(request -> {
@@ -58,7 +59,9 @@ public interface GenApiDelegate {
     }
 
     /**
+     * @param fileId The unique id of the file, provided in a {@link ResponseCode} response.
      * @see GenApi#downloadFile
+     * @return A {@link ResponseEntity} of the requested {@link Resource}.
      */
     default ResponseEntity<Resource> downloadFile(String  fileId) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
@@ -66,7 +69,10 @@ public interface GenApiDelegate {
     }
 
     /**
+     * @param language The target generator (language is a misnomer here, but kept for API consistency).
+     * @param generatorInput The configuration settings to be used during client generation.
      * @see GenApi#generateClient
+     * @return A {@link ResponseEntity} referencing the unique download id and a link to download the requested client code.
      */
     default ResponseEntity<ResponseCode> generateClient( String  language,
          GeneratorInput  generatorInput) {
@@ -83,7 +89,10 @@ public interface GenApiDelegate {
     }
 
     /**
+     * @param framework The target generator name (framework is a slight misnomer here, as we may have a framework like Spring implemented in multiple languages).
+     * @param generatorInput The configuration settings to be used during server generation.
      * @see GenApi#generateServerForLanguage
+     * @return A {@link ResponseEntity} referencing the unique download id and a link to download the requested server code.
      */
     default ResponseEntity<ResponseCode> generateServerForLanguage( String  framework,
          GeneratorInput  generatorInput) {
@@ -100,7 +109,9 @@ public interface GenApiDelegate {
     }
 
     /**
+     * @param language The target generator (language is a misnomer here, but kept for API consistency).
      * @see GenApi#getClientOptions
+     * @return A {@link ResponseEntity} of {@link CliOption}, grouped by language (generator name).
      */
     default ResponseEntity<Map<String, CliOption>> getClientOptions(String  language) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
@@ -108,7 +119,9 @@ public interface GenApiDelegate {
     }
 
     /**
+     * @param framework The target generator name (framework is a slight misnomer here, as we may have a framework like Spring implemented in multiple languages).
      * @see GenApi#getServerOptions
+     * @return A {@link ResponseEntity} of {@link CliOption}, grouped by framework (generator name).
      */
     default ResponseEntity<Map<String, CliOption>> getServerOptions( String  framework) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
@@ -117,6 +130,7 @@ public interface GenApiDelegate {
 
     /**
      * @see GenApi#serverOptions
+     * @return A {@link ResponseEntity} listing options for the target server generator.
      */
     default ResponseEntity<List<String>> serverOptions() {
         getRequest().ifPresent(request -> {


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This fixes javadoc warnings in GenApiDelegate only. see #63. Comments on the PR suggest the remaining 4 warnings are fixed in other open PRs.
