### PR TITLE
Docker: use correct MAVEN_CONFIG

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ pattern="@Command(name = \"$1\""
 if expr "x$1" : 'x[a-z][a-z-]*$' > /dev/null && fgrep -qe "$pattern" "$cmdsrc"/*.java || expr "$1" = 'help' > /dev/null; then
     # If ${GEN_DIR} has been mapped elsewhere from default, and that location has not been built
     if [[ ! -f "${codegen}" ]]; then
-        (cd "${GEN_DIR}" && exec mvn -am -pl "modules/openapi-generator-cli" -Duser.home=$(dirname MAVEN_CONFIG) package)
+        (cd "${GEN_DIR}" && exec mvn -am -pl "modules/openapi-generator-cli" -Duser.home=$(dirname $MAVEN_CONFIG) package)
     fi
     command=$1
     shift


### PR DESCRIPTION
the variable wasn't used correctly. i always fell back to use `.` as homedir.
