### PR TITLE
[Java] option for the prefix of boolean getters

### DIFF
--- a/bin/java-petstore-feign.sh
+++ b/bin/java-petstore-feign.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/feign -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-feign.json -o samples/client/petstore/java/feign -DhideGenerationTimestamp=true $@"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/feign -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-feign.json -o samples/client/petstore/java/feign -DhideGenerationTimestamp=true -DbooleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/feign/src/main"
 rm -rf samples/client/petstore/java/feign/src/main

--- a/bin/java-petstore-jersey2-java6.sh
+++ b/bin/java-petstore-jersey2-java6.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate --artifact-id petstore-jersey2-java6 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java6 -DhideGenerationTimestamp=true,supportJava6=true $@"
+ags="generate --artifact-id petstore-jersey2-java6 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java6 -DhideGenerationTimestamp=true,supportJava6=true,booleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2-java6/src/main"
 rm -rf samples/client/petstore/java/jersey2-java6/src/main

--- a/bin/java-petstore-rest-assured.sh
+++ b/bin/java-petstore-rest-assured.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/rest-assured -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-rest-assured.json -o samples/client/petstore/java/rest-assured -DhideGenerationTimestamp=true $@"
+ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/rest-assured -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-rest-assured.json -o samples/client/petstore/java/rest-assured -DhideGenerationTimestamp=true --additional-properties booleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/rest-assured/src/main"
 rm -rf samples/client/petstore/java/rest-assured/src/main

--- a/bin/spring-mvc-petstore-j8-localdatetime.sh
+++ b/bin/spring-mvc-petstore-j8-localdatetime.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/spring-mvc-petstore-j8-localdatetime.json -o samples/server/petstore/spring-mvc-j8-localdatetime -DhideGenerationTimestamp=true --additional-properties serverPort=8002 $@"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/spring-mvc-petstore-j8-localdatetime.json -o samples/server/petstore/spring-mvc-j8-localdatetime -DhideGenerationTimestamp=true -DbooleanGetterPrefix=get --additional-properties serverPort=8002 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-mvc-petstore-server.sh
+++ b/bin/spring-mvc-petstore-server.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/spring-mvc-petstore-server.json -o samples/server/petstore/spring-mvc -DhideGenerationTimestamp=true,java8=false --additional-properties serverPort=8002 $@"
+ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/spring-mvc-petstore-server.json -o samples/server/petstore/spring-mvc -DhideGenerationTimestamp=true,java8=false --additional-properties serverPort=8002 --additional-properties booleanGetterPrefix=get $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/docs/migration-guide.adoc
+++ b/docs/migration-guide.adoc
@@ -1,0 +1,27 @@
+== Migration guide between OpenAPI-Generator versions
+
+This page summaries the important changes between major and minor version of OpenAPI-Generator.
+It does not contain a detailed list of changes, for that refer to each individual release notes.
+
+It is written to help migration by indicating the most impacting changes.
+Do not hesitate to contribute additional notes if you discover something during your migration and think that the information might help other users.
+
+=== From 3.0.x to 3.1.0
+
+Version `3.1.0` is the first minor version of OpenAPI-Generator, in comparison to `3.0.3` it contains some breaking changes, but with the possibility to fallback to the old behavior.
+The default value of some options might change.
+Projects relying on generated code might need to be adapted.
+
+==== Java
+
+A new option is introduced to specify the prefix of boolean getters: `booleanGetterPrefix`.
+Possible values:
+
+* `is`: the value used in `3.0.x`.
+* `get`: the new default value.
+
+If you use the default value you will see your generated code changing from `isActive()` to `getActive()`.
+
+=== Migrating from Swagger-Codegen
+
+Please read the specific migration guide: link:migration-from-swagger-codegen.md[From Swagger-Codegen to OpenAPI-Generator]

--- a/docs/migration-guide.adoc
+++ b/docs/migration-guide.adoc
@@ -3,8 +3,13 @@
 This page summaries the important changes between major and minor version of OpenAPI-Generator.
 It does not contain a detailed list of changes, for that refer to each individual release notes.
 
