### PR TITLE
[typescript] fix cast problem

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -325,13 +325,10 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         } else if (ModelUtils.isDateTimeSchema(p)) {
             return UNDEFINED_VALUE;
         } else if (ModelUtils.isNumberSchema(p)) {
-            if  (p instanceof  NumberSchema ){
-                NumberSchema dp = (NumberSchema) p;
-                if (dp.getDefault() != null) {
-                    return dp.getDefault().toString();
-                }
-            }
-            return UNDEFINED_VALUE;
+           if (p.getDefault() != null) {
+             return p.getDefault().toString();
+           }
+           return UNDEFINED_VALUE;
         } else if (ModelUtils.isIntegerSchema(p)) {
             if (p.getDefault() != null) {
                 return p.getDefault().toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -325,9 +325,11 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         } else if (ModelUtils.isDateTimeSchema(p)) {
             return UNDEFINED_VALUE;
         } else if (ModelUtils.isNumberSchema(p)) {
-            NumberSchema dp = (NumberSchema) p;
-            if (dp.getDefault() != null) {
-                return dp.getDefault().toString();
+            if  (p instanceof  NumberSchema ){
+                NumberSchema dp = (NumberSchema) p;
+                if (dp.getDefault() != null) {
+                    return dp.getDefault().toString();
+                }
             }
             return UNDEFINED_VALUE;
         } else if (ModelUtils.isIntegerSchema(p)) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/masterCONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01)
### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
In same  cases there is error when generate typescript-angular
Exception: io.swagger.v3.oas.models.media.Schema cannot be cast to io.swagger.v3.oas.models.media.NumberSchema
	at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:934)
	at org.openapitools.codegen.DefaultGenerator.processPaths(DefaultGenerator.java:825)
	at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:460)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:786)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:315)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:58)
Caused by: java.lang.ClassCastException: io.swagger.v3.oas.models.media.Schema cannot be cast to io.swagger.v3.oas.models.media.NumberSchema
	at org.openapitools.codegen.languages.AbstractTypeScriptClientCodegen.toDefaultValue(AbstractTypeScriptClientCodegen.java:328)
	at org.openapitools.codegen.DefaultCodegen.fromProperty(DefaultCodegen.java:1609)
	at org.openapitools.codegen.DefaultCodegen.fromParameter(DefaultCodegen.java:2530)
	at org.openapitools.codegen.DefaultCodegen.fromOperation(DefaultCodegen.java:2221)
	at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:902)
	... 5 more


