### PR TITLE
CI: prevent ELM to run on Shippable

### DIFF
--- a/CI/pom.xml.shippable
+++ b/CI/pom.xml.shippable
@@ -840,7 +840,7 @@
             </modules>
         </profile>
         <profile>
-            <id>samples</id>
+            <id>samples.shippable</id>
             <activation>
                 <property>
                     <name>env</name>

--- a/shippable.yml
+++ b/shippable.yml
@@ -31,6 +31,6 @@ build:
     - elixir --version
     - mix --version
     # test samples defined in pom.xml
-    - mvn --quiet verify -P samples -f CI/pom.xml.shippable
+    - mvn --quiet verify -P samples.shippable -f CI/pom.xml.shippable
     # generate all petstore samples (client, servers, doc)
     - ./bin/run-all-petstore


### PR DESCRIPTION
Reported by @wing328 on Gitter:

> I wonder if you can take a look at https://app.shippable.com/github/OpenAPITools/openapi-generator/runs/772/1/console
the error is related to elm
but there's no elm in `CI/pom.xml.shippable`...

Error:

```
Compiling src/Main.elm
./elm-compile-test: line 7: elm: command not found
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.2.1:exec (bundle-test) on project ElmClientTests: Command execution failed.: Process exited with an error: 127 (Exit value: 127) -> [Help 1]
```


This is probably a side effect of the change I have made in #280 to solve this error:

> [ERROR] [FATAL] Non-resolvable parent POM for org.openapitools:openapi-generator-cli:[unknown-version]: Could not find artifact org.openapitools:openapi-generator-project:pom:3.0.1 in sonatype-snapshots (https://oss.sonatype.org/content/repositories/snapshots) and 'parent.relativePath' points at wrong local POM @ line 3, column 11

Change made in #280:

I needed to call the main POM: `/pom.xml` from `CI/pom.xml.shippable` in order to build the missing module.

It probably introduces the observed side-effect in https://app.shippable.com/github/OpenAPITools/openapi-generator/runs/772/1/console

---

This PR changes the profile name for Shippable from `samples` to `samples.shippable`.

Changed files:

* `CI/pom.xml.shippable` : new definition
* `shippable.yaml` : activate the correct profile with `-P`