-It is written to help migration by indicating the most impacting changes.
+This page is written to help migration by indicating the most impacting changes.
 Do not hesitate to contribute additional notes if you discover something during your migration and think that the information might help other users.
+
+Another approach to find breaking changes is to look at issue and pull requests with following labels:
+
+* link:https://github.com/OpenAPITools/openapi-generator/labels/Breaking%20change%20%28with%20fallback%29[Breaking change (with fallback)]
+* link:https://github.com/OpenAPITools/openapi-generator/labels/Breaking%20change%20%28without%20fallback%29[Breaking change (without fallback)]
 
 === From 3.0.x to 3.1.0
 
@@ -14,7 +19,7 @@ Projects relying on generated code might need to be adapted.
 
 ==== Java
 
-A new option is introduced to specify the prefix of boolean getters: `booleanGetterPrefix`.
+A new option is introduced with link:https://github.com/OpenAPITools/openapi-generator/pull/432[#432] to specify the prefix of boolean getters: `booleanGetterPrefix`.
 Possible values:
 
 * `is`: the value used in `3.0.x`.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -64,6 +64,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String SUPPORT_JAVA6 = "supportJava6";
     public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
     public static final String BOOLEAN_GETTER_PREFIX = "booleanGetterPrefix";
+    public static final String BOOLEAN_GETTER_PREFIX_DEFAULT = "get";
 
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
@@ -97,7 +98,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String modelDocPath = "docs/";
     protected boolean supportJava6= false;
     protected boolean disableHtmlEscaping = false;
-    protected String booleanGetterPrefix = "is";
+    protected String booleanGetterPrefix = BOOLEAN_GETTER_PREFIX_DEFAULT;
 
     public AbstractJavaCodegen() {
         super();
@@ -190,7 +191,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(java8Mode);
 
         cliOptions.add(CliOption.newBoolean(DISABLE_HTML_ESCAPING, "Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)"));
-        cliOptions.add(CliOption.newString(BOOLEAN_GETTER_PREFIX, "Set booleanGetterPrefix (default value 'is')"));
+        cliOptions.add(CliOption.newString(BOOLEAN_GETTER_PREFIX, "Set booleanGetterPrefix (default value '" + BOOLEAN_GETTER_PREFIX_DEFAULT + "')"));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -63,6 +63,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
     public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
+    public static final String BOOLEAN_GETTER_PREFIX = "booleanGetterPrefix";
 
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
@@ -96,6 +97,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String modelDocPath = "docs/";
     protected boolean supportJava6= false;
     protected boolean disableHtmlEscaping = false;
+    protected String booleanGetterPrefix = "is";
 
     public AbstractJavaCodegen() {
         super();
@@ -188,6 +190,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(java8Mode);
 
         cliOptions.add(CliOption.newBoolean(DISABLE_HTML_ESCAPING, "Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)"));
+        cliOptions.add(CliOption.newString(BOOLEAN_GETTER_PREFIX, "Set booleanGetterPrefix (default value 'is')"));
     }
 
     @Override
@@ -203,6 +206,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             this.setDisableHtmlEscaping(Boolean.valueOf(additionalProperties.get(DISABLE_HTML_ESCAPING).toString()));
         }
         additionalProperties.put(DISABLE_HTML_ESCAPING, disableHtmlEscaping);
+
+        if (additionalProperties.containsKey(BOOLEAN_GETTER_PREFIX)) {
+            this.setBooleanGetterPrefix(additionalProperties.get(BOOLEAN_GETTER_PREFIX).toString());
+        }
+        additionalProperties.put(BOOLEAN_GETTER_PREFIX, booleanGetterPrefix);
 
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             this.setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
@@ -1233,6 +1241,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         this.disableHtmlEscaping = disabled;
     }
 
