### PR TITLE
[java] add useNullForUnknownEnumValue option

### DIFF
--- a/bin/java-petstore-jersey1.sh
+++ b/bin/java-petstore-jersey1.sh
@@ -27,7 +27,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate --artifact-id petstore-java-client-jersey1 -t modules/openapi-generator/src/main/resources/Java -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -o samples/client/petstore/java/jersey1 -DhideGenerationTimestamp=true --library=jersey1 $@"
+ags="generate --artifact-id petstore-java-client-jersey1 -t modules/openapi-generator/src/main/resources/Java -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -o samples/client/petstore/java/jersey1 -DhideGenerationTimestamp=true --library=jersey1 --additional-properties useNullForUnknownEnumValue=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey1/src/main"
 rm -rf samples/client/petstore/java/jersey1/src/main

--- a/bin/java-petstore-jersey2.json
+++ b/bin/java-petstore-jersey2.json
@@ -1,7 +1,7 @@
 {
     "library": "jersey2",
     "artifactId": "petstore-jersey2",
-	"additionalProperties" : {
-		"useNullForUnknownEnumValue" : true
-	}
+        "additionalProperties" : {
+            "useNullForUnknownEnumValue" : true
+        }
 }

--- a/bin/java-petstore-jersey2.json
+++ b/bin/java-petstore-jersey2.json
@@ -1,4 +1,7 @@
 {
     "library": "jersey2",
-    "artifactId": "petstore-jersey2"
+    "artifactId": "petstore-jersey2",
+	"additionalProperties" : {
+		"useNullForUnknownEnumValue" : true
+	}
 }

--- a/docs/migration-guide.adoc
+++ b/docs/migration-guide.adoc
@@ -25,6 +25,17 @@ For the templates, this is not an API change, because the same values are availa
 
 If you have your own `Codegen` class (to support your own generator for example) then you might get some compile error due to the change.
 
+==== Java
+
+Schema with enum values are mapped to java enum in the generated code.
+In previous version, when an unknown value was deserialized, the value was set to `null`.
+
+With `3.2.0` a new option is introduced: `useNullForUnknownEnumValue`.
+
+* When set to `false` (default value), an Exception (`IllegalArgumentException`) is thrown when the value not available in the enum.
+* When set to `true`, unknown values are mapped to `null` as it was the case in previous versions.
+
+
 === From 3.0.x to 3.1.0
 
 Version `3.1.0` is the first minor version of OpenAPI-Generator, in comparison to `3.0.3` it contains some breaking changes, but with the possibility to fallback to the old behavior.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -65,6 +65,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
     public static final String BOOLEAN_GETTER_PREFIX = "booleanGetterPrefix";
     public static final String BOOLEAN_GETTER_PREFIX_DEFAULT = "get";
+    public static final String USE_NULL_FOR_UNKNOWN_ENUM_VALUE = "useNullForUnknownEnumValue";
 
     protected String dateLibrary = "threetenbp";
     protected boolean supportAsync = false;
@@ -99,6 +100,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected boolean supportJava6= false;
     protected boolean disableHtmlEscaping = false;
     protected String booleanGetterPrefix = BOOLEAN_GETTER_PREFIX_DEFAULT;
+    protected boolean useNullForUnknownEnumValue = false;
 
     public AbstractJavaCodegen() {
         super();
@@ -212,6 +214,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             this.setBooleanGetterPrefix(additionalProperties.get(BOOLEAN_GETTER_PREFIX).toString());
         }
         additionalProperties.put(BOOLEAN_GETTER_PREFIX, booleanGetterPrefix);
+
+        if (additionalProperties.containsKey(USE_NULL_FOR_UNKNOWN_ENUM_VALUE)) {
+            this.setUseNullForUnknownEnumValue(Boolean.valueOf(additionalProperties.get(USE_NULL_FOR_UNKNOWN_ENUM_VALUE).toString()));
+        }
+        additionalProperties.put(USE_NULL_FOR_UNKNOWN_ENUM_VALUE, useNullForUnknownEnumValue);
 
         if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
             this.setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));
