### PR TITLE
Update typescript-angularjs to generate top level enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angularjs/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angularjs/model.mustache
@@ -8,6 +8,16 @@ import * as models from './models';
  * {{{description}}}
  */
 {{/description}}
+{{#isEnum}}
+export enum {{{classname}}} {
+{{#allowableValues}}
+{{#enumVars}}
+    {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
+{{/enumVars}}
+{{/allowableValues}}
+}
+{{/isEnum}}
+{{^isEnum}}
 export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{#vars}}
 {{#description}}
@@ -26,7 +36,7 @@ export namespace {{classname}} {
     export enum {{enumName}} {
     {{#allowableValues}}
     {{#enumVars}}
-        {{{name}}} = <any> {{{value}}}{{^-last}},{{/-last}}
+        {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
     {{/enumVars}}
     {{/allowableValues}}
     }
@@ -34,5 +44,6 @@ export namespace {{classname}} {
 {{/vars}}
 }
 {{/hasEnums}}
+{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/typescript-angularjs/.openapi-generator/VERSION
+++ b/samples/client/petstore/typescript-angularjs/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-3.0.0-SNAPSHOT
+unset

--- a/samples/client/petstore/typescript-angularjs/model/Order.ts
+++ b/samples/client/petstore/typescript-angularjs/model/Order.ts
@@ -29,8 +29,8 @@ export interface Order {
 
 export namespace Order {
     export enum StatusEnum {
-        Placed = <any> 'placed',
-        Approved = <any> 'approved',
-        Delivered = <any> 'delivered'
+        Placed = 'placed',
+        Approved = 'approved',
+        Delivered = 'delivered'
     }
 }

--- a/samples/client/petstore/typescript-angularjs/model/Pet.ts
+++ b/samples/client/petstore/typescript-angularjs/model/Pet.ts
@@ -29,8 +29,8 @@ export interface Pet {
 
 export namespace Pet {
     export enum StatusEnum {
-        Available = <any> 'available',
-        Pending = <any> 'pending',
-        Sold = <any> 'sold'
+        Available = 'available',
+        Pending = 'pending',
+        Sold = 'sold'
     }
 }


### PR DESCRIPTION
Enums previously were generated as empty interfaces. They are now generated
as proper first class enum objects in typescript.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc: @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny

### Description of the PR

Adds support for generating top level enums in TypeScript.
