### PR TITLE
[rust-server] Update to error-chain 0.12

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -47,4 +47,4 @@ uuid = {version = "0.5", optional = true, features = ["serde", "v4"]}
 
 [dev-dependencies]
 clap = "2.25"
-error-chain = "0.11"
+error-chain = "0.12"

--- a/pom.xml
+++ b/pom.xml
@@ -959,7 +959,7 @@
                 <module>samples/client/petstore/typescript-angular-v4.3/npm</module>
                 <!--<module>samples/client/petstore/bash</module>-->
                 <module>samples/client/petstore/ruby</module>
-                <!--<module>samples/server/petstore/rust-server</module>-->
+                <module>samples/server/petstore/rust-server</module>
             </modules>
         </profile>
         <profile>

--- a/samples/server/petstore/rust-server/Cargo.toml
+++ b/samples/server/petstore/rust-server/Cargo.toml
@@ -45,4 +45,4 @@ serde-xml-rs = {git = "git://github.com/Metaswitch/serde-xml-rs.git" , branch = 
 
 [dev-dependencies]
 clap = "2.25"
-error-chain = "0.11"
+error-chain = "0.12"


### PR DESCRIPTION


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

Should fix #389. error-chain 0.11 doesn't work with Rust 1.27.0 (new warnings). 0.12 is fully back-compatible - the only change was to silence the new warning

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

