### PR TITLE
Java6 support: fix pom and gradle files, avoid diamond notation

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -18,7 +18,7 @@
 ## Requirements
 
 Building the API client library requires:
-1. Java {{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}+
+1. Java {{#supportJava6}}1.6{{/supportJava6}}{{^supportJava6}}{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}{{/supportJava6}}+
 2. Maven/Gradle
 
 ## Installation

--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -31,6 +31,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -39,6 +44,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -83,6 +89,11 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven'
 
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
     {{#java8}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -91,6 +102,7 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
     {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -84,8 +90,20 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven'
 
-    sourceCompatibility = JavaVersion.VERSION_{{^java8}}1_7{{/java8}}{{#java8}}1_8{{/java8}}
-    targetCompatibility = JavaVersion.VERSION_{{^java8}}1_7{{/java8}}{{#java8}}1_8{{/java8}}
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
+    {{#java8}}
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    {{/java8}}
+    {{^java8}}
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+    {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -291,7 +291,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
+        <java.version>{{#supportJava6}}1.6{{/supportJava6}}{{^supportJava6}}{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}{{/supportJava6}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.18</swagger-core-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 22
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
     
         // Rename the aar correctly
@@ -84,6 +90,11 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven'
 
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
     {{#java8}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -92,6 +103,7 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
     {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -139,6 +139,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
+                    {{#supportJava6}}
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    {{/supportJava6}}
+                    {{^supportJava6}}
                     {{#java8}}
                         <source>1.8</source>
                         <target>1.8</target>
@@ -147,6 +152,7 @@
                         <source>1.7</source>
                         <target>1.7</target>
                     {{/java8}}
+                    {{/supportJava6}}
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -709,12 +709,12 @@ public class ApiClient {
       Map<String, List<String>> responseHeaders = buildResponseHeaders(response);
 
       if (response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
-        return new ApiResponse<>(statusCode, responseHeaders);
+        return new ApiResponse<{{#supportJava6}}T{{/supportJava6}}>(statusCode, responseHeaders);
       } else if (response.getStatusInfo().getFamily() == Status.Family.SUCCESSFUL) {
         if (returnType == null)
-          return new ApiResponse<>(statusCode, responseHeaders);
+          return new ApiResponse<{{#supportJava6}}T{{/supportJava6}}>(statusCode, responseHeaders);
         else
-          return new ApiResponse<>(statusCode, responseHeaders, deserialize(response, returnType));
+          return new ApiResponse<{{#supportJava6}}T{{/supportJava6}}>(statusCode, responseHeaders, deserialize(response, returnType));
       } else {
         String message = "error";
         String respBody = null;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -83,6 +89,11 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven'
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
     {{#java8}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -91,6 +102,7 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
     {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -139,6 +139,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
+                    {{#supportJava6}}
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    {{/supportJava6}}
+                    {{^supportJava6}}
                     {{#java8}}
                         <source>1.8</source>
                         <target>1.8</target>
@@ -147,6 +152,7 @@
                         <source>1.7</source>
                         <target>1.7</target>
                     {{/java8}}
+                    {{/supportJava6}}
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -84,8 +90,20 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven'
 
-    sourceCompatibility = JavaVersion.VERSION_{{^java8}}1_7{{/java8}}{{#java8}}1_8{{/java8}}
-    targetCompatibility = JavaVersion.VERSION_{{^java8}}1_7{{/java8}}{{#java8}}1_8{{/java8}}
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
+    {{#java8}}
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    {{/java8}}
+    {{^java8}}
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+    {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -267,7 +267,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
+        <java.version>{{#supportJava6}}1.6{{/supportJava6}}{{^supportJava6}}{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}{{/supportJava6}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 23
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -83,6 +89,11 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven'
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
     {{#java8}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -91,6 +102,7 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
     {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -120,6 +120,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
+                    {{#supportJava6}}
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    {{/supportJava6}}
+                    {{^supportJava6}}
                     {{#java8}}
                         <source>1.8</source>
                         <target>1.8</target>
@@ -128,6 +133,7 @@
                         <source>1.7</source>
                         <target>1.7</target>
                     {{/java8}}
+                    {{/supportJava6}}
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 22
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
     
         // Rename the aar correctly
@@ -84,6 +90,11 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven'
 
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
     {{#java8}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -92,6 +103,7 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
     {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -139,6 +139,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
+                    {{#supportJava6}}
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    {{/supportJava6}}
+                    {{^supportJava6}}
                     {{#java8}}
                         <source>1.8</source>
                         <target>1.8</target>
@@ -147,6 +152,7 @@
                         <source>1.7</source>
                         <target>1.7</target>
                     {{/java8}}
+                    {{/supportJava6}}
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -139,8 +139,20 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
-                    <source>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</source>
-                    <target>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</target>
+                {{#supportJava6}}
+                    <source>1.6</source>
+                    <target>1.6</target>
+                {{/supportJava6}}
+                {{^supportJava6}}
+                {{#java8}}
+                    <source>1.8</source>
+                    <target>1.8</target>
+                {{/java8}}
+                {{^java8}}
+                    <source>1.7</source>
+                    <target>1.7</target>
+                {{/java8}}
+                {{/supportJava6}}
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -32,6 +32,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -40,6 +45,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -84,8 +90,20 @@ if(hasProperty('target') && target == 'android') {
     apply plugin: 'java'
     apply plugin: 'maven'
 
-    sourceCompatibility = JavaVersion.VERSION_{{^java8}}1_7{{/java8}}{{#java8}}1_8{{/java8}}
-    targetCompatibility = JavaVersion.VERSION_{{^java8}}1_7{{/java8}}{{#java8}}1_8{{/java8}}
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
+    {{#java8}}
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    {{/java8}}
+    {{^java8}}
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+    {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
@@ -40,7 +40,7 @@ public class ApiClient {
 
     public ApiClient() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<>();{{#authMethods}}{{#isBasic}}
+        authentications = new HashMap<{{#supportJava6}}String, Authentication{{/supportJava6}}>();{{#authMethods}}{{#isBasic}}
         // authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         // authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
@@ -57,8 +57,8 @@ public class ApiClient {
             basePath = basePath + "/";
         }
 
-        Map<String, String> extraHeaders = new HashMap<>();
-        List<Pair> extraQueryParams = new ArrayList<>();
+        Map<String, String> extraHeaders = new HashMap<{{#supportJava6}}String, String{{/supportJava6}}>();
+        List<Pair> extraQueryParams = new ArrayList<{{#supportJava6}}Pair{{/supportJava6}}>();
 
         for (String authName : authentications.keySet()) {
             Authentication auth = authentications.get(authName);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play25/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play25/ApiClient.mustache
@@ -40,7 +40,7 @@ public class ApiClient {
 
     public ApiClient() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<>();{{#authMethods}}{{#isBasic}}
+        authentications = new HashMap<{{#supportJava6}}String, Authentication{{/supportJava6}}>();{{#authMethods}}{{#isBasic}}
         // authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         // authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
@@ -57,8 +57,8 @@ public class ApiClient {
             basePath = basePath + "/";
         }
 
-        Map<String, String> extraHeaders = new HashMap<>();
-        List<Pair> extraQueryParams = new ArrayList<>();
+        Map<String, String> extraHeaders = new HashMap<{{#supportJava6}}String, String{{/supportJava6}}>();
+        List<Pair> extraQueryParams = new ArrayList<{{#supportJava6}}Pair{{/supportJava6}}>();
 
         for (String authName : authentications.keySet()) {
             Authentication auth = authentications.get(authName);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -327,7 +327,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}</java.version>
+        <java.version>{{#supportJava6}}1.6{{/supportJava6}}{{^supportJava6}}{{#java8}}1.8{{/java8}}{{^java8}}1.7{{/java8}}{{/supportJava6}}</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.0</gson-fire-version>

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -139,6 +139,11 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
+                    {{#supportJava6}}
+                        <source>1.6</source>
+                        <target>1.6</target>
+                    {{/supportJava6}}
+                    {{^supportJava6}}
                     {{#java8}}
                         <source>1.8</source>
                         <target>1.8</target>
@@ -147,6 +152,7 @@
                         <source>1.7</source>
                         <target>1.7</target>
                     {{/java8}}
+                    {{/supportJava6}}
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/openapi-generator/src/main/resources/android/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/build.mustache
@@ -56,6 +56,11 @@ android {
         {{/androidSdkVersion}}
     }
     compileOptions {
+        {{#supportJava6}}
+        sourceCompatibility JavaVersion.VERSION_1_6
+        targetCompatibility JavaVersion.VERSION_1_6
+        {{/supportJava6}}
+        {{^supportJava6}}
         {{#java8}}
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -64,6 +69,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
         {{/java8}}
+        {{/supportJava6}}
     }
 
     // Rename the aar correctly

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
@@ -35,6 +35,11 @@ android {
         targetSdkVersion 25
     }
     compileOptions {
+        {{#supportJava6}}
+        sourceCompatibility JavaVersion.VERSION_1_6
+        targetCompatibility JavaVersion.VERSION_1_6
+        {{/supportJava6}}
+        {{^supportJava6}}
         {{#java8}}
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -43,6 +48,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
         {{/java8}}
+        {{/supportJava6}}
     }
 
     // Rename the aar correctly

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.gradle.mustache
@@ -34,6 +34,11 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 23
         }
         compileOptions {
+            {{#supportJava6}}
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
+            {{/supportJava6}}
+            {{^supportJava6}}
             {{#java8}}
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -42,6 +47,7 @@ if(hasProperty('target') && target == 'android') {
             sourceCompatibility JavaVersion.VERSION_1_7
             targetCompatibility JavaVersion.VERSION_1_7
             {{/java8}}
+            {{/supportJava6}}
         }
 
         // Rename the aar correctly
@@ -85,6 +91,11 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven'
+    {{#supportJava6}}
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
+    {{/supportJava6}}
+    {{^supportJava6}}
     {{#java8}}
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -93,6 +104,7 @@ if(hasProperty('target') && target == 'android') {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
     {{/java8}}
+    {{/supportJava6}}
 
     install {
         repositories.mavenInstaller {

--- a/samples/client/petstore/java/jersey2-java6/README.md
+++ b/samples/client/petstore/java/jersey2-java6/README.md
@@ -12,7 +12,7 @@ This spec is mainly for testing Petstore server and contains fake endpoints, mod
 ## Requirements
 
 Building the API client library requires:
-1. Java 1.7+
+1. Java 1.6+
 2. Maven/Gradle
 
 ## Installation
@@ -108,6 +108,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**fakeOuterCompositeSerialize**](docs/FakeApi.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fakeOuterNumberSerialize**](docs/FakeApi.md#fakeOuterNumberSerialize) | **POST** /fake/outer/number | 
 *FakeApi* | [**fakeOuterStringSerialize**](docs/FakeApi.md#fakeOuterStringSerialize) | **POST** /fake/outer/string | 
+*FakeApi* | [**testBodyWithFileSchema**](docs/FakeApi.md#testBodyWithFileSchema) | **PUT** /fake/body-with-file-schema | 
 *FakeApi* | [**testBodyWithQueryParams**](docs/FakeApi.md#testBodyWithQueryParams) | **PUT** /fake/body-with-query-params | 
 *FakeApi* | [**testClientModel**](docs/FakeApi.md#testClientModel) | **PATCH** /fake | To test \&quot;client\&quot; model
 *FakeApi* | [**testEndpointParameters**](docs/FakeApi.md#testEndpointParameters) | **POST** /fake | Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -123,6 +124,7 @@ Class | Method | HTTP request | Description
 *PetApi* | [**updatePet**](docs/PetApi.md#updatePet) | **PUT** /pet | Update an existing pet
 *PetApi* | [**updatePetWithForm**](docs/PetApi.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
 *PetApi* | [**uploadFile**](docs/PetApi.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
+*PetApi* | [**uploadFileWithRequiredFile**](docs/PetApi.md#uploadFileWithRequiredFile) | **POST** /fake/{petId}/uploadImageWithRequiredFile | uploads an image (required)
 *StoreApi* | [**deleteOrder**](docs/StoreApi.md#deleteOrder) | **DELETE** /store/order/{order_id} | Delete purchase order by ID
 *StoreApi* | [**getInventory**](docs/StoreApi.md#getInventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**getOrderById**](docs/StoreApi.md#getOrderById) | **GET** /store/order/{order_id} | Find purchase order by ID
@@ -154,6 +156,7 @@ Class | Method | HTTP request | Description
  - [EnumArrays](docs/EnumArrays.md)
  - [EnumClass](docs/EnumClass.md)
  - [EnumTest](docs/EnumTest.md)
+ - [FileSchemaTestClass](docs/FileSchemaTestClass.md)
  - [FormatTest](docs/FormatTest.md)
  - [HasOnlyReadOnly](docs/HasOnlyReadOnly.md)
  - [MapTest](docs/MapTest.md)
@@ -169,6 +172,7 @@ Class | Method | HTTP request | Description
  - [Pet](docs/Pet.md)
  - [ReadOnlyFirst](docs/ReadOnlyFirst.md)
  - [SpecialModelName](docs/SpecialModelName.md)
+ - [StringBooleanMap](docs/StringBooleanMap.md)
  - [Tag](docs/Tag.md)
  - [User](docs/User.md)
 

--- a/samples/client/petstore/java/jersey2-java6/build.gradle
+++ b/samples/client/petstore/java/jersey2-java6/build.gradle
@@ -32,8 +32,8 @@ if(hasProperty('target') && target == 'android') {
             targetSdkVersion 25
         }
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
+            sourceCompatibility JavaVersion.VERSION_1_6
+            targetCompatibility JavaVersion.VERSION_1_6
         }
 
         // Rename the aar correctly
@@ -77,8 +77,8 @@ if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'java'
     apply plugin: 'maven'
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_6
+    targetCompatibility = JavaVersion.VERSION_1_6
 
     install {
         repositories.mavenInstaller {

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -139,8 +139,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.6</source>
+                        <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
@@ -698,12 +698,12 @@ public class ApiClient {
       Map<String, List<String>> responseHeaders = buildResponseHeaders(response);
 
       if (response.getStatus() == Status.NO_CONTENT.getStatusCode()) {
-        return new ApiResponse<>(statusCode, responseHeaders);
+        return new ApiResponse<T>(statusCode, responseHeaders);
       } else if (response.getStatusInfo().getFamily() == Status.Family.SUCCESSFUL) {
         if (returnType == null)
-          return new ApiResponse<>(statusCode, responseHeaders);
+          return new ApiResponse<T>(statusCode, responseHeaders);
         else
-          return new ApiResponse<>(statusCode, responseHeaders, deserialize(response, returnType));
+          return new ApiResponse<T>(statusCode, responseHeaders, deserialize(response, returnType));
       } else {
         String message = "error";
         String respBody = null;

--- a/samples/client/petstore/java/jersey2-java6/src/test/java/org/openapitools/client/api/FakeApiTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/test/java/org/openapitools/client/api/FakeApiTest.java
@@ -17,6 +17,7 @@ import org.openapitools.client.ApiException;
 import java.math.BigDecimal;
 import org.openapitools.client.model.Client;
 import java.io.File;
+import org.openapitools.client.model.FileSchemaTestClass;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
 import org.openapitools.client.model.OuterComposite;
@@ -98,6 +99,22 @@ public class FakeApiTest {
     public void fakeOuterStringSerializeTest() throws ApiException {
         String body = null;
         String response = api.fakeOuterStringSerialize(body);
+
+        // TODO: test validations
+    }
+    
+    /**
+     * 
+     *
+     * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void testBodyWithFileSchemaTest() throws ApiException {
+        FileSchemaTestClass fileSchemaTestClass = null;
+        api.testBodyWithFileSchema(fileSchemaTestClass);
 
         // TODO: test validations
     }

--- a/samples/client/petstore/java/jersey2-java6/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -167,4 +167,22 @@ public class PetApiTest {
         // TODO: test validations
     }
     
+    /**
+     * uploads an image (required)
+     *
+     * 
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void uploadFileWithRequiredFileTest() throws ApiException {
+        Long petId = null;
+        File requiredFile = null;
+        String additionalMetadata = null;
+        ModelApiResponse response = api.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+
+        // TODO: test validations
+    }
+    
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

Better support for Java6, see https://github.com/OpenAPITools/openapi-generator/issues/517


