### PR TITLE
Fix version incompatibility in resteasy client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.github.joschi.jackson</groupId>
             <artifactId>jackson-datatype-threetenbp</artifactId>
-            <version>${jackson-version}</version>
+            <version>${threetenbp-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -261,7 +261,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.18</swagger-core-version>
         <resteasy-version>3.1.3.Final</resteasy-version>
-        <jackson-version>2.6.4</jackson-version>
+        <jackson-version>2.8.6</jackson-version>
+        <threetenbp-version>2.6.4</threetenbp-version>
         {{^java8}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/java8}}

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>com.github.joschi.jackson</groupId>
             <artifactId>jackson-datatype-threetenbp</artifactId>
-            <version>${jackson-version}</version>
+            <version>${threetenbp-version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>
@@ -217,7 +217,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.18</swagger-core-version>
         <resteasy-version>3.1.3.Final</resteasy-version>
-        <jackson-version>2.6.4</jackson-version>
+        <jackson-version>2.8.6</jackson-version>
+        <threetenbp-version>2.6.4</threetenbp-version>
         <jodatime-version>2.9.9</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The RESTEasy client has incompatible versions for its Jackson libraries, as can be seen in this partial output from `mvn dependency:tree` in a generated client:

```
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.6.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.6.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.6.4:compile
[INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.6.4:compile
[INFO] +- joda-time:joda-time:jar:2.9.9:compile
[INFO] +- com.brsanthu:migbase64:jar:2.2:compile
[INFO] +- org.jboss.resteasy:resteasy-jackson2-provider:jar:3.1.3.Final:compile
[INFO] |  \- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.8.6:compile
[INFO] |     +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.8.6:compile
[INFO] |     \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.8.6:compile
[INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.6.4:compile
[INFO] +- com.github.joschi.jackson:jackson-datatype-threetenbp:jar:2.6.4:compile
```

The core library (etc) uses 2.6.4, but resteast-jackson2-provider uses 2.8.6.

This causes a `NoSuchMethodError` when trying to invoke an API call from the client, in some cases. This PR fixes this by bumping the jackson version up to 2.8.6.

Note that previously, the version for the `jackson-datatype-threetenbp` library was also set to `${jackson-version}`. However, this no longer works, because there is no 2.8.6 version of that library, so I kept that at 2.6.4 (which seems to work).