### PR TITLE
Use case sensitivity when checking reserved words

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -48,7 +48,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         importMapping.clear();
 
         supportsInheritance = true;
-        setReservedWordsLowerCase(Arrays.asList(
+        
+        // NOTE: TypeScript uses camel cased reserved words, while models are title cased. We don't want lowercase comparisons.
+        reservedWords.addAll(Arrays.asList(
                 // local variable names used in API methods (endpoints)
                 "varLocalPath", "queryParameters", "headerParams", "formParams", "useFormData", "varLocalDeferred",
                 "requestOptions",
@@ -343,6 +345,12 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             return UNDEFINED_VALUE;
         }
 
+    }
+    
+    @Override
+    protected boolean isReservedWord(String word) {
+        // NOTE: This differs from super's implementation in that TypeScript does _not_ want case insensitive matching.
+        return reservedWords.contains(word);
     }
 
     @Override


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Open API generator previously wasn't case sensitive when checking for reserved words in the typescript generator. This will allow us to have the "Package" model in ProductCatalogs without needing to rename anything. Related issue: https://github.com/OpenAPITools/openapi-generator/issues/349

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny
