### PR TITLE
[CLI] Add graceful error handling for unknown command

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/OpenAPIGenerator.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/OpenAPIGenerator.java
@@ -19,6 +19,7 @@ package org.openapitools.codegen;
 
 import io.airlift.airline.Cli;
 import io.airlift.airline.Help;
+import io.airlift.airline.ParseArgumentsUnexpectedException;
 import io.airlift.airline.ParseOptionMissingException;
 import io.airlift.airline.ParseOptionMissingValueException;
 import org.openapitools.codegen.cmd.*;
@@ -67,6 +68,9 @@ public class OpenAPIGenerator {
             if (args.length == 0) {
                 System.exit(1);
             }
+        } catch (ParseArgumentsUnexpectedException e) {
+            System.err.printf("[error] %s%n%nSee 'openapi-generator-cli help' for usage.%n", e.getMessage());
+            System.exit(1);
         } catch (ParseOptionMissingException | ParseOptionMissingValueException e) {
             System.err.printf("[error] %s%n", e.getMessage());
             System.exit(1);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Currently, the CLI throws an exception when an unknown command is encountered such as the following for `--help` as mentioned here: https://github.com/OpenAPITools/openapi-generator/issues/490

> It's hard to figure out the command line options when the software crashes when called with `--help`.

The uncaught exception will result in the following:

```
$ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar --help
Exception in thread "main" io.airlift.airline.ParseArgumentsUnexpectedException: Found unexpected parameters: [--help]
	at io.airlift.airline.Cli.validate(Cli.java:148)
	at io.airlift.airline.Cli.parse(Cli.java:116)
	at io.airlift.airline.Cli.parse(Cli.java:97)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:58)
```

A few people have run into this as mentioned here: https://github.com/airlift/airline/issues/45

> `--help` is the first thing I run on a new command

This PR will return a graceful error for any unknown command by gracefully catching `io.airlift.airline.ParseArgumentsUnexpectedException` such as the following:

```
$ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar --help
[error] Found unexpected parameters: [--help]

See 'openapi-generator-cli help' for usage.
```

A DWIM approach would alias `--help` to `help` but this may lead to more issues as we may need to alias all the other commands as well to avoid confusion. This approach returns an nicer error message and encourages the user to learn the correct syntax for the CLI. However, if we decide it is better to alias, I can look into this too.