### PR TITLE
[Java][Spring] Add stopWait to pom.xml

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -36,6 +36,7 @@
                     <webAppSourceDirectory>target/${project.artifactId}-${project.version}</webAppSourceDirectory>
                     <stopPort>8079</stopPort>
                     <stopKey>stopit</stopKey>
+                    <stopWait>10</stopWait>
                     <httpConnector>
                         <port>{{serverPort}}</port>
                         <idleTimeout>60000</idleTimeout>

--- a/samples/server/petstore/spring-mvc-j8-async/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-async/pom.xml
@@ -36,6 +36,7 @@
                     <webAppSourceDirectory>target/${project.artifactId}-${project.version}</webAppSourceDirectory>
                     <stopPort>8079</stopPort>
                     <stopKey>stopit</stopKey>
+                    <stopWait>10</stopWait>
                     <httpConnector>
                         <port>8002</port>
                         <idleTimeout>60000</idleTimeout>

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
@@ -36,6 +36,7 @@
                     <webAppSourceDirectory>target/${project.artifactId}-${project.version}</webAppSourceDirectory>
                     <stopPort>8079</stopPort>
                     <stopKey>stopit</stopKey>
+                    <stopWait>10</stopWait>
                     <httpConnector>
                         <port>8002</port>
                         <idleTimeout>60000</idleTimeout>

--- a/samples/server/petstore/spring-mvc/pom.xml
+++ b/samples/server/petstore/spring-mvc/pom.xml
@@ -36,6 +36,7 @@
                     <webAppSourceDirectory>target/${project.artifactId}-${project.version}</webAppSourceDirectory>
                     <stopPort>8079</stopPort>
                     <stopKey>stopit</stopKey>
+                    <stopWait>10</stopWait>
                     <httpConnector>
                         <port>8002</port>
                         <idleTimeout>60000</idleTimeout>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR should fix the following:
> [ERROR] Failed to execute goal org.eclipse.jetty:jetty-maven-plugin:9.2.15.v20160210:start (start-jetty) on project spring-mvc-j8-localdatetime: Failure: ShutdownMonitorThread already started -> [Help 1]

Ref: 
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=412637
- https://stackoverflow.com/questions/37419969/embedded-jetty-with-maven-example-fails-to-restart-address-already-in-use
