### PR TITLE
[cpp-qt5] sanitize model names 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
@@ -248,7 +248,7 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
         if (!folder.isEmpty())
             folder += File.separator;
 
-        return "#include \"" + folder + name + ".h\"";
+        return "#include \"" + folder + toModelName(name) + ".h\"";
     }
 
     /**
@@ -285,7 +285,7 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
 
     @Override
     public String toModelFilename(String name) {
-        return modelNamePrefix + initialCaps(name);
+        return initialCaps(toModelName(name));
     }
 
     @Override
@@ -381,7 +381,7 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
     @Override
     public String toModelName(String type) {
         if (type == null) {
-            LOGGER.warn("Model name can't be null. Defaul to 'UnknownModel'.");
+            LOGGER.warn("Model name can't be null. Default to 'UnknownModel'.");
             type = "UnknownModel";
         }
 
@@ -392,30 +392,31 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
                 languageSpecificPrimitives.contains(type)) {
             return type;
         } else {
-            return modelNamePrefix + Character.toUpperCase(type.charAt(0)) + type.substring(1);
+            String typeName = sanitizeName(type);
+            return modelNamePrefix + Character.toUpperCase(typeName.charAt(0)) + typeName.substring(1);
         }
     }
 
     @Override
     public String toVarName(String name) {
         // sanitize name
-        name = sanitizeName(name); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+        String varName = sanitizeName(name); 
 
         // if it's all uppper case, convert to lower case
-        if (name.matches("^[A-Z_]*$")) {
-            name = name.toLowerCase();
+        if (varName.matches("^[A-Z_]*$")) {
+            name = varName.toLowerCase();
         }
 
         // camelize (lower first character) the variable name
         // petId => pet_id
-        name = underscore(name);
+        varName = underscore(varName);
 
         // for reserved word or word starting with number, append _
-        if (isReservedWord(name) || name.matches("^\\d.*")) {
-            name = escapeReservedWord(name);
+        if (isReservedWord(varName) || varName.matches("^\\d.*")) {
+            varName = escapeReservedWord(varName);
         }
 
-        return name;
+        return varName;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
@@ -404,7 +404,7 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
 
         // if it's all uppper case, convert to lower case
         if (varName.matches("^[A-Z_]*$")) {
-            name = varName.toLowerCase();
+            varName = varName.toLowerCase();
         }
 
         // camelize (lower first character) the variable name


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Allows sanitizing of Model names when the Model definition in the spec contains a language significant symbol.
e.g `v1.0.Pet` contains `.` which has a special meaning in C++. 
This would have created a code which had the model name as `class OAIV1.0.Pet { ` which is invalid in C++
PetStore sample not impacted
Solves #281

@stkrwork @MartinDelille @ravinikam 