### PR TITLE
ModelUtils: isMap only if additionalProperties is a Schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -304,7 +304,7 @@ public class ModelUtils {
         if (schema instanceof MapSchema) {
             return true;
         }
-        if (schema.getAdditionalProperties() != null) {
+        if (schema.getAdditionalProperties() instanceof Schema) {
             return true;
         }
         return false;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/html/StaticHtmlGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/html/StaticHtmlGeneratorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.html;
+
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.languages.StaticHtmlGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+public class StaticHtmlGeneratorTest {
+
+    @Test
+    public void testAdditionalPropertiesFalse() {
+        final StaticHtmlGenerator codegen = new StaticHtmlGenerator();
+
+        Schema schema = new ObjectSchema()
+                .additionalProperties(false)
+                .addProperties("id", new IntegerSchema())
+                .addProperties("name", new StringSchema());
+        CodegenModel cm = codegen.fromModel("test", schema, Collections.emptyMap());
+        Assert.assertNotNull(cm);
+    }
+
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team 

### Description of the PR

Fix for issue #409. The `ClassCastException` is no longer present (see Unit Test)

More details:

As discussed in #409 `getAdditionalProperties()` can return a `Boolean` or a `Schema`.

* When `Schema`: Map case as already implemented
* When `Boolean`: (out of scope for this PR)
    - `true` => for Free-Form Objects"
    - `false` => can be ignored, default value (to be verified)