+    public void setBooleanGetterPrefix(String booleanGetterPrefix) {
+        this.booleanGetterPrefix = booleanGetterPrefix;
+    }
+
     @Override
     public String escapeQuotationMark(String input) {
         // remove " to avoid code injection
@@ -1291,7 +1303,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
      * @return getter name based on naming convention
      */
     public String toBooleanGetter(String name) {
-        return "is" + getterAndSetterCapitalize(name);
+        return booleanGetterPrefix + getterAndSetterCapitalize(name);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -96,7 +96,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "invalidPackageName");
         Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "org.openapitools");
-        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "is");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "get");
     }
 
     @Test
@@ -106,7 +106,7 @@ public class AbstractJavaCodegenTest {
         codegen.setModelPackage("xyz.yyyyy.zzzzzzz.model");
         codegen.setApiPackage("xyz.yyyyy.zzzzzzz.api");
         codegen.setInvokerPackage("xyz.yyyyy.zzzzzzz.invoker");
-        codegen.setBooleanGetterPrefix("get");
+        codegen.setBooleanGetterPrefix("is");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
@@ -117,7 +117,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
-        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "get");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "is");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -96,6 +96,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "invalidPackageName");
         Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "org.openapitools");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "is");
     }
 
     @Test
@@ -105,6 +106,7 @@ public class AbstractJavaCodegenTest {
         codegen.setModelPackage("xyz.yyyyy.zzzzzzz.model");
         codegen.setApiPackage("xyz.yyyyy.zzzzzzz.api");
         codegen.setInvokerPackage("xyz.yyyyy.zzzzzzz.invoker");
+        codegen.setBooleanGetterPrefix("get");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
@@ -115,6 +117,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "get");
     }
 
     @Test
@@ -124,6 +127,7 @@ public class AbstractJavaCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.model.oooooo");
         codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.api.oooooo");
         codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "xyz.yyyyy.invoker.oooooo");
