### PR TITLE
fix: The values for @Produces annotation were not separated by a comma.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3917,6 +3917,11 @@ public class DefaultCodegen implements CodegenConfig {
                     mediaType.put("hasMore", null);
                 }
 
+                if (!codegenOperation.produces.isEmpty()) {
+                    final Map<String, String> lastMediaType = codegenOperation.produces.get(codegenOperation.produces.size() - 1);
+                    lastMediaType.put("hasMore", "true");
+                }
+
                 codegenOperation.produces.add(mediaType);
                 codegenOperation.hasProduces = Boolean.TRUE;
             }


### PR DESCRIPTION
###Bug found with jaxrs-resteay source code.
Issue #443

### Description of the PR

Before adding a new mediaType into the produces list, we put a ["hasMore", "true"] to the last mediaType in order to be sure "hasMore" value is "true" because in some situations, "hasMore"  value in the map was null.


