### PR TITLE
[Java][Client][RestTemplate] Fixed invalid URL-encoding of query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -46,6 +46,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
@@ -542,8 +544,15 @@ public class ApiClient {
             }
             builder.queryParams(queryParams);
         }
+		
+		URI uri;
+        try {
+            uri = new URI(builder.build().toUriString());
+        } catch(URISyntaxException ex)  {
+            throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
+        }
         
-        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build().toUri());
+        final BodyBuilder requestBuilder = RequestEntity.method(method, uri);
         if(accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
@@ -535,8 +537,15 @@ public class ApiClient {
             }
             builder.queryParams(queryParams);
         }
+		
+		URI uri;
+        try {
+            uri = new URI(builder.build().toUriString());
+        } catch(URISyntaxException ex)  {
+            throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
+        }
         
-        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build().toUri());
+        final BodyBuilder requestBuilder = RequestEntity.method(method, uri);
         if(accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -35,6 +35,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
@@ -530,8 +532,15 @@ public class ApiClient {
             }
             builder.queryParams(queryParams);
         }
+		
+		URI uri;
+        try {
+            uri = new URI(builder.build().toUriString());
+        } catch(URISyntaxException ex)  {
+            throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
+        }
         
-        final BodyBuilder requestBuilder = RequestEntity.method(method, builder.build().toUri());
+        final BodyBuilder requestBuilder = RequestEntity.method(method, uri);
         if(accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.2.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for https://github.com/OpenAPITools/openapi-generator/issues/644. Changed the way the URI is created from the given query parameters in ApiClient::invokeAPI in order to prevent a double escaping of `%` characters in the URL.

The #249 issue originally addresses the problem in the URL-encoding of query parameters in the Java RestTemplate client generation. A fix is attempted in #260, but without full success, in which this re-encoding of `%` characters is experienced.

https://github.com/OpenAPITools/openapi-generator/pull/260 PR cc: @jmini @wing328 @simingweng 
technical committee cc: @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)