### PR TITLE
Consider ComposedSchema in DefaultCodegen#fromRequestBody(..)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4226,7 +4226,7 @@ public class DefaultCodegen implements CodegenConfig {
                 codegenProperty = codegenProperty.items;
             }
 
-        } else if (ModelUtils.isObjectSchema(schema)) {
+        } else if (ModelUtils.isObjectSchema(schema) || ModelUtils.isComposedSchema(schema)) {
             CodegenModel codegenModel = null;
             if (StringUtils.isNotBlank(name)) {
                 schema.setName(name);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -19,6 +19,9 @@ package org.openapitools.codegen.java;
 
 import com.google.common.collect.ImmutableMap;
 
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
@@ -28,6 +31,7 @@ import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 
 import org.openapitools.codegen.CodegenConstants;
@@ -37,6 +41,7 @@ import org.openapitools.codegen.CodegenModelType;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.languages.JavaClientCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -303,6 +308,17 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "org.openapitools.client.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.mmmmm");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.mmmmm");
+    }
+
+    @Test
+    public void testGetSchemaTypeWithComposedSchemaWithAllOf() {
+        final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/2_0/composed-allof.yaml", null, new ParseOptions()).getOpenAPI();
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+
+        Operation operation = openAPI.getPaths().get("/ping").getPost();
+        CodegenOperation co = codegen.fromOperation("/ping", "POST", operation, ModelUtils.getSchemas(openAPI), openAPI);
+        Assert.assertEquals(co.allParams.size(), 1);
+        Assert.assertEquals(co.allParams.get(0).baseType, "MessageEventCoreWithTimeListEntries");
     }
 
     private CodegenParameter createPathParam(String name) {

--- a/modules/openapi-generator/src/test/resources/2_0/composed-allof.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/composed-allof.yaml
@@ -1,0 +1,53 @@
+swagger: "2.0"
+info:
+  version: "2"
+  title: "Test API"
+basePath: "/xx2"
+consumes:
+- "application/json"
+produces:
+- "application/json"
+paths:
+  /ping:
+    post:
+      tags:
+        - Messaging
+      summary: Add a message event to the given message calendar
+      operationId: addMessageEventToMessageCalendar
+      parameters:
+        - in: body
+          name: new-message-event
+          required: true
+          schema:
+            $ref: "#/definitions/MessageEventCoreWithTimeListEntries"
+      responses:
+        200:
+          description: OK
+definitions:
+  MessageEventCoreWithTimeListEntries:
+    type: object
+    description: "Base of a message event with Time List entries"
+    allOf:
+      - $ref: "#/definitions/MessageEventCore"
+      - type: object
+        required:
+          - timeListEntries
+        properties:
+          timeListEntries:
+            type: array
+            items:
+              $ref: "#/definitions/TimeListEntry"
+  MessageEventCore:
+    type: object
+    properties:
+      id:
+        type: integer
+      message:
+        type: string
+  TimeListEntry:
+    type: object
+    properties:
+      p1:
+        type: string
+      p2:
+        type: string


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This is a fix for #192.

In `DefaultCodegen#fromRequestBody(..)` the composed-schema case was going through the default else case.

https://github.com/OpenAPITools/openapi-generator/blob/231202d0a3b4602e5b20e853c62a49446c1db200/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L4247-L4271

In my opinion, the composed-schema is more like the object case. This is why I have added `|| ModelUtils.isComposedSchema(schema)` to the else condition here:

https://github.com/OpenAPITools/openapi-generator/blob/231202d0a3b4602e5b20e853c62a49446c1db200/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java#L4229-L4247

A unit test with the spec provided in #192 is added to the change to demonstrate the effect of the change.

