### PR TITLE
 Call super management for managing imports in postProcessModelProperty

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaResteasyEapServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaResteasyEapServerCodegen.java
@@ -147,6 +147,7 @@ public class JavaResteasyEapServerCodegen extends AbstractJavaJAXRSServerCodegen
 
     @Override
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
         // Add imports for Jackson
         if (!BooleanUtils.toBoolean(model.isEnum)) {
             model.imports.add("JsonProperty");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaResteasyEapServerCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaResteasyEapServerCodegenModelTest.java
@@ -1,0 +1,29 @@
+package org.openapitools.codegen.java.jaxrs;
+
+import io.swagger.util.Json;
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.languages.JavaResteasyEapServerCodegen;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class JavaResteasyEapServerCodegenModelTest {
+
+    @Test(description = "convert a simple java model with java8 types")
+    public void mapModelTest() {
+        final Schema model = new Schema()
+                .description("A model with a map")
+                .addProperties("map", new MapSchema());
+
+        final JavaResteasyEapServerCodegen codegen = new JavaResteasyEapServerCodegen();
+        final CodegenModel cm = codegen.fromModel("sample", model, Collections.singletonMap("sample", model));
+
+        assertEquals(cm.vars.get(0).baseType, "Map");
+        assertTrue(cm.imports.contains("HashMap"));
+    }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Call super method for adding default java imports.
Add unit test for asserting import is done when Map property is present.

Must fix [#8168](https://github.com/swagger-api/swagger-codegen/issues/8168)

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

