### PR TITLE
[qt5 server] Improvement in response handling

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
@@ -34,7 +34,8 @@ import java.util.Map;
 import java.util.Set;
 
 public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implements CodegenConfig {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CppQt5QHttpEngineServerCodegen.class);
+    @SuppressWarnings("unused")
+	private static final Logger LOGGER = LoggerFactory.getLogger(CppQt5QHttpEngineServerCodegen.class);
 
     public static final String CPP_NAMESPACE = "cppNamespace";
     public static final String CPP_NAMESPACE_DESC = "C++ namespace (convention: name::space::for::api).";
@@ -327,6 +328,7 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
      * @return a string value used as the `dataType` field for model templates, `returnType` for api templates
      */
     @Override
+    @SuppressWarnings("rawtypes")
     public String getTypeDeclaration(Schema p) {
         String openAPIType = getSchemaType(p);
 
@@ -352,6 +354,7 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
     }
 
     @Override
+    @SuppressWarnings("rawtypes")    
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isBooleanSchema(p)) {
             return "false";
@@ -391,6 +394,7 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
      * @return a string value of the type or complex model for this property
      */
     @Override
+    @SuppressWarnings("rawtypes")    
     public String getSchemaType(Schema p) {
         String openAPIType = super.getSchemaType(p);
 
@@ -407,24 +411,6 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
             type = openAPIType;
         }
         return toModelName(type);
-    }
-
-    @Override
-    public String toModelName(String type) {
-        if (type == null) {
-            LOGGER.warn("Model name can't be null. Defaul to 'UnknownModel'.");
-            type = "UnknownModel";
-        }
-
-        if (typeMapping.keySet().contains(type) ||
-                typeMapping.values().contains(type) ||
-                importMapping.values().contains(type) ||
-                defaultIncludes.contains(type) ||
-                languageSpecificPrimitives.contains(type)) {
-            return type;
-        } else {
-            return modelNamePrefix + Character.toUpperCase(type.charAt(0)) + type.substring(1);
-        }
     }
 
     @Override
@@ -453,22 +439,6 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
     @Override
     public String toParamName(String name) {
         return toVarName(name);
-    }
-
-    @Override
-    public String toApiName(String type) {
-        return modelNamePrefix + Character.toUpperCase(type.charAt(0)) + type.substring(1) + "Api";
-    }
-
-    @Override
-    public String escapeQuotationMark(String input) {
-        // remove " to avoid code injection
-        return input.replace("\"", "");
-    }
-
-    @Override
-    public String escapeUnsafeCharacters(String input) {
-        return input.replace("*/", "*_/").replace("/*", "/_*");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
@@ -263,21 +263,7 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
 
         return "#include \"" + folder + name + ".h\"";
     }
