### PR TITLE
Add test case for produces

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -138,6 +138,24 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testGetProducesInfo() throws Exception {
+        final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/produces.yaml", null, new ParseOptions()).getOpenAPI();
+        final DefaultCodegen codegen = new DefaultCodegen();
+
+        Operation textOperation = openAPI.getPaths().get("/ping/text").getGet();
+        CodegenOperation coText = codegen.fromOperation("/ping/text", "get", textOperation, ModelUtils.getSchemas(openAPI), openAPI);
+        Assert.assertTrue(coText.hasProduces);
+        Assert.assertEquals(coText.produces.size(), 1);
+        Assert.assertEquals(coText.produces.get(0).get("mediaType"), "text/plain");
+
+        Operation jsonOperation = openAPI.getPaths().get("/ping/json").getGet();
+        CodegenOperation coJson = codegen.fromOperation("/ping/json", "get", jsonOperation, ModelUtils.getSchemas(openAPI), openAPI);
+        Assert.assertTrue(coJson.hasProduces);
+        Assert.assertEquals(coJson.produces.size(), 1);
+        Assert.assertEquals(coJson.produces.get(0).get("mediaType"), "application/json");
+    }
+
+    @Test
     public void testInitialConfigValues() throws Exception {
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.processOpts();

--- a/modules/openapi-generator/src/test/resources/3_0/produces.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/produces.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://api.example.com/v3'
+info:
+  version: 1.0.0
+  title: OpenAPI Test
+  license:
+    name: Apache-2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /ping/text:
+    get:
+      operationId: pingText
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              example: "Hello world 2018-06-29T07:32:23Z"
+  /ping/json:
+    get:
+      operationId: pingJson
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  timestamp:
+                    type: string
+              example: '{ "message": "Hello world", "timestamp": "2018-06-29T07:32:23Z"}'


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @OpenAPITools/generator-core-team 

### Description of the PR

Ensure that `addProducesInfo(OpenAPI openAPI, ApiResponse inputResponse, CodegenOperation codegenOperation)` works for the 2 cases discussed in #361.

This PR is just about adding unit-test, no changes to the existing implementation.

