### PR TITLE
[cpp-qt5] Fix memory leaks in Pet Store client sample

### DIFF
--- a/samples/client/petstore/cpp-qt5/PetStore/main.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/main.cpp
@@ -3,10 +3,6 @@
 
 int main(int argc, char *argv[]) {
     QCoreApplication a(argc, argv);
-
     PetApiTests::runTests();
-
-
-
     return a.exec();
 }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the correct branch: Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Allow generated code to do cleanup of allocated memory by preventing premature loop exit.
The generated code has the possibility to delete all memory allocations from itself but the sample client is terminating the loop before allowing the callback to return and memory de-allocation to take place.
With this change the callback from the timer and response schedule an event to the eventloop and then perform the clean up after which the exit is done.

Tests
- [X] Running valgrind on the PetStore Client sample binary produces no warning of memory leak.

@stkrwork @MartinDelille @ravinikam @fvarose 

