### PR TITLE
[PHP] Escape media type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -702,6 +702,22 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         return super.escapeText(input).trim();
     }
 
+    public void escapeMediaType(List<CodegenOperation> operationList) {
+        for (CodegenOperation op : operationList) {
+            if (!op.hasProduces) {
+                continue;
+            }
+
+            List<Map<String, String>> c = op.produces;
+            for (Map<String, String> mediaType : c) {
+                // "*/*" causes a syntax error
+                if ("*/*".equals(mediaType.get("mediaType"))) {
+                    mediaType.put("mediaType", "*_/_*");
+                }
+            }
+        }
+    }
+
     protected String extractSimpleName(String phpClassName) {
         if (phpClassName == null) {
             return null;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLumenServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLumenServerCodegen.java
@@ -133,6 +133,8 @@ public class PhpLumenServerCodegen extends AbstractPhpCodegen {
             }
         });
 
+        escapeMediaType(operations);
+
         return objs;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -124,17 +124,7 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
-        for (CodegenOperation op : operationList) {
-            if (op.hasProduces) {
-                // need to escape */* values because they breakes current mustaches
-                List<Map<String, String>> c = op.produces;
-                for (Map<String, String> mediaType : c) {
-                    if ("*/*".equals(mediaType.get("mediaType"))) {
-                        mediaType.put("mediaType", "*_/_*");
-                    }
-                }
-            }
-        }
+        escapeMediaType(operationList);
         return objs;
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/AbstractPhpCodegenTest.java
@@ -17,12 +17,16 @@
 
 package org.openapitools.codegen.php;
 
+import org.openapitools.codegen.CodegenOperation;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
+
+import java.util.Arrays;
+import java.util.HashMap;
 
 public class AbstractPhpCodegenTest {
 
@@ -77,6 +81,24 @@ public class AbstractPhpCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "PHPinvoker\\PHPapi");
         Assert.assertEquals(codegen.getInvokerPackage(), "PHPinvoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "PHPinvoker");
+    }
+
+    @Test
+    public void testEscapeMediaType() throws Exception {
+        HashMap<String, String> all = new HashMap<>();
+        all.put("mediaType", "*/*");
+        HashMap<String, String> applicationJson = new HashMap<>();
+        applicationJson.put("mediaType", "application/json");
+
+        CodegenOperation codegenOperation = new CodegenOperation();
+        codegenOperation.hasProduces = true;
+        codegenOperation.produces = Arrays.asList(all, applicationJson);
+
+        final AbstractPhpCodegen codegen = new P_AbstractPhpCodegen();
+        codegen.escapeMediaType(Arrays.asList(codegenOperation));
+
+        Assert.assertEquals(codegenOperation.produces.get(0).get("mediaType"), "*_/_*");
+        Assert.assertEquals(codegenOperation.produces.get(1).get("mediaType"), "application/json");
     }
 
     private static class P_AbstractPhpCodegen extends AbstractPhpCodegen {

--- a/samples/server/petstore/php-lumen/lib/app/Http/routes.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/routes.php
@@ -81,28 +81,28 @@ $app->get('/v2/fake/jsonFormData', 'FakeApi@testJsonFormData');
  * post fakeOuterBooleanSerialize
  * Summary: 
  * Notes: Test serialization of outer boolean types
- * Output-Formats: [*/*]
+ * Output-Formats: [*_/_*]
  */
 $app->post('/v2/fake/outer/boolean', 'FakeApi@fakeOuterBooleanSerialize');
 /**
  * post fakeOuterCompositeSerialize
  * Summary: 
  * Notes: Test serialization of object with outer number type
- * Output-Formats: [*/*]
+ * Output-Formats: [*_/_*]
  */
 $app->post('/v2/fake/outer/composite', 'FakeApi@fakeOuterCompositeSerialize');
 /**
  * post fakeOuterNumberSerialize
  * Summary: 
  * Notes: Test serialization of outer number types
- * Output-Formats: [*/*]
+ * Output-Formats: [*_/_*]
  */
 $app->post('/v2/fake/outer/number', 'FakeApi@fakeOuterNumberSerialize');
 /**
  * post fakeOuterStringSerialize
  * Summary: 
  * Notes: Test serialization of outer string types
- * Output-Formats: [*/*]
+ * Output-Formats: [*_/_*]
  */
 $app->post('/v2/fake/outer/string', 'FakeApi@fakeOuterStringSerialize');
 /**


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

In case of using `mediaType` in doc comment, `*/*` causes a syntax error.

What this PR did:

- Move the escaping logic for mediaType to AbstractPhpCodegen
- Apply the logic into other generator

