### PR TITLE
Fix getReferenced...() methods in ModelUtils

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -423,7 +423,7 @@ public class ModelUtils {
     }
 
     /**
-     * If a Schema contains a reference to an other Schema with '$ref', returns the referenced Schema or the actual Schema in the other cases.
+     * If a Schema contains a reference to an other Schema with '$ref', returns the referenced Schema if it is found or the actual Schema in the other cases.
      * @param openAPI specification being checked
      * @param schema potentially containing a '$ref'
      * @return schema without '$ref'
@@ -431,7 +431,10 @@ public class ModelUtils {
     public static Schema getReferencedSchema(OpenAPI openAPI, Schema schema) {
         if (schema != null && StringUtils.isNotEmpty(schema.get$ref())) {
             String name = getSimpleRef(schema.get$ref());
-            return getSchema(openAPI, name);
+            Schema referencedSchema = getSchema(openAPI, name);
+            if(referencedSchema != null) {
+                return referencedSchema;
+            }
         }
         return schema;
     }
@@ -452,7 +455,7 @@ public class ModelUtils {
     }
 
     /**
-     * If a RequestBody contains a reference to an other RequestBody with '$ref', returns the referenced RequestBody or the actual RequestBody in the other cases.
+     * If a RequestBody contains a reference to an other RequestBody with '$ref', returns the referenced RequestBody if it is found or the actual RequestBody in the other cases.
      * @param openAPI specification being checked
      * @param requestBody potentially containing a '$ref'
      * @return requestBody without '$ref'
@@ -460,7 +463,10 @@ public class ModelUtils {
     public static RequestBody getReferencedRequestBody(OpenAPI openAPI, RequestBody requestBody) {
         if (requestBody != null && StringUtils.isNotEmpty(requestBody.get$ref())) {
             String name = getSimpleRef(requestBody.get$ref());
-            return getRequestBody(openAPI, name);
+            RequestBody referencedRequestBody = getRequestBody(openAPI, name);
+            if(referencedRequestBody != null) {
+                return referencedRequestBody;
+            }
         }
         return requestBody;
     }
@@ -477,7 +483,7 @@ public class ModelUtils {
     }
 
     /**
-     * If a ApiResponse contains a reference to an other ApiResponse with '$ref', returns the referenced ApiResponse or the actual ApiResponse in the other cases.
+     * If a ApiResponse contains a reference to an other ApiResponse with '$ref', returns the referenced ApiResponse if it is found or the actual ApiResponse in the other cases.
      * @param openAPI specification being checked
      * @param apiResponse potentially containing a '$ref'
      * @return apiResponse without '$ref'
@@ -485,7 +491,10 @@ public class ModelUtils {
     public static ApiResponse getReferencedApiResponse(OpenAPI openAPI, ApiResponse apiResponse) {
         if (apiResponse != null && StringUtils.isNotEmpty(apiResponse.get$ref())) {
             String name = getSimpleRef(apiResponse.get$ref());
-            return getApiResponse(openAPI, name);
+            ApiResponse referencedApiResponse = getApiResponse(openAPI, name);
+            if(referencedApiResponse != null) {
+                return referencedApiResponse;
+            }
         }
         return apiResponse;
     }
@@ -495,14 +504,14 @@ public class ModelUtils {
             return null;
         }
 
-        if (openAPI != null && openAPI.getComponents() != null && openAPI.getComponents().getRequestBodies() != null) {
+        if (openAPI != null && openAPI.getComponents() != null && openAPI.getComponents().getResponses() != null) {
             return openAPI.getComponents().getResponses().get(name);
         }
         return null;
     }
 
     /**
-     * If a Parameter contains a reference to an other Parameter with '$ref', returns the referenced Parameter or the actual Parameter in the other cases.
+     * If a Parameter contains a reference to an other Parameter with '$ref', returns the referenced Parameter if it is found or the actual Parameter in the other cases.
      * @param openAPI specification being checked
      * @param parameter potentially containing a '$ref'
      * @return parameter without '$ref'
@@ -510,7 +519,10 @@ public class ModelUtils {
     public static Parameter getReferencedParameter(OpenAPI openAPI, Parameter parameter) {
         if (parameter != null && StringUtils.isNotEmpty(parameter.get$ref())) {
             String name = getSimpleRef(parameter.get$ref());
-            return getParameter(openAPI, name);
+            Parameter referencedParameter = getParameter(openAPI, name);
+            if(referencedParameter != null) {
+                return referencedParameter;
+            }
         }
         return parameter;
     }
@@ -520,7 +532,7 @@ public class ModelUtils {
             return null;
         }
 
-        if (openAPI != null && openAPI.getComponents() != null && openAPI.getComponents().getRequestBodies() != null) {
+        if (openAPI != null && openAPI.getComponents() != null && openAPI.getComponents().getParameters() != null) {
             return openAPI.getComponents().getParameters().get(name);
         }
         return null;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -1,0 +1,27 @@
+package org.openapitools.codegen;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+
+import java.util.Collections;
+
+public class TestUtils {
+
+    public static OpenAPI createOpenAPI() {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+
+        final Info info = new Info();
+        info.setDescription("API under test");
+        info.setVersion("1.0.7");
+        info.setTitle("My title");
+        openAPI.setInfo(info);
+
+        final Server server = new Server();
+        server.setUrl("https://localhost:9999/root");
+        openAPI.setServers(Collections.singletonList(server));
+        return openAPI;
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -19,8 +19,16 @@ package org.openapitools.codegen.utils;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.core.models.ParseOptions;
 
+import org.openapitools.codegen.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -88,5 +96,65 @@ public class ModelUtilsTest {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/2_0/globalProducesConsumesTest.yaml", null, new ParseOptions()).getOpenAPI();
         List<String> unusedSchemas = ModelUtils.getSchemasUsedOnlyInFormParam(openAPI);
         Assert.assertEquals(unusedSchemas.size(), 0);
+    }
+
+    @Test
+    public void testReferencedSchema() {
+        Schema otherObj = new ObjectSchema().addProperties("sprop", new StringSchema()).addProperties("iprop", new IntegerSchema());
+
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addSchemas("OtherObj", otherObj);
+
+        Schema notExistingReferencedSchema = new Schema().$ref("NotExisting");
+        Schema result1 = ModelUtils.getReferencedSchema(openAPI, notExistingReferencedSchema);
+        Assert.assertEquals(result1, notExistingReferencedSchema);
+
+        Schema result2 = ModelUtils.getReferencedSchema(openAPI, new Schema().$ref("#/components/schemas/OtherObj"));
+        Assert.assertEquals(result2, otherObj);
+    }
+
+    @Test
+    public void testReferencedRequestBody() {
+        RequestBody otherRequestBody = new RequestBody().description("Some Description");
+
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addRequestBodies("OtherRequestBody", otherRequestBody);
+
+        RequestBody notExistingRequestBody = new RequestBody().$ref("NotExisting");
+        RequestBody result1 = ModelUtils.getReferencedRequestBody(openAPI, notExistingRequestBody);
+        Assert.assertEquals(result1, notExistingRequestBody);
+
+        RequestBody result2 = ModelUtils.getReferencedRequestBody(openAPI, new RequestBody().$ref("#/components/requestBodies/OtherRequestBody"));
+        Assert.assertEquals(result2, otherRequestBody);
+    }
+
+    @Test
+    public void testReferencedApiResponse() {
+        ApiResponse otherApiResponse = new ApiResponse().description("Some Description");
+
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addResponses("OtherApiResponse", otherApiResponse);
+
+        ApiResponse notExistingApiResponse = new ApiResponse().$ref("NotExisting");
+        ApiResponse result1 = ModelUtils.getReferencedApiResponse(openAPI, notExistingApiResponse);
+        Assert.assertEquals(result1, notExistingApiResponse);
+
+        ApiResponse result2 = ModelUtils.getReferencedApiResponse(openAPI, new ApiResponse().$ref("#/components/responses/OtherApiResponse"));
+        Assert.assertEquals(result2, otherApiResponse);
+    }
+
+    @Test
+    public void testReferencedParameter() {
+        Parameter otherParameter = new Parameter().description("Some Description");
+
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addParameters("OtherParameter", otherParameter);
+
+        Parameter notExistingParameter = new Parameter().$ref("NotExisting");
+        Parameter result1 = ModelUtils.getReferencedParameter(openAPI, notExistingParameter);
+        Assert.assertEquals(result1, notExistingParameter);
+
+        Parameter result2 = ModelUtils.getReferencedParameter(openAPI, new Parameter().$ref("#/components/parameters/OtherParameter"));
+        Assert.assertEquals(result2, otherParameter);
     }
 }


### PR DESCRIPTION
* New: methods return the element containing the $ref if the referenced
element is not found
* Fix null check in getApiResponse(OpenAPI, String)
* Fix null check in getParameter(OpenAPI, String)