### PR TITLE
openapi-generator-gradle-plugin-mvn-wrapper should not be uploaded

### DIFF
--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -23,19 +23,28 @@
     </dependencies>
 
     <build>
-        <plugins>
+        <!-- NOTE: Consider this temporary, as a way to cleanly hook into our pipeline.
+            We've discussed moving the entire project to gradle https://github.com/OpenAPITools/openapi-generator/issues/200, which would avoid this fitting. -->
+        <pluginManagement>
+            <plugins>
+                <!-- 1) disable maven install. This wrapper is not needed. (gradle will install a jar and a pom into the local maven repo) -->
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <!-- 3) disable maven deploy. This wrapper is not needed. -->
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 
-            <!-- NOTE: Consider this temporary, as a way to cleanly hook into our pipeline.
-                We've discussed moving the entire project to gradle https://github.com/OpenAPITools/openapi-generator/issues/200, which would avoid this fitting. -->
-            <!-- 1) disable maven install. This wrapper is not needed. (gradle will install a jar and a pom into the local maven repo) -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
+        <plugins>
             <!-- 2) run gradle -->
             <plugin>
                 <groupId>org.fortasoft</groupId>
@@ -64,15 +73,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <!-- 3) disable maven deploy. This wrapper is not needed. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -13,6 +13,9 @@
     <name>openapi-generator-gradle-plugin (maven wrapper)</name>
     <description>This is a maven wrapper to call gradle during installation phase</description>
 
+    <properties>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+    </properties>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
The file [`modules/openapi-generator-gradle-plugin/pom.xml`](https://github.com/OpenAPITools/openapi-generator/blob/4664c07034fac99cfb6354fae6301d85f4f96810/modules/openapi-generator-gradle-plugin/pom.xml) defines the `openapi-generator-gradle-plugin-mvn-wrapper` that is just a maven pom to start gradle. Gradle is creating, installing, and deploying the  real `openapi-generator-gradle-plugin` artifact.

---

The idea of #202 was to create this artifact and to prevent to install and to deploy the `openapi-generator-gradle-plugin-mvn-wrapper`.

In some travis log you see: 
```
[INFO] --- maven-deploy-plugin:2.8.2:deploy (default-deploy) @ openapi-generator-gradle-plugin-mvn-wrapper ---
[INFO] Skipping artifact deployment
```
Example: https://api.travis-ci.org/v3/job/394868611/log.txt

But this does not work, because you see the artifact online:
https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/

And also on maven central:
http://central.maven.org/maven2/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/

----

So I had to figure out what went wrong.

In this log you see: https://api.travis-ci.org/v3/job/394867936/log.txt
```
[INFO] --- nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy) @ openapi-generator-gradle-plugin-mvn-wrapper ---
[INFO] Performing deferred deploys (gathering into "/home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred")...
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-gradle-plugin/pom.xml to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/openapi-generator-gradle-plugin-mvn-wrapper-3.0.3-SNAPSHOT.pom
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-gradle-plugin/target/openapi-generator-gradle-plugin-mvn-wrapper-3.0.3-SNAPSHOT.pom.asc to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/openapi-generator-gradle-plugin-mvn-wrapper-3.0.3-SNAPSHOT.pom.asc
[INFO] Execution skipped to the last project...

....
....
....

[INFO] --- nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy) @ openapi-generator-online ---
[INFO] Performing deferred deploys (gathering into "/home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred")...
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT.jar to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT.jar
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/pom.xml to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT.pom
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT-javadoc.jar to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT-javadoc.jar
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT-sources.jar to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT-sources.jar
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT.jar.asc to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT.jar.asc
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT.pom.asc to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT.pom.asc
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT-javadoc.jar.asc to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT-javadoc.jar.asc
[INFO] Installing /home/travis/build/OpenAPITools/openapi-generator/modules/openapi-generator-online/target/openapi-generator-online-3.0.3-SNAPSHOT-sources.jar.asc to /home/travis/build/OpenAPITools/openapi-generator/target/nexus-staging/deferred/org/openapitools/openapi-generator-online/3.0.3-SNAPSHOT/openapi-generator-online-3.0.3-SNAPSHOT-sources.jar.asc
[INFO] Deploying remotely...
[INFO] Bulk deploying locally gathered artifacts from directory: 
[INFO]  * Bulk deploying locally gathered snapshot artifacts
...
[INFO] Downloading from ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/maven-metadata.xml
[INFO] Downloaded from ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/maven-metadata.xml (813 B at 3.2 kB/s)
[INFO] Uploading to ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/openapi-generator-gradle-plugin-mvn-wrapper-3.0.3-20180621.062100-5.pom
[INFO] Uploaded to ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/openapi-generator-gradle-plugin-mvn-wrapper-3.0.3-20180621.062100-5.pom (3.3 kB at 9.8 kB/s)
[INFO] Downloading from ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/maven-metadata.xml
[INFO] Downloaded from ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/maven-metadata.xml (459 B at 1.7 kB/s)
[INFO] Uploading to ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/maven-metadata.xml
[INFO] Uploaded to ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/3.0.3-SNAPSHOT/maven-metadata.xml (813 B at 2.3 kB/s)
[INFO] Uploading to ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/maven-metadata.xml
[INFO] Uploaded to ossrh: https://oss.sonatype.org/content/repositories/snapshots/org/openapitools/openapi-generator-gradle-plugin-mvn-wrapper/maven-metadata.xml (459 B at 1.3 kB/s)
```

----

This PR:

* Prevent to force the version of the `maven-install-plugin` and of `maven-deploy-plugin` by disabling the plugins at `pluginManagement` section (instead of the `build` section)
* Set `skipNexusStagingDeployMojo` to `true` in order to prevent the `openapi-generator-gradle-plugin-mvn-wrapper` to be handled by the `nexus-staging-maven-plugin`. Read more here: https://stackoverflow.com/questions/25305850/how-to-disable-nexus-staging-maven-plugin-in-sub-modules