### PR TITLE
[all] Fix inconsistent parameter names when ensuring uniqueness.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2351,6 +2351,13 @@ public class DefaultCodegen implements CodegenConfig {
 
                 CodegenParameter p = fromParameter(param, imports);
 
+                // ensure unique params
+                if (ensureUniqueParams) {
+                    if (!isParameterNameUnique(p, allParams)) {
+                        p.paramName = generateNextName(p.paramName);
+                    }
+                }
+
                 allParams.add(p);
 
                 if (param instanceof QueryParameter || "query".equalsIgnoreCase(param.getIn())) {
@@ -2376,17 +2383,6 @@ public class DefaultCodegen implements CodegenConfig {
 
             for (CodegenParameter cp : bodyParams) {
                 allParams.add(cp.copy());
-            }
-        }
-
-        // ensure unique parameter name
-        for (CodegenParameter cp : allParams) {
-            if (ensureUniqueParams) {
-                if (isParameterNameUnique(cp, allParams)) {
-                    continue;
-                } else {
-                    cp.paramName = generateNextName(cp.paramName);
-                }
             }
         }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.2.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

If parameter renaming takes place while ensuring unique names in DefaultCodegen.java fromOperation method, parameter lists queryParams, pathParams, headerParams, cookieParams are not updated accordingly which causes wrong parameters to be selected when using {{#pathParams}}, {{#queryParams}} etc. in mustache templates.

