### PR TITLE
[php-symfony] Fixed a bug with access of non-existing property in generated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -19,6 +19,7 @@
 
 namespace {{controllerPackage}};
 
+use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use {{servicePackage}}\SerializerInterface;
@@ -32,7 +33,7 @@ use {{servicePackage}}\ValidatorInterface;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class Controller
+class Controller extends BaseController
 {
     protected $validator;
     protected $serializer;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -29,6 +29,7 @@
 
 namespace OpenAPI\Server\Controller;
 
+use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use OpenAPI\Server\Service\SerializerInterface;
@@ -42,7 +43,7 @@ use OpenAPI\Server\Service\ValidatorInterface;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class Controller
+class Controller extends BaseController
 {
     protected $validator;
     protected $serializer;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This PR fixes #577 
The Controller must extend BaseController to be able to access container property.

CC @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh



