### PR TITLE
[Java][Client][RestTemplate] Fixed issue #513

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -61,7 +61,7 @@ public class {{classname}} {
 {{/externalDocs}}
      */
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws RestClientException {
-        Object {{localVariablePrefix}}postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}new Object(){{/bodyParam}};
+        Object {{localVariablePrefix}}postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         {{#allParams}}{{#required}}
         // verify the required parameter '{{paramName}}' is set
         if ({{paramName}} == null) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -300,7 +300,7 @@ public class FakeApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'number' is set
         if (number == null) {
@@ -385,7 +385,7 @@ public class FakeApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         String path = UriComponentsBuilder.fromPath("/fake").build().toUriString();
         
@@ -462,7 +462,7 @@ public class FakeApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testJsonFormData(String param, String param2) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'param' is set
         if (param == null) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/PetApi.java
@@ -89,7 +89,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deletePet(Long petId, String apiKey) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -128,7 +128,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public List<Pet> findPetsByStatus(List<String> status) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'status' is set
         if (status == null) {
@@ -165,7 +165,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public List<Pet> findPetsByTags(List<String> tags) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'tags' is set
         if (tags == null) {
@@ -203,7 +203,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Pet getPetById(Long petId) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -276,7 +276,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updatePetWithForm(Long petId, String name, String status) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -320,7 +320,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -366,7 +366,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -54,7 +54,7 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteOrder(String orderId) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -88,7 +88,7 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Map<String, Integer> getInventory() throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         String path = UriComponentsBuilder.fromPath("/store/inventory").build().toUriString();
         
@@ -119,7 +119,7 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Order getOrderById(Long orderId) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
@@ -147,7 +147,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteUser(String username) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -184,7 +184,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public User getUserByName(String username) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -223,7 +223,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public String loginUser(String username, String password) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -263,7 +263,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void logoutUser() throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         String path = UriComponentsBuilder.fromPath("/user/logout").build().toUriString();
         

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -300,7 +300,7 @@ public class FakeApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'number' is set
         if (number == null) {
@@ -385,7 +385,7 @@ public class FakeApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         String path = UriComponentsBuilder.fromPath("/fake").build().toUriString();
         
@@ -462,7 +462,7 @@ public class FakeApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testJsonFormData(String param, String param2) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'param' is set
         if (param == null) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/PetApi.java
@@ -89,7 +89,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deletePet(Long petId, String apiKey) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -128,7 +128,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public List<Pet> findPetsByStatus(List<String> status) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'status' is set
         if (status == null) {
@@ -165,7 +165,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public List<Pet> findPetsByTags(List<String> tags) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'tags' is set
         if (tags == null) {
@@ -203,7 +203,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Pet getPetById(Long petId) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -276,7 +276,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updatePetWithForm(Long petId, String name, String status) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -320,7 +320,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {
@@ -366,7 +366,7 @@ public class PetApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'petId' is set
         if (petId == null) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -54,7 +54,7 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteOrder(String orderId) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {
@@ -88,7 +88,7 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Map<String, Integer> getInventory() throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         String path = UriComponentsBuilder.fromPath("/store/inventory").build().toUriString();
         
@@ -119,7 +119,7 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Order getOrderById(Long orderId) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'orderId' is set
         if (orderId == null) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
@@ -147,7 +147,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteUser(String username) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -184,7 +184,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public User getUserByName(String username) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -223,7 +223,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public String loginUser(String username, String password) throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         // verify the required parameter 'username' is set
         if (username == null) {
@@ -263,7 +263,7 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void logoutUser() throws RestClientException {
-        Object postBody = new Object();
+        Object postBody = null;
         
         String path = UriComponentsBuilder.fromPath("/user/logout").build().toUriString();
         


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixed issue #513, introduced in pull request https://github.com/OpenAPITools/openapi-generator/pull/98. While the change introduced in https://github.com/OpenAPITools/openapi-generator/pull/98 is appropriate for many java client libraries, that directly serialize via Jackson or Gson, it breaks the RestTemplate generation (as RestTemplate relies on message converters and these are not able to serialize java.lang.Objects.

This PR rolls https://github.com/OpenAPITools/openapi-generator/pull/98 back exclusively for the RestTemplate client library.

cc @jmini @bmordue @macjohnny @bbdouglas @JFCote  @sreeshas  @jfiala @lukoyanov @cbornet @jeff9finger 
