### PR TITLE
[rust-server] add support for '|' in path segments

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -254,8 +254,8 @@ impl<F, C> Api<C> for Client<F> where
 
         let uri = format!(
             "{}{{{basePathWithoutHost}}}{{path}}{{#queryParams}}{{#-first}}?{{/-first}}{{=<% %>=}}{<% paramName %>}<%={{ }}=%>{{/queryParams}}",
-            self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), USERINFO_ENCODE_SET){{/pathParams}}{{#queryParams}},
-            {{{paramName}}}=utf8_percent_encode(&query_{{{paramName}}}, ID_ENCODE_SET){{/queryParams}}
+            self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}{{#queryParams}},
+            {{{paramName}}}=utf8_percent_encode(&query_{{{paramName}}}, QUERY_ENCODE_SET){{/queryParams}}
         );
 
         let uri = match Uri::from_str(&uri) {

--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -43,6 +43,14 @@ use {Api{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
      };
 use models;
 
+define_encode_set! {
+    /// This encode set is used for object IDs
+    ///
+    /// Aside from the special characters defined in the `PATH_SEGMENT_ENCODE_SET`,
+    /// the vertical bar (|) is encoded.
+    pub ID_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | {'|'}
+}
+
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
 fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
     // First convert to Uri, since a base path is a subset of Uri.
@@ -246,8 +254,8 @@ impl<F, C> Api<C> for Client<F> where
 
         let uri = format!(
             "{}{{{basePathWithoutHost}}}{{path}}{{#queryParams}}{{#-first}}?{{/-first}}{{=<% %>=}}{<% paramName %>}<%={{ }}=%>{{/queryParams}}",
-            self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), PATH_SEGMENT_ENCODE_SET){{/pathParams}}{{#queryParams}},
-            {{{paramName}}}=utf8_percent_encode(&query_{{{paramName}}}, QUERY_ENCODE_SET){{/queryParams}}
+            self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), USERINFO_ENCODE_SET){{/pathParams}}{{#queryParams}},
+            {{{paramName}}}=utf8_percent_encode(&query_{{{paramName}}}, ID_ENCODE_SET){{/queryParams}}
         );
 
         let uri = match Uri::from_str(&uri) {

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -19,6 +19,9 @@ extern crate hyper;
 
 extern crate swagger;
 
+#[macro_use]
+extern crate url;
+
 use futures::Stream;
 use std::io::Error;
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -74,6 +74,14 @@ use {Api,
      };
 use models;
 
+define_encode_set! {
+    /// This encode set is used for object IDs
+    ///
+    /// Aside from the special characters defined in the `PATH_SEGMENT_ENCODE_SET`,
+    /// the vertical bar (|) is encoded.
+    pub ID_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | {'|'}
+}
+
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
 fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
     // First convert to Uri, since a base path is a subset of Uri.
@@ -1236,7 +1244,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/pet/{petId}",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1461,7 +1469,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/pet/{petId}",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1629,7 +1637,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/pet/{petId}",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1693,7 +1701,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/pet/{petId}/uploadImage",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1767,7 +1775,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/store/order/{order_id}",
-            self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1900,7 +1908,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/store/order/{order_id}",
-            self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2262,7 +2270,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/user/{username}",
-            self.base_path, username=utf8_percent_encode(&param_username.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2328,7 +2336,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/user/{username}",
-            self.base_path, username=utf8_percent_encode(&param_username.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2566,7 +2574,7 @@ if let Some(body) = body {
 
         let uri = format!(
             "{}/v2/user/{username}",
-            self.base_path, username=utf8_percent_encode(&param_username.to_string(), PATH_SEGMENT_ENCODE_SET)
+            self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -19,6 +19,9 @@ extern crate hyper;
 
 extern crate swagger;
 
+#[macro_use]
+extern crate url;
+
 use futures::Stream;
 use std::io::Error;
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

This merge request changes the characters that are encoded for object IDs to also include the vertical bar character (|). This is causing an issue with some of our microservices that are sending IDs containing the vertical bar character as part of the URL path to other services, which are responding with a `400 Bad request`. Testing has shown that it is the presence of the unencoded vertical bar character that is causing this error. According to RFC 3986 this is neither unreserved nor sub-delims and so should be encoded.

Tested by building the microservice that was having the issue and capturing the network traffic. The vertical bar characters are now being correctly encoded as `%7C`.

There is another encode set called `USERINFO_ENCODE_SET` (https://docs.diesel.rs/percent_encoding/struct.USERINFO_ENCODE_SET.html) but this includes a lot of additional characters. It's possible that this set would be suitable in this situation but we were reluctant to change that much in a tool that is widely used in case it adversely impacts other users.

Many thanks to @rwincewicz, the original author of this contribution on whose behalf I am submitting this upstream.