-
-    /**
-     * Escapes a reserved word as defined in the `reservedWords` array. Handle escaping
-     * those terms here.  This logic is only called if a variable matches the reserved words
-     *
-     * @return the escaped term
-     */
-    @Override
-    public String escapeReservedWord(String name) {
-        if (this.reservedWordsMappings().containsKey(name)) {
-            return this.reservedWordsMappings().get(name);
-        }
-        return "_" + name;
-    }
-
+   
     /**
      * Location to write model files.  You can use the modelPackage() as defined when the class is
      * instantiated

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
@@ -234,7 +234,7 @@ public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implement
     }
 
     /**
-     * Returns human-friendly help for the generator.  Provide the consumer with help
+     * Returns human-friendly help for the generator. Provide the consumer with help
      * tips, parameters here
      *
      * @return A string value for the help message

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 public class CppQt5QHttpEngineServerCodegen extends AbstractCppCodegen implements CodegenConfig {
     @SuppressWarnings("unused")
-	private static final Logger LOGGER = LoggerFactory.getLogger(CppQt5QHttpEngineServerCodegen.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CppQt5QHttpEngineServerCodegen.class);
 
     public static final String CPP_NAMESPACE = "cppNamespace";
     public static final String CPP_NAMESPACE_DESC = "C++ namespace (convention: name::space::for::api).";

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apihandler.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apihandler.h.mustache
@@ -1,6 +1,6 @@
 {{>licenseInfo}}
-#ifndef _{{prefix}}_{{classname}}Handler_H_
-#define _{{prefix}}_{{classname}}Handler_H_
+#ifndef {{prefix}}_{{classname}}Handler_H
+#define {{prefix}}_{{classname}}Handler_H
 
 #include <QObject>
 
@@ -30,4 +30,4 @@ public slots:
 }
 {{/cppNamespaceDeclarations}}
 
-#endif // _{{prefix}}_{{classname}}Handler_H_
+#endif // {{prefix}}_{{classname}}Handler_H

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -13,6 +13,10 @@ namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
 {{classname}}Request::{{classname}}Request(QHttpEngine::Socket *s, {{classname}}Handler* hdl) : QObject(s), socket(s), handler(hdl) {
+    auto headers = s->headers();
+    for(auto itr = headers.begin(); itr != headers.end(); itr++) {
+        requestHeaders.insert(QString(itr.key()), QString(itr.value()));
+    }     
 }
 
 {{classname}}Request::~{{classname}}Request(){
@@ -21,12 +25,14 @@ namespace {{this}} {
 }
 
 QMap<QString, QString> 
-{{classname}}Request::getDefaultHeaders() const {
-    return defaultHeaders;
+{{classname}}Request::getRequestHeaders() const {
+    return requestHeaders;
 }
 
-void {{classname}}Request::setHeaders(QMultiMap<QString, QString> headers){
-
+void {{classname}}Request::setResponseHeaders(const QMultiMap<QString, QString>& headers){
+    for(auto itr = headers.begin(); itr != headers.end(); ++itr) {
+        responseHeaders.insert(itr.key(), itr.value());
+    }
 }
 
 
@@ -69,10 +75,10 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     {{/isListContainer}}
     {{^isListContainer}}
     {{^isMapContainer}}
-    {{#isPrimitive}}
+    {{#isPrimitiveType}}
     {{{dataType}}} {{paramName}};
     ::{{cppNamespace}}::fromStringValue((QString(socket->readAll()), {{paramName}});
-    {{/isPrimitive}}
+    {{/isPrimitiveType}}
     {{/isMapContainer}}
     {{#isMapContainer}}
     QJsonDocument doc;
@@ -86,13 +92,13 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     }
     {{/isMapContainer}}
     {{^isMapContainer}}
-    {{^isPrimitive}}
+    {{^isPrimitiveType}}
     QJsonDocument doc;
     socket->readJson(doc);
     QJsonObject obj = doc.object();
     {{{dataType}}} {{paramName}};
     ::{{cppNamespace}}::fromJsonValue({{paramName}}, obj);
-    {{/isPrimitive}}
+    {{/isPrimitiveType}}
     {{/isMapContainer}}
     {{/isListContainer}}        
     {{/bodyParam}}{{/bodyParams}}
@@ -103,33 +109,50 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 {{/operation}}{{/operations}}  
 
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Response({{#returnType}}{{{returnType}}} res{{/returnType}}){
-    {{#returnType}}Q_UNUSED(res);{{/returnType}}
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();{{#returnType}}{{^isPrimitiveType}}
+    QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
+    socket->writeJson(resDoc);{{#isPrimitiveType}}
+    socket->write(::{{cppNamespace}}::toStringValue(res).toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
+    socket->setStatusCode(QHttpEngine::Socket::OK);{{/returnType}}
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
-{{/operation}}{{/operations}}
 
+{{/operation}}{{/operations}}
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Error({{#returnType}}{{{returnType}}} res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    {{#returnType}}Q_UNUSED(res);{{/returnType}}     
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();{{#returnType}}
+    Q_UNUSED(error_str);  // response will be used instead of error string{{^isPrimitiveType}}
+    QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
+    socket->writeJson(resDoc);{{#isPrimitiveType}}
+    socket->write(::{{cppNamespace}}::toStringValue(res).toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());{{/returnType}}
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 {{/operation}}{{/operations}}
-
 void {{classname}}Request::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
     
 void {{classname}}Request::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -41,7 +41,7 @@ QHttpEngine::Socket* {{classname}}Request::getRawSocket(){
 }
 
 {{#operations}}{{#operation}}
-void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}str{{/pathParams}}{{/hasPathParams}}){
+void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}str{{#hasMore}}, {{/hasMore}}{{/pathParams}}{{/hasPathParams}}){
     qDebug() << "{{{basePathWithoutHost}}}{{{path}}}";
     connect(this, &{{classname}}Request::{{nickname}}, handler, &{{classname}}Handler::{{nickname}});
     

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -109,12 +109,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 {{/operation}}{{/operations}}  
 
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Response({{#returnType}}{{{returnType}}} res{{/returnType}}){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();{{#returnType}}{{^isPrimitiveType}}
+    writeResponseHeaders();{{#returnType}}{{^isPrimitiveType}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
     socket->writeJson(resDoc);{{#isPrimitiveType}}
     socket->write(::{{cppNamespace}}::toStringValue(res).toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
@@ -127,12 +122,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 {{/operation}}{{/operations}}
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Error({{#returnType}}{{{returnType}}} res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();{{#returnType}}
+    writeResponseHeaders();{{#returnType}}
     Q_UNUSED(error_str);  // response will be used instead of error string{{^isPrimitiveType}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
     socket->writeJson(resDoc);{{#isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -112,7 +112,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     writeResponseHeaders();{{#returnType}}{{^isPrimitiveType}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
     socket->writeJson(resDoc);{{#isPrimitiveType}}
-    socket->write(::{{cppNamespace}}::toStringValue(res).toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
+    socket->write(::{{cppNamespace}}{{#isListContainer}}QString("["+{{/isListContainer}}::toStringValue(res){{#isListContainer}}+"]"){{/isListContainer}}.toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
     socket->setStatusCode(QHttpEngine::Socket::OK);{{/returnType}}
     if(socket->isOpen()){
         socket->close();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -112,7 +112,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     writeResponseHeaders();{{#returnType}}{{^isPrimitiveType}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
     socket->writeJson(resDoc);{{#isPrimitiveType}}
-    socket->write(::{{cppNamespace}}{{#isListContainer}}QString("["+{{/isListContainer}}::toStringValue(res){{#isListContainer}}+"]"){{/isListContainer}}.toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
+    socket->write({{#isListContainer}}QString("["+{{/isListContainer}}::{{cppNamespace}}::toStringValue(res){{#isListContainer}}+"]"){{/isListContainer}}.toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
     socket->setStatusCode(QHttpEngine::Socket::OK);{{/returnType}}
     if(socket->isOpen()){
         socket->close();
@@ -126,7 +126,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     Q_UNUSED(error_str);  // response will be used instead of error string{{^isPrimitiveType}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
     socket->writeJson(resDoc);{{#isPrimitiveType}}
-    socket->write(::{{cppNamespace}}::toStringValue(res).toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
+    socket->write({{#isListContainer}}QString("["+{{/isListContainer}}::{{cppNamespace}}::toStringValue(res){{#isListContainer}}+"]"){{/isListContainer}}.toUtf8());{{/isPrimitiveType}}{{/returnType}}{{^returnType}}    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());{{/returnType}}
     if(socket->isOpen()){

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -41,7 +41,7 @@ QHttpEngine::Socket* {{classname}}Request::getRawSocket(){
 }
 
 {{#operations}}{{#operation}}
-void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}QString {{{paramName}}}str{{/pathParams}}{{/hasPathParams}}){
+void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}str{{/pathParams}}{{/hasPathParams}}){
     qDebug() << "{{{basePathWithoutHost}}}{{{path}}}";
     connect(this, &{{classname}}Request::{{nickname}}, handler, &{{classname}}Handler::{{nickname}});
     
@@ -108,7 +108,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 
 {{/operation}}{{/operations}}  
 
-{{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Response({{#returnType}}{{{returnType}}} res{{/returnType}}){
+{{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Response({{#returnType}}const {{{returnType}}}& res{{/returnType}}){
     writeResponseHeaders();{{#returnType}}{{^isPrimitiveType}}
     QJsonDocument resDoc(::{{cppNamespace}}::toJsonValue(res).to{{^isListContainer}}Object{{/isListContainer}}{{#isListContainer}}Array{{/isListContainer}}());{{/isPrimitiveType}}
     socket->writeJson(resDoc);{{#isPrimitiveType}}
@@ -120,7 +120,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 }
 
 {{/operation}}{{/operations}}
-{{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Error({{#returnType}}{{{returnType}}} res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str){
+{{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Error({{#returnType}}const {{{returnType}}}& res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();{{#returnType}}
     Q_UNUSED(error_str);  // response will be used instead of error string{{^isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -21,9 +21,14 @@ namespace {{this}} {
 }
 
 QMap<QString, QString> 
-{{classname}}Request::getDefaultHeaders(){
+{{classname}}Request::getDefaultHeaders() const {
     return defaultHeaders;
 }
+
+void {{classname}}Request::setHeaders(QMultiMap<QString, QString> headers){
+
+}
+
 
 QHttpEngine::Socket* {{classname}}Request::getRawSocket(){
     return socket;
@@ -98,6 +103,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 {{/operation}}{{/operations}}  
 
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Response({{#returnType}}{{{returnType}}} res{{/returnType}}){
+    {{#returnType}}Q_UNUSED(res);{{/returnType}}
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -108,7 +114,8 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 
 {{#operations}}{{#operation}}void {{classname}}Request::{{nickname}}Error({{#returnType}}{{{returnType}}} res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    {{#returnType}}Q_UNUSED(res);{{/returnType}}     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -117,7 +124,13 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 }
 {{/operation}}{{/operations}}
 
+void {{classname}}Request::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
 
+}
+    
+void {{classname}}Request::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
+
+}
 
 {{#cppNamespaceDeclarations}}
 }

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -53,6 +53,15 @@ private:
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     {{classname}}Handler *handler;
+
+    inline void writeResponseHeaders(){
+        QHttpEngine::Socket::HeaderMap resHeaders;
+        for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+            resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+        }
+        socket->setHeaders(resHeaders);
+        socket->writeHeaders();        
+    }
 };
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -38,18 +38,19 @@ public:
 
     void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
 
-    QMap<QString, QString> getDefaultHeaders() const;
+    QMap<QString, QString> getRequestHeaders() const;
 
     QHttpEngine::Socket* getRawSocket();
 
-    void setHeaders(QMultiMap<QString,QString> headers);
+    void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
 signals:
     {{#operations}}{{#operation}}void {{nickname}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
     {{/operation}}{{/operations}}
 
 private:
-    QMap<QString, QString> defaultHeaders;
+    QMap<QString, QString> requestHeaders;
+    QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     {{classname}}Handler *handler;
 };

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -25,13 +25,13 @@ public:
     {{classname}}Request(QHttpEngine::Socket *s, {{classname}}Handler* handler);
     virtual ~{{classname}}Request();
 
-    {{#operations}}{{#operation}}void {{nickname}}Request({{#hasPathParams}}{{#pathParams}}QString {{{paramName}}}{{/pathParams}}{{/hasPathParams}});
+    {{#operations}}{{#operation}}void {{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}{{/pathParams}}{{/hasPathParams}});
     {{/operation}}{{/operations}}
 
-    {{#operations}}{{#operation}}void {{nickname}}Response({{#returnType}}{{{returnType}}} res{{/returnType}});
+    {{#operations}}{{#operation}}void {{nickname}}Response({{#returnType}}const {{{returnType}}}& res{{/returnType}});
     {{/operation}}{{/operations}}
 
-    {{#operations}}{{#operation}}void {{nickname}}Error({{#returnType}}{{{returnType}}} res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str);
+    {{#operations}}{{#operation}}void {{nickname}}Error({{#returnType}}const {{{returnType}}}& res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str);
     {{/operation}}{{/operations}}
 
     void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -25,7 +25,7 @@ public:
     {{classname}}Request(QHttpEngine::Socket *s, {{classname}}Handler* handler);
     virtual ~{{classname}}Request();
 
-    {{#operations}}{{#operation}}void {{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}{{/pathParams}}{{/hasPathParams}});
+    {{#operations}}{{#operation}}void {{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}{{/hasPathParams}});
     {{/operation}}{{/operations}}
 
     {{#operations}}{{#operation}}void {{nickname}}Response({{#returnType}}const {{{returnType}}}& res{{/returnType}});

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -1,9 +1,10 @@
 {{>licenseInfo}}
-#ifndef _{{prefix}}_{{classname}}Request_H_
-#define _{{prefix}}_{{classname}}Request_H_
+#ifndef {{prefix}}_{{classname}}Request_H
+#define {{prefix}}_{{classname}}Request_H
 
 #include <QObject>
 #include <QStringList>
+#include <QMultiMap>
 #include <QNetworkReply>
 #include <QSharedPointer>
 
@@ -33,8 +34,15 @@ public:
     {{#operations}}{{#operation}}void {{nickname}}Error({{#returnType}}{{{returnType}}} res, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str);
     {{/operation}}{{/operations}}
 
-    QMap<QString, QString> getDefaultHeaders();
+    void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);
+
+    void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
+
+    QMap<QString, QString> getDefaultHeaders() const;
+
     QHttpEngine::Socket* getRawSocket();
+
+    void setHeaders(QMultiMap<QString,QString> headers);
 
 signals:
     {{#operations}}{{#operation}}void {{nickname}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
@@ -50,4 +58,4 @@ private:
 }
 {{/cppNamespaceDeclarations}}
 
-#endif // _{{prefix}}_{{classname}}Request_H_
+#endif // {{prefix}}_{{classname}}Request_H

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
@@ -58,10 +58,8 @@ void ApiRouter::setUpRoutes() {
 
 void ApiRouter::processRequest(QHttpEngine::Socket *socket){
     if (Routes.contains(socket->path())) {
-        auto itr = Routes.find(socket->path());
-        while (itr != Routes.end() && itr.key() == socket->path()) {
-            itr.value().operator()(socket);
-            ++itr;
+        for(auto endpoints : Routes.values(socket->path())) {
+            endpoints.operator()(socket);
         }
     } else
     {  {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#pathParams}}        

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
@@ -75,7 +75,7 @@ void ApiRouter::processRequest(QHttpEngine::Socket *socket){
             if ((toQHttpEngineMethod("{{httpMethod}}") == socket->method()) && match.hasMatch() ) {
                 QString pathparam = match.captured(1);
                 auto reqObj = new {{classname}}Request(socket, {{classname}}ApiHandler);
-                reqObj->{{nickname}}Request({{#hasPathParams}}{{#pathParams}}pathparam{{/pathParams}}{{/hasPathParams}});;
+                reqObj->{{nickname}}Request({{#hasPathParams}}{{#pathParams}}pathparam{{/pathParams}}{{/hasPathParams}});
                 return; 
             }
         }{{/pathParams}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
@@ -28,21 +28,15 @@ namespace {{this}} {
     QString toStringValue(const double &value);
 
     template <typename T>
-    QList<QString> toStringValue(const QList<T> &val) {
-        QList<QString> strArray;
+    QString toStringValue(const QList<T> &val) {
+        QString strArray;
         for(auto item : val) {
-            strArray.append(toStringValue(item));
+            strArray.append(toStringValue(item) + ",");
+        }
+        if(val.count() > 0) {
+            strArray.chop(1);
         }
         return strArray;
-    }
-
-    template <typename T>
-    QMap<QString, QString> toStringValue(const QMap<QString, T> &val) {
-        QMap<QString, QString> strMap;
-        for(auto itemkey : val.keys()) {
-            strMap.insert(itemkey, toStringValue(val.value(itemkey)));
-        }
-        return strMap;
     }
 
     QJsonValue toJsonValue(const QString &value);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
@@ -1,6 +1,6 @@
 {{>licenseInfo}}
-#ifndef __{{prefix}}_HELPERS_H__
-#define __{{prefix}}_HELPERS_H__
+#ifndef {{prefix}}_HELPERS_H
+#define {{prefix}}_HELPERS_H
 
 #include <QJsonObject>
 #include <QJsonValue>
@@ -141,4 +141,4 @@ namespace {{this}} {
 }
 {{/cppNamespaceDeclarations}}
 
-#endif // __{{prefix}}_HELPERS_H__
+#endif // {{prefix}}_HELPERS_H

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
@@ -1,6 +1,6 @@
 {{>licenseInfo}}
-#ifndef {{prefix}}_HELPERS_H
-#define {{prefix}}_HELPERS_H
+#ifndef __{{prefix}}_HELPERS_H__
+#define __{{prefix}}_HELPERS_H__
 
 #include <QJsonObject>
 #include <QJsonValue>
@@ -141,4 +141,4 @@ namespace {{this}} {
 }
 {{/cppNamespaceDeclarations}}
 
-#endif // {{prefix}}_HELPERS_H
+#endif // __{{prefix}}_HELPERS_H__

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/main.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/main.cpp.mustache
@@ -72,6 +72,7 @@ int main(int argc, char * argv[])
    
     QSharedPointer<{{cppNamespace}}::RequestHandler> handler(new {{cppNamespace}}::RequestHandler());
     {{cppNamespace}}::ApiRouter   router;
+    router.setUpRoutes();
     QObject::connect(handler.data(), &{{cppNamespace}}::RequestHandler::requestReceived, [&](QHttpEngine::Socket *socket) {
         router.processRequest(socket);
     });

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-body.mustache
@@ -90,7 +90,7 @@ QJsonObject
 
 {{#vars}}
 {{{dataType}}}
-{{classname}}::{{getter}}() {
+{{classname}}::{{getter}}() const {
     return {{name}};
 }
 void

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-header.mustache
@@ -5,8 +5,8 @@
  * {{description}}
  */
 
