### PR TITLE
Add extra modules to main dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ COPY ./LICENSE ${GEN_DIR}
 COPY ./google_checkstyle.xml ${GEN_DIR}
 
 # Modules are copied individually here to allow for caching of docker layers between major.minor versions
-# NOTE: openapi-generator-online is not included here
+COPY ./modules/openapi-generator-gradle-plugin ${GEN_DIR}/modules/openapi-generator-gradle-plugin
 COPY ./modules/openapi-generator-maven-plugin ${GEN_DIR}/modules/openapi-generator-maven-plugin
+COPY ./modules/openapi-generator-online ${GEN_DIR}/modules/openapi-generator-online
 COPY ./modules/openapi-generator-cli ${GEN_DIR}/modules/openapi-generator-cli
 COPY ./modules/openapi-generator ${GEN_DIR}/modules/openapi-generator
 COPY ./pom.xml ${GEN_DIR}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.2.x`, `4.0.x`. Default: `master`.
~- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.~

### Description of the PR

Fix for https://github.com/OpenAPITools/openapi-generator/issues/648.

Pulls in additional modules so that the `mvn package` is successful.

This does give us a ~400 MB container, though. I think we could shrink it back down somewhat by deleting all the mvn outputs save for `swagger-codegen-cli.jar`. I'm not entirely sure what the purpose of this docker container is, though, so am not sure whether that would be acceptable.
