### PR TITLE
[cli] Enable recommendations on validate command

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
@@ -21,7 +21,9 @@ import io.airlift.airline.Command;
 import io.airlift.airline.Option;
 
 import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.openapitools.codegen.utils.ModelUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -34,26 +36,58 @@ public class Validate implements Runnable {
             description = "location of the OpenAPI spec, as URL or file (required)")
     private String spec;
 
+    @Option(name = { "--recommend"}, title = "recommend spec improvements")
+    private Boolean recommend;
+
     @Override
     public void run() {
         System.out.println("Validating spec (" + spec + ")");
 
         SwaggerParseResult result = new OpenAPIParser().readLocation(spec, null, null);
         List<String> messageList = result.getMessages();
-        Set<String> messages = new HashSet<String>(messageList);
+        Set<String> errors = new HashSet<String>(messageList);
+        Set<String> warnings = new HashSet<String>();
 
-        if (messages.size() > 0) {
-            StringBuilder sb = new StringBuilder();
-            sb.append(System.lineSeparator());
-            for (String message : messages) {
-                sb.append(String.format("\t- %s%s", message, System.lineSeparator()));
+        StringBuilder sb = new StringBuilder();
+        OpenAPI specification = result.getOpenAPI();
+
+        if (Boolean.TRUE.equals(recommend)) {
+            if (specification != null) {
+                // Add information about unused models to the warnings set.
+                List<String> unusedModels = ModelUtils.getUnusedSchemas(specification);
+                if (unusedModels != null) {
+                    unusedModels.forEach(name -> warnings.add("Unused model: " + name));
+                }
             }
+        }
+
+        if (errors.size() > 0) {
+            sb.append("Errors:").append(System.lineSeparator());
+            errors.forEach(msg ->
+                    sb.append("\t-").append(msg).append(System.lineSeparator())
+            );
+        }
+
+        if (!warnings.isEmpty()) {
+            sb.append("Warnings: ").append(System.lineSeparator());
+            warnings.forEach(msg ->
+                    sb.append("\t-").append(msg).append(System.lineSeparator())
+            );
+        }
+
+        if (!errors.isEmpty()) {
             sb.append(System.lineSeparator());
-            sb.append("[error] Spec is invalid.");
+            sb.append("[error] Spec has ").append(errors.size()).append(" errors.");
             System.err.println(sb.toString());
             System.exit(1);
+        } else if (!warnings.isEmpty()) {
+            sb.append(System.lineSeparator());
+            sb.append("[info] Spec has ").append(warnings.size()).append(" recommendation(s).");
         } else {
-            System.out.println("No validation errors detected.");
+            // we say "issues" here rather than "errors" to account for both errors and issues.
+            sb.append("No validation issues detected.");
         }
+
+        System.out.println(sb.toString());
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

see #142

Adds a `--recommend` option to cli's `validate`.

`validate` with no switches has no functional change; it will print errors and exit with status code 1.

`validate --recommends` will work in the following way:

* If spec has errors + recommendations, output is written to stderr and exit code is 1
* If spec has no errors but recommendations, output is written to stdout, and exit code is 0

In all cases, no errors/recommendations outputs a message that there are no issues and status code is 0.

Sample spec:

```
openapi: "3.0.0"
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /:
    get:
      responses:
        '200':
          description: A paged array of pets
          headers:
            x-next:
              description: A link to the next page of responses
              schema:
                type: string
components:
  schemas:
    Pet:
      required:
        - id
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
        tag:
          type: string
    Pets:
      type: array
      items:
        $ref: "#/components/schemas/Pet"
    Error:
      required:
        - code
        - message
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
```

Sample command(s):

```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar validate --input-spec invalid.yaml --recommend

java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar validate --input-spec invalid.yaml
```

Sample output:

```
Validating spec (.bak/invalid.yaml)
Errors:
	-attribute info is missing

[error] Spec has 1 errors.
```

```
Validating spec (.bak/invalid.yaml)
Errors:
	-attribute info is missing
Warnings:
	-Unused model: Pets
	-Unused model: Error
	-Unused model: Pet

[error] Spec has 1 errors.
```

note: output is almost identical to error/warnings from #251. There's possibly opportunity there once both are merged to combine outputs.