### PR TITLE
[aspnetcore] Fix new keyword collection

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -58,7 +58,7 @@ public class CodegenModel {
     public Set<String> allMandatory;
 
     public Set<String> imports = new TreeSet<String>();
-    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren;
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isCollectionModel;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocumentation externalDocumentation;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -58,7 +58,7 @@ public class CodegenModel {
     public Set<String> allMandatory;
 
     public Set<String> imports = new TreeSet<String>();
-    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isCollectionModel;
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocumentation externalDocumentation;
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -218,7 +218,7 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     parent.getChildren().add(cm);
                     if (parent.getDiscriminator() == null) {
-                        parent = allModels.get(parent.parent);
+                        parent = allModels.get(parent.getParent());
                     } else {
                         parent = null;
                     }
@@ -1412,6 +1412,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         if (ModelUtils.isArraySchema(schema)) {
             m.isArrayModel = true;
+            m.isCollectionModel = true;
             m.arrayModelType = fromProperty(name, schema).complexType;
             addParentContainer(m, name, schema);
         } else if (schema instanceof ComposedSchema) {
@@ -1521,6 +1522,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (ModelUtils.isMapSchema(schema)) {
                 addAdditionPropertiesToCodeGenModel(m, schema);
+                m.isCollectionModel = true;
             }
             addVars(m, schema.getProperties(), schema.getRequired());
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1412,7 +1412,6 @@ public class DefaultCodegen implements CodegenConfig {
 
         if (ModelUtils.isArraySchema(schema)) {
             m.isArrayModel = true;
-            m.isCollectionModel = true;
             m.arrayModelType = fromProperty(name, schema).complexType;
             addParentContainer(m, name, schema);
         } else if (schema instanceof ComposedSchema) {
@@ -1522,7 +1521,7 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (ModelUtils.isMapSchema(schema)) {
                 addAdditionPropertiesToCodeGenModel(m, schema);
-                m.isCollectionModel = true;
+                m.isMapModel = true;
             }
             addVars(m, schema.getProperties(), schema.getRequired());
         }

--- a/modules/openapi-generator/src/main/resources/aspnetcore/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/model.mustache
@@ -56,7 +56,7 @@ namespace {{packageName}}.Models
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public {{#parent}}{{^isCollectionModel}}new {{/isCollectionModel}}{{/parent}}string ToJson()
+        public {{#parent}}{{^isMapModel}}{{^isArrayModel}}new {{/isArrayModel}}{{/isMapModel}}{{/parent}}string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }

--- a/modules/openapi-generator/src/main/resources/aspnetcore/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/model.mustache
@@ -56,7 +56,7 @@ namespace {{packageName}}.Models
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public {{#parent}} new {{/parent}}string ToJson()
+        public {{#parent}}{{^isCollectionModel}}new {{/isCollectionModel}}{{/parent}}string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -68,7 +68,7 @@ namespace {{packageName}}.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals(({{classname}})obj);
         }
@@ -80,7 +80,7 @@ namespace {{packageName}}.Models
         /// <returns>Boolean</returns>
         public bool Equals({{classname}} other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return {{#vars}}{{#isNotContainer}}

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/ApiResponse.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/ApiResponse.cs
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((ApiResponse)obj);
         }
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public bool Equals(ApiResponse other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return 

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Category.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Category.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((Category)obj);
         }
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public bool Equals(Category other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return 

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Order.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Order.cs
@@ -122,7 +122,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((Order)obj);
         }
@@ -134,7 +134,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public bool Equals(Order other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return 

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Pet.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Pet.cs
@@ -124,7 +124,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((Pet)obj);
         }
@@ -136,7 +136,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public bool Equals(Pet other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return 

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Tag.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/Tag.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((Tag)obj);
         }
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public bool Equals(Tag other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return 

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/User.cs
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Models/User.cs
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
+            if (obj is null) return false;
             if (ReferenceEquals(this, obj)) return true;
             return obj.GetType() == GetType() && Equals((User)obj);
         }
@@ -121,7 +121,7 @@ namespace Org.OpenAPITools.Models
         /// <returns>Boolean</returns>
         public bool Equals(User other)
         {
-            if (ReferenceEquals(null, other)) return false;
+            if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
             return 


### PR DESCRIPTION
### PR checklist
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Add `isMapModel` to `CodegenModel` to allow distinguishing if a Model is inherited from `ICollection`. 
Small refactor in `model.mustache` to allow removal of some VS hints.

Solves #275 

@mandrean @jimschubert 
cc core team for `DefaultCodegen` and `CodegenModel` Changes
@wing328 @jimschubert @cbornet @jaz-ah @ackintosh @JFCote @jmini 