### PR TITLE
Doc extension

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -230,6 +230,10 @@ public interface CodegenConfig {
 
     String getHttpUserAgent();
 
+    void setDocExtension(String docExtension);
+
+    String getDocExtension();
+
     String getCommonTemplateDir();
 
     void setIgnoreFilePathOverride(String ignoreFileOverride);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -251,4 +251,7 @@ public class CodegenConstants {
 
     public static final String STRIP_PACKAGE_NAME = "stripPackageName";
     public static final String STRIP_PACKAGE_NAME_DESC = "Whether to strip leading dot-separated packages from generated model classes";
+
+    public static final String DOCEXTENSION = "docExtension";
+    public static final String DOCEXTENSION_DESC = "The extension of the generated documentation files, defaults to markdown, .md";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -115,7 +115,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> typeAliases = null;
     protected Boolean prependFormOrBodyParameters = false;
     // The extension of the generated documentation files (defaults to markdown .md)
-    protected String docExtension = ".md";
+    protected String docExtension;
 
     protected String ignoreFilePathOverride;
 
@@ -3422,7 +3422,8 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the API documentation file name with full path
      */
     public String apiDocFilename(String templateName, String tag) {
-        String suffix = apiDocTemplateFiles().get(templateName);
+        String docExtension = getDocExtension();
+        String suffix = docExtension != null ? docExtension: apiDocTemplateFiles().get(templateName);
         return apiDocFileFolder() + File.separator + toApiDocFilename(tag) + suffix;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -114,6 +114,8 @@ public class DefaultCodegen implements CodegenConfig {
     // When a model is an alias for a simple type
     protected Map<String, String> typeAliases = null;
     protected Boolean prependFormOrBodyParameters = false;
+    // The extension of the generated documentation files (defaults to markdown .md)
+    protected String docExtension = ".md";
 
     protected String ignoreFilePathOverride;
 
@@ -171,6 +173,11 @@ public class DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.REMOVE_OPERATION_ID_PREFIX)) {
             this.setRemoveOperationIdPrefix(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.REMOVE_OPERATION_ID_PREFIX).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.DOCEXTENSION)){
+            this.setDocExtension(String.valueOf(additionalProperties
+                    .get(CodegenConstants.DOCEXTENSION).toString()));
         }
     }
 
@@ -3551,6 +3558,25 @@ public class DefaultCodegen implements CodegenConfig {
     public String getReleaseNote() {
         return releaseNote;
     }
+
+    /**
+     * Documentation files extension
+     *
+     * @return Documentation files extension
+     */
+    public String getDocExtension() {
+        return docExtension;
+    }
+
+    /**
+     * Set Documentation files extension
+     *
+     * @param userDocExtension documentation files extension
+     */
+    public void setDocExtension(String userDocExtension) {
+        this.docExtension = userDocExtension;
+    }
+
 
     /**
      * Set HTTP user agent.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -278,7 +278,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
     private void generateModelDocumentation(List<File> files, Map<String, Object> models, String modelName) throws IOException {
         for (String templateName : config.modelDocTemplateFiles().keySet()) {
-            String suffix = config.modelDocTemplateFiles().get(templateName);
+            String docExtension = config.getDocExtension();
+            String suffix = docExtension!=null ? docExtension : config.modelDocTemplateFiles().get(templateName);
             String filename = config.modelDocFileFolder() + File.separator + config.toModelDocFilename(modelName) + suffix;
             if (!config.shouldOverwrite(filename)) {
                 LOGGER.info("Skipped overwriting " + filename);


### PR DESCRIPTION
### PR checklist

- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

moved from https://github.com/swagger-api/swagger-codegen/pull/7681 there might still be rebase issues, but it looks fine to me

This enables to generate some supporting file (documentation) by specifying a different file extension for it, useful when you're using customised templates with e.g. Restructured Text in it, and don't want to have the files forced to be named README.md or Api.md

