### PR TITLE
Obtain the example value from examples

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -24,6 +24,7 @@ import com.samskivert.mustache.Mustache.Compiler;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.CookieParameter;
@@ -1092,6 +1093,14 @@ public class DefaultCodegen implements CodegenConfig {
             return;
         }
 
+        if (parameter.getExamples() != null && !parameter.getExamples().isEmpty()) {
+            Example example = parameter.getExamples().values().iterator().next();
+            if(example.getValue() != null) {
+                codegenParameter.example = example.getValue().toString();
+                return;
+            }
+        }
+
         Schema schema = parameter.getSchema();
         if (schema != null && schema.getExample() != null) {
             codegenParameter.example = schema.getExample().toString();
@@ -1119,6 +1128,14 @@ public class DefaultCodegen implements CodegenConfig {
         if (mediaType.getExample() != null) {
             codegenParameter.example = mediaType.getExample().toString();
             return;
+        }
+
+        if (mediaType.getExamples() != null && !mediaType.getExamples().isEmpty()) {
+            Example example = mediaType.getExamples().values().iterator().next();
+            if(example.getValue() != null) {
+                codegenParameter.example = example.getValue().toString();
+                return;
+            }
         }
 
         setParameterExampleValue(codegenParameter);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -274,7 +274,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/examples.yaml", null, new ParseOptions()).getOpenAPI();
         final DefaultCodegen codegen = new DefaultCodegen();
 
-        Operation operation = openAPI.getPaths().get("/example4").getGet();
+        Operation operation = openAPI.getPaths().get("/example4").getPost();
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getRequestBody());
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -243,6 +243,12 @@ public class DefaultCodegenTest {
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
         Assert.assertEquals(codegenParameter.example, "example1 value");
+
+        Operation operation2 = openAPI.getPaths().get("/example1/plural").getGet();
+        CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
+        codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
+
+        Assert.assertEquals(codegenParameter2.example, "An example1 value");
     }
 
     @Test
@@ -267,6 +273,12 @@ public class DefaultCodegenTest {
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
         Assert.assertEquals(codegenParameter.example, "example3: parameter value");
+
+        Operation operation2 = openAPI.getPaths().get("/example3/plural").getGet();
+        CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
+        codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
+
+        Assert.assertEquals(codegenParameter2.example, "example3: parameter value");
     }
 
     @Test
@@ -279,6 +291,12 @@ public class DefaultCodegenTest {
         codegen.setParameterExampleValue(codegenParameter, operation.getRequestBody());
 
         Assert.assertEquals(codegenParameter.example, "example4 value");
+
+        Operation operation2 = openAPI.getPaths().get("/example4/plural").getPost();
+        CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
+        codegen.setParameterExampleValue(codegenParameter2, operation2.getRequestBody());
+
+        Assert.assertEquals(codegenParameter2.example, "An example4 value");
     }
 
     private CodegenProperty codegenPropertyWithArrayOfIntegerValues() {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -238,7 +238,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/examples.yaml", null, new ParseOptions()).getOpenAPI();
         final DefaultCodegen codegen = new DefaultCodegen();
 
-        Operation operation = openAPI.getPaths().get("/example1").getGet();
+        Operation operation = openAPI.getPaths().get("/example1/singular").getGet();
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
@@ -250,7 +250,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/examples.yaml", null, new ParseOptions()).getOpenAPI();
         final DefaultCodegen codegen = new DefaultCodegen();
 
-        Operation operation = openAPI.getPaths().get("/example2").getGet();
+        Operation operation = openAPI.getPaths().get("/example2/singular").getGet();
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
@@ -262,7 +262,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/examples.yaml", null, new ParseOptions()).getOpenAPI();
         final DefaultCodegen codegen = new DefaultCodegen();
 
-        Operation operation = openAPI.getPaths().get("/example3").getGet();
+        Operation operation = openAPI.getPaths().get("/example3/singular").getGet();
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getParameters().get(0));
 
@@ -274,7 +274,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/examples.yaml", null, new ParseOptions()).getOpenAPI();
         final DefaultCodegen codegen = new DefaultCodegen();
 
-        Operation operation = openAPI.getPaths().get("/example4").getPost();
+        Operation operation = openAPI.getPaths().get("/example4/singular").getPost();
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter, operation.getRequestBody());
 

--- a/modules/openapi-generator/src/test/resources/3_0/examples.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/examples.yaml
@@ -8,9 +8,9 @@ info:
     name: Apache-2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
-  /example1:
+  /example1/singular:
     get:
-      operationId: example1Get
+      operationId: example1GetSingular
       parameters:
         - name: parameter
           in: query
@@ -20,9 +20,9 @@ paths:
       responses:
         '200':
           description: successful operation
-  /example2:
+  /example2/singular:
     get:
-      operationId: example2Get
+      operationId: example2GetSingular
       parameters:
         - name: parameter
           in: query
@@ -32,9 +32,9 @@ paths:
       responses:
         '200':
           description: successful operation
-  /example3:
+  /example3/singular:
     get:
-      operationId: example3Get
+      operationId: example3GetSingular
       parameters:
         - name: parameter
           in: query
@@ -45,9 +45,9 @@ paths:
       responses:
         '200':
           description: successful operation
-  /example4:
+  /example4/singular:
     post:
-      operationId: example4Post
+      operationId: example4PostSingular
       requestBody:
         content:
           application/x-www-form-urlencoded:

--- a/modules/openapi-generator/src/test/resources/3_0/examples.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/examples.yaml
@@ -46,8 +46,8 @@ paths:
         '200':
           description: successful operation
   /example4:
-    get:
-      operationId: example4Get
+    post:
+      operationId: example4Post
       requestBody:
         content:
           application/x-www-form-urlencoded:

--- a/modules/openapi-generator/src/test/resources/3_0/examples.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/examples.yaml
@@ -20,6 +20,20 @@ paths:
       responses:
         '200':
           description: successful operation
+  /example1/plural:
+    get:
+      operationId: example1GetPlural
+      parameters:
+        - name: parameter
+          in: query
+          examples:
+            AnExample:
+              value: 'An example1 value'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
   /example2/singular:
     get:
       operationId: example2GetSingular
@@ -45,6 +59,22 @@ paths:
       responses:
         '200':
           description: successful operation
+  /example3/plural:
+    get:
+      operationId: example3GetSingular
+      parameters:
+        - name: parameter
+          in: query
+          example: 'example3: parameter value'
+          examples:
+            AnExample:
+              value: 'An example3 value'
+          schema:
+            type: string
+            example: 'example3: schema value'
+      responses:
+        '200':
+          description: successful operation
   /example4/singular:
     post:
       operationId: example4PostSingular
@@ -57,6 +87,23 @@ paths:
                 name:
                   type: string
             example: 'example4 value'
+      responses:
+        '200':
+          description: successful operation
+  /example4/plural:
+    post:
+      operationId: example4PostSingular
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+            examples:
+              AnExample:
+                value: 'An example4 value'
       responses:
         '200':
           description: successful operation


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @OpenAPITools/generator-core-team 

### Description of the PR

After #183 made by @ackintosh, I think it would also be good to support `examples` in addition to `example` (in a similar way).

If both (`example` and `examples` properties) are set, we keep the `example` value, if multiple `examples` are set we keep the first one.

In the future we might want to update codegen classes so that they support multiple examples values (OAS3 feature)