### PR TITLE
Shippable: fix bin/java-petstore-webclient.sh

### DIFF
--- a/bin/java-petstore-webclient.sh
+++ b/bin/java-petstore-webclient.sh
@@ -33,13 +33,3 @@ echo "Removing files and folders under samples/client/petstore/java/webclient/sr
 rm -rf samples/client/petstore/java/webclient/src/main
 find samples/client/petstore/java/webclient -maxdepth 1 -type f ! -name "README.md" -exec rm {} +
 java $JAVA_OPTS -jar $executable $ags
-
-# copy additional manually written unit-tests
-mkdir samples/client/petstore/java/webclient/src/test/java/org/openapitools/client
-mkdir samples/client/petstore/java/webclient/src/test/java/org/openapitools/client/auth
-mkdir samples/client/petstore/java/webclient/src/test/java/org/openapitools/client/model
-
-cp CI/samples.ci/client/petstore/java/test-manual/webclient/ApiClientTest.java samples/client/petstore/java/webclient/src/test/java/org/openapitools/client/ApiClientTest.java
-cp CI/samples.ci/client/petstore/java/test-manual/webclient/auth/ApiKeyAuthTest.java samples/client/petstore/java/webclient/src/test/java/org/openapitools/client/auth/ApiKeyAuthTest.java
-cp CI/samples.ci/client/petstore/java/test-manual/webclient/auth/HttpBasicAuthTest.java samples/client/petstore/java/webclient/src/test/java/org/openapitools/client/auth/HttpBasicAuthTest.java
-cp CI/samples.ci/client/petstore/java/test-manual/webclient/model/EnumValueTest.java samples/client/petstore/java/webclient/src/test/java/org/openapitools/client/model/EnumValueTest.java


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The script `bin/java-petstore-webclient.sh` introduced with #435 by @0v1se produces this output:

```
...
./bin/run-all-petstore
...
Running ./bin/java-petstore-webclient.sh
# START SCRIPT: ./bin/java-petstore-webclient.sh
Removing files and folders under samples/client/petstore/java/webclient/src/main
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256M; support was removed in 8.0
[main] INFO  o.o.c.ignore.CodegenIgnoreProcessor - No .openapi-generator-ignore file found.
...
cp: cannot stat 'CI/samples.ci/client/petstore/java/test-manual/webclient/ApiClientTest.java': No such file or directory
cp: cannot stat 'CI/samples.ci/client/petstore/java/test-manual/webclient/auth/ApiKeyAuthTest.java': No such file or directory
cp: cannot stat 'CI/samples.ci/client/petstore/java/test-manual/webclient/auth/HttpBasicAuthTest.java': No such file or directory
cp: cannot stat 'CI/samples.ci/client/petstore/java/test-manual/webclient/model/EnumValueTest.java': No such file or directory
ERROR!! FAILED TO RUN ./bin/java-petstore-webclient.sh
...
[ERROR] 1 out of 184 scripts failed.
```

The fix consist of removing the copy file section. It seems that there is no manually written unit test at the indicated location.