@@ -1244,6 +1251,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     public void setBooleanGetterPrefix(String booleanGetterPrefix) {
         this.booleanGetterPrefix = booleanGetterPrefix;
+    }
+
+    public void setUseNullForUnknownEnumValue(boolean useNullForUnknownEnumValue) {
+        this.useNullForUnknownEnumValue = useNullForUnknownEnumValue;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/Java/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/modelEnum.mustache
@@ -48,7 +48,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 {{#gson}}
 

--- a/modules/openapi-generator/src/main/resources/Java/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/modelInnerEnum.mustache
@@ -39,7 +39,7 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
 {{#gson}}
 

--- a/modules/openapi-generator/src/main/resources/JavaInflector/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/JavaInflector/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + v + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + v + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumOuterClass.mustache
@@ -42,7 +42,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
   
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/modelEnum.mustache
@@ -37,7 +37,7 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
@@ -28,6 +28,6 @@ public enum {{datatypeWithEnum}} {
                 return b;
             }
         }
-        return null;
+        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + v + "'");{{/useNullForUnknownEnumValue}}
     }
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
@@ -38,6 +38,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/JavaVertXServer/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXServer/enumOuterClass.mustache
@@ -31,6 +31,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/MSF4J/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/MSF4J/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/MSF4J/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/MSF4J/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/java-pkmst/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/enumClass.mustache
@@ -39,6 +39,6 @@
           return b;
         }
       }
-      return null;
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/java-pkmst/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/enumOuterClass.mustache
@@ -37,6 +37,6 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
         return b;
       }
     }
-    return null;
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
 }

--- a/modules/openapi-generator/src/main/resources/undertow/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/undertow/enumOuterClass.mustache
@@ -37,6 +37,6 @@ if (String.valueOf(b.value).equals(text)) {
 return b;
 }
 }
-return null;
+{{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
 }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -98,6 +98,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "org.openapitools");
         Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "get");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.USE_NULL_FOR_UNKNOWN_ENUM_VALUE), Boolean.FALSE);
     }
 
     @Test
@@ -108,6 +109,7 @@ public class AbstractJavaCodegenTest {
         codegen.setApiPackage("xyz.yyyyy.zzzzzzz.api");
         codegen.setInvokerPackage("xyz.yyyyy.zzzzzzz.invoker");
         codegen.setBooleanGetterPrefix("is");
+        codegen.setUseNullForUnknownEnumValue(true);
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
@@ -119,6 +121,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "is");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.USE_NULL_FOR_UNKNOWN_ENUM_VALUE), Boolean.TRUE);
     }
 
     @Test
@@ -129,6 +132,7 @@ public class AbstractJavaCodegenTest {
         codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.api.oooooo");
         codegen.additionalProperties().put(CodegenConstants.INVOKER_PACKAGE, "xyz.yyyyy.invoker.oooooo");
         codegen.additionalProperties().put(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX, "getBoolean");
+        codegen.additionalProperties().put(AbstractJavaCodegen.USE_NULL_FOR_UNKNOWN_ENUM_VALUE, "true");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
@@ -140,6 +144,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.invoker.oooooo");
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE), "xyz.yyyyy.invoker.oooooo");
         Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX), "getBoolean");
