### PR TITLE
Fix subResourcePath when using tags in java-jersey

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
@@ -159,6 +159,19 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
         if (useTags) {
+            String basePath = resourcePath;
+            if (basePath.startsWith("/")) {
+                basePath = basePath.substring(1);
+            }
+            int pos = basePath.indexOf("/");
+            if (pos > 0) {
+                basePath = basePath.substring(0, pos);
+            }
+
+            if (co.path.startsWith("/" + basePath)) {
+                co.path = co.path.substring(("/" + basePath).length());
+            }
+            co.subresourceOperation = !co.path.isEmpty();
             super.addOperationToGroup(tag, resourcePath, operation, co, operations);
         } else {
             String basePath = resourcePath;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
I am porting this PR over from swagger-codegen

The java jersey useTags option added in #6278 breaks functionality for subResourcePaths (@PATH is only added to the class route, not each method), this causes conflicts on startup as swagger-core assumes every method in the class is using the same path, and flags "conflicting methods" when all other annotations are identical (ie http type and @produces and @consumes).

View https://github.com/swagger-api/swagger-codegen/compare/master...tht13:java-jersey-tags-path-issue?expand=1#diff-f6306c950fed66746e045d2f532af0e6 for an example of the missing @PATH annotations

@wing328 