### PR TITLE
[JAVA][Rest-assured] Added constants

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -70,7 +70,7 @@ public class {{classname}} {
      * @see #{{#isPathParam}}{{paramName}}Path{{/isPathParam}}{{#isQueryParam}}{{paramName}}Query{{/isQueryParam}}{{#isFormParam}}{{^isFile}}{{paramName}}Form{{/isFile}}{{#isFile}}{{paramName}}MultiPart{{/isFile}}{{/isFormParam}}{{#isHeaderParam}}{{paramName}}Header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
      {{/allParams}}
      {{#returnType}}
-     * return {{returnType}}
+     * return {{{returnType}}}
      {{/returnType}}
      {{#isDeprecated}}
      * @deprecated
@@ -85,7 +85,9 @@ public class {{classname}} {
     {{/isDeprecated}}
     public class {{operationIdCamelCase}}Oper {
 
+        public static final String REQ_METHOD = "{{httpMethod}}";
         public static final String REQ_URI = "{{path}}";
+        public static final String SUMMARY = "{{{summary}}}";
 
         private RequestSpecBuilder reqSpec;
 
@@ -131,7 +133,7 @@ public class {{classname}} {
         /**
          * {{httpMethod}} {{path}}
          * @param handler handler
-         * @return {{returnType}}
+         * @return {{{returnType}}}
          */
         public {{{returnType}}} executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<{{{returnType}}}>(){}.getType();
@@ -141,7 +143,7 @@ public class {{classname}} {
         {{#bodyParams}}
 
          /**
-         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper body({{{dataType}}} {{paramName}}) {
@@ -154,7 +156,7 @@ public class {{classname}} {
         public static final String {{#convert}}{{paramName}}{{/convert}}_HEADER = "{{baseName}}";
 
         /**
-         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Header(String {{paramName}}) {
@@ -167,7 +169,7 @@ public class {{classname}} {
         public static final String {{#convert}}{{paramName}}{{/convert}}_PATH = "{{baseName}}";
 
         /**
-         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Path(Object {{paramName}}) {
@@ -180,7 +182,7 @@ public class {{classname}} {
         public static final String {{#convert}}{{paramName}}{{/convert}}_QUERY = "{{baseName}}";
 
         /**
-         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Query(Object... {{paramName}}) {
@@ -194,7 +196,7 @@ public class {{classname}} {
          public static final String {{#convert}}{{paramName}}{{/convert}}_FORM = "{{baseName}}";
 
          /**
-         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
          public {{operationIdCamelCase}}Oper {{paramName}}Form(Object... {{paramName}}) {
@@ -209,7 +211,7 @@ public class {{classname}} {
          /**
          * It will assume that the control name is file and the &lt;content-type&gt; is &lt;application/octet-stream&gt;
          * @see #reqSpec for customise
-         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
          public {{operationIdCamelCase}}Oper {{paramName}}MultiPart({{{dataType}}} {{paramName}}) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -70,7 +70,9 @@ public class AnotherFakeApi {
      */
     public class TestSpecialTagsOper {
 
+        public static final String REQ_METHOD = "PATCH";
         public static final String REQ_URI = "/another-fake/dummy";
+        public static final String SUMMARY = "To test special tags";
 
         private RequestSpecBuilder reqSpec;
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -117,7 +117,9 @@ public class FakeApi {
      */
     public class FakeOuterBooleanSerializeOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake/outer/boolean";
+        public static final String SUMMARY = "";
 
         private RequestSpecBuilder reqSpec;
 
@@ -195,7 +197,9 @@ public class FakeApi {
      */
     public class FakeOuterCompositeSerializeOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake/outer/composite";
+        public static final String SUMMARY = "";
 
         private RequestSpecBuilder reqSpec;
 
@@ -273,7 +277,9 @@ public class FakeApi {
      */
     public class FakeOuterNumberSerializeOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake/outer/number";
+        public static final String SUMMARY = "";
 
         private RequestSpecBuilder reqSpec;
 
@@ -351,7 +357,9 @@ public class FakeApi {
      */
     public class FakeOuterStringSerializeOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake/outer/string";
+        public static final String SUMMARY = "";
 
         private RequestSpecBuilder reqSpec;
 
@@ -428,7 +436,9 @@ public class FakeApi {
      */
     public class TestBodyWithFileSchemaOper {
 
+        public static final String REQ_METHOD = "PUT";
         public static final String REQ_URI = "/fake/body-with-file-schema";
+        public static final String SUMMARY = "";
 
         private RequestSpecBuilder reqSpec;
 
@@ -496,7 +506,9 @@ public class FakeApi {
      */
     public class TestBodyWithQueryParamsOper {
 
+        public static final String REQ_METHOD = "PUT";
         public static final String REQ_URI = "/fake/body-with-query-params";
+        public static final String SUMMARY = "";
 
         private RequestSpecBuilder reqSpec;
 
@@ -575,7 +587,9 @@ public class FakeApi {
      */
     public class TestClientModelOper {
 
+        public static final String REQ_METHOD = "PATCH";
         public static final String REQ_URI = "/fake";
+        public static final String SUMMARY = "To test \"client\" model";
 
         private RequestSpecBuilder reqSpec;
 
@@ -665,7 +679,9 @@ public class FakeApi {
      */
     public class TestEndpointParametersOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake";
+        public static final String SUMMARY = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ";
 
         private RequestSpecBuilder reqSpec;
 
@@ -884,7 +900,9 @@ public class FakeApi {
      */
     public class TestEnumParametersOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/fake";
+        public static final String SUMMARY = "To test enum parameters";
 
         private RequestSpecBuilder reqSpec;
 
@@ -917,7 +935,7 @@ public class FakeApi {
         public static final String ENUM_HEADER_STRING_ARRAY_HEADER = "enum_header_string_array";
 
         /**
-         * @param enumHeaderStringArray (List&lt;String&gt;) Header parameter enum test (string array) (optional)
+         * @param enumHeaderStringArray (List<String>) Header parameter enum test (string array) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumHeaderStringArrayHeader(String enumHeaderStringArray) {
@@ -939,7 +957,7 @@ public class FakeApi {
         public static final String ENUM_QUERY_STRING_ARRAY_QUERY = "enum_query_string_array";
 
         /**
-         * @param enumQueryStringArray (List&lt;String&gt;) Query parameter enum test (string array) (optional)
+         * @param enumQueryStringArray (List<String>) Query parameter enum test (string array) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumQueryStringArrayQuery(Object... enumQueryStringArray) {
@@ -983,7 +1001,7 @@ public class FakeApi {
          public static final String ENUM_FORM_STRING_ARRAY_FORM = "enum_form_string_array";
 
          /**
-         * @param enumFormStringArray (List&lt;String&gt;) Form parameter enum test (string array) (optional, default to $)
+         * @param enumFormStringArray (List<String>) Form parameter enum test (string array) (optional, default to $)
          * @return operation
          */
          public TestEnumParametersOper enumFormStringArrayForm(Object... enumFormStringArray) {
@@ -1030,7 +1048,9 @@ public class FakeApi {
      */
     public class TestInlineAdditionalPropertiesOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake/inline-additionalProperties";
+        public static final String SUMMARY = "test inline additionalProperties";
 
         private RequestSpecBuilder reqSpec;
 
@@ -1061,7 +1081,7 @@ public class FakeApi {
         }
 
          /**
-         * @param requestBody (Map&lt;String, String&gt;) request body (required)
+         * @param requestBody (Map<String, String>) request body (required)
          * @return operation
          */
         public TestInlineAdditionalPropertiesOper body(Map<String, String> requestBody) {
@@ -1098,7 +1118,9 @@ public class FakeApi {
      */
     public class TestJsonFormDataOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/fake/jsonFormData";
+        public static final String SUMMARY = "test json serialization of form data";
 
         private RequestSpecBuilder reqSpec;
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -70,7 +70,9 @@ public class FakeClassnameTags123Api {
      */
     public class TestClassnameOper {
 
+        public static final String REQ_METHOD = "PATCH";
         public static final String REQ_URI = "/fake_classname_test";
+        public static final String SUMMARY = "To test class name in snake case";
 
         private RequestSpecBuilder reqSpec;
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
@@ -104,7 +104,9 @@ public class PetApi {
      */
     public class AddPetOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/pet";
+        public static final String SUMMARY = "Add a new pet to the store";
 
         private RequestSpecBuilder reqSpec;
 
@@ -172,7 +174,9 @@ public class PetApi {
      */
     public class DeletePetOper {
 
+        public static final String REQ_METHOD = "DELETE";
         public static final String REQ_URI = "/pet/{petId}";
+        public static final String SUMMARY = "Deletes a pet";
 
         private RequestSpecBuilder reqSpec;
 
@@ -247,11 +251,13 @@ public class PetApi {
      * Multiple status values can be provided with comma separated strings
      *
      * @see #statusQuery Status values that need to be considered for filter (required)
-     * return List&lt;Pet&gt;
+     * return List<Pet>
      */
     public class FindPetsByStatusOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/pet/findByStatus";
+        public static final String SUMMARY = "Finds Pets by status";
 
         private RequestSpecBuilder reqSpec;
 
@@ -282,7 +288,7 @@ public class PetApi {
         /**
          * GET /pet/findByStatus
          * @param handler handler
-         * @return List&lt;Pet&gt;
+         * @return List<Pet>
          */
         public List<Pet> executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<List<Pet>>(){}.getType();
@@ -292,7 +298,7 @@ public class PetApi {
         public static final String STATUS_QUERY = "status";
 
         /**
-         * @param status (List&lt;String&gt;) Status values that need to be considered for filter (required)
+         * @param status (List<String>) Status values that need to be considered for filter (required)
          * @return operation
          */
         public FindPetsByStatusOper statusQuery(Object... status) {
@@ -325,13 +331,15 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      *
      * @see #tagsQuery Tags to filter by (required)
-     * return List&lt;Pet&gt;
+     * return List<Pet>
      * @deprecated
      */
     @Deprecated
     public class FindPetsByTagsOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/pet/findByTags";
+        public static final String SUMMARY = "Finds Pets by tags";
 
         private RequestSpecBuilder reqSpec;
 
@@ -362,7 +370,7 @@ public class PetApi {
         /**
          * GET /pet/findByTags
          * @param handler handler
-         * @return List&lt;Pet&gt;
+         * @return List<Pet>
          */
         public List<Pet> executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<List<Pet>>(){}.getType();
@@ -372,7 +380,7 @@ public class PetApi {
         public static final String TAGS_QUERY = "tags";
 
         /**
-         * @param tags (List&lt;String&gt;) Tags to filter by (required)
+         * @param tags (List<String>) Tags to filter by (required)
          * @return operation
          */
         public FindPetsByTagsOper tagsQuery(Object... tags) {
@@ -409,7 +417,9 @@ public class PetApi {
      */
     public class GetPetByIdOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/pet/{petId}";
+        public static final String SUMMARY = "Find pet by ID";
 
         private RequestSpecBuilder reqSpec;
 
@@ -486,7 +496,9 @@ public class PetApi {
      */
     public class UpdatePetOper {
 
+        public static final String REQ_METHOD = "PUT";
         public static final String REQ_URI = "/pet";
+        public static final String SUMMARY = "Update an existing pet";
 
         private RequestSpecBuilder reqSpec;
 
@@ -555,7 +567,9 @@ public class PetApi {
      */
     public class UpdatePetWithFormOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/pet/{petId}";
+        public static final String SUMMARY = "Updates a pet in the store with form data";
 
         private RequestSpecBuilder reqSpec;
 
@@ -649,7 +663,9 @@ public class PetApi {
      */
     public class UploadFileOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/pet/{petId}/uploadImage";
+        public static final String SUMMARY = "uploads an image";
 
         private RequestSpecBuilder reqSpec;
 
@@ -753,7 +769,9 @@ public class PetApi {
      */
     public class UploadFileWithRequiredFileOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/fake/{petId}/uploadImageWithRequiredFile";
+        public static final String SUMMARY = "uploads an image (required)";
 
         private RequestSpecBuilder reqSpec;
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -81,7 +81,9 @@ public class StoreApi {
      */
     public class DeleteOrderOper {
 
+        public static final String REQ_METHOD = "DELETE";
         public static final String REQ_URI = "/store/order/{order_id}";
+        public static final String SUMMARY = "Delete purchase order by ID";
 
         private RequestSpecBuilder reqSpec;
 
@@ -144,11 +146,13 @@ public class StoreApi {
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      *
-     * return Map&lt;String, Integer&gt;
+     * return Map<String, Integer>
      */
     public class GetInventoryOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/store/inventory";
+        public static final String SUMMARY = "Returns pet inventories by status";
 
         private RequestSpecBuilder reqSpec;
 
@@ -179,7 +183,7 @@ public class StoreApi {
         /**
          * GET /store/inventory
          * @param handler handler
-         * @return Map&lt;String, Integer&gt;
+         * @return Map<String, Integer>
          */
         public Map<String, Integer> executeAs(Function<Response, Response> handler) {
             Type type = new TypeToken<Map<String, Integer>>(){}.getType();
@@ -215,7 +219,9 @@ public class StoreApi {
      */
     public class GetOrderByIdOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/store/order/{order_id}";
+        public static final String SUMMARY = "Find purchase order by ID";
 
         private RequestSpecBuilder reqSpec;
 
@@ -293,7 +299,9 @@ public class StoreApi {
      */
     public class PlaceOrderOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/store/order";
+        public static final String SUMMARY = "Place an order for a pet";
 
         private RequestSpecBuilder reqSpec;
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -97,7 +97,9 @@ public class UserApi {
      */
     public class CreateUserOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/user";
+        public static final String SUMMARY = "Create user";
 
         private RequestSpecBuilder reqSpec;
 
@@ -164,7 +166,9 @@ public class UserApi {
      */
     public class CreateUsersWithArrayInputOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/user/createWithArray";
+        public static final String SUMMARY = "Creates list of users with given input array";
 
         private RequestSpecBuilder reqSpec;
 
@@ -195,7 +199,7 @@ public class UserApi {
         }
 
          /**
-         * @param user (List&lt;User&gt;) List of user object (required)
+         * @param user (List<User>) List of user object (required)
          * @return operation
          */
         public CreateUsersWithArrayInputOper body(List<User> user) {
@@ -231,7 +235,9 @@ public class UserApi {
      */
     public class CreateUsersWithListInputOper {
 
+        public static final String REQ_METHOD = "POST";
         public static final String REQ_URI = "/user/createWithList";
+        public static final String SUMMARY = "Creates list of users with given input array";
 
         private RequestSpecBuilder reqSpec;
 
@@ -262,7 +268,7 @@ public class UserApi {
         }
 
          /**
-         * @param user (List&lt;User&gt;) List of user object (required)
+         * @param user (List<User>) List of user object (required)
          * @return operation
          */
         public CreateUsersWithListInputOper body(List<User> user) {
@@ -298,7 +304,9 @@ public class UserApi {
      */
     public class DeleteUserOper {
 
+        public static final String REQ_METHOD = "DELETE";
         public static final String REQ_URI = "/user/{username}";
+        public static final String SUMMARY = "Delete user";
 
         private RequestSpecBuilder reqSpec;
 
@@ -366,7 +374,9 @@ public class UserApi {
      */
     public class GetUserByNameOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/user/{username}";
+        public static final String SUMMARY = "Get user by user name";
 
         private RequestSpecBuilder reqSpec;
 
@@ -445,7 +455,9 @@ public class UserApi {
      */
     public class LoginUserOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/user/login";
+        public static final String SUMMARY = "Logs user into the system";
 
         private RequestSpecBuilder reqSpec;
 
@@ -532,7 +544,9 @@ public class UserApi {
      */
     public class LogoutUserOper {
 
+        public static final String REQ_METHOD = "GET";
         public static final String REQ_URI = "/user/logout";
+        public static final String SUMMARY = "Logs out current logged in user session";
 
         private RequestSpecBuilder reqSpec;
 
@@ -589,7 +603,9 @@ public class UserApi {
      */
     public class UpdateUserOper {
 
+        public static final String REQ_METHOD = "PUT";
         public static final String REQ_URI = "/user/{username}";
+        public static final String SUMMARY = "Updated user";
 
         private RequestSpecBuilder reqSpec;
 

--- a/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/rest-assured/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -14,6 +14,8 @@
 package org.openapitools.client.api;
 
 import java.io.File;
+
+import io.restassured.response.ResponseBody;
 import org.openapitools.client.model.ModelApiResponse;
 import org.openapitools.client.model.Pet;
 import org.openapitools.client.ApiClient;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Added constant "httpMethod", "summary" and fixed javadoc for "returnType", "dataType".

