### PR TITLE
Build improvements

### DIFF
--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -65,57 +65,14 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- 3) copy the gradle artifacts to '/target/gradle-artifacts'. -->
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-gradle-artifacts</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.basedir}/target/gradle-artifacts</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${settings.localRepository}/org/openapitools/openapi-generator-gradle-plugin/${project.version}/</directory>
-                                    <filtering>false</filtering>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- 4) change maven-deploy-plugin. -->
+            <!-- 3) disable maven deploy. This wrapper is not needed. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
-                <executions>
-                    <!-- deploying this wrapper is not needed -->
-                    <execution>
-                        <id>default-deploy</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <!-- deploy the jar and the pom from the local maven repo (the one created by gradle) -->
-                    <execution>
-                        <id>custom-deploy</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy-file</goal>
-                        </goals>
-                        <configuration>
-                            <id>sonatype-nexus-snapshots</id>
-                            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                            <file>${project.basedir}/target/gradle-artifacts/openapi-generator-gradle-plugin-${project.version}.jar</file>
-                            <pomFile>${project.basedir}/target/gradle-artifacts/openapi-generator-gradle-plugin-${project.version}.pom</pomFile>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -8,9 +8,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>openapi-generator-gradle-plugin</artifactId>
+    <artifactId>openapi-generator-gradle-plugin-mvn-wrapper</artifactId>
+    <packaging>pom</packaging>
+    <name>openapi-generator-gradle-plugin (maven wrapper)</name>
+    <description>This is a maven wrapper to call gradle during installation phase</description>
 
-    <name>openapi-generator-gradle-plugin (gradle-plugin)</name>
 
     <dependencies>
         <dependency>
@@ -25,7 +27,7 @@
 
             <!-- NOTE: Consider this temporary, as a way to cleanly hook into our pipeline.
                 We've discussed moving the entire project to gradle https://github.com/OpenAPITools/openapi-generator/issues/200, which would avoid this fitting. -->
-            <!-- 1) disable maven install (gradle will install a jar and a pom into the local maven repo) -->
+            <!-- 1) disable maven install. This wrapper is not needed. (gradle will install a jar and a pom into the local maven repo) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
@@ -59,6 +61,58 @@
                                 <task>build</task>
                                 <task>publishToMavenLocal</task>
                             </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- 3) copy the gradle artifacts to '/target/gradle-artifacts'. -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-gradle-artifacts</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/gradle-artifacts</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${settings.localRepository}/org/openapitools/openapi-generator-gradle-plugin/${project.version}/</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- 4) change maven-deploy-plugin. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <executions>
+                    <!-- deploying this wrapper is not needed -->
+                    <execution>
+                        <id>default-deploy</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                    <!-- deploy the jar and the pom from the local maven repo (the one created by gradle) -->
+                    <execution>
+                        <id>custom-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy-file</goal>
+                        </goals>
+                        <configuration>
+                            <id>sonatype-nexus-snapshots</id>
+                            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                            <file>${project.basedir}/target/gradle-artifacts/openapi-generator-gradle-plugin-${project.version}.jar</file>
+                            <pomFile>${project.basedir}/target/gradle-artifacts/openapi-generator-gradle-plugin-${project.version}.pom</pomFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -24,7 +24,17 @@
         <plugins>
 
             <!-- NOTE: Consider this temporary, as a way to cleanly hook into our pipeline.
-                We've discussed moving the entire project to gradle, which would avoid this fitting. -->
+                We've discussed moving the entire project to gradle https://github.com/OpenAPITools/openapi-generator/issues/200, which would avoid this fitting. -->
+            <!-- 1) disable maven install (gradle will install a jar and a pom into the local maven repo) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!-- 2) run gradle -->
             <plugin>
                 <groupId>org.fortasoft</groupId>
                 <artifactId>gradle-maven-plugin</artifactId>

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -11,7 +11,7 @@ Add to your `build->plugins` section (default phase is `generate-sources` phase)
 <plugin>
     <groupId>org.openapitools</groupId>
     <artifactId>openapi-generator-maven-plugin</artifactId>
-    <version>2.3.1</version>
+    <version>3.0.0</version>
     <executions>
         <execution>
             <goals>


### PR DESCRIPTION
* Docs: set version to 3.0.0  in the Readme of `openapi-generator-maven-plugin`
* Changes "openapi-generator-gradle-plugin" 
  - Change artifactId to avoid confusion between the real gradle plugin and the maven wrapper that calls gradle.
  - Disable maven-install-plugin for the wrapper
  - Disable maven-deploy-plugin for the wrapper