### PR TITLE
Improve Docker Tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,10 +122,27 @@ after_success:
         popd;
       fi;
     fi;
-  ## docker: build and push openapi-generator-online to DockerHub
-  - if [ $DOCKER_HUB_USERNAME ]; then echo "$DOCKER_HUB_PASSWORD" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin && docker build -t $DOCKER_GENERATOR_IMAGE_NAME ./modules/openapi-generator-online && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_GENERATOR_IMAGE_NAME && echo "Pushed to $DOCKER_GENERATOR_IMAGE_NAME"; fi; fi
-  ## docker: build cli image and push to Docker Hub
-  - if [ $DOCKER_HUB_USERNAME ]; then echo "$DOCKER_HUB_PASSWORD" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin && docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME ./modules/openapi-generator-cli && if [ ! -z "$TRAVIS_TAG" ]; then docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG; fi && if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME && echo "Pushed to $DOCKER_CODEGEN_CLI_IMAGE_NAME"; fi; fi
-
+  ## docker build and push images to DockerHub (openapi-generator-online, openapi-generator-cli)
+  - if [ $DOCKER_HUB_USERNAME ]; then 
+        read -r MVN_VERSION_FOR_DOCKER_TAG < target/ci/version-for-docker-tag.txt
+        echo "Tag for Docker derived from maven version: $MVN_VERSION_FOR_DOCKER_TAG"
+        echo "$DOCKER_HUB_PASSWORD" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
+        if [ ! -z "$TRAVIS_TAG" ]; then
+          docker build -t $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG -t $DOCKER_GENERATOR_IMAGE_NAME:$MVN_VERSION_FOR_DOCKER_TAG ./modules/openapi-generator-online
+          docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG -t $DOCKER_GENERATOR_IMAGE_NAME:$MVN_VERSION_FOR_DOCKER_TAG ./modules/openapi-generator-cli
+        elif [ "$TRAVIS_BRANCH" == "master" ]; then
+          docker build -t $DOCKER_GENERATOR_IMAGE_NAME -t $DOCKER_GENERATOR_IMAGE_NAME:$MVN_VERSION_FOR_DOCKER_TAG ./modules/openapi-generator-online
+          docker build -t $DOCKER_CODEGEN_CLI_IMAGE_NAME -t $DOCKER_GENERATOR_IMAGE_NAME:$MVN_VERSION_FOR_DOCKER_TAG ./modules/openapi-generator-cli
+        else
+          docker build -t $DOCKER_GENERATOR_IMAGE_NAME:$MVN_VERSION_FOR_DOCKER_TAG ./modules/openapi-generator-online
+          docker build -t $DOCKER_GENERATOR_IMAGE_NAME:$MVN_VERSION_FOR_DOCKER_TAG ./modules/openapi-generator-cli
+        fi;
+        if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "3.1.x" ] || [ "$TRAVIS_BRANCH" == "4.0.x" ];
+          docker push $DOCKER_GENERATOR_IMAGE_NAME
+          echo "Pushed to $DOCKER_GENERATOR_IMAGE_NAME"; 
+          docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME
+          echo "Pushed to $DOCKER_CODEGEN_CLI_IMAGE_NAME"; 
+        fi;
+    fi;
 env:
   - DOCKER_GENERATOR_IMAGE_NAME=openapitools/openapi-generator-online DOCKER_CODEGEN_CLI_IMAGE_NAME=openapitools/openapi-generator-cli NODE_ENV=test

--- a/CI/resources/version-for-docker-tag.txt
+++ b/CI/resources/version-for-docker-tag.txt
@@ -1,0 +1,1 @@
+${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.x

--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ To reinstall with the latest master, run `brew reinstall --HEAD openapi-generato
  - [https://hub.docker.com/r/openapitools/openapi-generator-cli/](https://hub.docker.com/r/openapitools/openapi-generator-cli/) (official CLI)
  - [https://hub.docker.com/r/openapitools/openapi-generator-online/](https://hub.docker.com/r/openapitools/openapi-generator-online/) (official web service)
 
+#### Docker tags
+
+`lastest` Tag contains the continuously built version from our `master` branch.
+
+`v0.0.0` Tags correspond to a released version in this git repository. Examples:
+
+* `v3.0.0` Tag
+* `v3.0.1` Tag
+* `v3.0.2` Tag
+
+`0.0.x` Tags correspond to continuously built versions (after each commit), regardless of the branch it is built from. Examples:
+
+* `3.0.x` Tag: contains first `3.0.2-SNAPSHOT` and after the `3.0.2` release it contains `3.0.3-SNAPSHOT` and so on.
+* `3.1.x` Tag: contains first `3.1.0-SNAPSHOT` and after the `3.1.0` release it contains `3.1.1-SNAPSHOT` and so on.
+* `4.0.x` Tag: contains first `4.0.0-SNAPSHOT` and after the `4.0.0` release it contains `4.0.1-SNAPSHOT` and so on.
+
 
 #### OpenAPI Generator CLI Docker Image
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,41 @@
         <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>parse-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/CI/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>net.revelc.code</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
                 <!-- Uncomment this to format before checkstyle -->


### PR DESCRIPTION
This PR improve the way Docker-Tags are made. See the discussion in #364.

In addition to what we have now (`latest` and tags for version), new tags for `SNAPSHOT` version are introduced:

* `3.0.x` Tag: contains first `3.0.2-SNAPSHOT` and after the `3.0.2` release it contains `3.0.3-SNAPSHOT` and so on.
* `3.1.x` Tag: contains first `3.1.0-SNAPSHOT` and after the `3.1.0` release it contains `3.1.1-SNAPSHOT` and so on.
* `4.0.x` Tag: contains first `4.0.0-SNAPSHOT` and after the `4.0.0` release it contains `4.0.1-SNAPSHOT` and so on.