### PR TITLE
[aspnetcore] Add processing of Port defined in spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -21,13 +21,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.samskivert.mustache.Mustache;
 
+import io.swagger.v3.oas.models.OpenAPI;
+
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
-
+import org.openapitools.codegen.utils.URLPathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.net.URL;
 import java.util.*;
 
 import static java.util.UUID.randomUUID;
@@ -42,6 +45,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     protected Logger LOGGER = LoggerFactory.getLogger(AspNetCoreServerCodegen.class);
 
     private boolean useSwashbuckle = true;
+    protected int serverPort = 8080;
+    protected String serverHost = "0.0.0.0";
+
 
     public AspNetCoreServerCodegen() {
         super();
@@ -111,6 +117,13 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     @Override
     public String getHelp() {
         return "Generates an ASP.NET Core Web API server.";
+    }
+    @Override
+    public void preprocessOpenAPI(OpenAPI openAPI) {
+        super.preprocessOpenAPI(openAPI);
+        URL url = URLPathUtils.getServerURL(openAPI);
+        additionalProperties.put("serverHost", url.getHost());
+        additionalProperties.put("serverPort", URLPathUtils.getPort(url, 8080));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/aspnetcore/Program.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/Program.mustache
@@ -24,7 +24,8 @@ namespace {{packageName}}
         /// <returns>Webhost</returns>
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+                .UseStartup<Startup>()                
+                .UseUrls("http://0.0.0.0:{{#serverPort}}{{serverPort}}{{/serverPort}}{{^serverPort}}8080{{/serverPort}}/")
                 .Build();
     }
 }

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Program.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Program.cs
@@ -24,7 +24,8 @@ namespace Org.OpenAPITools
         /// <returns>Webhost</returns>
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+                .UseStartup<Startup>()                
+                .UseUrls("http://0.0.0.0:8080/")
                 .Build();
     }
 }


### PR DESCRIPTION
### PR checklist

- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).

### Description of the PR
Port defined in the spec is processed so that the server is accessible on a predefined port stated in spec instead of default Kestrel port `5000`

Listening on `0.0.0.0` is needed to make the server accessible not only when it is running on host but also inside a docker container.

@mandrean @jimschubert 
