### PR TITLE
Add 1-liner about customized templates, minor fix to dataType in the migration guide

### DIFF
--- a/docs/migration-from-swagger-codegen.md
+++ b/docs/migration-from-swagger-codegen.md
@@ -131,8 +131,9 @@ Some examples:
 ### Renamed Mustache Template Variables 
 
 The template variable `{{datatype}}` was renamed to `{{dataType}}` for consistency reason.
-Corresponding java code: `CodegenProperty.datatype` is renamed to `CodegenProperty.datatype`.
+Corresponding java code: `CodegenProperty.datatype` is renamed to `CodegenProperty.dataType`.
 
+(If you're **not** using customized templates with the `-t` option, you can ignore the mustache variable renaming above.)
 
 ### Ignore file
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

