### PR TITLE
Consider cases where complexType is null

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4423,7 +4423,11 @@ public class DefaultCodegen implements CodegenConfig {
             }
 
             if (StringUtils.isEmpty(bodyParameterName)) {
-                codegenParameter.baseName = mostInnerItem.complexType;
+                if(StringUtils.isEmpty(mostInnerItem.complexType)) {
+                    codegenParameter.baseName = "request_body";
+                } else {
+                    codegenParameter.baseName = mostInnerItem.complexType;
+                }
             } else {
                 codegenParameter.baseName = bodyParameterName;
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
@@ -17,11 +17,17 @@
 
 package org.openapitools.codegen.perl;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.parser.core.models.ParseOptions;
 
 import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.languages.PerlClientCodegen;
+import org.openapitools.codegen.utils.ModelUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class PerlClientCodegenTest {
 
@@ -52,6 +58,16 @@ public class PerlClientCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+    }
+
+    @Test
+    public void testIssue677() {
+        final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/issue677.yaml", null, new ParseOptions()).getOpenAPI();
+        final PerlClientCodegen codegen = new PerlClientCodegen();
+
+        Operation operation = openAPI.getPaths().get("/issue677").getPost();
+        CodegenOperation co = codegen.fromOperation("/issue677", "POST", operation, ModelUtils.getSchemas(openAPI), openAPI);
+        Assert.assertNotNull(co);
     }
 
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue677.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue677.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.1
+info:
+  title: My title
+  description: API under test
+  version: 1.0.7
+servers:
+- url: https://localhost:9999/root
+paths:
+  /issue677:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        201:
+          description: OK
+components: {}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team (change to DefaultCodegen)

### Description of the PR

Fixes #677 

There is a null pointer for when request body is an array of items that are simple-types:

```yaml
      requestBody:
        content:
          application/json:
            schema:
              type: array
              items:
                type: string
```

This PR set the name to `request_body` for those cases (as it is the case for map).
A Unit Test is added.

---

Stacktrace before the fix:

```
  Exception: null
	at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:942)
	at org.openapitools.codegen.DefaultGenerator.processPaths(DefaultGenerator.java:836)
	at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:463)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:794)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:315)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:59)
Caused by: java.lang.NullPointerException
	at org.openapitools.codegen.DefaultCodegen.underscore(DefaultCodegen.java:3129)
	at org.openapitools.codegen.languages.PerlClientCodegen.toVarName(PerlClientCodegen.java:279)
	at org.openapitools.codegen.languages.PerlClientCodegen.toParamName(PerlClientCodegen.java:292)
	at org.openapitools.codegen.DefaultCodegen.toArrayModelParamName(DefaultCodegen.java:795)
	at org.openapitools.codegen.DefaultCodegen.fromRequestBody(DefaultCodegen.java:4395)
	at org.openapitools.codegen.DefaultCodegen.fromOperation(DefaultCodegen.java:2329)
	at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:910)
... 5 more
```

