### PR TITLE
Add PHP scripts to `bin/ensure-up-to-date` 

### DIFF
--- a/bin/ensure-up-to-date
+++ b/bin/ensure-up-to-date
@@ -17,6 +17,13 @@ sleep 5
 ./bin/kotlin-client-string.sh
 ./bin/kotlin-client-threetenbp.sh
 ./bin/kotlin-server-petstore.sh
+./bin/php-petstore.sh
+./bin/php-silex-petstore-server.sh
+./bin/php-symfony-petstore.sh
+./bin/lumen-petstore-server.sh
+./bin/slim-petstore-server.sh
+./bin/ze-ph-petstore-server.sh
+./bin/openapi3/php-petstore.sh
 
 # Check:
 if [ -n "$(git status --porcelain)" ]; then

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -434,7 +434,7 @@ Name | Type | Description  | Notes
  **enum_query_string** | **string**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional]
  **enum_query_double** | **double**| Query parameter enum test (double) | [optional]
- **enum_form_string_array** | **string[]**| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
+ **enum_form_string_array** | [**string[]**](../Model/string.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
  **enum_form_string** | **string**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
 
 ### Return type

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -385,7 +385,7 @@ Name | Type | Description  | Notes
  **enum_query_string** | **string**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
  **enum_query_integer** | **int**| Query parameter enum test (double) | [optional]
  **enum_query_double** | **double**| Query parameter enum test (double) | [optional]
- **enum_form_string_array** | **string[]**| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
+ **enum_form_string_array** | [**string[]**](../Model/string.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;]
  **enum_form_string** | **string**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;]
 
 ### Return type

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -1566,6 +1566,10 @@ class FakeApi
                 'Missing the required parameter $pattern_without_delimiter when calling testEndpointParameters'
             );
         }
+        if (!preg_match("/^[A-Z].*/", $pattern_without_delimiter)) {
+            throw new \InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
+        }
+
         // verify the required parameter 'byte' is set
         if ($byte === null || (is_array($byte) && count($byte) === 0)) {
             throw new \InvalidArgumentException(
@@ -1588,6 +1592,10 @@ class FakeApi
 
         if ($float !== null && $float > 987.6) {
             throw new \InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
+        }
+
+        if ($string !== null && !preg_match("/[a-z]/i", $string)) {
+            throw new \InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
         }
 
         if ($password !== null && strlen($password) > 64) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -304,6 +304,10 @@ class FormatTest implements ModelInterface, ArrayAccess
             $invalidProperties[] = "invalid value for 'double', must be bigger than or equal to 67.8.";
         }
 
+        if (!is_null($this->container['string']) && !preg_match("/[a-z]/i", $this->container['string'])) {
+            $invalidProperties[] = "invalid value for 'string', must be conform to the pattern /[a-z]/i.";
+        }
+
         if ($this->container['byte'] === null) {
             $invalidProperties[] = "'byte' can't be null";
         }
@@ -539,6 +543,11 @@ class FormatTest implements ModelInterface, ArrayAccess
      */
     public function setString($string)
     {
+
+        if (!is_null($string) && (!preg_match("/[a-z]/i", $string))) {
+            throw new \InvalidArgumentException("invalid value for $string when calling FormatTest., must conform to the pattern /[a-z]/i.");
+        }
+
         $this->container['string'] = $string;
 
         return $this;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Related issue: https://github.com/OpenAPITools/openapi-generator/issues/80

Added PHP scripts to `bin/ensure-up-to-date` in order to enforce the samples to be up-to-date.