### PR TITLE
POM: Remove secondary dependencies

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -200,29 +200,14 @@
     <dependencies>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-models</artifactId>
-            <version>${swagger-core-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-core</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser-core</artifactId>
-            <version>${swagger-parser-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser-v3</artifactId>
-            <version>${swagger-parser-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger.parser.v3</groupId>
-            <artifactId>swagger-parser</artifactId>
-            <version>${swagger-parser-version}</version>
-        </dependency>
+        <dependency> 
+            <groupId>io.swagger.parser.v3</groupId> 
+            <artifactId>swagger-parser</artifactId> 
+            <version>${swagger-parser-version}</version> 
+        </dependency> 
         <dependency>
             <groupId>com.samskivert</groupId>
             <artifactId>jmustache</artifactId>


### PR DESCRIPTION
In the dependencies list, some items are not necessary because they are dependencies of some main dependencies we are using. This PR removes them from our POM.