### PR TITLE
Add RepreZen API Studio to Companies/Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,10 +419,10 @@ Here are some companies/projects (alphabetical order) using OpenAPI Generator in
 - [Bithost GmbH](https://www.bithost.ch)
 - [GMO Pepabo](https://pepabo.com/en/)
 - [Raiffeisen Schweiz Genossenschaft](https://www.raiffeisen.ch)
+- [RepreZen API Studio](https://www.reprezen.com/swagger-openapi-code-generation-api-first-microservices-enterprise-development)
 - [REST United](https://restunited.com)
 - [Telstra](https://dev.telstra.com)
 - [unblu inc.](https://www.unblu.com/)
-- [RepreZen API Studio](https://www.reprezen.com/swagger-openapi-code-generation-api-first-microservices-enterprise-development)
 
 ## [5 - Presentations/Videos/Tutorials/Books](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ Here are some companies/projects (alphabetical order) using OpenAPI Generator in
 - [REST United](https://restunited.com)
 - [Telstra](https://dev.telstra.com)
 - [unblu inc.](https://www.unblu.com/)
-
+- [RepreZen API Studio](https://www.reprezen.com/swagger-openapi-code-generation-api-first-microservices-enterprise-development)
 
 ## [5 - Presentations/Videos/Tutorials/Books](#table-of-contents)
 


### PR DESCRIPTION
Per discussion with @wing328

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] (N/A) Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.1.x`, `4.0.x`. Default: `master`.
- [ ] (N/A) Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Simple update to README.  RepreZen API Studio, our commercial API design tool, now has built-in support for OpenAPI-Generator for both OpenAPI 2.0 and 3.0 source documents.  Thanks!