### PR TITLE
Restore unit test that consider minLength, maxLength and pattern in referenced schema

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -943,11 +943,11 @@ public class JavaModelTest {
         Assert.assertTrue(cp.isNotContainer);
         Assert.assertFalse(cp.isLong);
         Assert.assertFalse(cp.isInteger);
-        // Assert.assertTrue(cp.isString); //TODO: issue swagger-api/swagger-codegen#8001
+        Assert.assertTrue(cp.isString);
         Assert.assertEquals(cp.getter, "getSomePropertyWithMinMaxAndPattern");
-        // Assert.assertEquals(cp.minLength, Integer.valueOf(3)); //TODO: issue swagger-api/swagger-codegen#8001
-        // Assert.assertEquals(cp.maxLength, Integer.valueOf(10)); //TODO: issue swagger-api/swagger-codegen#8001
-        // Assert.assertEquals(cp.pattern, "^[A-Z]+$"); //TODO: issue swagger-api/swagger-codegen#8001
+        Assert.assertEquals(cp.minLength, Integer.valueOf(3));
+        Assert.assertEquals(cp.maxLength, Integer.valueOf(10));
+        Assert.assertEquals(cp.pattern, "^[A-Z]+$");
     }
 
     @Test(description = "convert an array schema")


### PR DESCRIPTION
This PR restores the unit test that consider `minLength`, `maxLength` and `pattern` when they are defined in a in referenced schema.

OAS2 example:

```
definitions:
  SomeObj:
    type: object
    properties:
      nick:
        $ref: "#/definitions/NickName"
  NickName:
    type: string
    minLength: 1
    maxLength: 3
    pattern: "^[A-Z]+$"
```

This was filed as originally as swagger-api/swagger-codegen#8001

I have tried to implement a solution for this with #45, but my solution had too many side effects and was reverted with #82.

This PR brings back the tests without changing anything to the implementation. I think the changes made with #360 by @wing328 solves also issue swagger-api/swagger-codegen#8001.

