### PR TITLE
[java-jaxrs] Fix paths when useTags=true is used

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -32,8 +32,8 @@ import org.openapitools.codegen.utils.URLPathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URL;
 import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -154,6 +154,8 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         @SuppressWarnings("unchecked")
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         if (operations != null) {
+            String commonBaseName = null;
+            boolean baseNameEquals = true;
             @SuppressWarnings("unchecked")
             List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
             for (CodegenOperation operation : ops) {
@@ -219,6 +221,23 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
                 } else if ("map".equals(operation.returnContainer)) {
                     operation.returnContainer = "Map";
                 }
+                
+                if(commonBaseName == null) {
+                    commonBaseName = operation.baseName;
+                } else if(!commonBaseName.equals(operation.baseName)) {
+                    baseNameEquals = false;
+                }
+            }
+            if(baseNameEquals) {
+                objs.put("commonPath", commonBaseName);
+            } else {
+                for (CodegenOperation operation : ops) {
+                    if(operation.baseName != null) {
+                        operation.path = "/" + operation.baseName + operation.path;
+                        operation.baseName = null;
+                    }
+                }
+                objs.put("commonPath", null);
             }
         }
         return objs;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJerseyServerCodegen.java
@@ -159,7 +159,7 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
     @Override
     public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation co, Map<String, List<CodegenOperation>> operations) {
         if (useTags) {
-            String basePath = resourcePath;
+            String basePath = tag.toLowerCase();
             if (basePath.startsWith("/")) {
                 basePath = basePath.substring(1);
             }
@@ -168,11 +168,17 @@ public class JavaJerseyServerCodegen extends AbstractJavaJAXRSServerCodegen {
                 basePath = basePath.substring(0, pos);
             }
 
-            if (co.path.startsWith("/" + basePath)) {
+            boolean pathStartsWithBasePath = co.path.startsWith("/" + basePath);
+            if (pathStartsWithBasePath) {
                 co.path = co.path.substring(("/" + basePath).length());
             }
             co.subresourceOperation = !co.path.isEmpty();
             super.addOperationToGroup(tag, resourcePath, operation, co, operations);
+            if (pathStartsWithBasePath) {
+                co.baseName = basePath;
+            } else {
+                co.baseName = null;
+            }
         } else {
             String basePath = resourcePath;
             if (basePath.startsWith("/")) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
@@ -28,7 +28,7 @@ import javax.ws.rs.*;
 import javax.validation.constraints.*;
 {{/useBeanValidation}}
 
-@Path("/{{{baseName}}}")
+{{#commonPath}}@Path("/{{{commonPath}}}"){{/commonPath}}{{^commonPath}}@Path(""){{/commonPath}}
 {{#hasConsumes}}@Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} }){{/hasConsumes}}
 {{#hasProduces}}@Produces({ {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }){{/hasProduces}}
 @io.swagger.annotations.Api(description = "the {{{baseName}}} API")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -31,7 +31,7 @@ public class TestUtils {
     }
 
     public static WrittenTemplateBasedFile getTemplateBasedFile(MockDefaultGenerator generator, File root, String filename) {
-        String defaultApiFilename = new File(root, filename).getAbsolutePath();
+        String defaultApiFilename = new File(root, filename).getAbsolutePath().replace("\\", "/");
         Optional<WrittenTemplateBasedFile> optional = generator.getTemplateBasedFiles().stream().filter(f -> defaultApiFilename.equals(f.getOutputFilename())).findFirst();
         Assert.assertTrue(optional.isPresent());
         return optional.get();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -5,7 +5,12 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 
+import org.openapitools.codegen.MockDefaultGenerator.WrittenTemplateBasedFile;
+import org.testng.Assert;
+
+import java.io.File;
 import java.util.Collections;
+import java.util.Optional;
 
 public class TestUtils {
 
@@ -23,5 +28,12 @@ public class TestUtils {
         server.setUrl("https://localhost:9999/root");
         openAPI.setServers(Collections.singletonList(server));
         return openAPI;
+    }
+
+    public static WrittenTemplateBasedFile getTemplateBasedFile(MockDefaultGenerator generator, File root, String filename) {
+        String defaultApiFilename = new File(root, filename).getAbsolutePath();
+        Optional<WrittenTemplateBasedFile> optional = generator.getTemplateBasedFiles().stream().filter(f -> defaultApiFilename.equals(f.getOutputFilename())).findFirst();
+        Assert.assertTrue(optional.isPresent());
+        return optional.get();
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -44,6 +44,7 @@ import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.MockDefaultGenerator;
 import org.openapitools.codegen.MockDefaultGenerator.WrittenTemplateBasedFile;
+import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -59,7 +60,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class JavaClientCodegenTest {
@@ -406,9 +406,8 @@ public class JavaClientCodegenTest {
         String defaultApiConent = generatedFiles.get(defaultApiFilename);
         Assert.assertTrue(defaultApiConent.contains("public class DefaultApi")); 
 
-        Optional<WrittenTemplateBasedFile> optional = generator.getTemplateBasedFiles().stream().filter(f -> defaultApiFilename.equals(f.getOutputFilename())).findFirst();
-        Assert.assertTrue(optional.isPresent());
-        Assert.assertEquals(optional.get().getTemplateData().get("classname"), "DefaultApi");
+        WrittenTemplateBasedFile templateBasedFile = TestUtils.getTemplateBasedFile(generator, output, "src/main/java/xyz/abcdef/api/DefaultApi.java");
+        Assert.assertEquals(templateBasedFile.getTemplateData().get("classname"), "DefaultApi");
 
         output.deleteOnExit();
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJerseyServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJerseyServerCodegenTest.java
@@ -108,6 +108,7 @@ public class JavaJerseyServerCodegenTest {
 
         WrittenTemplateBasedFile group1File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group1Api.java");
         Assert.assertEquals(group1File.getTemplateData().get("baseName"), "group1");
+        Assert.assertEquals(group1File.getTemplateData().get("commonPath"), "group1");
         List<CodegenOperation> group1 = getOperationsList(group1File.getTemplateData());
         Assert.assertEquals(group1.size(), 2);
         Assert.assertEquals(group1.get(0).path, "/op1");
@@ -119,6 +120,7 @@ public class JavaJerseyServerCodegenTest {
 
         WrittenTemplateBasedFile group2File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group2Api.java");
         Assert.assertEquals(group2File.getTemplateData().get("baseName"), "group2");
+        Assert.assertEquals(group2File.getTemplateData().get("commonPath"), "group2");
         List<CodegenOperation> group2 = getOperationsList(group2File.getTemplateData());
         Assert.assertEquals(group2.size(), 1);
         Assert.assertEquals(group2.get(0).path, "/op3");
@@ -127,6 +129,7 @@ public class JavaJerseyServerCodegenTest {
 
         WrittenTemplateBasedFile group3File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group3Api.java");
         Assert.assertEquals(group3File.getTemplateData().get("baseName"), "group3");
+        Assert.assertEquals(group3File.getTemplateData().get("commonPath"), "group3");
         List<CodegenOperation> group3 = getOperationsList(group3File.getTemplateData());
         Assert.assertEquals(group3.size(), 1);
         Assert.assertEquals(group3.get(0).path, "/op4");
@@ -135,6 +138,7 @@ public class JavaJerseyServerCodegenTest {
 
         WrittenTemplateBasedFile group4File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group4Api.java");
         Assert.assertEquals(group4File.getTemplateData().get("baseName"), "group4");
+        Assert.assertEquals(group4File.getTemplateData().get("commonPath"), "group4");
         List<CodegenOperation> group4 = getOperationsList(group4File.getTemplateData());
         Assert.assertEquals(group4.size(), 2);
         Assert.assertEquals(group4.get(0).path, "/op5");
@@ -146,6 +150,7 @@ public class JavaJerseyServerCodegenTest {
 
         WrittenTemplateBasedFile group5File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group5Api.java");
         Assert.assertEquals(group5File.getTemplateData().get("baseName"), "group5");
+        Assert.assertEquals(group5File.getTemplateData().get("commonPath"), "group5");
         List<CodegenOperation> group5 = getOperationsList(group5File.getTemplateData());
         Assert.assertEquals(group5.size(), 1);
         Assert.assertEquals(group5.get(0).path, "/op7");
@@ -154,11 +159,86 @@ public class JavaJerseyServerCodegenTest {
 
         WrittenTemplateBasedFile group6File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group6Api.java");
         Assert.assertEquals(group6File.getTemplateData().get("baseName"), "group6");
+        Assert.assertEquals(group6File.getTemplateData().get("commonPath"), "group6");
         List<CodegenOperation> group6 = getOperationsList(group6File.getTemplateData());
         Assert.assertEquals(group6.size(), 1);
         Assert.assertEquals(group6.get(0).path, "/op8");
         Assert.assertEquals(group6.get(0).baseName, "group6");
         Assert.assertEquals(group6.get(0).subresourceOperation, true);
+    }
+
+    @Test
+    public void testAddOperationToGroupUseTagsTrue() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/tags.yaml", null, new ParseOptions()).getOpenAPI();
+        JavaJerseyServerCodegen codegen = new JavaJerseyServerCodegen();
+        codegen.setUseTags(true);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOpts opts = new ClientOpts();
+        ClientOptInput input = new ClientOptInput();
+        input.setOpenAPI(openAPI);
+        input.setConfig(codegen);
+        input.setOpts(opts);
+
+        MockDefaultGenerator generator = new MockDefaultGenerator();
+        generator.opts(input).generate();
+
+        WrittenTemplateBasedFile tag1File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Tag1Api.java");
+        Assert.assertEquals(tag1File.getTemplateData().get("baseName"), "Tag1");
+        Assert.assertEquals(tag1File.getTemplateData().get("commonPath"), null);
+        List<CodegenOperation> tag1List = getOperationsList(tag1File.getTemplateData());
+        Assert.assertEquals(tag1List.size(), 1);
+        Assert.assertEquals(tag1List.get(0).path, "/group1/op1");
+        Assert.assertEquals(tag1List.get(0).baseName, null);
+        Assert.assertEquals(tag1List.get(0).subresourceOperation, true);
+
+        WrittenTemplateBasedFile tag2File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Tag2Api.java");
+        Assert.assertEquals(tag2File.getTemplateData().get("baseName"), "Tag2");
+        Assert.assertEquals(tag2File.getTemplateData().get("commonPath"), null);
+        List<CodegenOperation> tag2List = getOperationsList(tag2File.getTemplateData());
+        Assert.assertEquals(tag2List.size(), 2);
+        Assert.assertEquals(tag2List.get(0).path, "/group1/op2");
+        Assert.assertEquals(tag2List.get(0).baseName, null);
+        Assert.assertEquals(tag2List.get(0).subresourceOperation, true);
+        Assert.assertEquals(tag2List.get(1).path, "/group2/op3");
+        Assert.assertEquals(tag2List.get(1).baseName, null);
+        Assert.assertEquals(tag2List.get(1).subresourceOperation, true);
+
+        WrittenTemplateBasedFile defaultFile = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/DefaultApi.java");
+        Assert.assertEquals(defaultFile.getTemplateData().get("baseName"), "Default");
+        Assert.assertEquals(defaultFile.getTemplateData().get("commonPath"), null);
+        List<CodegenOperation> defaultList = getOperationsList(defaultFile.getTemplateData());
+        Assert.assertEquals(defaultList.size(), 1);
+        Assert.assertEquals(defaultList.get(0).path, "/group3/op4");
+        Assert.assertEquals(defaultList.get(0).baseName, null);
+        Assert.assertEquals(defaultList.get(0).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group4File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group4Api.java");
+        Assert.assertEquals(group4File.getTemplateData().get("baseName"), "Group4");
+        Assert.assertEquals(group4File.getTemplateData().get("commonPath"), "group4");
+        List<CodegenOperation> group4List = getOperationsList(group4File.getTemplateData());
+        Assert.assertEquals(group4List.size(), 2);
+        Assert.assertEquals(group4List.get(0).path, "/op5");
+        Assert.assertEquals(group4List.get(0).baseName, "group4");
+        Assert.assertEquals(group4List.get(0).subresourceOperation, true);
+        Assert.assertEquals(group4List.get(1).path, "/op6");
+        Assert.assertEquals(group4List.get(1).baseName, "group4");
+        Assert.assertEquals(group4List.get(1).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group5File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group5Api.java");
+        Assert.assertEquals(group5File.getTemplateData().get("baseName"), "Group5");
+        Assert.assertEquals(group5File.getTemplateData().get("commonPath"), null);
+        List<CodegenOperation> group5List = getOperationsList(group5File.getTemplateData());
+        Assert.assertEquals(group5List.size(), 2);
+        Assert.assertEquals(group5List.get(0).path, "/group5/op7");
+        Assert.assertEquals(group5List.get(0).baseName, null);
+        Assert.assertEquals(group5List.get(0).subresourceOperation, true);
+        Assert.assertEquals(group5List.get(1).path, "/group6/op8");
+        Assert.assertEquals(group5List.get(1).baseName, null);
+        Assert.assertEquals(group5List.get(1).subresourceOperation, true);
     }
 
     @SuppressWarnings("unchecked")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJerseyServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJerseyServerCodegenTest.java
@@ -1,0 +1,171 @@
+package org.openapitools.codegen.java.jaxrs;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.parser.core.models.ParseOptions;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.ClientOpts;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.MockDefaultGenerator;
+import org.openapitools.codegen.MockDefaultGenerator.WrittenTemplateBasedFile;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.JavaJerseyServerCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+public class JavaJerseyServerCodegenTest {
+
+    @Test
+    public void testInitialConfigValues() throws Exception {
+        final JavaJerseyServerCodegen codegen = new JavaJerseyServerCodegen();
+        codegen.processOpts();
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.addServersItem(new Server().url("https://api.abcde.xy:8082/v2"));
+        codegen.preprocessOpenAPI(openAPI);
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+        Assert.assertEquals(codegen.modelPackage(), "org.openapitools.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "org.openapitools.model");
+        Assert.assertEquals(codegen.apiPackage(), "org.openapitools.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "org.openapitools.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "org.openapitools.api");
+        Assert.assertEquals(codegen.additionalProperties().get(JavaJerseyServerCodegen.SERVER_PORT), "8082");
+    }
+
+    @Test
+    public void testSettersForConfigValues() throws Exception {
+        final JavaJerseyServerCodegen codegen = new JavaJerseyServerCodegen();
+        codegen.setHideGenerationTimestamp(true);
+        codegen.setModelPackage("xx.yyyyyyyy.model");
+        codegen.setApiPackage("xx.yyyyyyyy.api");
+        codegen.setInvokerPackage("xx.yyyyyyyy.invoker");
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xx.yyyyyyyy.model");
+        Assert.assertEquals(codegen.apiPackage(), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xx.yyyyyyyy.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xx.yyyyyyyy.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xx.yyyyyyyy.invoker");
+    }
+
+    @Test
+    public void testAdditionalPropertiesPutForConfigValues() throws Exception {
+        final JavaJerseyServerCodegen codegen = new JavaJerseyServerCodegen();
+        codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true");
+        codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.aaaaa.api");
+        codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE,"xyz.yyyyy.iiii.invoker");
+        codegen.additionalProperties().put("serverPort","8088");
+        codegen.processOpts();
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.addServersItem(new Server().url("https://api.abcde.xy:8082/v2"));
+        codegen.preprocessOpenAPI(openAPI);
+
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
+        Assert.assertEquals(codegen.isHideGenerationTimestamp(), true);
+        Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE), "xyz.yyyyy.mmmmm.model");
+        Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.aaaaa.api");
+        Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.iiii.invoker");
+        Assert.assertEquals(codegen.additionalProperties().get(JavaJerseyServerCodegen.SERVER_PORT), "8088");
+    }
+
+    @Test
+    public void testAddOperationToGroupUseTagsFalse() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/tags.yaml", null, new ParseOptions()).getOpenAPI();
+        JavaJerseyServerCodegen codegen = new JavaJerseyServerCodegen();
+        codegen.setUseTags(false);
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOpts opts = new ClientOpts();
+        ClientOptInput input = new ClientOptInput();
+        input.setOpenAPI(openAPI);
+        input.setConfig(codegen);
+        input.setOpts(opts);
+
+        MockDefaultGenerator generator = new MockDefaultGenerator();
+        generator.opts(input).generate();
+
+        WrittenTemplateBasedFile group1File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group1Api.java");
+        Assert.assertEquals(group1File.getTemplateData().get("baseName"), "group1");
+        List<CodegenOperation> group1 = getOperationsList(group1File.getTemplateData());
+        Assert.assertEquals(group1.size(), 2);
+        Assert.assertEquals(group1.get(0).path, "/op1");
+        Assert.assertEquals(group1.get(0).baseName, "group1");
+        Assert.assertEquals(group1.get(0).subresourceOperation, true);
+        Assert.assertEquals(group1.get(1).path, "/op2");
+        Assert.assertEquals(group1.get(1).baseName, "group1");
+        Assert.assertEquals(group1.get(1).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group2File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group2Api.java");
+        Assert.assertEquals(group2File.getTemplateData().get("baseName"), "group2");
+        List<CodegenOperation> group2 = getOperationsList(group2File.getTemplateData());
+        Assert.assertEquals(group2.size(), 1);
+        Assert.assertEquals(group2.get(0).path, "/op3");
+        Assert.assertEquals(group2.get(0).baseName, "group2");
+        Assert.assertEquals(group2.get(0).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group3File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group3Api.java");
+        Assert.assertEquals(group3File.getTemplateData().get("baseName"), "group3");
+        List<CodegenOperation> group3 = getOperationsList(group3File.getTemplateData());
+        Assert.assertEquals(group3.size(), 1);
+        Assert.assertEquals(group3.get(0).path, "/op4");
+        Assert.assertEquals(group3.get(0).baseName, "group3");
+        Assert.assertEquals(group3.get(0).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group4File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group4Api.java");
+        Assert.assertEquals(group4File.getTemplateData().get("baseName"), "group4");
+        List<CodegenOperation> group4 = getOperationsList(group4File.getTemplateData());
+        Assert.assertEquals(group4.size(), 2);
+        Assert.assertEquals(group4.get(0).path, "/op5");
+        Assert.assertEquals(group4.get(0).baseName, "group4");
+        Assert.assertEquals(group4.get(0).subresourceOperation, true);
+        Assert.assertEquals(group4.get(1).path, "/op6");
+        Assert.assertEquals(group4.get(1).baseName, "group4");
+        Assert.assertEquals(group4.get(1).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group5File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group5Api.java");
+        Assert.assertEquals(group5File.getTemplateData().get("baseName"), "group5");
+        List<CodegenOperation> group5 = getOperationsList(group5File.getTemplateData());
+        Assert.assertEquals(group5.size(), 1);
+        Assert.assertEquals(group5.get(0).path, "/op7");
+        Assert.assertEquals(group5.get(0).baseName, "group5");
+        Assert.assertEquals(group5.get(0).subresourceOperation, true);
+
+        WrittenTemplateBasedFile group6File = TestUtils.getTemplateBasedFile(generator, output, "src/gen/java/org/openapitools/api/Group6Api.java");
+        Assert.assertEquals(group6File.getTemplateData().get("baseName"), "group6");
+        List<CodegenOperation> group6 = getOperationsList(group6File.getTemplateData());
+        Assert.assertEquals(group6.size(), 1);
+        Assert.assertEquals(group6.get(0).path, "/op8");
+        Assert.assertEquals(group6.get(0).baseName, "group6");
+        Assert.assertEquals(group6.get(0).subresourceOperation, true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<CodegenOperation> getOperationsList(Map<String, Object> templateData) {
+        Assert.assertTrue(templateData.get("operations") instanceof Map);
+        Map<String, Object> operations = (Map<String, Object>) templateData.get("operations");
+        Assert.assertTrue(operations.get("operation") instanceof List);
+        return (List<CodegenOperation>) operations.get("operation");
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/tags.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/tags.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Test API
+  description: Tags Test
+  version: 1.0.0
+servers:
+  - url: 'http://api.company.xyz/v2'
+paths:
+  /group1/op1:
+    get:
+      tags:
+        - tag1
+      operationId: op1
+      responses:
+        '200':
+          description: Ok
+  /group1/op2:
+    get:
+      tags:
+        - tag2
+      operationId: op2
+      responses:
+        '200':
+          description: Ok
+  /group2/op3:
+    get:
+      tags:
+        - tag2
+      operationId: op3
+      responses:
+        '200':
+          description: Ok
+  /group3/op4:
+    get:
+      operationId: op4
+      responses:
+        '200':
+          description: Ok
+  /group4/op5:
+    get:
+      tags:
+        - group4
+      operationId: op5
+      responses:
+        '200':
+          description: Ok
+  /group4/op6:
+    get:
+      tags:
+        - group4
+      operationId: op6
+      responses:
+        '200':
+          description: Ok
+  /group5/op7:
+    get:
+      tags:
+        - group5
+      operationId: op7
+      responses:
+        '200':
+          description: Ok
+  /group6/op8:
+    get:
+      tags:
+        - group5
+      operationId: op8
+      responses:
+        '200':
+          description: Ok
+# Section bellow is requested because of issue #436
+components:
+  schemas:
+    SomeObj:
+      type: object
+      properties:
+        someProp:
+          type: string

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -35,7 +35,7 @@ public class AnotherFakeApi  {
    private final AnotherFakeApiService delegate = AnotherFakeApiServiceFactory.getAnotherFakeApi();
 
     @PATCH
-    @Path("/dummy")
+    @Path("/another-fake/dummy")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags", response = Client.class, tags={ "$another-fake?" })

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -35,7 +35,7 @@ public class FakeClassnameTags123Api  {
    private final FakeClassnameTags123ApiService delegate = FakeClassnameTags123ApiServiceFactory.getFakeClassnameTags123Api();
 
     @PATCH
-    
+    @Path("/fake_classname_test")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "To test class name in snake case", notes = "To test class name in snake case", response = Client.class, authorizations = {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -55,7 +55,7 @@ public class PetApi  {
         return delegate.addPet(pet,securityContext);
     }
     @DELETE
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     
     
     @io.swagger.annotations.ApiOperation(value = "Deletes a pet", notes = "", response = Void.class, authorizations = {
@@ -74,7 +74,7 @@ public class PetApi  {
         return delegate.deletePet(petId,apiKey,securityContext);
     }
     @GET
-    @Path("/findByStatus")
+    @Path("/pet/findByStatus")
     
     @Produces({ "application/xml", "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -93,7 +93,7 @@ public class PetApi  {
         return delegate.findPetsByStatus(status,securityContext);
     }
     @GET
-    @Path("/findByTags")
+    @Path("/pet/findByTags")
     
     @Produces({ "application/xml", "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Finds Pets by tags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -112,7 +112,7 @@ public class PetApi  {
         return delegate.findPetsByTags(tags,securityContext);
     }
     @GET
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     
     @Produces({ "application/xml", "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Find pet by ID", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -149,7 +149,7 @@ public class PetApi  {
         return delegate.updatePet(pet,securityContext);
     }
     @POST
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     
     @io.swagger.annotations.ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = Void.class, authorizations = {
@@ -169,7 +169,7 @@ public class PetApi  {
         return delegate.updatePetWithForm(petId,name,status,securityContext);
     }
     @POST
-    @Path("/{petId}/uploadImage")
+    @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "uploads an image", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -190,7 +190,7 @@ public class PetApi  {
         return delegate.uploadFile(petId,additionalMetadata,inputStream, fileDetail,securityContext);
     }
     @POST
-    @Path("/{petId}/uploadImageWithRequiredFile")
+    @Path("/fake/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "uploads an image (required)", notes = "", response = ModelApiResponse.class, authorizations = {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.*;
 import javax.validation.constraints.*;
 
-@Path("/AnotherFake")
+@Path("")
 
 
 @io.swagger.annotations.Api(description = "the AnotherFake API")
@@ -55,7 +55,7 @@ public class AnotherFakeApi  {
    }
 
     @PATCH
-    @Path("/dummy")
+    @Path("/another-fake/dummy")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags", response = Client.class, tags={ "$another-fake?", })

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.*;
 import javax.validation.constraints.*;
 
-@Path("/Fake")
+@Path("/fake")
 
 
 @io.swagger.annotations.Api(description = "the Fake API")

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.*;
 import javax.validation.constraints.*;
 
-@Path("/FakeClassnameTags123")
+@Path("")
 
 
 @io.swagger.annotations.Api(description = "the FakeClassnameTags123 API")
@@ -55,7 +55,7 @@ public class FakeClassnameTags123Api  {
    }
 
     @PATCH
-    
+    @Path("/fake_classname_test")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "To test class name in snake case", notes = "To test class name in snake case", response = Client.class, authorizations = {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.*;
 import javax.validation.constraints.*;
 
-@Path("/Pet")
+@Path("")
 
 
 @io.swagger.annotations.Api(description = "the Pet API")
@@ -74,7 +74,7 @@ public class PetApi  {
         return delegate.addPet(pet,securityContext);
     }
     @DELETE
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     
     
     @io.swagger.annotations.ApiOperation(value = "Deletes a pet", notes = "", response = Void.class, authorizations = {
@@ -92,7 +92,7 @@ public class PetApi  {
         return delegate.deletePet(petId,apiKey,securityContext);
     }
     @GET
-    @Path("/findByStatus")
+    @Path("/pet/findByStatus")
     
     @Produces({ "application/xml", "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Finds Pets by status", notes = "Multiple status values can be provided with comma separated strings", response = Pet.class, responseContainer = "List", authorizations = {
@@ -111,7 +111,7 @@ public class PetApi  {
         return delegate.findPetsByStatus(status,securityContext);
     }
     @GET
-    @Path("/findByTags")
+    @Path("/pet/findByTags")
     
     @Produces({ "application/xml", "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Finds Pets by tags", notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.", response = Pet.class, responseContainer = "List", authorizations = {
@@ -130,7 +130,7 @@ public class PetApi  {
         return delegate.findPetsByTags(tags,securityContext);
     }
     @GET
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     
     @Produces({ "application/xml", "application/json" })
     @io.swagger.annotations.ApiOperation(value = "Find pet by ID", notes = "Returns a single pet", response = Pet.class, authorizations = {
@@ -169,7 +169,7 @@ public class PetApi  {
         return delegate.updatePet(pet,securityContext);
     }
     @POST
-    @Path("/{petId}")
+    @Path("/pet/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
     
     @io.swagger.annotations.ApiOperation(value = "Updates a pet in the store with form data", notes = "", response = Void.class, authorizations = {
@@ -188,7 +188,7 @@ public class PetApi  {
         return delegate.updatePetWithForm(petId,name,status,securityContext);
     }
     @POST
-    @Path("/{petId}/uploadImage")
+    @Path("/pet/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "uploads an image", notes = "", response = ModelApiResponse.class, authorizations = {
@@ -209,7 +209,7 @@ public class PetApi  {
         return delegate.uploadFile(petId,additionalMetadata,fileInputStream, fileDetail,securityContext);
     }
     @POST
-    @Path("/{petId}/uploadImageWithRequiredFile")
+    @Path("/fake/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })
     @Produces({ "application/json" })
     @io.swagger.annotations.ApiOperation(value = "uploads an image (required)", notes = "", response = ModelApiResponse.class, authorizations = {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.*;
 import javax.validation.constraints.*;
 
-@Path("/Store")
+@Path("/store")
 
 
 @io.swagger.annotations.Api(description = "the Store API")

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.*;
 import javax.validation.constraints.*;
 
-@Path("/User")
+@Path("/user")
 
 
 @io.swagger.annotations.Api(description = "the User API")


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Java: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas  (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)  @jeff9finger (2018/01)

### Description of the PR

Detected during test of #215.
When you use the `useTags` boolean option with the `jaxrs-jersey` generator, there is a problem with the paths.

Example spec: [tags.yaml](https://github.com/jmini/openapi-generator/blob/d35ca3ee6d19310177dee711cab3045a085812f9/modules/openapi-generator/src/test/resources/3_0/tags.yaml) (added to this PR as test case)

Then the endpoints are:

```
http://localhost:8080/v2/Tag1/op1
http://localhost:8080/v2/Tag2/op2
http://localhost:8080/v2/Tag2/op3
http://localhost:8080/v2/Default/op4
http://localhost:8080/v2/Group4/op5
http://localhost:8080/v2/Group4/op6
```
They are driven by the tags (and tags name).

They should be as specified in the `paths` section:

```
http://localhost:8080/v2/group1/op1
http://localhost:8080/v2/group1/op2
http://localhost:8080/v2/group2/op3
http://localhost:8080/v2/group3/op4
http://localhost:8080/v2/group4/op5
http://localhost:8080/v2/group4/op6
```

This PR introduces a new variable accessible in the JaxRS templates: `{{commonPath}}`.
This is because the `{{baseName}}` when tags are used can not be used in the top level `@Path` annotation value.
`{{commonPath}}` contains the path common to all operations of the generated groups.

A unit test to ensure that nothing was changed cases where `useTags` is set to `false` (default behavior) is also added to the PR.