### PR TITLE
Fix base path when it's not defined in the spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -193,8 +193,14 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         URL url = URLPathUtils.getServerURL(openAPI);
         contextPath = config.escapeText(url.getPath());
-        basePath = config.escapeText(URLPathUtils.getHost(openAPI));
         basePathWithoutHost = contextPath; // for backward compatibility
+        basePath = config.escapeText(URLPathUtils.getHost(openAPI));
+        if ("/".equals(basePath.substring(basePath.length() - 1))) {
+            // remove trailing "/"
+            // https://host.example.com/ => https://host.example.com
+            basePath = basePath.substring(0, basePath.length() - 1);
+        }
+
     }
 
     private void configureOpenAPIInfo() {


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR will change the basePath by removing the trailing "/", e.g. `https://www.host.com/` to `https//www.host.com`

To close https://github.com/OpenAPITools/openapi-generator/issues/669