+        Assert.assertEquals(codegen.additionalProperties().get(AbstractJavaCodegen.USE_NULL_FOR_UNKNOWN_ENUM_VALUE), Boolean.TRUE);
     }
 
     @Test

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,7 @@ public class EnumArrays implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -114,7 +114,7 @@ public class EnumArrays implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -58,7 +58,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,7 @@ public class EnumTest implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -117,7 +117,7 @@ public class EnumTest implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -168,7 +168,7 @@ public class EnumTest implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -219,7 +219,7 @@ public class EnumTest implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
@@ -69,7 +69,7 @@ public class MapTest implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
@@ -80,7 +80,7 @@ public class Order implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -58,7 +58,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
@@ -87,7 +87,7 @@ public class Pet implements Parcelable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -112,7 +112,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -56,7 +56,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -115,7 +115,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -166,7 +166,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -217,7 +217,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -67,7 +67,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -78,7 +78,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -56,7 +56,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -85,7 +85,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -112,7 +112,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -56,7 +56,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -115,7 +115,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -166,7 +166,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -217,7 +217,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -67,7 +67,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -78,7 +78,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -56,7 +56,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -85,7 +85,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -64,7 +64,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -104,7 +104,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -55,7 +55,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -65,7 +65,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -107,7 +107,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -147,7 +147,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -187,7 +187,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -73,7 +73,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -85,7 +85,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -55,7 +55,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -103,7 +103,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -112,7 +112,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -56,7 +56,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -115,7 +115,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -166,7 +166,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -217,7 +217,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
@@ -67,7 +67,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
@@ -78,7 +78,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -56,7 +56,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
@@ -85,7 +85,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -99,7 +99,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -55,7 +55,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -102,7 +102,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -140,7 +140,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -178,7 +178,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
@@ -66,7 +66,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
@@ -74,7 +74,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -55,7 +55,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
@@ -80,7 +80,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -99,7 +99,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -55,7 +55,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -102,7 +102,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -140,7 +140,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -178,7 +178,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
@@ -66,7 +66,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
@@ -74,7 +74,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -55,7 +55,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
@@ -80,7 +80,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -112,7 +112,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -56,7 +56,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -115,7 +115,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -166,7 +166,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -217,7 +217,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -67,7 +67,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
@@ -78,7 +78,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -56,7 +56,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
@@ -85,7 +85,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -112,7 +112,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -56,7 +56,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -115,7 +115,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -166,7 +166,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -217,7 +217,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -67,7 +67,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
@@ -78,7 +78,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -56,7 +56,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
@@ -85,7 +85,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -61,7 +61,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<JustSymbolEnum> {
@@ -112,7 +112,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<ArrayEnumEnum> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -56,7 +56,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<EnumClass> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -62,7 +62,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringEnum> {
@@ -115,7 +115,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumStringRequiredEnum> {
@@ -166,7 +166,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumIntegerEnum> {
@@ -217,7 +217,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<EnumNumberEnum> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -67,7 +67,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<InnerEnum> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
@@ -78,7 +78,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -56,7 +56,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 
   public static class Adapter extends TypeAdapter<OuterEnum> {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
@@ -85,7 +85,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -59,7 +59,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -97,7 +97,7 @@ public class EnumArrays {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -53,7 +53,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -60,7 +60,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -100,7 +100,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -138,7 +138,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -176,7 +176,7 @@ public class EnumTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -72,7 +72,7 @@ public class Order {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -53,7 +53,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -78,7 +78,7 @@ public class Pet {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -57,7 +57,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -65,7 +65,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -57,7 +57,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -65,7 +65,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Order.java
@@ -61,7 +61,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Pet.java
@@ -69,7 +69,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Order.java
@@ -55,7 +55,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
@@ -61,7 +61,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Order.java
@@ -61,7 +61,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Pet.java
@@ -69,7 +69,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -45,7 +45,7 @@ public enum JustSymbolEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -80,7 +80,7 @@ public enum ArrayEnumEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumClass.java
@@ -36,7 +36,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
   
 }

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public enum EnumStringEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -79,7 +79,7 @@ public enum EnumStringRequiredEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -114,7 +114,7 @@ public enum EnumIntegerEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -149,7 +149,7 @@ public enum EnumNumberEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/MapTest.java
@@ -51,7 +51,7 @@ public enum InnerEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -36,7 +36,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
   
 }

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -56,7 +56,7 @@ public class EnumArrays  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -90,7 +90,7 @@ public class EnumArrays  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumClass.java
@@ -49,7 +49,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumTest.java
@@ -57,7 +57,7 @@ public class EnumTest  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -93,7 +93,7 @@ public class EnumTest  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -127,7 +127,7 @@ public class EnumTest  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -161,7 +161,7 @@ public class EnumTest  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
@@ -61,7 +61,7 @@ public class MapTest  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
@@ -69,7 +69,7 @@ public class Order  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -49,7 +49,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
@@ -75,7 +75,7 @@ public class Pet  implements Serializable {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public enum JustSymbolEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -77,7 +77,7 @@ public enum ArrayEnumEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumClass.java
@@ -38,7 +38,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -42,7 +42,7 @@ public enum EnumStringEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -76,7 +76,7 @@ public enum EnumStringRequiredEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -110,7 +110,7 @@ public enum EnumIntegerEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -144,7 +144,7 @@ public enum EnumNumberEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -46,7 +46,7 @@ public enum InnerEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -46,7 +46,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -38,7 +38,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -50,7 +50,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public enum JustSymbolEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -77,7 +77,7 @@ public enum ArrayEnumEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumClass.java
@@ -38,7 +38,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -42,7 +42,7 @@ public enum EnumStringEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -76,7 +76,7 @@ public enum EnumStringRequiredEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -110,7 +110,7 @@ public enum EnumIntegerEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 
@@ -144,7 +144,7 @@ public enum EnumNumberEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -46,7 +46,7 @@ public enum InnerEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -46,7 +46,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -38,7 +38,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -50,7 +50,7 @@ public enum StatusEnum {
                 return b;
             }
         }
-        return null;
+        throw new IllegalArgumentException("Unexpected value '" + v + "'");
     }
 }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -55,7 +55,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -89,7 +89,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumClass.java
@@ -48,7 +48,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumTest.java
@@ -56,7 +56,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -92,7 +92,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -126,7 +126,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -160,7 +160,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -60,7 +60,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -68,7 +68,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -48,7 +48,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -74,7 +74,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -55,7 +55,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -89,7 +89,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumClass.java
@@ -48,7 +48,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumTest.java
@@ -56,7 +56,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -92,7 +92,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -126,7 +126,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -160,7 +160,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
@@ -60,7 +60,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
@@ -68,7 +68,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -48,7 +48,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
@@ -74,7 +74,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -55,7 +55,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -89,7 +89,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumClass.java
@@ -48,7 +48,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumTest.java
@@ -56,7 +56,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -92,7 +92,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -126,7 +126,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -160,7 +160,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -60,7 +60,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -68,7 +68,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -48,7 +48,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -74,7 +74,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -55,7 +55,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -89,7 +89,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumClass.java
@@ -48,7 +48,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumTest.java
@@ -56,7 +56,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -92,7 +92,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -126,7 +126,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -160,7 +160,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
@@ -60,7 +60,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
  

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
@@ -68,7 +68,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -48,7 +48,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
@@ -74,7 +74,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArrays.java
@@ -43,7 +43,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -77,7 +77,7 @@ public class EnumArrays   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumClass.java
@@ -37,7 +37,7 @@ public enum EnumClass {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTest.java
@@ -44,7 +44,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -80,7 +80,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -114,7 +114,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 
@@ -148,7 +148,7 @@ public class EnumTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTest.java
@@ -49,7 +49,7 @@ public class MapTest   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -56,7 +56,7 @@ public class Order   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterEnum.java
@@ -37,7 +37,7 @@ public enum OuterEnum {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
 }
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -64,7 +64,7 @@ public class Pet   {
           return b;
         }
       }
-      return null;
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.2.x`, `4.0.x`. Default: `master`.
- [x] Java Technical Committee: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

cc: @TehBakker, @slarti-b, @wing328, @cbornet

### Description of the PR

Fixes #625

This PR introduce a new option `useNullForUnknownEnumValue`.

* When `false` the generated code throws an exception when the value is unknown (not present in the enum)
* When `true` (`3.1.x` and `3.0.x` behavior): unknown values are mapped to `null`

Migration guide is updated with this PR.

2 Java samples are still using the old behavior:

* `bin/java-petstore-jersey1.sh`
* `bin/java-petstore-jersey2.sh`
