### PR TITLE
feat(security): add cookie-auth support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenSecurity.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenSecurity.java
@@ -30,7 +30,7 @@ public class CodegenSecurity {
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
     // ApiKey specific
     public String keyParamName;
-    public Boolean isKeyInQuery, isKeyInHeader;
+    public Boolean isKeyInQuery, isKeyInHeader, isKeyInCookie;
     // Oauth specific
     public String flow, authorizationUrl, tokenUrl;
     public List<Map<String, Object>> scopes;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2801,12 +2801,13 @@ public class DefaultCodegen implements CodegenConfig {
                 cs.isApiKey = true;
                 cs.keyParamName = securityScheme.getName();
                 cs.isKeyInHeader = securityScheme.getIn() == SecurityScheme.In.HEADER;
-                cs.isKeyInQuery = !cs.isKeyInHeader;
+                cs.isKeyInQuery = securityScheme.getIn() == SecurityScheme.In.QUERY;
+                cs.isKeyInCookie = securityScheme.getIn() == SecurityScheme.In.COOKIE;  //it assumes a validation step prior to generation. (cookie-auth supported from OpenAPI 3.0.0)
             } else if (SecurityScheme.Type.HTTP.equals(securityScheme.getType())) {
-                cs.isKeyInHeader = cs.isKeyInQuery = cs.isApiKey = cs.isOAuth = false;
+                cs.isKeyInHeader = cs.isKeyInQuery = cs.isKeyInCookie = cs.isApiKey = cs.isOAuth = false;
                 cs.isBasic = true;
             } else if (SecurityScheme.Type.OAUTH2.equals(securityScheme.getType())) {
-                cs.isKeyInHeader = cs.isKeyInQuery = cs.isApiKey = cs.isBasic = false;
+                cs.isKeyInHeader = cs.isKeyInQuery = cs.isKeyInCookie = cs.isApiKey = cs.isBasic = false;
                 cs.isOAuth = true;
                 final OAuthFlows flows = securityScheme.getFlows();
                 if (securityScheme.getFlows() == null) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

It adds cookie-auth support as specified in the [spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject)  

It relates to issue #208 

### Test performed
run the codegen with `-DdebugOperations=true` on an OpenAPI spec file with cookie auth.

input:

    ...
    securitySchemes:
      user_creator:
        type: apiKey
        in: cookie
        name: JSESSIONID
    ....

output:
   
    ...
    "authMethods" : [ {
        "name" : "user_creator",
        "type" : "apiKey",
        "hasMore" : false,
        "isBasic" : false,
        "isOAuth" : false,
        "isApiKey" : true,
        "vendorExtensions" : { },
        "keyParamName" : "JSESSIONID",
        "isKeyInQuery" : false,
        "isKeyInHeader" : false,
        "isKeyInCookie" : true,
        "isCode" : false,
        "isPassword" : false,
        "isApplication" : false,
        "isImplicit" : false
      } ]
    ....
