### PR TITLE
Don't use visible = true in Java model classes

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/typeInfoAnnotation.mustache
@@ -1,5 +1,5 @@
 {{#jackson}}
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminatorName}}}", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminatorName}}}")
 @JsonSubTypes({
   {{#children}}
   @JsonSubTypes.Type(value = {{classname}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{name}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.*;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
@@ -28,7 +28,7 @@ import javax.validation.Valid;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
@@ -28,7 +28,7 @@ import javax.validation.Valid;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Animal
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className", visible = true )
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "className")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
   @JsonSubTypes.Type(value = Cat.class, name = "Cat"),


### PR DESCRIPTION
This causes errors when deserializing polymorphic classes.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

When deserializing polymorphic classes using a discriminator property in the Java client, I get these errors from Jackson:
```
javax.ws.rs.ProcessingException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field <fieldname> not marked as ignorable
```
This is because we have `@JsonTypeInfo(..., visible = true)` in the model classes. This PR removed the `visible = true` part, which fixes the problem.

Tagging Java tech committee:
@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)