### PR TITLE
Add missing "openapi.properties" files in spring samples

### DIFF
--- a/samples/server/petstore/spring-mvc-j8-async/src/main/resources/openapi.properties
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/resources/openapi.properties
@@ -1,0 +1,2 @@
+springfox.documentation.swagger.v2.path=/api-docs
+#server.port=8090

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/resources/openapi.properties
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/resources/openapi.properties
@@ -1,0 +1,2 @@
+springfox.documentation.swagger.v2.path=/api-docs
+#server.port=8090

--- a/samples/server/petstore/spring-mvc/src/main/resources/openapi.properties
+++ b/samples/server/petstore/spring-mvc/src/main/resources/openapi.properties
@@ -1,0 +1,2 @@
+springfox.documentation.swagger.v2.path=/api-docs
+#server.port=8090


### PR DESCRIPTION
Right now we have problems with the `./bin/spring-all-pestore.sh` in `bin/ensure-up-to-date` (see #80)

Shippable CI is failing with:

```
UNCOMMITTED CHANGES ERROR
There are uncommitted changes in working tree after execution of 'bin/ensure-up-to-date'
HEAD detached from FETCH_HEAD
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	samples/server/petstore/spring-mvc-j8-async/src/main/resources/openapi.properties
	samples/server/petstore/spring-mvc-j8-localdatetime/src/main/resources/openapi.properties
	samples/server/petstore/spring-mvc/src/main/resources/openapi.properties

nothing added to commit but untracked files present (use "git add" to track)
Please run 'bin/ensure-up-to-date' locally and commit changes
```

This PR add the missing files.

