### PR TITLE
Updates README based on new release changes

### DIFF
--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -5,6 +5,12 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/releases/"
+        }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -35,6 +41,12 @@ targetCompatibility = 1.8
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/releases/"
+    }
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
 }
 
 dependencies {

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/README.md
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/README.md
@@ -2,7 +2,7 @@
 
 This example assumes you have Gradle 4.7+ installed. No gradle wrapper is provided in samples.
 
-First, publish the openapi-generator-gradle-plugin locally via `sh gradlew build publishToMavenLocal` in the module directory.
+First, publish the openapi-generator-gradle-plugin locally via `./gradlew assemble install` in the module directory.
 
 Then, run the following tasks in this example directory.
 
@@ -11,4 +11,10 @@ gradle openApiGenerate
 gradle openApiMeta
 gradle openApiValidate
 gradle buildGoSdk
+```
+
+The samples can be tested against other versions of the plugin using the `openApiGeneratorVersion` property. For example:
+
+```bash
+gradle -PopenApiGeneratorVersion=3.0.1-SNAPSHOT openApiValidate
 ```

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -13,7 +13,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:3.0.0-SNAPSHOT"
+        // Updated version can be passed via command line arg as -PopenApiGeneratorVersion=VERSION
+        classpath "org.openapitools:openapi-generator-gradle-plugin:$openApiGeneratorVersion"
     }
 }
 

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle.properties
@@ -1,0 +1,1 @@
+openApiGeneratorVersion=3.0.1-SNAPSHOT


### PR DESCRIPTION
The release management changes moved from maven-publish (newer plugin)
to maven (older plugin, only one that works currently with signing).
This updates docs in the samples/local-spec project with current
directions.

Also:

* Includes sonatype releases/snapshots on repo lookup
* Adds openApiGeneratorVersion property

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

