### PR TITLE
[Java] version in the generated README dependent from {{java8}}

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -18,7 +18,7 @@
 ## Requirements
 
 Building the API client library requires:
-1. Java 1.8+
+1. Java {{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}+
 2. Maven/Gradle
 
 ## Installation

--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -18,7 +18,7 @@
 ## Requirements
 
 Building the API client library requires:
-1. Java 1.7+
+1. Java 1.8+
 2. Maven/Gradle
 
 ## Installation

--- a/samples/client/petstore/java/jersey2-java8/README.md
+++ b/samples/client/petstore/java/jersey2-java8/README.md
@@ -12,7 +12,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 ## Requirements
 
 Building the API client library requires:
-1. Java 1.7+
+1. Java 1.8+
 2. Maven/Gradle
 
 ## Installation

--- a/samples/client/petstore/java/vertx/README.md
+++ b/samples/client/petstore/java/vertx/README.md
@@ -12,7 +12,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 ## Requirements
 
 Building the API client library requires:
-1. Java 1.7+
+1. Java 1.8+
 2. Maven/Gradle
 
 ## Installation


### PR DESCRIPTION
Same issue as per https://github.com/swagger-api/swagger-codegen/issues/7259 just need to update the README

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

