### PR TITLE
Configuration option to disable HTML escaping when using Gson

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -62,6 +62,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String SUPPORT_ASYNC = "supportAsync";
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
+    public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
 
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
@@ -93,7 +94,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected boolean serializeBigDecimalAsString = false;
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
-    protected boolean supportJava6 = false;
+    protected boolean supportJava6= false;
+    protected boolean disableHtmlEscaping = false;
 
     public AbstractJavaCodegen() {
         super();
@@ -185,6 +187,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         java8Mode.setEnum(java8ModeOptions);
         cliOptions.add(java8Mode);
 
+        cliOptions.add(CliOption.newBoolean(DISABLE_HTML_ESCAPING, "Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)"));
     }
 
     @Override
@@ -196,6 +199,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
         additionalProperties.put(SUPPORT_JAVA6, supportJava6);
 
+        if (additionalProperties.containsKey(DISABLE_HTML_ESCAPING)) {
+            this.setDisableHtmlEscaping(Boolean.valueOf(additionalProperties.get(DISABLE_HTML_ESCAPING).toString()));
+        }
+        additionalProperties.put(DISABLE_HTML_ESCAPING, disableHtmlEscaping);
 
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             this.setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
@@ -1220,6 +1227,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     public void setSupportAsync(boolean enabled) {
         this.supportAsync = enabled;
+    }
+
+    public void setDisableHtmlEscaping(boolean disabled) {
+        this.disableHtmlEscaping = disabled;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/Java/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/JSON.mustache
@@ -76,7 +76,11 @@ public class JSON {
           })
         {{/parent}}
         ;
-        return fireBuilder.createGsonBuilder();
+        GsonBuilder builder = fireBuilder.createGsonBuilder();
+        {{#disableHtmlEscaping}}
+        builder.disableHtmlEscaping();
+        {{/disableHtmlEscaping}}
+        return builder;
     }
 
     private static String getDiscriminatorValue(JsonElement readElement, String discriminatorField) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,8 @@ public class JSON {
             }
           })
         ;
-        return fireBuilder.createGsonBuilder();
+        GsonBuilder builder = fireBuilder.createGsonBuilder();
+        return builder;
     }
 
     private static String getDiscriminatorValue(JsonElement readElement, String discriminatorField) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,8 @@ public class JSON {
             }
           })
         ;
-        return fireBuilder.createGsonBuilder();
+        GsonBuilder builder = fireBuilder.createGsonBuilder();
+        return builder;
     }
 
     private static String getDiscriminatorValue(JsonElement readElement, String discriminatorField) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/JSON.java
@@ -64,7 +64,8 @@ public class JSON {
             }
           })
         ;
-        return fireBuilder.createGsonBuilder();
+        GsonBuilder builder = fireBuilder.createGsonBuilder();
+        return builder;
     }
 
     private static String getDiscriminatorValue(JsonElement readElement, String discriminatorField) {


### PR DESCRIPTION
Already merged into swagger-codegen, see [7966](https://github.com/swagger-api/swagger-codegen/pull/7966 ).