### PR TITLE
[Java] Fix ignored resteasy default HTTP headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -636,11 +636,11 @@ public class ApiClient {
       }
     }
 
-    for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
-      if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
-        String value = defaultHeaderEnrty.getKey();
+    for (Entry<String, String> entry: defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(entry.getKey())) {
+        String value = entry.getValue();
         if (value != null) {
-          invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
+          invocationBuilder = invocationBuilder.header(entry.getKey(), value);
         }
       }
     }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
@@ -631,11 +631,11 @@ public class ApiClient {
       }
     }
 
-    for (Entry<String, String> defaultHeaderEnrty: defaultHeaderMap.entrySet()) {
-      if (!headerParams.containsKey(defaultHeaderEnrty.getKey())) {
-        String value = defaultHeaderEnrty.getKey();
+    for (Entry<String, String> entry: defaultHeaderMap.entrySet()) {
+      if (!headerParams.containsKey(entry.getKey())) {
+        String value = entry.getValue();
         if (value != null) {
-          invocationBuilder = invocationBuilder.header(defaultHeaderEnrty.getKey(), value);
+          invocationBuilder = invocationBuilder.header(entry.getKey(), value);
         }
       }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee to review the pull request if your PR is targeting a particular programming language. Java: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas  (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09)  @jeff9finger (2018/01)

### Description of the PR

Original issue: https://github.com/swagger-api/swagger-codegen/issues/7758

I have cherry-picked the commit proposed by @paulrene in https://github.com/swagger-api/swagger-codegen/pull/7759

