### PR TITLE
[typescript] allow $ in var name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -18,7 +18,6 @@
 package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import org.apache.commons.lang3.StringUtils;
@@ -157,7 +156,7 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
     @Override
     public String toVarName(String name) {
         // sanitize name
-        name = sanitizeName(name);
+        name = sanitizeName(name, "\\W-[\\$]");
 
         if ("_".equals(name)) {
             name = "_u";

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -1,0 +1,19 @@
+package org.openapitools.codegen.typescript.typescriptnode;
+
+import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TypeScriptNodeClientCodegenTest {
+
+    @Test
+    public void convertVarName() throws Exception {
+       TypeScriptNodeClientCodegen codegen = new TypeScriptNodeClientCodegen();
+       Assert.assertEquals(codegen.toVarName("name"), "name");
+       Assert.assertEquals(codegen.toVarName("$name"), "$name");
+       Assert.assertEquals(codegen.toVarName("nam$$e"), "nam$$e");
+       Assert.assertEquals(codegen.toVarName("user-name"), "userName");
+       Assert.assertEquals(codegen.toVarName("user_name"), "userName");
+       Assert.assertEquals(codegen.toVarName("user|name"), "userName");
+   }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: Typescript @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01)

### Description of the PR

Fixes #664, allow `$` in var name to support cases like:

```yaml
    Dummy:
      type: object
      properties:
        ‘$_type':
          type: string
        'type':
          type: string
```
(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

