### PR TITLE
[Java][Spring] do webflux controllers the right way

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -12,7 +12,9 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 {{/jdk8-no-delegate}}
+{{^reactive}}
 import org.springframework.http.ResponseEntity;
+{{/reactive}}
 {{#useBeanValidation}}
 import org.springframework.validation.annotation.Validated;
 {{/useBeanValidation}}
@@ -99,13 +101,13 @@ public interface {{classname}} {
         produces = { {{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}} }, {{/hasProduces}}{{#hasConsumes}}
         consumes = { {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} },{{/hasConsumes}}{{/singleContentTypes}}
         method = RequestMethod.{{httpMethod}})
-    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{#delegate-method}}_{{/delegate-method}}{{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
+    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}{{^reactive}}ResponseEntity<{{/reactive}}{{>returnTypes}}{{^reactive}}>{{/reactive}}{{#responseWrapper}}>{{/responseWrapper}} {{#delegate-method}}_{{/delegate-method}}{{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
         {{#delegate-method}}
         return {{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
     }
 
     // Override this method
-    default {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{{dataType}}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}) {
+    default {{#responseWrapper}}{{.}}<{{/responseWrapper}}{{^reactive}}ResponseEntity<{{/reactive}}{{>returnTypes}}{{^reactive}}>{{/reactive}}{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{{dataType}}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}) {
         {{/delegate-method}}
         {{^isDelegate}}
         {{>methodBody}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiController.mustache
@@ -6,9 +6,17 @@ package {{package}};
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+{{^reactive}}
 import org.springframework.http.ResponseEntity;
+{{/reactive}}
 {{/jdk8}}
+{{^reactive}}
 import org.springframework.stereotype.Controller;
+{{/reactive}}
+{{#reactive}}
+import org.springframework.web.bind.annotation.RestController;
+{{/reactive}}
+
 {{^jdk8}}
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,7 +49,7 @@ import java.util.concurrent.Callable;
     {{/async}}
 {{/jdk8}}
 {{>generatedAnnotation}}
-@Controller
+@{{#reactive}}Rest{{/reactive}}Controller
 {{=<% %>=}}
 @RequestMapping("${openapi.<%title%>.base-path:<%>defaultBasePath%>}")
 <%={{ }}=%>
@@ -87,7 +95,7 @@ public class {{classname}}Controller implements {{classname}} {
 
 {{^jdk8}}
 {{#operation}}
-    public {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {
+    public {{#responseWrapper}}{{.}}<{{/responseWrapper}}{{^reactive}}ResponseEntity<{{/reactive}}{{>returnTypes}}{{^reactive}}>{{/reactive}}{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}) {
     {{^isDelegate}}
         {{^async}}
         {{>methodBody}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -7,7 +7,9 @@ import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 {{/jdk8}}
+{{^reactive}}
 import org.springframework.http.ResponseEntity;
+{{/reactive}}
 {{#jdk8}}
 import org.springframework.web.context.request.NativeWebRequest;
 {{/jdk8}}
@@ -45,7 +47,7 @@ public interface {{classname}}Delegate {
     /**
      * @see {{classname}}#{{operationId}}
      */
-    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}} {{>optionalDataType}} {{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
+    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}{{^reactive}}ResponseEntity<{{/reactive}}{{>returnTypes}}{{^reactive}}>{{/reactive}}{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}} {{>optionalDataType}} {{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
         {{/hasMore}}{{^hasMore}}{{#reactive}},
         {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
         {{>methodBody}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/methodBody.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/methodBody.mustache
@@ -43,5 +43,8 @@ return {{#jdk8}}{{#async}}CompletableFuture.completedFuture({{/async}}{{/jdk8}}n
         }
         {{/-last}}
     {{/examples}}
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body({{^isListContainer}}{{#allParams}}{{#isBodyParam}}{{paramName}}.then({{/isBodyParam}}{{/allParams}}{{/isListContainer}}{{#isListContainer}}{{#allParams}}{{#isBodyParam}}{{paramName}}.thenMany({{/isBodyParam}}{{/allParams}}{{/isListContainer}}result{{#allParams}}{{#isBodyParam}}){{/isBodyParam}}{{/allParams}});
+        {{#reactive}}
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return {{^isListContainer}}{{#allParams}}{{#isBodyParam}}{{paramName}}.then({{/isBodyParam}}{{/allParams}}{{/isListContainer}}{{#isListContainer}}{{#allParams}}{{#isBodyParam}}{{paramName}}.thenMany({{/isBodyParam}}{{/allParams}}{{/isListContainer}}result{{#allParams}}{{#isBodyParam}}){{/isBodyParam}}{{/allParams}};
+        {{/reactive}}
 {{/reactive}}

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApiController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/PetApiController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/StoreApiController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/UserApiController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApiController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/PetApiController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/StoreApiController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/UserApiController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.Optional;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApiController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApiController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -9,7 +9,6 @@ import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,7 +39,7 @@ public interface AnotherFakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default ResponseEntity<Mono<Client>> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
+    default Mono<Client> testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
         Mono<Client> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -49,7 +48,8 @@ public interface AnotherFakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(client.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return client.then(result);
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,11 +1,12 @@
 package org.openapitools.api;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class AnotherFakeApiController implements AnotherFakeApi {
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
@@ -18,7 +18,6 @@ import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,7 +47,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/boolean",
         produces = { "*/*" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Boolean>> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Mono<Boolean> body, ServerWebExchange exchange) {
+    default Mono<Boolean> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Mono<Boolean> body, ServerWebExchange exchange) {
         Mono<Boolean> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -57,7 +56,8 @@ public interface FakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(body.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return body.then(result);
 
     }
 
@@ -68,7 +68,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/composite",
         produces = { "*/*" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<OuterComposite>> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody Mono<OuterComposite> outerComposite, ServerWebExchange exchange) {
+    default Mono<OuterComposite> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody Mono<OuterComposite> outerComposite, ServerWebExchange exchange) {
         Mono<OuterComposite> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -77,7 +77,8 @@ public interface FakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(outerComposite.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return outerComposite.then(result);
 
     }
 
@@ -88,7 +89,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/number",
         produces = { "*/*" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<BigDecimal>> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody Mono<BigDecimal> body, ServerWebExchange exchange) {
+    default Mono<BigDecimal> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody Mono<BigDecimal> body, ServerWebExchange exchange) {
         Mono<BigDecimal> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -97,7 +98,8 @@ public interface FakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(body.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return body.then(result);
 
     }
 
@@ -108,7 +110,7 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/outer/string",
         produces = { "*/*" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<String>> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody Mono<String> body, ServerWebExchange exchange) {
+    default Mono<String> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody Mono<String> body, ServerWebExchange exchange) {
         Mono<String> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -117,7 +119,8 @@ public interface FakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(body.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return body.then(result);
 
     }
 
@@ -128,9 +131,10 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/body-with-file-schema",
         consumes = { "application/json" },
         method = RequestMethod.PUT)
-    default ResponseEntity<Mono<Void>> testBodyWithFileSchema(@ApiParam(value = "" ,required=true )  @Valid @RequestBody Mono<FileSchemaTestClass> fileSchemaTestClass, ServerWebExchange exchange) {
+    default Mono<Void> testBodyWithFileSchema(@ApiParam(value = "" ,required=true )  @Valid @RequestBody Mono<FileSchemaTestClass> fileSchemaTestClass, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(fileSchemaTestClass.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return fileSchemaTestClass.then(result);
 
     }
 
@@ -141,9 +145,10 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/body-with-query-params",
         consumes = { "application/json" },
         method = RequestMethod.PUT)
-    default ResponseEntity<Mono<Void>> testBodyWithQueryParams(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "query", required = true) String query,@ApiParam(value = "" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
+    default Mono<Void> testBodyWithQueryParams(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "query", required = true) String query,@ApiParam(value = "" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(user.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return user.then(result);
 
     }
 
@@ -155,7 +160,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default ResponseEntity<Mono<Client>> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
+    default Mono<Client> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
         Mono<Client> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -164,7 +169,8 @@ public interface FakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(client.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return client.then(result);
 
     }
 
@@ -178,9 +184,10 @@ public interface FakeApi {
     @RequestMapping(value = "/fake",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> testEndpointParameters(@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="integer", required=false)  Integer integer,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="int32", required=false)  Integer int32,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="int64", required=false)  Long int64,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="float", required=false)  Float _float,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="string", required=false)  String string,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile binary,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="date", required=false)  LocalDate date,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="password", required=false)  String password,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="callback", required=false)  String paramCallback, ServerWebExchange exchange) {
+    default Mono<Void> testEndpointParameters(@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="integer", required=false)  Integer integer,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="int32", required=false)  Integer int32,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="int64", required=false)  Long int64,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="float", required=false)  Float _float,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="string", required=false)  String string,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile binary,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="date", required=false)  LocalDate date,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="password", required=false)  String password,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="callback", required=false)  String paramCallback, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -192,9 +199,10 @@ public interface FakeApi {
     @RequestMapping(value = "/fake",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<Void>> testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1.1, -1.2") @Valid @RequestParam(value = "enum_query_double", required = false) Double enumQueryDouble,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$") @RequestParam(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestParam(value="enum_form_string", required=false)  String enumFormString, ServerWebExchange exchange) {
+    default Mono<Void> testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1.1, -1.2") @Valid @RequestParam(value = "enum_query_double", required = false) Double enumQueryDouble,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$") @RequestParam(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestParam(value="enum_form_string", required=false)  String enumFormString, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -205,9 +213,10 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/inline-additionalProperties",
         consumes = { "application/json" },
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Mono<String> requestBody, ServerWebExchange exchange) {
+    default Mono<Void> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Mono<String> requestBody, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(requestBody.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return requestBody.then(result);
 
     }
 
@@ -218,9 +227,10 @@ public interface FakeApi {
     @RequestMapping(value = "/fake/jsonFormData",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<Void>> testJsonFormData(@ApiParam(value = "field1", required=true, defaultValue="null") @RequestParam(value="param", required=true)  String param,@ApiParam(value = "field2", required=true, defaultValue="null") @RequestParam(value="param2", required=true)  String param2, ServerWebExchange exchange) {
+    default Mono<Void> testJsonFormData(@ApiParam(value = "field1", required=true, defaultValue="null") @RequestParam(value="param", required=true)  String param,@ApiParam(value = "field2", required=true, defaultValue="null") @RequestParam(value="param2", required=true)  String param2, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -237,7 +247,7 @@ public interface FakeApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<ModelApiResponse>> uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile requiredFile,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata, ServerWebExchange exchange) {
+    default Mono<ModelApiResponse> uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile requiredFile,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata, ServerWebExchange exchange) {
         Mono<ModelApiResponse> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -246,7 +256,8 @@ public interface FakeApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,11 +1,12 @@
 package org.openapitools.api;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class FakeApiController implements FakeApi {
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -9,7 +9,6 @@ import org.openapitools.model.Client;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,7 +41,7 @@ public interface FakeClassnameTestApi {
         produces = { "application/json" }, 
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
-    default ResponseEntity<Mono<Client>> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
+    default Mono<Client> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
         Mono<Client> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -51,7 +50,8 @@ public interface FakeClassnameTestApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(client.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return client.then(result);
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,11 +1,12 @@
 package org.openapitools.api;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -11,7 +11,6 @@ import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,9 +45,10 @@ public interface PetApi {
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Mono<Pet> pet, ServerWebExchange exchange) {
+    default Mono<Void> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Mono<Pet> pet, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(pet.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return pet.then(result);
 
     }
 
@@ -63,9 +63,10 @@ public interface PetApi {
         @ApiResponse(code = 400, message = "Invalid pet value") })
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
-    default ResponseEntity<Mono<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, ServerWebExchange exchange) {
+    default Mono<Void> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -82,7 +83,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByStatus",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Flux<Pet>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, ServerWebExchange exchange) {
+    default Flux<Pet> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, ServerWebExchange exchange) {
         Flux<Pet> result = Flux.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -96,7 +97,8 @@ public interface PetApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -113,7 +115,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/findByTags",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Flux<Pet>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, ServerWebExchange exchange) {
+    default Flux<Pet> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, ServerWebExchange exchange) {
         Flux<Pet> result = Flux.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -127,7 +129,8 @@ public interface PetApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -142,7 +145,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<Pet>> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, ServerWebExchange exchange) {
+    default Mono<Pet> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, ServerWebExchange exchange) {
         Mono<Pet> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -156,7 +159,8 @@ public interface PetApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -174,9 +178,10 @@ public interface PetApi {
     @RequestMapping(value = "/pet",
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
-    default ResponseEntity<Mono<Void>> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Mono<Pet> pet, ServerWebExchange exchange) {
+    default Mono<Void> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Mono<Pet> pet, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(pet.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return pet.then(result);
 
     }
 
@@ -192,9 +197,10 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false)  String status, ServerWebExchange exchange) {
+    default Mono<Void> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false)  String status, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -211,7 +217,7 @@ public interface PetApi {
         produces = { "application/json" }, 
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<ModelApiResponse>> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, ServerWebExchange exchange) {
+    default Mono<ModelApiResponse> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, ServerWebExchange exchange) {
         Mono<ModelApiResponse> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -220,7 +226,8 @@ public interface PetApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,11 +1,12 @@
 package org.openapitools.api;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class PetApiController implements PetApi {
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -10,7 +10,6 @@ import org.openapitools.model.Order;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,9 +39,10 @@ public interface StoreApi {
         @ApiResponse(code = 404, message = "Order not found") })
     @RequestMapping(value = "/store/order/{order_id}",
         method = RequestMethod.DELETE)
-    default ResponseEntity<Mono<Void>> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, ServerWebExchange exchange) {
+    default Mono<Void> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -55,9 +55,10 @@ public interface StoreApi {
     @RequestMapping(value = "/store/inventory",
         produces = { "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<Map<String, Integer>>> getInventory(ServerWebExchange exchange) {
+    default Mono<Map<String, Integer>> getInventory(ServerWebExchange exchange) {
         Mono<Map<String, Integer>> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -70,7 +71,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<Order>> getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, ServerWebExchange exchange) {
+    default Mono<Order> getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, ServerWebExchange exchange) {
         Mono<Order> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -84,7 +85,8 @@ public interface StoreApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -96,7 +98,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Order>> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Mono<Order> order, ServerWebExchange exchange) {
+    default Mono<Order> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Mono<Order> order, ServerWebExchange exchange) {
         Mono<Order> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -110,7 +112,8 @@ public interface StoreApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(order.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return order.then(result);
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,11 +1,12 @@
 package org.openapitools.api;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class StoreApiController implements StoreApi {
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -10,7 +10,6 @@ import org.openapitools.model.User;
 import io.swagger.annotations.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,9 +38,10 @@ public interface UserApi {
         @ApiResponse(code = 200, message = "successful operation") })
     @RequestMapping(value = "/user",
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
+    default Mono<Void> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(user.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return user.then(result);
 
     }
 
@@ -51,9 +51,10 @@ public interface UserApi {
         @ApiResponse(code = 200, message = "successful operation") })
     @RequestMapping(value = "/user/createWithArray",
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody Flux<List> user, ServerWebExchange exchange) {
+    default Mono<Void> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody Flux<List> user, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(user.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return user.then(result);
 
     }
 
@@ -63,9 +64,10 @@ public interface UserApi {
         @ApiResponse(code = 200, message = "successful operation") })
     @RequestMapping(value = "/user/createWithList",
         method = RequestMethod.POST)
-    default ResponseEntity<Mono<Void>> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody Flux<List> user, ServerWebExchange exchange) {
+    default Mono<Void> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody Flux<List> user, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(user.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return user.then(result);
 
     }
 
@@ -76,9 +78,10 @@ public interface UserApi {
         @ApiResponse(code = 404, message = "User not found") })
     @RequestMapping(value = "/user/{username}",
         method = RequestMethod.DELETE)
-    default ResponseEntity<Mono<Void>> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, ServerWebExchange exchange) {
+    default Mono<Void> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -91,7 +94,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<User>> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathVariable("username") String username, ServerWebExchange exchange) {
+    default Mono<User> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathVariable("username") String username, ServerWebExchange exchange) {
         Mono<User> result = Mono.empty();
         for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -105,7 +108,8 @@ public interface UserApi {
                 break;
             }
         }
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -117,9 +121,10 @@ public interface UserApi {
     @RequestMapping(value = "/user/login",
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<String>> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, ServerWebExchange exchange) {
+    default Mono<String> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, ServerWebExchange exchange) {
         Mono<String> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -129,9 +134,10 @@ public interface UserApi {
         @ApiResponse(code = 200, message = "successful operation") })
     @RequestMapping(value = "/user/logout",
         method = RequestMethod.GET)
-    default ResponseEntity<Mono<Void>> logoutUser(ServerWebExchange exchange) {
+    default Mono<Void> logoutUser(ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(result);
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result;
 
     }
 
@@ -142,9 +148,10 @@ public interface UserApi {
         @ApiResponse(code = 404, message = "User not found") })
     @RequestMapping(value = "/user/{username}",
         method = RequestMethod.PUT)
-    default ResponseEntity<Mono<Void>> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
+    default Mono<Void> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
         Mono<Void> result = Mono.empty();
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).body(user.then(result));
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return user.then(result);
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,11 +1,12 @@
 package org.openapitools.api;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class UserApiController implements UserApi {
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/PetApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/UserApiController.java
@@ -1,6 +1,7 @@
 package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;


### PR DESCRIPTION
Hello, there is a problem with mustache templates for spring-boot-webflux reactive case.
ResponseEntity<Mono|Flux>  is wrong way for this case.
Right way is to use @RestController annotation and return directly Flux or Mono objects from controllers.

Here is patchset to make generator do it right.