### PR TITLE
Update swagger-parser

### DIFF
--- a/CI/pom.xml.bash
+++ b/CI/pom.xml.bash
@@ -920,7 +920,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.1</swagger-parser-version>
+        <swagger-parser-version>2.0.2-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.circleci
+++ b/CI/pom.xml.circleci
@@ -976,7 +976,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.1</swagger-parser-version>
+        <swagger-parser-version>2.0.2-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.circleci.java7
+++ b/CI/pom.xml.circleci.java7
@@ -948,7 +948,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.1</swagger-parser-version>
+        <swagger-parser-version>2.0.2-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.ios
+++ b/CI/pom.xml.ios
@@ -928,7 +928,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.1</swagger-parser-version>
+        <swagger-parser-version>2.0.2-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -204,9 +204,9 @@
             <version>${swagger-core-version}</version>
         </dependency>
         <dependency> 
-            <groupId>io.swagger.parser.v3</groupId> 
-            <artifactId>swagger-parser</artifactId> 
-            <version>${swagger-parser-version}</version> 
+            <groupId>org.openapitools.swagger.parser</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>${swagger-parser-version}</version>
         </dependency> 
         <dependency>
             <groupId>com.samskivert</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1054,7 +1054,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.1</swagger-parser-version>
+        <swagger-parser-version>2.0.2-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team 

### Description of the PR

Until swagger-parser `2.0.2` is released (see https://github.com/swagger-api/swagger-parser/issues/780), OpenAPI will use this temporary version of [v2.0.2-OpenAPITools.org-1](https://github.com/OpenAPITools/swagger-parser/releases/tag/v2.0.2-OpenAPITools.org-1).


