### PR TITLE
[Spec] Add default http scheme for server URL, Fix #181

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -135,9 +135,21 @@ public class URLPathUtils {
     }
 
     private static String sanitizeUrl(String url) {
-        if (url.startsWith("/")) {
-            LOGGER.warn("'host' not defined in the spec (2.0). Default to " + LOCAL_HOST);
+        if (url.startsWith("//")) {
+            url = "http:" + url;
+            LOGGER.warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
+        } else if (url.startsWith("/")) {
             url = LOCAL_HOST + url;
+            LOGGER.warn("'host' not defined in the spec (2.0). Default to [{}] for server URL [{}]", LOCAL_HOST, url);
+        } else if (!url.matches("[a-zA-Z][0-9a-zA-Z.+\\-]+://.+")) {
+            // Add http scheme for urls without a scheme.
+            // 2.0 spec is restricted to the following schemes: "http", "https", "ws", "wss"
+            // 3.0 spec does not have an enumerated list of schemes
+            // This regex attempts to capture all schemes in IANA example schemes which
+            // can have alpha-numeric characters and [.+-]. Examples are here:
+            // https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
+            url = "http://" + url;
+            LOGGER.warn("'scheme' not defined in the spec (2.0). Default to [http] for server URL [{}]", url);
         }
 
         return url;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/URLPathUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/URLPathUtilsTest.java
@@ -55,4 +55,24 @@ public class URLPathUtilsTest {
         Assert.assertEquals(URLPathUtils.getPort(serverURL, "8081"), "9999");
         Assert.assertEquals(URLPathUtils.getPath(serverURL, "/abc"), "/some/path");
     }
+
+    @Test
+    public void testSanitizeUrl() throws Exception {
+        String[][] testData = {
+            { "https://abc1.xyz:9999/some/path", "https://abc1.xyz:9999/some/path" },
+            { "HTTPS://abc2.xyz:9999/some/path", "https://abc2.xyz:9999/some/path" },
+            { "http://abc3.xyz:9999/some/path", "http://abc3.xyz:9999/some/path" },
+            { "HTTP://abc4.xyz:9999/some/path", "http://abc4.xyz:9999/some/path" },
+            { "//abc5.xyz:9999/some/path", "http://abc5.xyz:9999/some/path" },
+            { "abc6.xyz:9999/some/path", "http://abc6.xyz:9999/some/path" },
+            { "localhost:9000/api", "http://localhost:9000/api" },
+            { "/some/path", "http://localhost/some/path" } };
+
+        for (String[] t:testData) {
+            OpenAPI openAPI = new OpenAPI();
+            openAPI.addServersItem(new Server().url(t[0]));
+
+            Assert.assertEquals(URLPathUtils.getServerURL(openAPI).toString(), t[1]);
+        }
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fix https://github.com/OpenAPITools/openapi-generator/issues/181

1. Includes additional tests for `sanitizeUrl`.
1. Checks against scheme patterns shown by [IANA list](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml), which includes `[0-9a-z.+\-]`. Can be made more generic to match `[^\p{Space}:/]`
1. Ran the `bin/go-petstore.sh` after removing the `scheme` from the spec and it works as expected. Didn't check in the changes because it requires a change in the spec.

**Current Behavior before PR for `bin/go-petstore.sh`**

Removing the scheme from the spec results in the following warning and a non-working client.

```
[main] WARN  o.o.codegen.utils.URLPathUtils - Not valid URL: petstore.swagger.io:80/v2. Default to http://localhost.
```

Generated `configuration.go` causes `mvn integration-test` to fail:

```go
func NewConfiguration() *Configuration {
	cfg := &Configuration{
		BasePath:      "petstore.swagger.io:80/v2",
		DefaultHeader: make(map[string]string),
		UserAgent:     "OpenAPI-Generator/1.0.0/go",
	}
	return cfg
}
```

**New Behavior**

`bin/go-petstore.sh`

```
[main] WARN  o.o.codegen.utils.URLPathUtils - 'scheme' not defined in the spec (2.0). Default to [http] for server URL [http://petstore.swagger.io:80/v2]
```

`configuration.go` with `http` scheme and passing integration tests.

```go
func NewConfiguration() *Configuration {
	cfg := &Configuration{
		BasePath:      "http://petstore.swagger.io:80/v2",
		DefaultHeader: make(map[string]string),
		UserAgent:     "OpenAPI-Generator/1.0.0/go",
	}
	return cfg
}
```