### PR TITLE
[cpp-pistache] Fix compilation of petstore for Pistache

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -102,6 +102,7 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
         typeMapping.put("binary", "std::string");
         typeMapping.put("number", "double");
         typeMapping.put("UUID", "std::string");
+        typeMapping.put("ByteArray", "std::string");
 
         super.importMapping = new HashMap<String, String>();
         importMapping.put("std::vector", "#include <vector>");
@@ -292,6 +293,9 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
             Schema inner = (Schema) p.getAdditionalProperties();
             return getSchemaType(p) + "<std::string, " + getTypeDeclaration(inner) + ">";
         }
+        else if (ModelUtils.isByteArraySchema(p)) {
+            return "std::string";
+        }
         if (ModelUtils.isStringSchema(p)
                 || ModelUtils.isDateSchema(p)
                 || ModelUtils.isDateTimeSchema(p) || ModelUtils.isFileSchema(p)
@@ -320,6 +324,9 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
                 return "0L";
             }
             return "0";
+        } 
+        else if (ModelUtils.isByteArraySchema(p)) {
+            return "";
         } else if (ModelUtils.isMapSchema(p)) {
             String inner = getSchemaType((Schema) p.getAdditionalProperties());
             return "std::map<std::string, " + inner + ">()";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -403,4 +403,9 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
     public String escapeUnsafeCharacters(String input) {
         return input.replace("*/", "*_/").replace("/*", "/_*");
     }
+    
+    @Override
+    public String getTypeDeclaration(String str) {
+        return toModelName(str);
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -153,6 +153,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
         typeMapping.put("binary", "std::string");
         typeMapping.put("number", "double");
         typeMapping.put("UUID", "utility::string_t");
+        typeMapping.put("ByteArray", "utility::string_t");        
 
         super.importMapping = new HashMap<String, String>();
         importMapping.put("std::vector", "#include <vector>");

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
@@ -52,8 +52,8 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
     {{/hasPathParams}}{{#hasBodyParam}}
     // Getting the body param
     {{#bodyParam}}
-    {{^isPrimitiveType}}
-    {{baseType}} {{paramName}};{{/isPrimitiveType}}
+    {{^isPrimitiveType}}{{^isContainer}}
+    {{baseType}} {{paramName}};{{/isContainer}}{{#isListContainer}}std::vector<{{items.baseType}}> {{paramName}};{{/isListContainer}}{{#isMapContainer}}std::map<std::string, {{items.baseType}}> {{paramName}};{{/isMapContainer}}{{/isPrimitiveType}}
     {{#isPrimitiveType}}
     {{dataType}} {{paramName}};
     {{/isPrimitiveType}}
@@ -74,9 +74,9 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
     {{#hasBodyParam}}
     {{#bodyParam}}
       nlohmann::json request_body = nlohmann::json::parse(request.body());
-    {{^isPrimitiveType}}
+    {{^isPrimitiveType}}{{^isContainer}}
       {{paramName}}.fromJson(request_body);
-    {{/isPrimitiveType}}
+    {{/isContainer}}{{/isPrimitiveType}}{{#isContainer}}  {{paramName}} = {{#isListContainer}}  ModelArrayHelper{{/isListContainer}}{{#isMapContainer}}  ModelMapHelper{{/isMapContainer}}::fromJson<{{items.baseType}}>(request_body);{{/isContainer}}
     {{#isPrimitiveType}}
       // The conversion is done automatically by the json library
       {{paramName}} = request_body;

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/cmake.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/cmake.mustache
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.2)
 
 project(server)
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=c++11)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pg -g3" )
 
 link_directories(/usr/local/lib/)
 

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -79,11 +79,11 @@ void {{classname}}::fromJson(nlohmann::json& val)
             {{/items.isDateTime}}{{^items.isDateTime}}
             if(item.is_null())
             {
-                m_{{name}}.push_back( {{{items.datatype}}}(nullptr) );
+                m_{{name}}.push_back( {{{items.datatype}}}() );
             }
             else
             {
-                {{{items.datatype}}} newItem({{{items.defaultValue}}});
+                {{{items.datatype}}} newItem;
                 newItem.fromJson(item);
                 m_{{name}}.push_back( newItem );
             }
@@ -99,7 +99,7 @@ void {{classname}}::fromJson(nlohmann::json& val)
         {{/isString}}{{^isString}}{{#isDateTime}}{{setter}}(val.at("{{baseName}}"));
         {{/isDateTime}}{{^isDateTime}}if(!val["{{baseName}}"].is_null())
         {
-            {{{dataType}}} newItem({{{defaultValue}}});
+            {{{dataType}}} newItem;
             newItem.fromJson(val["{{baseName}}"]);
             {{setter}}( newItem );
         }

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -95,15 +95,15 @@ void {{classname}}::fromJson(nlohmann::json& val)
     }
     {{/isListContainer}}{{^isListContainer}}{{^isPrimitiveType}}{{^required}}if(val.find("{{baseName}}") != val.end())
     {
-        {{#isString}}{{setter}}(val.at("{{baseName}}"));
-        {{/isString}}{{^isString}}{{#isDateTime}}{{setter}}(val.at("{{baseName}}"));
-        {{/isDateTime}}{{^isDateTime}}if(!val["{{baseName}}"].is_null())
+        {{#isString}}{{setter}}(val.at("{{baseName}}"));{{/isString}}{{#isByteArray}}{{setter}}(val.at("{{baseName}}"));
+        {{/isByteArray}}{{^isString}}{{#isDateTime}}{{setter}}(val.at("{{baseName}}"));
+        {{/isDateTime}}{{^isDateTime}}{{^isByteArray}}if(!val["{{baseName}}"].is_null())
         {
             {{{dataType}}} newItem;
             newItem.fromJson(val["{{baseName}}"]);
             {{setter}}( newItem );
         }
-        {{/isDateTime}}{{/isString}}
+        {{/isByteArray}}{{/isDateTime}}{{/isString}}
     }
     {{/required}}{{#required}}{{#isString}}{{setter}}(val.at("{{baseName}}"));
     {{/isString}}{{^isString}}{{#isDateTime}}{{setter}}(val.at("{{baseName}}"));

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-header.mustache
@@ -39,51 +39,96 @@ public:
     static nlohmann::json toJson(ModelBase const& content ); 
 };
 
-class  ModelArrayHelper {
+class ModelArrayHelper {
 public:
-template <typename T>
+	template<typename T>
 	static std::vector<T> fromJson(nlohmann::json& json) {
 		T *ptrTest;
 		std::vector<T> val;
 		if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
 			if (!json.empty()) {
-				for (auto &item : json.items()){
+				for (auto &item : json.items()) {
 					T entry;
 					entry.fromJson(item.value());
 					val.push_back(entry);
 				}
 			}
-		} else {
-			// TODO Primitives
 		}
 		return val;
-}
-
+	}
+	template<typename T>
+	static nlohmann::json toJson(std::vector<T> val) {
+		// TODO
+		return nlohmann::json();
+	}
 };
 
-class  ModelMapHelper {
+class ArrayHelper {
+public:
+	template<typename T>
+	static std::vector<T> fromJson(nlohmann::json& json) {
+		std::vector<T> val;
+		nlohmann::from_json(json, val);
+		return val;
+	}
+
+	template<typename T>
+	static nlohmann::json toJson(std::vector<T> val) {
+		nlohmann::json json;
+		nlohmann::to_json(json, val);
+		return json;
+	}
+};
+
+class ModelMapHelper {
 public:
 
-template <typename T>
-static std::map<std::string, T> & fromJson(nlohmann::json& json){
-	T *ptrTest;
-	std::map<std::string, T> val;
-	if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
-		if (!json.empty()) {
-			for (auto &item : json.items()){
-				T entry;
-				entry.fromJson(item.value());
-				val.insert(val.end(), std::pair<std::string ,T>(item.key(),entry));
+	template<typename T>
+	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
+		T *ptrTest;
+		std::map<std::string, T> val;
+		if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
+			if (!json.empty()) {
+				for (auto &item : json.items()) {
+					T entry;
+					entry.fromJson(item.value());
+					val.insert(val.end(),
+							std::pair<std::string, T>(item.key(), entry));
+				}
 			}
 		}
-	} else {
-		// TODO Primitives
+		return val;
 	}
-    return val;
-}
-
+	template<typename T>
+	static nlohmann::json toJson(std::map<std::string, T> val) {
+		nlohmann::json json;
+		// TODO
+		return json;
+	}
 };
 
+class MapHelper {
+public:
+
+	template<typename T>
+	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
+		std::map<std::string, T> val;
+		if (!json.empty()) {
+			for (auto &item : json.items()) {
+				T entry = item.value();
+				val.insert(val.end(),
+						std::pair<std::string, T>(item.key(), entry));
+			}
+		}
+		return val;
+	}
+	template<typename T>
+	static nlohmann::json toJson(std::map<std::string, T> val) {
+		nlohmann::json json;
+		// TODO
+		return json;
+	}
+};
 
 {{#modelNamespaceDeclarations}}
 }

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-header.mustache
@@ -58,8 +58,11 @@ public:
 	}
 	template<typename T>
 	static nlohmann::json toJson(std::vector<T> val) {
-		// TODO
-		return nlohmann::json();
+		nlohmann::json json;
+		for(auto item : val){
+			json.push_back(item.toJson());
+		}
+		return json;
 	}
 };
 
@@ -71,7 +74,6 @@ public:
 		nlohmann::from_json(json, val);
 		return val;
 	}
-
 	template<typename T>
 	static nlohmann::json toJson(std::vector<T> val) {
 		nlohmann::json json;
@@ -82,7 +84,6 @@ public:
 
 class ModelMapHelper {
 public:
-
 	template<typename T>
 	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
 		T *ptrTest;
@@ -102,14 +103,15 @@ public:
 	template<typename T>
 	static nlohmann::json toJson(std::map<std::string, T> val) {
 		nlohmann::json json;
-		// TODO
+		for (auto const& item : val) {
+		  json[item.first] = item.second.toJson();
+		}
 		return json;
 	}
 };
 
 class MapHelper {
 public:
-
 	template<typename T>
 	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
 		std::map<std::string, T> val;
@@ -125,7 +127,10 @@ public:
 	template<typename T>
 	static nlohmann::json toJson(std::map<std::string, T> val) {
 		nlohmann::json json;
-		// TODO
+		for (auto const& item : val) {
+		  nlohmann::json jitem = item.second;
+		  json[item.first] = jitem;
+		}
 		return json;
 	}
 };

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-header.mustache
@@ -12,6 +12,8 @@
 #include "json.hpp"
 #include <ctime>
 #include <string>
+#include <vector>
+#include <map>
 
 {{#modelNamespaceDeclarations}}
 namespace {{this}} {
@@ -34,9 +36,54 @@ public:
     static int64_t toJson( int64_t const value );
     static double toJson( double const value );
     static bool toJson( bool const value );
-    static nlohmann::json toJson(ModelBase const& content );
+    static nlohmann::json toJson(ModelBase const& content ); 
+};
+
+class  ModelArrayHelper {
+public:
+template <typename T>
+	static std::vector<T> fromJson(nlohmann::json& json) {
+		T *ptrTest;
+		std::vector<T> val;
+		if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
+			if (!json.empty()) {
+				for (auto &item : json.items()){
+					T entry;
+					entry.fromJson(item.value());
+					val.push_back(entry);
+				}
+			}
+		} else {
+			// TODO Primitives
+		}
+		return val;
+}
 
 };
+
+class  ModelMapHelper {
+public:
+
+template <typename T>
+static std::map<std::string, T> & fromJson(nlohmann::json& json){
+	T *ptrTest;
+	std::map<std::string, T> val;
+	if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
+		if (!json.empty()) {
+			for (auto &item : json.items()){
+				T entry;
+				entry.fromJson(item.value());
+				val.insert(val.end(), std::pair<std::string ,T>(item.key(),entry));
+			}
+		}
+	} else {
+		// TODO Primitives
+	}
+    return val;
+}
+
+};
+
 
 {{#modelNamespaceDeclarations}}
 }

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/modelbase-source.mustache
@@ -44,7 +44,7 @@ bool ModelBase::toJson( bool const value )
     return value;
 }
 
-nlohmann::json ModelBase::toJson(ModelBase content )
+nlohmann::json ModelBase::toJson(ModelBase const& content )
 {
     return content.toJson();
 }

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -245,26 +245,29 @@ void {{classname}}::fromJson(web::json::value& val)
         {{#isString}}
         {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
         {{/isString}}
+        {{#isByteArray}}{{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));{{/isByteArray}}
         {{^isString}}
         {{#isDateTime}}
         {{setter}}(ModelBase::dateFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
         {{/isDateTime}}
-        {{^isDateTime}}
+        {{^isDateTime}}{{^isByteArray}}
         if(!val[utility::conversions::to_string_t("{{baseName}}")].is_null())
         {
             {{{dataType}}} newItem({{{defaultValue}}});
             newItem->fromJson(val[utility::conversions::to_string_t("{{baseName}}")]);
             {{setter}}( newItem );
         }
-        {{/isDateTime}}
+        {{/isByteArray}}{{/isDateTime}}
         {{/isString}}
     }
     {{/required}}
     {{#required}}
     {{#isString}}
     {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
-    {{/isString}}
-    {{^isString}}
+    {{/isString}}{{#isByteArray}}
+    {{setter}}(ModelBase::stringFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
+    {{/isByteArray}}
+    {{^isString}}{{^isByteArray}}
     {{#isDateTime}}
     {{setter}}
     (ModelBase::dateFromJson(val[utility::conversions::to_string_t("{{baseName}}")]));
@@ -279,7 +282,7 @@ void {{classname}}::fromJson(web::json::value& val)
     {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}
-    {{/isString}}
+    {{/isByteArray}}{{/isString}}
     {{/required}}
     {{/isPrimitiveType}}
     {{/isMapContainer}}
@@ -353,31 +356,33 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
     {{^required}}
     if(m_{{name}}IsSet)
     {
-        {{#isString}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
-        {{/isString}}{{^isString}}{{#isDateTime}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
-        {{/isDateTime}}{{^isDateTime}}if (m_{{name}}.get())
+        {{#isString}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));{{/isString}}{{#isByteArray}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
+        {{/isByteArray}}{{^isString}}{{#isDateTime}}multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
+        {{/isDateTime}}{{^isDateTime}}{{^isByteArray}}if (m_{{name}}.get())
         {
             m_{{name}}->toMultipart(multipart, utility::conversions::to_string_t("{{baseName}}."));
         }
-        {{/isDateTime}}{{/isString}}
+       {{/isByteArray}}{{/isDateTime}}{{/isString}}
     }
     {{/required}}
     {{#required}}
     {{#isString}}
     multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
-    {{/isString}}
+    {{/isString}}{{#isByteArray}}
+    multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
+    {{/isByteArray}}
     {{^isString}}
     {{#isDateTime}}
     multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/isDateTime}}
-    {{^isDateTime}}
+    {{^isDateTime}}{{^isByteArray}}
     {{#vendorExtensions.x-codegen-file}}
     multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t("{{baseName}}"), m_{{name}}));
     {{/vendorExtensions.x-codegen-file}}
     {{^vendorExtensions.x-codegen-file}}
     m_{{name}}->toMultipart(multipart, utility::conversions::to_string_t("{{baseName}}."));
     {{/vendorExtensions.x-codegen-file}}
-    {{/isDateTime}}
+    {{/isByteArray}}{{/isDateTime}}
     {{/isString}}
     {{/required}}
     {{/isPrimitiveType}}
@@ -508,7 +513,8 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
         {{#isString}}
         {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         {{/isString}}
-        {{^isString}}
+        {{#isByteArray}}{{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));{{/isByteArray}}
+        {{^isString}}{{^isByteArray}}
         {{#isDateTime}}
         {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
         {{/isDateTime}}
@@ -520,14 +526,14 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
             {{setter}}( newItem );
         }
         {{/isDateTime}}
-        {{/isString}}
+        {{/isByteArray}}{{/isString}}
     }
     {{/required}}
     {{#required}}
     {{#isString}}
     {{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
-    {{/isString}}
-    {{^isString}}
+    {{/isString}}{{#isByteArray}}{{setter}}(ModelBase::stringFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));{{/isByteArray}}
+    {{^isString}}{{^isByteArray}}
     {{#isDateTime}}
     {{setter}}(ModelBase::dateFromHttpContent(multipart->getContent(utility::conversions::to_string_t("{{baseName}}"))));
     {{/isDateTime}}
@@ -541,7 +547,7 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
     {{setter}}( new{{name}} );
     {{/vendorExtensions.x-codegen-file}}
     {{/isDateTime}}
-    {{/isString}}
+    {{/isByteArray}}{{/isString}}
     {{/required}}
     {{/isPrimitiveType}}
     {{/isMapContainer}}

--- a/samples/server/petstore/cpp-pistache/CMakeLists.txt
+++ b/samples/server/petstore/cpp-pistache/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.2)
 
 project(server)
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=c++11)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pg -g3" )
 
 link_directories(/usr/local/lib/)
 

--- a/samples/server/petstore/cpp-pistache/api/PetApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.cpp
@@ -59,11 +59,14 @@ void PetApi::setupRoutes() {
 void PetApi::add_pet_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
 
     // Getting the body param
+    
     Pet pet;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
+    
       pet.fromJson(request_body);
+    
       this->add_pet(pet, response);
     } catch (std::runtime_error & e) {
       //send a 400 error
@@ -132,11 +135,14 @@ void PetApi::get_pet_by_id_handler(const Pistache::Rest::Request &request, Pista
 void PetApi::update_pet_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
 
     // Getting the body param
+    
     Pet pet;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
+    
       pet.fromJson(request_body);
+    
       this->update_pet(pet, response);
     } catch (std::runtime_error & e) {
       //send a 400 error

--- a/samples/server/petstore/cpp-pistache/api/PetApi.h
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.h
@@ -71,7 +71,7 @@ private:
     /// 
     /// </remarks>
     /// <param name="pet">Pet object that needs to be added to the store</param>
-    virtual void add_pet(const std::shared_ptr<Pet> &pet, Pistache::Http::ResponseWriter &response) = 0;
+    virtual void add_pet(const Pet &pet, Pistache::Http::ResponseWriter &response) = 0;
 
     /// <summary>
     /// Deletes a pet
@@ -117,7 +117,7 @@ private:
     /// 
     /// </remarks>
     /// <param name="pet">Pet object that needs to be added to the store</param>
-    virtual void update_pet(const std::shared_ptr<Pet> &pet, Pistache::Http::ResponseWriter &response) = 0;
+    virtual void update_pet(const Pet &pet, Pistache::Http::ResponseWriter &response) = 0;
 
     /// <summary>
     /// Updates a pet in the store with form data

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
@@ -92,11 +92,14 @@ void StoreApi::get_order_by_id_handler(const Pistache::Rest::Request &request, P
 void StoreApi::place_order_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
 
     // Getting the body param
+    
     Order order;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
+    
       order.fromJson(request_body);
+    
       this->place_order(order, response);
     } catch (std::runtime_error & e) {
       //send a 400 error

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.h
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.h
@@ -93,7 +93,7 @@ private:
     /// 
     /// </remarks>
     /// <param name="order">order placed for purchasing the pet</param>
-    virtual void place_order(const std::shared_ptr<Order> &order, Pistache::Http::ResponseWriter &response) = 0;
+    virtual void place_order(const Order &order, Pistache::Http::ResponseWriter &response) = 0;
 
 };
 

--- a/samples/server/petstore/cpp-pistache/api/UserApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.cpp
@@ -59,11 +59,14 @@ void UserApi::setupRoutes() {
 void UserApi::create_user_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
 
     // Getting the body param
+    
     User user;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
+    
       user.fromJson(request_body);
+    
       this->create_user(user, response);
     } catch (std::runtime_error & e) {
       //send a 400 error
@@ -75,11 +78,11 @@ void UserApi::create_user_handler(const Pistache::Rest::Request &request, Pistac
 void UserApi::create_users_with_array_input_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
 
     // Getting the body param
-    std::vector user;
+    std::vector<User> user;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
-      user.fromJson(request_body);
+      user =   ModelArrayHelper::fromJson<User>(request_body);
       this->create_users_with_array_input(user, response);
     } catch (std::runtime_error & e) {
       //send a 400 error
@@ -91,11 +94,11 @@ void UserApi::create_users_with_array_input_handler(const Pistache::Rest::Reques
 void UserApi::create_users_with_list_input_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
 
     // Getting the body param
-    std::vector user;
+    std::vector<User> user;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
-      user.fromJson(request_body);
+      user =   ModelArrayHelper::fromJson<User>(request_body);
       this->create_users_with_list_input(user, response);
     } catch (std::runtime_error & e) {
       //send a 400 error
@@ -161,11 +164,14 @@ void UserApi::update_user_handler(const Pistache::Rest::Request &request, Pistac
     auto username = request.param(":username").as<std::string>();
     
     // Getting the body param
+    
     User user;
     
     try {
       nlohmann::json request_body = nlohmann::json::parse(request.body());
+    
       user.fromJson(request_body);
+    
       this->update_user(username, user, response);
     } catch (std::runtime_error & e) {
       //send a 400 error

--- a/samples/server/petstore/cpp-pistache/api/UserApi.h
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.h
@@ -71,7 +71,7 @@ private:
     /// This can only be done by the logged in user.
     /// </remarks>
     /// <param name="user">Created user object</param>
-    virtual void create_user(const std::shared_ptr<User> &user, Pistache::Http::ResponseWriter &response) = 0;
+    virtual void create_user(const User &user, Pistache::Http::ResponseWriter &response) = 0;
 
     /// <summary>
     /// Creates list of users with given input array
@@ -135,7 +135,7 @@ private:
     /// </remarks>
     /// <param name="username">name that need to be deleted</param>
     /// <param name="user">Updated user object</param>
-    virtual void update_user(const std::string &username, const std::shared_ptr<User> &user, Pistache::Http::ResponseWriter &response) = 0;
+    virtual void update_user(const std::string &username, const User &user, Pistache::Http::ResponseWriter &response) = 0;
 
 };
 

--- a/samples/server/petstore/cpp-pistache/impl/PetApiImpl.cpp
+++ b/samples/server/petstore/cpp-pistache/impl/PetApiImpl.cpp
@@ -23,7 +23,7 @@ PetApiImpl::PetApiImpl(Pistache::Address addr)
     : PetApi(addr)
     { }
 
-void PetApiImpl::add_pet(const std::shared_ptr<Pet> &pet, Pistache::Http::ResponseWriter &response) {
+void PetApiImpl::add_pet(const Pet &pet, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
 void PetApiImpl::delete_pet(const int64_t &petId, const Pistache::Optional<Pistache::Http::Header::Raw> &apiKey, Pistache::Http::ResponseWriter &response) {
@@ -38,7 +38,7 @@ void PetApiImpl::find_pets_by_tags(const Pistache::Optional<std::string> &tags, 
 void PetApiImpl::get_pet_by_id(const int64_t &petId, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
-void PetApiImpl::update_pet(const std::shared_ptr<Pet> &pet, Pistache::Http::ResponseWriter &response) {
+void PetApiImpl::update_pet(const Pet &pet, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
 void PetApiImpl::update_pet_with_form(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter &response){

--- a/samples/server/petstore/cpp-pistache/impl/PetApiImpl.h
+++ b/samples/server/petstore/cpp-pistache/impl/PetApiImpl.h
@@ -45,12 +45,12 @@ public:
     PetApiImpl(Pistache::Address addr);
     ~PetApiImpl() { };
 
-    void add_pet(const std::shared_ptr<Pet> &pet, Pistache::Http::ResponseWriter &response);
+    void add_pet(const Pet &pet, Pistache::Http::ResponseWriter &response);
     void delete_pet(const int64_t &petId, const Pistache::Optional<Pistache::Http::Header::Raw> &apiKey, Pistache::Http::ResponseWriter &response);
     void find_pets_by_status(const Pistache::Optional<std::string> &status, Pistache::Http::ResponseWriter &response);
     void find_pets_by_tags(const Pistache::Optional<std::string> &tags, Pistache::Http::ResponseWriter &response);
     void get_pet_by_id(const int64_t &petId, Pistache::Http::ResponseWriter &response);
-    void update_pet(const std::shared_ptr<Pet> &pet, Pistache::Http::ResponseWriter &response);
+    void update_pet(const Pet &pet, Pistache::Http::ResponseWriter &response);
     void update_pet_with_form(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter &response);
     void upload_file(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter &response);
 

--- a/samples/server/petstore/cpp-pistache/impl/StoreApiImpl.cpp
+++ b/samples/server/petstore/cpp-pistache/impl/StoreApiImpl.cpp
@@ -32,7 +32,7 @@ void StoreApiImpl::get_inventory(Pistache::Http::ResponseWriter &response) {
 void StoreApiImpl::get_order_by_id(const int64_t &orderId, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
-void StoreApiImpl::place_order(const std::shared_ptr<Order> &order, Pistache::Http::ResponseWriter &response) {
+void StoreApiImpl::place_order(const Order &order, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
 

--- a/samples/server/petstore/cpp-pistache/impl/StoreApiImpl.h
+++ b/samples/server/petstore/cpp-pistache/impl/StoreApiImpl.h
@@ -48,7 +48,7 @@ public:
     void delete_order(const std::string &orderId, Pistache::Http::ResponseWriter &response);
     void get_inventory(Pistache::Http::ResponseWriter &response);
     void get_order_by_id(const int64_t &orderId, Pistache::Http::ResponseWriter &response);
-    void place_order(const std::shared_ptr<Order> &order, Pistache::Http::ResponseWriter &response);
+    void place_order(const Order &order, Pistache::Http::ResponseWriter &response);
 
 };
 

--- a/samples/server/petstore/cpp-pistache/impl/UserApiImpl.cpp
+++ b/samples/server/petstore/cpp-pistache/impl/UserApiImpl.cpp
@@ -23,7 +23,7 @@ UserApiImpl::UserApiImpl(Pistache::Address addr)
     : UserApi(addr)
     { }
 
-void UserApiImpl::create_user(const std::shared_ptr<User> &user, Pistache::Http::ResponseWriter &response) {
+void UserApiImpl::create_user(const User &user, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
 void UserApiImpl::create_users_with_array_input(const std::vector<User> &user, Pistache::Http::ResponseWriter &response) {
@@ -44,7 +44,7 @@ void UserApiImpl::login_user(const Pistache::Optional<std::string> &username, co
 void UserApiImpl::logout_user(Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
-void UserApiImpl::update_user(const std::string &username, const std::shared_ptr<User> &user, Pistache::Http::ResponseWriter &response) {
+void UserApiImpl::update_user(const std::string &username, const User &user, Pistache::Http::ResponseWriter &response) {
     response.send(Pistache::Http::Code::Ok, "Do some magic\n");
 }
 

--- a/samples/server/petstore/cpp-pistache/impl/UserApiImpl.h
+++ b/samples/server/petstore/cpp-pistache/impl/UserApiImpl.h
@@ -45,14 +45,14 @@ public:
     UserApiImpl(Pistache::Address addr);
     ~UserApiImpl() { };
 
-    void create_user(const std::shared_ptr<User> &user, Pistache::Http::ResponseWriter &response);
+    void create_user(const User &user, Pistache::Http::ResponseWriter &response);
     void create_users_with_array_input(const std::vector<User> &user, Pistache::Http::ResponseWriter &response);
     void create_users_with_list_input(const std::vector<User> &user, Pistache::Http::ResponseWriter &response);
     void delete_user(const std::string &username, Pistache::Http::ResponseWriter &response);
     void get_user_by_name(const std::string &username, Pistache::Http::ResponseWriter &response);
     void login_user(const Pistache::Optional<std::string> &username, const Pistache::Optional<std::string> &password, Pistache::Http::ResponseWriter &response);
     void logout_user(Pistache::Http::ResponseWriter &response);
-    void update_user(const std::string &username, const std::shared_ptr<User> &user, Pistache::Http::ResponseWriter &response);
+    void update_user(const std::string &username, const User &user, Pistache::Http::ResponseWriter &response);
 
 };
 

--- a/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
+++ b/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
@@ -68,12 +68,10 @@ void ApiResponse::fromJson(nlohmann::json& val)
     if(val.find("type") != val.end())
     {
         setType(val.at("type"));
-        
     }
     if(val.find("message") != val.end())
     {
         setMessage(val.at("message"));
-        
     }
     
 }

--- a/samples/server/petstore/cpp-pistache/model/Category.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Category.cpp
@@ -62,7 +62,6 @@ void Category::fromJson(nlohmann::json& val)
     if(val.find("name") != val.end())
     {
         setName(val.at("name"));
-        
     }
     
 }

--- a/samples/server/petstore/cpp-pistache/model/ModelBase.cpp
+++ b/samples/server/petstore/cpp-pistache/model/ModelBase.cpp
@@ -55,7 +55,7 @@ bool ModelBase::toJson( bool const value )
     return value;
 }
 
-nlohmann::json ModelBase::toJson(ModelBase content )
+nlohmann::json ModelBase::toJson(ModelBase const& content )
 {
     return content.toJson();
 }

--- a/samples/server/petstore/cpp-pistache/model/ModelBase.h
+++ b/samples/server/petstore/cpp-pistache/model/ModelBase.h
@@ -69,8 +69,11 @@ public:
 	}
 	template<typename T>
 	static nlohmann::json toJson(std::vector<T> val) {
-		// TODO
-		return nlohmann::json();
+		nlohmann::json json;
+		for(auto item : val){
+			json.push_back(item.toJson());
+		}
+		return json;
 	}
 };
 
@@ -82,7 +85,6 @@ public:
 		nlohmann::from_json(json, val);
 		return val;
 	}
-
 	template<typename T>
 	static nlohmann::json toJson(std::vector<T> val) {
 		nlohmann::json json;
@@ -93,7 +95,6 @@ public:
 
 class ModelMapHelper {
 public:
-
 	template<typename T>
 	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
 		T *ptrTest;
@@ -113,14 +114,15 @@ public:
 	template<typename T>
 	static nlohmann::json toJson(std::map<std::string, T> val) {
 		nlohmann::json json;
-		// TODO
+		for (auto const& item : val) {
+		  json[item.first] = item.second.toJson();
+		}
 		return json;
 	}
 };
 
 class MapHelper {
 public:
-
 	template<typename T>
 	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
 		std::map<std::string, T> val;
@@ -136,7 +138,10 @@ public:
 	template<typename T>
 	static nlohmann::json toJson(std::map<std::string, T> val) {
 		nlohmann::json json;
-		// TODO
+		for (auto const& item : val) {
+		  nlohmann::json jitem = item.second;
+		  json[item.first] = jitem;
+		}
 		return json;
 	}
 };

--- a/samples/server/petstore/cpp-pistache/model/ModelBase.h
+++ b/samples/server/petstore/cpp-pistache/model/ModelBase.h
@@ -22,6 +22,8 @@
 #include "json.hpp"
 #include <ctime>
 #include <string>
+#include <vector>
+#include <map>
 
 namespace org {
 namespace openapitools {
@@ -45,9 +47,54 @@ public:
     static int64_t toJson( int64_t const value );
     static double toJson( double const value );
     static bool toJson( bool const value );
-    static nlohmann::json toJson(ModelBase const& content );
+    static nlohmann::json toJson(ModelBase const& content ); 
+};
+
+class  ModelArrayHelper {
+public:
+template <typename T>
+	static std::vector<T> fromJson(nlohmann::json& json) {
+		T *ptrTest;
+		std::vector<T> val;
+		if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
+			if (!json.empty()) {
+				for (auto &item : json.items()){
+					T entry;
+					entry.fromJson(item.value());
+					val.push_back(entry);
+				}
+			}
+		} else {
+			// TODO Primitives
+		}
+		return val;
+}
 
 };
+
+class  ModelMapHelper {
+public:
+
+template <typename T>
+static std::map<std::string, T> & fromJson(nlohmann::json& json){
+	T *ptrTest;
+	std::map<std::string, T> val;
+	if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
+		if (!json.empty()) {
+			for (auto &item : json.items()){
+				T entry;
+				entry.fromJson(item.value());
+				val.insert(val.end(), std::pair<std::string ,T>(item.key(),entry));
+			}
+		}
+	} else {
+		// TODO Primitives
+	}
+    return val;
+}
+
+};
+
 
 }
 }

--- a/samples/server/petstore/cpp-pistache/model/ModelBase.h
+++ b/samples/server/petstore/cpp-pistache/model/ModelBase.h
@@ -50,51 +50,96 @@ public:
     static nlohmann::json toJson(ModelBase const& content ); 
 };
 
-class  ModelArrayHelper {
+class ModelArrayHelper {
 public:
-template <typename T>
+	template<typename T>
 	static std::vector<T> fromJson(nlohmann::json& json) {
 		T *ptrTest;
 		std::vector<T> val;
 		if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
 			if (!json.empty()) {
-				for (auto &item : json.items()){
+				for (auto &item : json.items()) {
 					T entry;
 					entry.fromJson(item.value());
 					val.push_back(entry);
 				}
 			}
-		} else {
-			// TODO Primitives
 		}
 		return val;
-}
-
+	}
+	template<typename T>
+	static nlohmann::json toJson(std::vector<T> val) {
+		// TODO
+		return nlohmann::json();
+	}
 };
 
-class  ModelMapHelper {
+class ArrayHelper {
+public:
+	template<typename T>
+	static std::vector<T> fromJson(nlohmann::json& json) {
+		std::vector<T> val;
+		nlohmann::from_json(json, val);
+		return val;
+	}
+
+	template<typename T>
+	static nlohmann::json toJson(std::vector<T> val) {
+		nlohmann::json json;
+		nlohmann::to_json(json, val);
+		return json;
+	}
+};
+
+class ModelMapHelper {
 public:
 
-template <typename T>
-static std::map<std::string, T> & fromJson(nlohmann::json& json){
-	T *ptrTest;
-	std::map<std::string, T> val;
-	if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
-		if (!json.empty()) {
-			for (auto &item : json.items()){
-				T entry;
-				entry.fromJson(item.value());
-				val.insert(val.end(), std::pair<std::string ,T>(item.key(),entry));
+	template<typename T>
+	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
+		T *ptrTest;
+		std::map<std::string, T> val;
+		if (dynamic_cast<ModelBase*>(ptrTest) != nullptr) {
+			if (!json.empty()) {
+				for (auto &item : json.items()) {
+					T entry;
+					entry.fromJson(item.value());
+					val.insert(val.end(),
+							std::pair<std::string, T>(item.key(), entry));
+				}
 			}
 		}
-	} else {
-		// TODO Primitives
+		return val;
 	}
-    return val;
-}
-
+	template<typename T>
+	static nlohmann::json toJson(std::map<std::string, T> val) {
+		nlohmann::json json;
+		// TODO
+		return json;
+	}
 };
 
+class MapHelper {
+public:
+
+	template<typename T>
+	static std::map<std::string, T> & fromJson(nlohmann::json& json) {
+		std::map<std::string, T> val;
+		if (!json.empty()) {
+			for (auto &item : json.items()) {
+				T entry = item.value();
+				val.insert(val.end(),
+						std::pair<std::string, T>(item.key(), entry));
+			}
+		}
+		return val;
+	}
+	template<typename T>
+	static nlohmann::json toJson(std::map<std::string, T> val) {
+		nlohmann::json json;
+		// TODO
+		return json;
+	}
+};
 
 }
 }

--- a/samples/server/petstore/cpp-pistache/model/Order.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Order.cpp
@@ -99,7 +99,6 @@ void Order::fromJson(nlohmann::json& val)
     if(val.find("status") != val.end())
     {
         setStatus(val.at("status"));
-        
     }
     if(val.find("complete") != val.end())
     {

--- a/samples/server/petstore/cpp-pistache/model/Pet.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Pet.cpp
@@ -91,7 +91,7 @@ void Pet::fromJson(nlohmann::json& val)
     {
         if(!val["category"].is_null())
         {
-            Category newItem(Category());
+            Category newItem;
             newItem.fromJson(val["category"]);
             setCategory( newItem );
         }
@@ -117,11 +117,11 @@ void Pet::fromJson(nlohmann::json& val)
             
             if(item.is_null())
             {
-                m_Tags.push_back( Tag(nullptr) );
+                m_Tags.push_back( Tag() );
             }
             else
             {
-                Tag newItem(Tag());
+                Tag newItem;
                 newItem.fromJson(item);
                 m_Tags.push_back( newItem );
             }

--- a/samples/server/petstore/cpp-pistache/model/Pet.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Pet.cpp
@@ -132,7 +132,6 @@ void Pet::fromJson(nlohmann::json& val)
     if(val.find("status") != val.end())
     {
         setStatus(val.at("status"));
-        
     }
     
 }

--- a/samples/server/petstore/cpp-pistache/model/Tag.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Tag.cpp
@@ -62,7 +62,6 @@ void Tag::fromJson(nlohmann::json& val)
     if(val.find("name") != val.end())
     {
         setName(val.at("name"));
-        
     }
     
 }

--- a/samples/server/petstore/cpp-pistache/model/User.cpp
+++ b/samples/server/petstore/cpp-pistache/model/User.cpp
@@ -98,32 +98,26 @@ void User::fromJson(nlohmann::json& val)
     if(val.find("username") != val.end())
     {
         setUsername(val.at("username"));
-        
     }
     if(val.find("firstName") != val.end())
     {
         setFirstName(val.at("firstName"));
-        
     }
     if(val.find("lastName") != val.end())
     {
         setLastName(val.at("lastName"));
-        
     }
     if(val.find("email") != val.end())
     {
         setEmail(val.at("email"));
-        
     }
     if(val.find("password") != val.end())
     {
         setPassword(val.at("password"));
-        
     }
     if(val.find("phone") != val.end())
     {
         setPhone(val.at("phone"));
-        
     }
     if(val.find("userStatus") != val.end())
     {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
- Add Map support
- Add Array support
- Add ByteArray support
- Fixed function signatures

Fixes #482 
Fixes #446 
Fixes #414 
Fixes #407
Fixes #258

@stkrwork @MartinDelille @ravinikam 