-#ifndef {{classname}}_H_
-#define {{classname}}_H_
+#ifndef {{classname}}_H
+#define {{classname}}_H
 
 #include <QJsonObject>
 
@@ -35,7 +35,7 @@ public:
     void fromJson(QString jsonString) override;
 
     {{#vars}}
-    {{{dataType}}} {{getter}}();
+    {{{dataType}}} {{getter}}() const;
     void {{setter}}(const {{{dataType}}} &{{name}});
 
     {{/vars}}
@@ -53,6 +53,6 @@ private:
 }
 {{/cppNamespaceDeclarations}}
 
-#endif /* {{classname}}_H_ */
+#endif // {{classname}}_H
 {{/model}}
 {{/models}}

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.cpp
@@ -133,10 +133,8 @@ void ApiRouter::setUpRoutes() {
 
 void ApiRouter::processRequest(QHttpEngine::Socket *socket){
     if (Routes.contains(socket->path())) {
-        auto itr = Routes.find(socket->path());
-        while (itr != Routes.end() && itr.key() == socket->path()) {
-            itr.value().operator()(socket);
-            ++itr;
+        for(auto endpoints : Routes.values(socket->path())) {
+            endpoints.operator()(socket);
         }
     } else
     {          

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIPetApiHandler.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIPetApiHandler.h
@@ -10,8 +10,8 @@
  * Do not edit the class manually.
  */
 
-#ifndef _OAI_OAIPetApiHandler_H_
-#define _OAI_OAIPetApiHandler_H_
+#ifndef OAI_OAIPetApiHandler_H
+#define OAI_OAIPetApiHandler_H
 
 #include <QObject>
 
@@ -46,4 +46,4 @@ public slots:
 
 }
 
-#endif // _OAI_OAIPetApiHandler_H_
+#endif // OAI_OAIPetApiHandler_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIStoreApiHandler.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIStoreApiHandler.h
@@ -10,8 +10,8 @@
  * Do not edit the class manually.
  */
 
-#ifndef _OAI_OAIStoreApiHandler_H_
-#define _OAI_OAIStoreApiHandler_H_
+#ifndef OAI_OAIStoreApiHandler_H
+#define OAI_OAIStoreApiHandler_H
 
 #include <QObject>
 
@@ -41,4 +41,4 @@ public slots:
 
 }
 
-#endif // _OAI_OAIStoreApiHandler_H_
+#endif // OAI_OAIStoreApiHandler_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIUserApiHandler.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIUserApiHandler.h
@@ -10,8 +10,8 @@
  * Do not edit the class manually.
  */
 
-#ifndef _OAI_OAIUserApiHandler_H_
-#define _OAI_OAIUserApiHandler_H_
+#ifndef OAI_OAIUserApiHandler_H
+#define OAI_OAIUserApiHandler_H
 
 #include <QObject>
 
@@ -45,4 +45,4 @@ public slots:
 
 }
 
-#endif // _OAI_OAIUserApiHandler_H_
+#endif // OAI_OAIUserApiHandler_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/main.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/main.cpp
@@ -83,6 +83,7 @@ int main(int argc, char * argv[])
    
     QSharedPointer<OpenAPI::RequestHandler> handler(new OpenAPI::RequestHandler());
     OpenAPI::ApiRouter   router;
+    router.setUpRoutes();
     QObject::connect(handler.data(), &OpenAPI::RequestHandler::requestReceived, [&](QHttpEngine::Socket *socket) {
         router.processRequest(socket);
     });

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.cpp
@@ -83,7 +83,7 @@ OAIApiResponse::asJsonObject() const {
 }
 
 qint32
-OAIApiResponse::getCode() {
+OAIApiResponse::getCode() const {
     return code;
 }
 void
@@ -93,7 +93,7 @@ OAIApiResponse::setCode(const qint32 &code) {
 }
 
 QString
-OAIApiResponse::getType() {
+OAIApiResponse::getType() const {
     return type;
 }
 void
@@ -103,7 +103,7 @@ OAIApiResponse::setType(const QString &type) {
 }
 
 QString
-OAIApiResponse::getMessage() {
+OAIApiResponse::getMessage() const {
     return message;
 }
 void

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.h
@@ -16,8 +16,8 @@
  * Describes the result of uploading an image resource
  */
 
-#ifndef OAIApiResponse_H_
-#define OAIApiResponse_H_
+#ifndef OAIApiResponse_H
+#define OAIApiResponse_H
 
 #include <QJsonObject>
 
@@ -40,13 +40,13 @@ public:
     void fromJsonObject(QJsonObject json) override;
     void fromJson(QString jsonString) override;
 
-    qint32 getCode();
+    qint32 getCode() const;
     void setCode(const qint32 &code);
 
-    QString getType();
+    QString getType() const;
     void setType(const QString &type);
 
-    QString getMessage();
+    QString getMessage() const;
     void setMessage(const QString &message);
 
     virtual bool isSet() const override;
@@ -65,4 +65,4 @@ private:
 
 }
 
-#endif /* OAIApiResponse_H_ */
+#endif // OAIApiResponse_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.cpp
@@ -77,7 +77,7 @@ OAICategory::asJsonObject() const {
 }
 
 qint64
-OAICategory::getId() {
+OAICategory::getId() const {
     return id;
 }
 void
@@ -87,7 +87,7 @@ OAICategory::setId(const qint64 &id) {
 }
 
 QString
-OAICategory::getName() {
+OAICategory::getName() const {
     return name;
 }
 void

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.h
@@ -16,8 +16,8 @@
  * A category for a pet
  */
 
-#ifndef OAICategory_H_
-#define OAICategory_H_
+#ifndef OAICategory_H
+#define OAICategory_H
 
 #include <QJsonObject>
 
@@ -40,10 +40,10 @@ public:
     void fromJsonObject(QJsonObject json) override;
     void fromJson(QString jsonString) override;
 
-    qint64 getId();
+    qint64 getId() const;
     void setId(const qint64 &id);
 
-    QString getName();
+    QString getName() const;
     void setName(const QString &name);
 
     virtual bool isSet() const override;
@@ -59,4 +59,4 @@ private:
 
 }
 
-#endif /* OAICategory_H_ */
+#endif // OAICategory_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
@@ -37,21 +37,15 @@ namespace OpenAPI {
     QString toStringValue(const double &value);
 
     template <typename T>
-    QList<QString> toStringValue(const QList<T> &val) {
-        QList<QString> strArray;
+    QString toStringValue(const QList<T> &val) {
+        QString strArray;
         for(auto item : val) {
-            strArray.append(toStringValue(item));
+            strArray.append(toStringValue(item) + ",");
+        }
+        if(val.count() > 0) {
+            strArray.chop(1);
         }
         return strArray;
-    }
-
-    template <typename T>
-    QMap<QString, QString> toStringValue(const QMap<QString, T> &val) {
-        QMap<QString, QString> strMap;
-        for(auto itemkey : val.keys()) {
-            strMap.insert(itemkey, toStringValue(val.value(itemkey)));
-        }
-        return strMap;
     }
 
     QJsonValue toJsonValue(const QString &value);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
@@ -10,8 +10,8 @@
  * Do not edit the class manually.
  */
 
-#ifndef OAI_HELPERS_H
-#define OAI_HELPERS_H
+#ifndef __OAI_HELPERS_H__
+#define __OAI_HELPERS_H__
 
 #include <QJsonObject>
 #include <QJsonValue>
@@ -148,4 +148,4 @@ namespace OpenAPI {
 
 }
 
-#endif // OAI_HELPERS_H
+#endif // __OAI_HELPERS_H__

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
@@ -10,8 +10,8 @@
  * Do not edit the class manually.
  */
 
-#ifndef __OAI_HELPERS_H__
-#define __OAI_HELPERS_H__
+#ifndef OAI_HELPERS_H
+#define OAI_HELPERS_H
 
 #include <QJsonObject>
 #include <QJsonValue>
@@ -148,4 +148,4 @@ namespace OpenAPI {
 
 }
 
-#endif // __OAI_HELPERS_H__
+#endif // OAI_HELPERS_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.cpp
@@ -101,7 +101,7 @@ OAIOrder::asJsonObject() const {
 }
 
 qint64
-OAIOrder::getId() {
+OAIOrder::getId() const {
     return id;
 }
 void
@@ -111,7 +111,7 @@ OAIOrder::setId(const qint64 &id) {
 }
 
 qint64
-OAIOrder::getPetId() {
+OAIOrder::getPetId() const {
     return pet_id;
 }
 void
@@ -121,7 +121,7 @@ OAIOrder::setPetId(const qint64 &pet_id) {
 }
 
 qint32
-OAIOrder::getQuantity() {
+OAIOrder::getQuantity() const {
     return quantity;
 }
 void
@@ -131,7 +131,7 @@ OAIOrder::setQuantity(const qint32 &quantity) {
 }
 
 QDateTime
-OAIOrder::getShipDate() {
+OAIOrder::getShipDate() const {
     return ship_date;
 }
 void
@@ -141,7 +141,7 @@ OAIOrder::setShipDate(const QDateTime &ship_date) {
 }
 
 QString
-OAIOrder::getStatus() {
+OAIOrder::getStatus() const {
     return status;
 }
 void
@@ -151,7 +151,7 @@ OAIOrder::setStatus(const QString &status) {
 }
 
 bool
-OAIOrder::isComplete() {
+OAIOrder::isComplete() const {
     return complete;
 }
 void

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.h
@@ -16,8 +16,8 @@
  * An order for a pets from the pet store
  */
 
-#ifndef OAIOrder_H_
-#define OAIOrder_H_
+#ifndef OAIOrder_H
+#define OAIOrder_H
 
 #include <QJsonObject>
 
@@ -41,22 +41,22 @@ public:
     void fromJsonObject(QJsonObject json) override;
     void fromJson(QString jsonString) override;
 
-    qint64 getId();
+    qint64 getId() const;
     void setId(const qint64 &id);
 
-    qint64 getPetId();
+    qint64 getPetId() const;
     void setPetId(const qint64 &pet_id);
 
-    qint32 getQuantity();
+    qint32 getQuantity() const;
     void setQuantity(const qint32 &quantity);
 
-    QDateTime getShipDate();
+    QDateTime getShipDate() const;
     void setShipDate(const QDateTime &ship_date);
 
-    QString getStatus();
+    QString getStatus() const;
     void setStatus(const QString &status);
 
-    bool isComplete();
+    bool isComplete() const;
     void setComplete(const bool &complete);
 
     virtual bool isSet() const override;
@@ -84,4 +84,4 @@ private:
 
 }
 
-#endif /* OAIOrder_H_ */
+#endif // OAIOrder_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.cpp
@@ -103,7 +103,7 @@ OAIPet::asJsonObject() const {
 }
 
 qint64
-OAIPet::getId() {
+OAIPet::getId() const {
     return id;
 }
 void
@@ -113,7 +113,7 @@ OAIPet::setId(const qint64 &id) {
 }
 
 OAICategory
-OAIPet::getCategory() {
+OAIPet::getCategory() const {
     return category;
 }
 void
@@ -123,7 +123,7 @@ OAIPet::setCategory(const OAICategory &category) {
 }
 
 QString
-OAIPet::getName() {
+OAIPet::getName() const {
     return name;
 }
 void
@@ -133,7 +133,7 @@ OAIPet::setName(const QString &name) {
 }
 
 QList<QString>
-OAIPet::getPhotoUrls() {
+OAIPet::getPhotoUrls() const {
     return photo_urls;
 }
 void
@@ -143,7 +143,7 @@ OAIPet::setPhotoUrls(const QList<QString> &photo_urls) {
 }
 
 QList<OAITag>
-OAIPet::getTags() {
+OAIPet::getTags() const {
     return tags;
 }
 void
@@ -153,7 +153,7 @@ OAIPet::setTags(const QList<OAITag> &tags) {
 }
 
 QString
-OAIPet::getStatus() {
+OAIPet::getStatus() const {
     return status;
 }
 void

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.h
@@ -16,8 +16,8 @@
  * A pet for sale in the pet store
  */
 
-#ifndef OAIPet_H_
-#define OAIPet_H_
+#ifndef OAIPet_H
+#define OAIPet_H
 
 #include <QJsonObject>
 
@@ -43,22 +43,22 @@ public:
     void fromJsonObject(QJsonObject json) override;
     void fromJson(QString jsonString) override;
 
-    qint64 getId();
+    qint64 getId() const;
     void setId(const qint64 &id);
 
-    OAICategory getCategory();
+    OAICategory getCategory() const;
     void setCategory(const OAICategory &category);
 
-    QString getName();
+    QString getName() const;
     void setName(const QString &name);
 
-    QList<QString> getPhotoUrls();
+    QList<QString> getPhotoUrls() const;
     void setPhotoUrls(const QList<QString> &photo_urls);
 
-    QList<OAITag> getTags();
+    QList<OAITag> getTags() const;
     void setTags(const QList<OAITag> &tags);
 
-    QString getStatus();
+    QString getStatus() const;
     void setStatus(const QString &status);
 
     virtual bool isSet() const override;
@@ -86,4 +86,4 @@ private:
 
 }
 
-#endif /* OAIPet_H_ */
+#endif // OAIPet_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.cpp
@@ -77,7 +77,7 @@ OAITag::asJsonObject() const {
 }
 
 qint64
-OAITag::getId() {
+OAITag::getId() const {
     return id;
 }
 void
@@ -87,7 +87,7 @@ OAITag::setId(const qint64 &id) {
 }
 
 QString
-OAITag::getName() {
+OAITag::getName() const {
     return name;
 }
 void

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.h
@@ -16,8 +16,8 @@
  * A tag for a pet
  */
 
-#ifndef OAITag_H_
-#define OAITag_H_
+#ifndef OAITag_H
+#define OAITag_H
 
 #include <QJsonObject>
 
@@ -40,10 +40,10 @@ public:
     void fromJsonObject(QJsonObject json) override;
     void fromJson(QString jsonString) override;
 
-    qint64 getId();
+    qint64 getId() const;
     void setId(const qint64 &id);
 
-    QString getName();
+    QString getName() const;
     void setName(const QString &name);
 
     virtual bool isSet() const override;
@@ -59,4 +59,4 @@ private:
 
 }
 
-#endif /* OAITag_H_ */
+#endif // OAITag_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.cpp
@@ -113,7 +113,7 @@ OAIUser::asJsonObject() const {
 }
 
 qint64
-OAIUser::getId() {
+OAIUser::getId() const {
     return id;
 }
 void
@@ -123,7 +123,7 @@ OAIUser::setId(const qint64 &id) {
 }
 
 QString
-OAIUser::getUsername() {
+OAIUser::getUsername() const {
     return username;
 }
 void
@@ -133,7 +133,7 @@ OAIUser::setUsername(const QString &username) {
 }
 
 QString
-OAIUser::getFirstName() {
+OAIUser::getFirstName() const {
     return first_name;
 }
 void
@@ -143,7 +143,7 @@ OAIUser::setFirstName(const QString &first_name) {
 }
 
 QString
-OAIUser::getLastName() {
+OAIUser::getLastName() const {
     return last_name;
 }
 void
@@ -153,7 +153,7 @@ OAIUser::setLastName(const QString &last_name) {
 }
 
 QString
-OAIUser::getEmail() {
+OAIUser::getEmail() const {
     return email;
 }
 void
@@ -163,7 +163,7 @@ OAIUser::setEmail(const QString &email) {
 }
 
 QString
-OAIUser::getPassword() {
+OAIUser::getPassword() const {
     return password;
 }
 void
@@ -173,7 +173,7 @@ OAIUser::setPassword(const QString &password) {
 }
 
 QString
-OAIUser::getPhone() {
+OAIUser::getPhone() const {
     return phone;
 }
 void
@@ -183,7 +183,7 @@ OAIUser::setPhone(const QString &phone) {
 }
 
 qint32
-OAIUser::getUserStatus() {
+OAIUser::getUserStatus() const {
     return user_status;
 }
 void

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.h
@@ -16,8 +16,8 @@
  * A User who is purchasing from the pet store
  */
 
-#ifndef OAIUser_H_
-#define OAIUser_H_
+#ifndef OAIUser_H
+#define OAIUser_H
 
 #include <QJsonObject>
 
@@ -40,28 +40,28 @@ public:
     void fromJsonObject(QJsonObject json) override;
     void fromJson(QString jsonString) override;
 
-    qint64 getId();
+    qint64 getId() const;
     void setId(const qint64 &id);
 
-    QString getUsername();
+    QString getUsername() const;
     void setUsername(const QString &username);
 
-    QString getFirstName();
+    QString getFirstName() const;
     void setFirstName(const QString &first_name);
 
-    QString getLastName();
+    QString getLastName() const;
     void setLastName(const QString &last_name);
 
-    QString getEmail();
+    QString getEmail() const;
     void setEmail(const QString &email);
 
-    QString getPassword();
+    QString getPassword() const;
     void setPassword(const QString &password);
 
-    QString getPhone();
+    QString getPhone() const;
     void setPhone(const QString &phone);
 
-    qint32 getUserStatus();
+    qint32 getUserStatus() const;
     void setUserStatus(const qint32 &user_status);
 
     virtual bool isSet() const override;
@@ -95,4 +95,4 @@ private:
 
 }
 
-#endif /* OAIUser_H_ */
+#endif // OAIUser_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -67,7 +67,7 @@ void OAIPetApiRequest::addPetRequest(){
 }
 
 
-void OAIPetApiRequest::deletePetRequest(QString pet_idstr){
+void OAIPetApiRequest::deletePetRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}";
     connect(this, &OAIPetApiRequest::deletePet, handler, &OAIPetApiHandler::deletePet);
     
@@ -117,7 +117,7 @@ void OAIPetApiRequest::findPetsByTagsRequest(){
 }
 
 
-void OAIPetApiRequest::getPetByIdRequest(QString pet_idstr){
+void OAIPetApiRequest::getPetByIdRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}";
     connect(this, &OAIPetApiRequest::getPetById, handler, &OAIPetApiHandler::getPetById);
     
@@ -147,7 +147,7 @@ void OAIPetApiRequest::updatePetRequest(){
 }
 
 
-void OAIPetApiRequest::updatePetWithFormRequest(QString pet_idstr){
+void OAIPetApiRequest::updatePetWithFormRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}";
     connect(this, &OAIPetApiRequest::updatePetWithForm, handler, &OAIPetApiHandler::updatePetWithForm);
     
@@ -162,7 +162,7 @@ void OAIPetApiRequest::updatePetWithFormRequest(QString pet_idstr){
 }
 
 
-void OAIPetApiRequest::uploadFileRequest(QString pet_idstr){
+void OAIPetApiRequest::uploadFileRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}/uploadImage";
     connect(this, &OAIPetApiRequest::uploadFile, handler, &OAIPetApiHandler::uploadFile);
     
@@ -194,7 +194,7 @@ void OAIPetApiRequest::deletePetResponse(){
     }
 }
 
-void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
+void OAIPetApiRequest::findPetsByStatusResponse(const QList<OAIPet>& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
@@ -203,7 +203,7 @@ void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
     }
 }
 
-void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
+void OAIPetApiRequest::findPetsByTagsResponse(const QList<OAIPet>& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
@@ -212,7 +212,7 @@ void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
     }
 }
 
-void OAIPetApiRequest::getPetByIdResponse(OAIPet res){
+void OAIPetApiRequest::getPetByIdResponse(const OAIPet& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -237,7 +237,7 @@ void OAIPetApiRequest::updatePetWithFormResponse(){
     }
 }
 
-void OAIPetApiRequest::uploadFileResponse(OAIApiResponse res){
+void OAIPetApiRequest::uploadFileResponse(const OAIApiResponse& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -267,7 +267,7 @@ void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QS
     }
 }
 
-void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIPetApiRequest::findPetsByStatusError(const QList<OAIPet>& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
@@ -278,7 +278,7 @@ void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::N
     }
 }
 
-void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIPetApiRequest::findPetsByTagsError(const QList<OAIPet>& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
@@ -289,7 +289,7 @@ void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::Net
     }
 }
 
-void OAIPetApiRequest::getPetByIdError(OAIPet res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIPetApiRequest::getPetByIdError(const OAIPet& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
@@ -320,7 +320,7 @@ void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_
     }
 }
 
-void OAIPetApiRequest::uploadFileError(OAIApiResponse res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIPetApiRequest::uploadFileError(const OAIApiResponse& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -30,9 +30,14 @@ OAIPetApiRequest::~OAIPetApiRequest(){
 }
 
 QMap<QString, QString> 
-OAIPetApiRequest::getDefaultHeaders(){
+OAIPetApiRequest::getDefaultHeaders() const {
     return defaultHeaders;
 }
+
+void OAIPetApiRequest::setHeaders(QMultiMap<QString, QString> headers){
+
+}
+
 
 QHttpEngine::Socket* OAIPetApiRequest::getRawSocket(){
     return socket;
@@ -168,6 +173,7 @@ void OAIPetApiRequest::uploadFileRequest(QString pet_idstr){
   
 
 void OAIPetApiRequest::addPetResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -175,6 +181,7 @@ void OAIPetApiRequest::addPetResponse(){
     }
 }
 void OAIPetApiRequest::deletePetResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -182,6 +189,7 @@ void OAIPetApiRequest::deletePetResponse(){
     }
 }
 void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -189,6 +197,7 @@ void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
     }
 }
 void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -196,6 +205,7 @@ void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
     }
 }
 void OAIPetApiRequest::getPetByIdResponse(OAIPet res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -203,6 +213,7 @@ void OAIPetApiRequest::getPetByIdResponse(OAIPet res){
     }
 }
 void OAIPetApiRequest::updatePetResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -210,6 +221,7 @@ void OAIPetApiRequest::updatePetResponse(){
     }
 }
 void OAIPetApiRequest::updatePetWithFormResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -217,6 +229,7 @@ void OAIPetApiRequest::updatePetWithFormResponse(){
     }
 }
 void OAIPetApiRequest::uploadFileResponse(OAIApiResponse res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -227,7 +240,8 @@ void OAIPetApiRequest::uploadFileResponse(OAIApiResponse res){
 
 void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -236,7 +250,8 @@ void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QStri
 }
 void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -245,7 +260,8 @@ void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QS
 }
 void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -254,7 +270,8 @@ void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::N
 }
 void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -263,7 +280,8 @@ void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::Net
 }
 void OAIPetApiRequest::getPetByIdError(OAIPet res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -272,7 +290,8 @@ void OAIPetApiRequest::getPetByIdError(OAIPet res, QNetworkReply::NetworkError e
 }
 void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -281,7 +300,8 @@ void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QS
 }
 void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -290,7 +310,8 @@ void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_
 }
 void OAIPetApiRequest::uploadFileError(OAIApiResponse res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -299,6 +320,12 @@ void OAIPetApiRequest::uploadFileError(OAIApiResponse res, QNetworkReply::Networ
 }
 
 
+void OAIPetApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
 
+}
+    
+void OAIPetApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
+
+}
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -179,12 +179,7 @@ void OAIPetApiRequest::uploadFileRequest(QString pet_idstr){
   
 
 void OAIPetApiRequest::addPetResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -192,12 +187,7 @@ void OAIPetApiRequest::addPetResponse(){
 }
 
 void OAIPetApiRequest::deletePetResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -205,12 +195,7 @@ void OAIPetApiRequest::deletePetResponse(){
 }
 
 void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -219,12 +204,7 @@ void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
 }
 
 void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -233,12 +213,7 @@ void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
 }
 
 void OAIPetApiRequest::getPetByIdResponse(OAIPet res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -247,12 +222,7 @@ void OAIPetApiRequest::getPetByIdResponse(OAIPet res){
 }
 
 void OAIPetApiRequest::updatePetResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -260,12 +230,7 @@ void OAIPetApiRequest::updatePetResponse(){
 }
 
 void OAIPetApiRequest::updatePetWithFormResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -273,12 +238,7 @@ void OAIPetApiRequest::updatePetWithFormResponse(){
 }
 
 void OAIPetApiRequest::uploadFileResponse(OAIApiResponse res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -289,12 +249,7 @@ void OAIPetApiRequest::uploadFileResponse(OAIApiResponse res){
 
 void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -304,12 +259,7 @@ void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QStri
 
 void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -319,12 +269,7 @@ void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QS
 
 void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
@@ -335,12 +280,7 @@ void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::N
 
 void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
     socket->writeJson(resDoc);
@@ -351,12 +291,7 @@ void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::Net
 
 void OAIPetApiRequest::getPetByIdError(OAIPet res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -367,12 +302,7 @@ void OAIPetApiRequest::getPetByIdError(OAIPet res, QNetworkReply::NetworkError e
 
 void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -382,12 +312,7 @@ void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QS
 
 void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -397,12 +322,7 @@ void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_
 
 void OAIPetApiRequest::uploadFileError(OAIApiResponse res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -22,6 +22,10 @@
 namespace OpenAPI {
 
 OAIPetApiRequest::OAIPetApiRequest(QHttpEngine::Socket *s, OAIPetApiHandler* hdl) : QObject(s), socket(s), handler(hdl) {
+    auto headers = s->headers();
+    for(auto itr = headers.begin(); itr != headers.end(); itr++) {
+        requestHeaders.insert(QString(itr.key()), QString(itr.value()));
+    }     
 }
 
 OAIPetApiRequest::~OAIPetApiRequest(){
@@ -30,12 +34,14 @@ OAIPetApiRequest::~OAIPetApiRequest(){
 }
 
 QMap<QString, QString> 
-OAIPetApiRequest::getDefaultHeaders() const {
-    return defaultHeaders;
+OAIPetApiRequest::getRequestHeaders() const {
+    return requestHeaders;
 }
 
-void OAIPetApiRequest::setHeaders(QMultiMap<QString, QString> headers){
-
+void OAIPetApiRequest::setResponseHeaders(const QMultiMap<QString, QString>& headers){
+    for(auto itr = headers.begin(); itr != headers.end(); ++itr) {
+        responseHeaders.insert(itr.key(), itr.value());
+    }
 }
 
 
@@ -173,159 +179,247 @@ void OAIPetApiRequest::uploadFileRequest(QString pet_idstr){
   
 
 void OAIPetApiRequest::addPetResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::deletePetResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::findPetsByStatusResponse(QList<OAIPet> res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::findPetsByTagsResponse(QList<OAIPet> res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::getPetByIdResponse(OAIPet res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::updatePetResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::updatePetWithFormResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::uploadFileResponse(OAIApiResponse res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
 
 
 void OAIPetApiRequest::addPetError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::deletePetError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::findPetsByStatusError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::findPetsByTagsError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toArray());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::getPetByIdError(OAIPet res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::updatePetError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::updatePetWithFormError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIPetApiRequest::uploadFileError(OAIApiResponse res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
 
 
 void OAIPetApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
     
 void OAIPetApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -92,6 +92,15 @@ private:
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     OAIPetApiHandler *handler;
+
+    inline void writeResponseHeaders(){
+        QHttpEngine::Socket::HeaderMap resHeaders;
+        for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+            resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+        }
+        socket->setHeaders(resHeaders);
+        socket->writeHeaders();        
+    }
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -37,33 +37,33 @@ public:
     virtual ~OAIPetApiRequest();
 
     void addPetRequest();
-    void deletePetRequest(QString pet_id);
+    void deletePetRequest(const QString& pet_id);
     void findPetsByStatusRequest();
     void findPetsByTagsRequest();
-    void getPetByIdRequest(QString pet_id);
+    void getPetByIdRequest(const QString& pet_id);
     void updatePetRequest();
-    void updatePetWithFormRequest(QString pet_id);
-    void uploadFileRequest(QString pet_id);
+    void updatePetWithFormRequest(const QString& pet_id);
+    void uploadFileRequest(const QString& pet_id);
     
 
     void addPetResponse();
     void deletePetResponse();
-    void findPetsByStatusResponse(QList<OAIPet> res);
-    void findPetsByTagsResponse(QList<OAIPet> res);
-    void getPetByIdResponse(OAIPet res);
+    void findPetsByStatusResponse(const QList<OAIPet>& res);
+    void findPetsByTagsResponse(const QList<OAIPet>& res);
+    void getPetByIdResponse(const OAIPet& res);
     void updatePetResponse();
     void updatePetWithFormResponse();
-    void uploadFileResponse(OAIApiResponse res);
+    void uploadFileResponse(const OAIApiResponse& res);
     
 
     void addPetError(QNetworkReply::NetworkError error_type, QString& error_str);
     void deletePetError(QNetworkReply::NetworkError error_type, QString& error_str);
-    void findPetsByStatusError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str);
-    void findPetsByTagsError(QList<OAIPet> res, QNetworkReply::NetworkError error_type, QString& error_str);
-    void getPetByIdError(OAIPet res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void findPetsByStatusError(const QList<OAIPet>& res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void findPetsByTagsError(const QList<OAIPet>& res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void getPetByIdError(const OAIPet& res, QNetworkReply::NetworkError error_type, QString& error_str);
     void updatePetError(QNetworkReply::NetworkError error_type, QString& error_str);
     void updatePetWithFormError(QNetworkReply::NetworkError error_type, QString& error_str);
-    void uploadFileError(OAIApiResponse res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void uploadFileError(const OAIApiResponse& res, QNetworkReply::NetworkError error_type, QString& error_str);
     
 
     void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -70,11 +70,11 @@ public:
 
     void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
 
-    QMap<QString, QString> getDefaultHeaders() const;
+    QMap<QString, QString> getRequestHeaders() const;
 
     QHttpEngine::Socket* getRawSocket();
 
-    void setHeaders(QMultiMap<QString,QString> headers);
+    void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
 signals:
     void addPet(OAIPet oai_pet);
@@ -88,7 +88,8 @@ signals:
     
 
 private:
-    QMap<QString, QString> defaultHeaders;
+    QMap<QString, QString> requestHeaders;
+    QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     OAIPetApiHandler *handler;
 };

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -10,11 +10,12 @@
  * Do not edit the class manually.
  */
 
-#ifndef _OAI_OAIPetApiRequest_H_
-#define _OAI_OAIPetApiRequest_H_
+#ifndef OAI_OAIPetApiRequest_H
+#define OAI_OAIPetApiRequest_H
 
 #include <QObject>
 #include <QStringList>
+#include <QMultiMap>
 #include <QNetworkReply>
 #include <QSharedPointer>
 
@@ -65,8 +66,15 @@ public:
     void uploadFileError(OAIApiResponse res, QNetworkReply::NetworkError error_type, QString& error_str);
     
 
-    QMap<QString, QString> getDefaultHeaders();
+    void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);
+
+    void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
+
+    QMap<QString, QString> getDefaultHeaders() const;
+
     QHttpEngine::Socket* getRawSocket();
+
+    void setHeaders(QMultiMap<QString,QString> headers);
 
 signals:
     void addPet(OAIPet oai_pet);
@@ -87,4 +95,4 @@ private:
 
 }
 
-#endif // _OAI_OAIPetApiRequest_H_
+#endif // OAI_OAIPetApiRequest_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -106,12 +106,7 @@ void OAIStoreApiRequest::placeOrderRequest(){
   
 
 void OAIStoreApiRequest::deleteOrderResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -119,12 +114,7 @@ void OAIStoreApiRequest::deleteOrderResponse(){
 }
 
 void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -133,12 +123,7 @@ void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
 }
 
 void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -147,12 +132,7 @@ void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
 }
 
 void OAIStoreApiRequest::placeOrderResponse(OAIOrder res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -163,12 +143,7 @@ void OAIStoreApiRequest::placeOrderResponse(OAIOrder res){
 
 void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -178,12 +153,7 @@ void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type
 
 void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -194,12 +164,7 @@ void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkRe
 
 void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -210,12 +175,7 @@ void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkE
 
 void OAIStoreApiRequest::placeOrderError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -50,7 +50,7 @@ QHttpEngine::Socket* OAIStoreApiRequest::getRawSocket(){
 }
 
 
-void OAIStoreApiRequest::deleteOrderRequest(QString order_idstr){
+void OAIStoreApiRequest::deleteOrderRequest(const QString& order_idstr){
     qDebug() << "/v2/store/order/{orderId}";
     connect(this, &OAIStoreApiRequest::deleteOrder, handler, &OAIStoreApiHandler::deleteOrder);
     
@@ -74,7 +74,7 @@ void OAIStoreApiRequest::getInventoryRequest(){
 }
 
 
-void OAIStoreApiRequest::getOrderByIdRequest(QString order_idstr){
+void OAIStoreApiRequest::getOrderByIdRequest(const QString& order_idstr){
     qDebug() << "/v2/store/order/{orderId}";
     connect(this, &OAIStoreApiRequest::getOrderById, handler, &OAIStoreApiHandler::getOrderById);
     
@@ -113,7 +113,7 @@ void OAIStoreApiRequest::deleteOrderResponse(){
     }
 }
 
-void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
+void OAIStoreApiRequest::getInventoryResponse(const QMap<QString, qint32>& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -122,7 +122,7 @@ void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
     }
 }
 
-void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
+void OAIStoreApiRequest::getOrderByIdResponse(const OAIOrder& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -131,7 +131,7 @@ void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
     }
 }
 
-void OAIStoreApiRequest::placeOrderResponse(OAIOrder res){
+void OAIStoreApiRequest::placeOrderResponse(const OAIOrder& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -151,7 +151,7 @@ void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type
     }
 }
 
-void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIStoreApiRequest::getInventoryError(const QMap<QString, qint32>& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
@@ -162,7 +162,7 @@ void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkRe
     }
 }
 
-void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIStoreApiRequest::getOrderByIdError(const OAIOrder& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
@@ -173,7 +173,7 @@ void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkE
     }
 }
 
-void OAIStoreApiRequest::placeOrderError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIStoreApiRequest::placeOrderError(const OAIOrder& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -30,9 +30,14 @@ OAIStoreApiRequest::~OAIStoreApiRequest(){
 }
 
 QMap<QString, QString> 
-OAIStoreApiRequest::getDefaultHeaders(){
+OAIStoreApiRequest::getDefaultHeaders() const {
     return defaultHeaders;
 }
+
+void OAIStoreApiRequest::setHeaders(QMultiMap<QString, QString> headers){
+
+}
+
 
 QHttpEngine::Socket* OAIStoreApiRequest::getRawSocket(){
     return socket;
@@ -95,6 +100,7 @@ void OAIStoreApiRequest::placeOrderRequest(){
   
 
 void OAIStoreApiRequest::deleteOrderResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -102,6 +108,7 @@ void OAIStoreApiRequest::deleteOrderResponse(){
     }
 }
 void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -109,6 +116,7 @@ void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
     }
 }
 void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -116,6 +124,7 @@ void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
     }
 }
 void OAIStoreApiRequest::placeOrderResponse(OAIOrder res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -126,7 +135,8 @@ void OAIStoreApiRequest::placeOrderResponse(OAIOrder res){
 
 void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -135,7 +145,8 @@ void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type
 }
 void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -144,7 +155,8 @@ void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkRe
 }
 void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -153,7 +165,8 @@ void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkE
 }
 void OAIStoreApiRequest::placeOrderError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -162,6 +175,12 @@ void OAIStoreApiRequest::placeOrderError(OAIOrder res, QNetworkReply::NetworkErr
 }
 
 
+void OAIStoreApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
 
+}
+    
+void OAIStoreApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
+
+}
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -22,6 +22,10 @@
 namespace OpenAPI {
 
 OAIStoreApiRequest::OAIStoreApiRequest(QHttpEngine::Socket *s, OAIStoreApiHandler* hdl) : QObject(s), socket(s), handler(hdl) {
+    auto headers = s->headers();
+    for(auto itr = headers.begin(); itr != headers.end(); itr++) {
+        requestHeaders.insert(QString(itr.key()), QString(itr.value()));
+    }     
 }
 
 OAIStoreApiRequest::~OAIStoreApiRequest(){
@@ -30,12 +34,14 @@ OAIStoreApiRequest::~OAIStoreApiRequest(){
 }
 
 QMap<QString, QString> 
-OAIStoreApiRequest::getDefaultHeaders() const {
-    return defaultHeaders;
+OAIStoreApiRequest::getRequestHeaders() const {
+    return requestHeaders;
 }
 
-void OAIStoreApiRequest::setHeaders(QMultiMap<QString, QString> headers){
-
+void OAIStoreApiRequest::setResponseHeaders(const QMultiMap<QString, QString>& headers){
+    for(auto itr = headers.begin(); itr != headers.end(); ++itr) {
+        responseHeaders.insert(itr.key(), itr.value());
+    }
 }
 
 
@@ -100,87 +106,133 @@ void OAIStoreApiRequest::placeOrderRequest(){
   
 
 void OAIStoreApiRequest::deleteOrderResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIStoreApiRequest::getInventoryResponse(QMap<QString, qint32> res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIStoreApiRequest::getOrderByIdResponse(OAIOrder res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIStoreApiRequest::placeOrderResponse(OAIOrder res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
 
 
 void OAIStoreApiRequest::deleteOrderError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIStoreApiRequest::getInventoryError(QMap<QString, qint32> res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIStoreApiRequest::getOrderByIdError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIStoreApiRequest::placeOrderError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
 
 
 void OAIStoreApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
     
 void OAIStoreApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -35,22 +35,22 @@ public:
     OAIStoreApiRequest(QHttpEngine::Socket *s, OAIStoreApiHandler* handler);
     virtual ~OAIStoreApiRequest();
 
-    void deleteOrderRequest(QString order_id);
+    void deleteOrderRequest(const QString& order_id);
     void getInventoryRequest();
-    void getOrderByIdRequest(QString order_id);
+    void getOrderByIdRequest(const QString& order_id);
     void placeOrderRequest();
     
 
     void deleteOrderResponse();
-    void getInventoryResponse(QMap<QString, qint32> res);
-    void getOrderByIdResponse(OAIOrder res);
-    void placeOrderResponse(OAIOrder res);
+    void getInventoryResponse(const QMap<QString, qint32>& res);
+    void getOrderByIdResponse(const OAIOrder& res);
+    void placeOrderResponse(const OAIOrder& res);
     
 
     void deleteOrderError(QNetworkReply::NetworkError error_type, QString& error_str);
-    void getInventoryError(QMap<QString, qint32> res, QNetworkReply::NetworkError error_type, QString& error_str);
-    void getOrderByIdError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str);
-    void placeOrderError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void getInventoryError(const QMap<QString, qint32>& res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void getOrderByIdError(const OAIOrder& res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void placeOrderError(const OAIOrder& res, QNetworkReply::NetworkError error_type, QString& error_str);
     
 
     void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -75,6 +75,15 @@ private:
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     OAIStoreApiHandler *handler;
+
+    inline void writeResponseHeaders(){
+        QHttpEngine::Socket::HeaderMap resHeaders;
+        for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+            resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+        }
+        socket->setHeaders(resHeaders);
+        socket->writeHeaders();        
+    }
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -57,11 +57,11 @@ public:
 
     void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
 
-    QMap<QString, QString> getDefaultHeaders() const;
+    QMap<QString, QString> getRequestHeaders() const;
 
     QHttpEngine::Socket* getRawSocket();
 
-    void setHeaders(QMultiMap<QString,QString> headers);
+    void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
 signals:
     void deleteOrder(QString order_id);
@@ -71,7 +71,8 @@ signals:
     
 
 private:
-    QMap<QString, QString> defaultHeaders;
+    QMap<QString, QString> requestHeaders;
+    QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     OAIStoreApiHandler *handler;
 };

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -10,11 +10,12 @@
  * Do not edit the class manually.
  */
 
-#ifndef _OAI_OAIStoreApiRequest_H_
-#define _OAI_OAIStoreApiRequest_H_
+#ifndef OAI_OAIStoreApiRequest_H
+#define OAI_OAIStoreApiRequest_H
 
 #include <QObject>
 #include <QStringList>
+#include <QMultiMap>
 #include <QNetworkReply>
 #include <QSharedPointer>
 
@@ -52,8 +53,15 @@ public:
     void placeOrderError(OAIOrder res, QNetworkReply::NetworkError error_type, QString& error_str);
     
 
-    QMap<QString, QString> getDefaultHeaders();
+    void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);
+
+    void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
+
+    QMap<QString, QString> getDefaultHeaders() const;
+
     QHttpEngine::Socket* getRawSocket();
+
+    void setHeaders(QMultiMap<QString,QString> headers);
 
 signals:
     void deleteOrder(QString order_id);
@@ -70,4 +78,4 @@ private:
 
 }
 
-#endif // _OAI_OAIStoreApiRequest_H_
+#endif // OAI_OAIStoreApiRequest_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -190,12 +190,7 @@ void OAIUserApiRequest::updateUserRequest(QString usernamestr){
   
 
 void OAIUserApiRequest::createUserResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -203,12 +198,7 @@ void OAIUserApiRequest::createUserResponse(){
 }
 
 void OAIUserApiRequest::createUsersWithArrayInputResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -216,12 +206,7 @@ void OAIUserApiRequest::createUsersWithArrayInputResponse(){
 }
 
 void OAIUserApiRequest::createUsersWithListInputResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -229,12 +214,7 @@ void OAIUserApiRequest::createUsersWithListInputResponse(){
 }
 
 void OAIUserApiRequest::deleteUserResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -242,12 +222,7 @@ void OAIUserApiRequest::deleteUserResponse(){
 }
 
 void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -256,12 +231,7 @@ void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
 }
 
 void OAIUserApiRequest::loginUserResponse(QString res){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
     if(socket->isOpen()){
@@ -270,12 +240,7 @@ void OAIUserApiRequest::loginUserResponse(QString res){
 }
 
 void OAIUserApiRequest::logoutUserResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -283,12 +248,7 @@ void OAIUserApiRequest::logoutUserResponse(){
 }
 
 void OAIUserApiRequest::updateUserResponse(){
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->close();
@@ -298,12 +258,7 @@ void OAIUserApiRequest::updateUserResponse(){
 
 void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -313,12 +268,7 @@ void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, 
 
 void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -328,12 +278,7 @@ void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkErr
 
 void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -343,12 +288,7 @@ void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkErro
 
 void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -358,12 +298,7 @@ void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, 
 
 void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -374,12 +309,7 @@ void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkEr
 
 void OAIUserApiRequest::loginUserError(QString res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();
+    writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -390,12 +320,7 @@ void OAIUserApiRequest::loginUserError(QString res, QNetworkReply::NetworkError 
 
 void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){
@@ -405,12 +330,7 @@ void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, 
 
 void OAIUserApiRequest::updateUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
-    QHttpEngine::Socket::HeaderMap resHeaders;
-    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
-        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
-    }
-    socket->setHeaders(resHeaders);
-    socket->writeHeaders();    
+    writeResponseHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     socket->write(error_str.toUtf8());
     if(socket->isOpen()){

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -22,6 +22,10 @@
 namespace OpenAPI {
 
 OAIUserApiRequest::OAIUserApiRequest(QHttpEngine::Socket *s, OAIUserApiHandler* hdl) : QObject(s), socket(s), handler(hdl) {
+    auto headers = s->headers();
+    for(auto itr = headers.begin(); itr != headers.end(); itr++) {
+        requestHeaders.insert(QString(itr.key()), QString(itr.value()));
+    }     
 }
 
 OAIUserApiRequest::~OAIUserApiRequest(){
@@ -30,12 +34,14 @@ OAIUserApiRequest::~OAIUserApiRequest(){
 }
 
 QMap<QString, QString> 
-OAIUserApiRequest::getDefaultHeaders() const {
-    return defaultHeaders;
+OAIUserApiRequest::getRequestHeaders() const {
+    return requestHeaders;
 }
 
-void OAIUserApiRequest::setHeaders(QMultiMap<QString, QString> headers){
-
+void OAIUserApiRequest::setResponseHeaders(const QMultiMap<QString, QString>& headers){
+    for(auto itr = headers.begin(); itr != headers.end(); ++itr) {
+        responseHeaders.insert(itr.key(), itr.value());
+    }
 }
 
 
@@ -184,159 +190,243 @@ void OAIUserApiRequest::updateUserRequest(QString usernamestr){
   
 
 void OAIUserApiRequest::createUserResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::createUsersWithArrayInputResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::createUsersWithListInputResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::deleteUserResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::loginUserResponse(QString res){
-    Q_UNUSED(res);
-    socket->setStatusCode(QHttpEngine::Socket::OK);
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::logoutUserResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::updateUserResponse(){
-    
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
 
 
 void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::loginUserError(QString res, QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-    Q_UNUSED(res);     
-    socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();
+    Q_UNUSED(error_str);  // response will be used instead of error string
+    QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
+    socket->writeJson(resDoc);
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
+
 void OAIUserApiRequest::updateUserError(QNetworkReply::NetworkError error_type, QString& error_str){
-    Q_UNUSED(error_type);
-    Q_UNUSED(error_str);
-         
+    Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
+    QHttpEngine::Socket::HeaderMap resHeaders;
+    for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+        resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+    }
+    socket->setHeaders(resHeaders);
+    socket->writeHeaders();    
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
+    socket->write(error_str.toUtf8());
     if(socket->isOpen()){
-        socket->writeHeaders();
         socket->close();
     }
 }
 
 
 void OAIUserApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
     
 void OAIUserApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-
+    Q_UNUSED(res);  // TODO
+    Q_UNUSED(error_type); // TODO
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -30,9 +30,14 @@ OAIUserApiRequest::~OAIUserApiRequest(){
 }
 
 QMap<QString, QString> 
-OAIUserApiRequest::getDefaultHeaders(){
+OAIUserApiRequest::getDefaultHeaders() const {
     return defaultHeaders;
 }
+
+void OAIUserApiRequest::setHeaders(QMultiMap<QString, QString> headers){
+
+}
+
 
 QHttpEngine::Socket* OAIUserApiRequest::getRawSocket(){
     return socket;
@@ -179,6 +184,7 @@ void OAIUserApiRequest::updateUserRequest(QString usernamestr){
   
 
 void OAIUserApiRequest::createUserResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -186,6 +192,7 @@ void OAIUserApiRequest::createUserResponse(){
     }
 }
 void OAIUserApiRequest::createUsersWithArrayInputResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -193,6 +200,7 @@ void OAIUserApiRequest::createUsersWithArrayInputResponse(){
     }
 }
 void OAIUserApiRequest::createUsersWithListInputResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -200,6 +208,7 @@ void OAIUserApiRequest::createUsersWithListInputResponse(){
     }
 }
 void OAIUserApiRequest::deleteUserResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -207,6 +216,7 @@ void OAIUserApiRequest::deleteUserResponse(){
     }
 }
 void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -214,6 +224,7 @@ void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
     }
 }
 void OAIUserApiRequest::loginUserResponse(QString res){
+    Q_UNUSED(res);
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -221,6 +232,7 @@ void OAIUserApiRequest::loginUserResponse(QString res){
     }
 }
 void OAIUserApiRequest::logoutUserResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -228,6 +240,7 @@ void OAIUserApiRequest::logoutUserResponse(){
     }
 }
 void OAIUserApiRequest::updateUserResponse(){
+    
     socket->setStatusCode(QHttpEngine::Socket::OK);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -238,7 +251,8 @@ void OAIUserApiRequest::updateUserResponse(){
 
 void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -247,7 +261,8 @@ void OAIUserApiRequest::createUserError(QNetworkReply::NetworkError error_type, 
 }
 void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -256,7 +271,8 @@ void OAIUserApiRequest::createUsersWithArrayInputError(QNetworkReply::NetworkErr
 }
 void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -265,7 +281,8 @@ void OAIUserApiRequest::createUsersWithListInputError(QNetworkReply::NetworkErro
 }
 void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -274,7 +291,8 @@ void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, 
 }
 void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -283,7 +301,8 @@ void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkEr
 }
 void OAIUserApiRequest::loginUserError(QString res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+    Q_UNUSED(res);     
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -292,7 +311,8 @@ void OAIUserApiRequest::loginUserError(QString res, QNetworkReply::NetworkError 
 }
 void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -301,7 +321,8 @@ void OAIUserApiRequest::logoutUserError(QNetworkReply::NetworkError error_type, 
 }
 void OAIUserApiRequest::updateUserError(QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type);
-    Q_UNUSED(error_str);     
+    Q_UNUSED(error_str);
+         
     socket->setStatusCode(QHttpEngine::Socket::NotFound);
     if(socket->isOpen()){
         socket->writeHeaders();
@@ -310,6 +331,12 @@ void OAIUserApiRequest::updateUserError(QNetworkReply::NetworkError error_type, 
 }
 
 
+void OAIUserApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
 
+}
+    
+void OAIUserApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
+
+}
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -111,7 +111,7 @@ void OAIUserApiRequest::createUsersWithListInputRequest(){
 }
 
 
-void OAIUserApiRequest::deleteUserRequest(QString usernamestr){
+void OAIUserApiRequest::deleteUserRequest(const QString& usernamestr){
     qDebug() << "/v2/user/{username}";
     connect(this, &OAIUserApiRequest::deleteUser, handler, &OAIUserApiHandler::deleteUser);
     
@@ -124,7 +124,7 @@ void OAIUserApiRequest::deleteUserRequest(QString usernamestr){
 }
 
 
-void OAIUserApiRequest::getUserByNameRequest(QString usernamestr){
+void OAIUserApiRequest::getUserByNameRequest(const QString& usernamestr){
     qDebug() << "/v2/user/{username}";
     connect(this, &OAIUserApiRequest::getUserByName, handler, &OAIUserApiHandler::getUserByName);
     
@@ -169,7 +169,7 @@ void OAIUserApiRequest::logoutUserRequest(){
 }
 
 
-void OAIUserApiRequest::updateUserRequest(QString usernamestr){
+void OAIUserApiRequest::updateUserRequest(const QString& usernamestr){
     qDebug() << "/v2/user/{username}";
     connect(this, &OAIUserApiRequest::updateUser, handler, &OAIUserApiHandler::updateUser);
     
@@ -221,7 +221,7 @@ void OAIUserApiRequest::deleteUserResponse(){
     }
 }
 
-void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
+void OAIUserApiRequest::getUserByNameResponse(const OAIUser& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -230,7 +230,7 @@ void OAIUserApiRequest::getUserByNameResponse(OAIUser res){
     }
 }
 
-void OAIUserApiRequest::loginUserResponse(QString res){
+void OAIUserApiRequest::loginUserResponse(const QString& res){
     writeResponseHeaders();
     QJsonDocument resDoc(::OpenAPI::toJsonValue(res).toObject());
     socket->writeJson(resDoc);
@@ -296,7 +296,7 @@ void OAIUserApiRequest::deleteUserError(QNetworkReply::NetworkError error_type, 
     }
 }
 
-void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIUserApiRequest::getUserByNameError(const OAIUser& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string
@@ -307,7 +307,7 @@ void OAIUserApiRequest::getUserByNameError(OAIUser res, QNetworkReply::NetworkEr
     }
 }
 
-void OAIUserApiRequest::loginUserError(QString res, QNetworkReply::NetworkError error_type, QString& error_str){
+void OAIUserApiRequest::loginUserError(const QString& res, QNetworkReply::NetworkError error_type, QString& error_str){
     Q_UNUSED(error_type); // TODO: Remap error_type to QHttpEngine::Socket errors
     writeResponseHeaders();
     Q_UNUSED(error_str);  // response will be used instead of error string

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -10,11 +10,12 @@
  * Do not edit the class manually.
  */
 
-#ifndef _OAI_OAIUserApiRequest_H_
-#define _OAI_OAIUserApiRequest_H_
+#ifndef OAI_OAIUserApiRequest_H
+#define OAI_OAIUserApiRequest_H
 
 #include <QObject>
 #include <QStringList>
+#include <QMultiMap>
 #include <QNetworkReply>
 #include <QSharedPointer>
 
@@ -64,8 +65,15 @@ public:
     void updateUserError(QNetworkReply::NetworkError error_type, QString& error_str);
     
 
-    QMap<QString, QString> getDefaultHeaders();
+    void sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type);
+
+    void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
+
+    QMap<QString, QString> getDefaultHeaders() const;
+
     QHttpEngine::Socket* getRawSocket();
+
+    void setHeaders(QMultiMap<QString,QString> headers);
 
 signals:
     void createUser(OAIUser oai_user);
@@ -86,4 +94,4 @@ private:
 
 }
 
-#endif // _OAI_OAIUserApiRequest_H_
+#endif // OAI_OAIUserApiRequest_H

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -91,6 +91,15 @@ private:
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     OAIUserApiHandler *handler;
+
+    inline void writeResponseHeaders(){
+        QHttpEngine::Socket::HeaderMap resHeaders;
+        for(auto itr = responseHeaders.begin(); itr != responseHeaders.end(); ++itr) {
+            resHeaders.insert(itr.key().toUtf8(), itr.value().toUtf8());
+        }
+        socket->setHeaders(resHeaders);
+        socket->writeHeaders();        
+    }
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -38,19 +38,19 @@ public:
     void createUserRequest();
     void createUsersWithArrayInputRequest();
     void createUsersWithListInputRequest();
-    void deleteUserRequest(QString username);
-    void getUserByNameRequest(QString username);
+    void deleteUserRequest(const QString& username);
+    void getUserByNameRequest(const QString& username);
     void loginUserRequest();
     void logoutUserRequest();
-    void updateUserRequest(QString username);
+    void updateUserRequest(const QString& username);
     
 
     void createUserResponse();
     void createUsersWithArrayInputResponse();
     void createUsersWithListInputResponse();
     void deleteUserResponse();
-    void getUserByNameResponse(OAIUser res);
-    void loginUserResponse(QString res);
+    void getUserByNameResponse(const OAIUser& res);
+    void loginUserResponse(const QString& res);
     void logoutUserResponse();
     void updateUserResponse();
     
@@ -59,8 +59,8 @@ public:
     void createUsersWithArrayInputError(QNetworkReply::NetworkError error_type, QString& error_str);
     void createUsersWithListInputError(QNetworkReply::NetworkError error_type, QString& error_str);
     void deleteUserError(QNetworkReply::NetworkError error_type, QString& error_str);
-    void getUserByNameError(OAIUser res, QNetworkReply::NetworkError error_type, QString& error_str);
-    void loginUserError(QString res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void getUserByNameError(const OAIUser& res, QNetworkReply::NetworkError error_type, QString& error_str);
+    void loginUserError(const QString& res, QNetworkReply::NetworkError error_type, QString& error_str);
     void logoutUserError(QNetworkReply::NetworkError error_type, QString& error_str);
     void updateUserError(QNetworkReply::NetworkError error_type, QString& error_str);
     

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -69,11 +69,11 @@ public:
 
     void sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type);
 
-    QMap<QString, QString> getDefaultHeaders() const;
+    QMap<QString, QString> getRequestHeaders() const;
 
     QHttpEngine::Socket* getRawSocket();
 
-    void setHeaders(QMultiMap<QString,QString> headers);
+    void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
 signals:
     void createUser(OAIUser oai_user);
@@ -87,7 +87,8 @@ signals:
     
 
 private:
-    QMap<QString, QString> defaultHeaders;
+    QMap<QString, QString> requestHeaders;
+    QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
     OAIUserApiHandler *handler;
 };


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
- Support serialization of response and error body for json and non json types
- Remove Leading underscore in headers due to clang warnings
- Support header insertion/retrieval
- Remove redundant overrides from super
- Add missing route setup
- Apply `const` and const reference where applicable
- Add placeholder to send custom responses
- Suppress known warnings in codegen class
- Implemented improvements mentioned here #272 

@stkrwork @MartinDelille 