### PR TITLE
[Java][RestTemplate] Fix query parameter URL encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -528,6 +528,7 @@ public class ApiClient {
         
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
         if (queryParams != null) {
+            //encode the query parameters in case they contain unsafe characters
             for (List<String> values : queryParams.values()) {
                 if (values != null) {
                     for (int i = 0; i < values.size(); i++) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -527,6 +528,17 @@ public class ApiClient {
         
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
         if (queryParams != null) {
+            for (List<String> values : queryParams.values()) {
+                if (values != null) {
+                    for (int i = 0; i < values.size(); i++) {
+                        try {
+                            values.set(i, URLEncoder.encode(values.get(i), "utf8"));
+                        } catch (UnsupportedEncodingException e) {
+
+                        }
+                    }
+                }
+            }
             builder.queryParams(queryParams);
         }
         

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -520,6 +521,18 @@ public class ApiClient {
         
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
         if (queryParams != null) {
+            //encode the query parameters in case they contain unsafe characters
+            for (List<String> values : queryParams.values()) {
+                if (values != null) {
+                    for (int i = 0; i < values.size(); i++) {
+                        try {
+                            values.set(i, URLEncoder.encode(values.get(i), "utf8"));
+                        } catch (UnsupportedEncodingException e) {
+
+                        }
+                    }
+                }
+            }
             builder.queryParams(queryParams);
         }
         

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -516,6 +516,7 @@ public class ApiClient {
         
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
         if (queryParams != null) {
+            //encode the query parameters in case they contain unsafe characters
             for (List<String> values : queryParams.values()) {
                 if (values != null) {
                     for (int i = 0; i < values.size(); i++) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -515,6 +516,17 @@ public class ApiClient {
         
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
         if (queryParams != null) {
+            for (List<String> values : queryParams.values()) {
+                if (values != null) {
+                    for (int i = 0; i < values.size(); i++) {
+                        try {
+                            values.set(i, URLEncoder.encode(values.get(i), "utf8"));
+                        } catch (UnsupportedEncodingException e) {
+
+                        }
+                    }
+                }
+            }
             builder.queryParams(queryParams);
         }
         


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for #249.

add URL encoding to every query parameter string in case it has unsafe character before building it into the request entity.

CI test on my branch has passed.