+        codegen.additionalProperties().put(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX, "getBoolean");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
@@ -134,6 +138,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.api.oooooo");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.invoker.oooooo");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.invoker.oooooo");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "getBoolean");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -768,7 +768,8 @@ public class JavaModelTest {
     @Test(description = "convert a boolean parameter")
     public void booleanPropertyTest() {
         final BooleanSchema property = new BooleanSchema();
-        final DefaultCodegen codegen = new JavaClientCodegen();
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setBooleanGetterPrefix("is");
         final CodegenProperty cp = codegen.fromProperty("property", property);
 
         Assert.assertEquals(cp.baseName, "property");

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
@@ -49,7 +49,7 @@ public class Cat extends Animal implements Parcelable {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
@@ -207,7 +207,7 @@ public class Order implements Parcelable {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -92,7 +92,7 @@ public class OuterComposite implements Parcelable {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,7 +44,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -203,7 +203,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -88,7 +88,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -47,7 +47,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -199,7 +199,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -93,7 +93,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,7 +44,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
@@ -203,7 +203,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -88,7 +88,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
@@ -42,7 +42,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -85,7 +85,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
@@ -42,7 +42,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
@@ -185,7 +185,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -85,7 +85,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,7 +44,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
@@ -203,7 +203,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -88,7 +88,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,7 +44,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
@@ -203,7 +203,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -88,7 +88,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,7 +44,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
@@ -203,7 +203,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -88,7 +88,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -182,7 +182,7 @@ public class Order {
    * @return complete
   **/
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -82,7 +82,7 @@ public class OuterComposite {
    * @return myBoolean
   **/
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -180,7 +180,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -180,7 +180,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Order.java
@@ -171,7 +171,7 @@ public enum StatusEnum {
    * @return complete
   **/
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
@@ -165,7 +165,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Order.java
@@ -171,7 +171,7 @@ public enum StatusEnum {
    * @return complete
   **/
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Cat.java
@@ -23,7 +23,7 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @JsonProperty("declawed")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Order.java
@@ -166,7 +166,7 @@ public enum StatusEnum {
    * @return complete
   **/
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -66,7 +66,7 @@ public class OuterComposite  {
    * @return myBoolean
   **/
   @JsonProperty("my_boolean")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Cat.java
@@ -41,7 +41,7 @@ public class Cat extends Animal implements Serializable {
    **/
   @JsonProperty("declawed")
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
@@ -185,7 +185,7 @@ public class Order  implements Serializable {
    **/
   @JsonProperty("complete")
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -85,7 +85,7 @@ public class OuterComposite  implements Serializable {
    **/
   @JsonProperty("my_boolean")
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Order.java
@@ -110,7 +110,7 @@ public class Order   {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/src/gen/java/org/openapitools/model/Order.java
@@ -117,7 +117,7 @@ public class Order   {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/org/openapitools/model/Order.java
@@ -117,7 +117,7 @@ public class Order   {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/org/openapitools/model/Order.java
@@ -117,7 +117,7 @@ public class Order   {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Order.java
@@ -110,7 +110,7 @@ public class Order   {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
@@ -25,7 +25,7 @@ public class Cat extends Animal implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("declawed")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
   public void setDeclawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -149,7 +149,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -61,7 +61,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_boolean")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -25,7 +25,7 @@ public class Cat extends Animal implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("declawed")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
   public void setDeclawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -149,7 +149,7 @@ public enum StatusEnum {
   
   @ApiModelProperty(value = "")
   @JsonProperty("complete")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
   public void setComplete(Boolean complete) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -61,7 +61,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_boolean")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal  {
    **/
   @JsonProperty("declawed")
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -184,7 +184,7 @@ public class Order   {
    **/
   @JsonProperty("complete")
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -84,7 +84,7 @@ public class OuterComposite   {
    **/
   @JsonProperty("my_boolean")
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal  {
    **/
   @JsonProperty("declawed")
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
@@ -184,7 +184,7 @@ public class Order   {
    **/
   @JsonProperty("complete")
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -84,7 +84,7 @@ public class OuterComposite   {
    **/
   @JsonProperty("my_boolean")
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal  {
    **/
   @JsonProperty("declawed")
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -184,7 +184,7 @@ public class Order   {
    **/
   @JsonProperty("complete")
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -84,7 +84,7 @@ public class OuterComposite   {
    **/
   @JsonProperty("my_boolean")
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Cat.java
@@ -40,7 +40,7 @@ public class Cat extends Animal  {
    **/
   @JsonProperty("declawed")
   @ApiModelProperty(value = "")
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
@@ -184,7 +184,7 @@ public class Order   {
    **/
   @JsonProperty("complete")
   @ApiModelProperty(value = "")
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -84,7 +84,7 @@ public class OuterComposite   {
    **/
   @JsonProperty("my_boolean")
   @ApiModelProperty(value = "")
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Cat.java
@@ -29,7 +29,7 @@ public class Cat extends Animal  {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isDeclawed() {
+  public Boolean getDeclawed() {
     return declawed;
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -179,7 +179,7 @@ public class Order   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isComplete() {
+  public Boolean getComplete() {
     return complete;
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterComposite.java
@@ -76,7 +76,7 @@ public class OuterComposite   {
   @ApiModelProperty(value = "")
 
 
-  public Boolean isMyBoolean() {
+  public Boolean getMyBoolean() {
     return myBoolean;
   }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
Java: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

This PR adds a new option to all java generators (java client, jaxrs server, spring, …): `booleanGetterPrefix`

This new option influence the name of the getter generated for a boolean property in a model.

Example values for `booleanGetterPrefix`: 

* `is`: default value in `3.0.x`.
* `get`: new default value starting with `3.1.0`

With following OAS3 (extract):

```yaml
components:
  schemas:
  schemas:
    Order:
      type: object
      properties:
        id:
          type: integer
          format: int64
        status:
          type: string
          enum:
            - placed
            - approved
            - delivered
        complete:
          type: boolean
```

Generated code with `is` value:

```java
  public Boolean isComplete() {
    return complete;
  }
```

With `get` value:

```java
  public Boolean getComplete() {
    return complete;
  }
```

This was also discussed in:

* swagger-api/swagger-codegen#7261
* swagger-api/swagger-codegen#7764
* swagger-api/swagger-codegen#7638
* ...

