### PR TITLE
Add an option to generate all models

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -106,6 +106,15 @@ java -Dapis -DmodelTests=false {opts}
 
 When using selective generation, _only_ the templates needed for the specific generation will be used.
 
+To generate all models including those skipped by the form parameters, please use `generateAllModels` (default o false)
+
+```sh
+java -DgenerateAllModels=true
+```
+
+This option will be helpful to generate models skipped by form parameters, which is defined different in OAS3 (there's no form parameter in OAS3)
+
+
 ### Ignore file format
 
 OpenAPI Generator supports a `.openapi-generator-ignore` file, similar to `.gitignore` or `.dockerignore` you're probably already familiar with.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -31,6 +31,7 @@ public class CodegenConstants {
     public static final String API_TESTS = "apiTests";
     public static final String API_DOCS = "apiDocs";
     public static final String WITH_XML = "withXml";
+    public static final String GENERATE_ALL_MODELS = "generateAllModels";
     /* /end System Properties */
 
     public static final String API_PACKAGE = "apiPackage";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -285,7 +285,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     private void generateModelDocumentation(List<File> files, Map<String, Object> models, String modelName) throws IOException {
         for (String templateName : config.modelDocTemplateFiles().keySet()) {
             String docExtension = config.getDocExtension();
-            String suffix = docExtension!=null ? docExtension : config.modelDocTemplateFiles().get(templateName);
+            String suffix = docExtension != null ? docExtension : config.modelDocTemplateFiles().get(templateName);
             String filename = config.modelDocFileFolder() + File.separator + config.toModelDocFilename(modelName) + suffix;
             if (!config.shouldOverwrite(filename)) {
                 LOGGER.info("Skipped overwriting " + filename);
@@ -381,6 +381,10 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             } */
         });
 
+        Boolean generateAllModels = System.getProperty(CodegenConstants.GENERATE_ALL_MODELS) != null ?
+                Boolean.valueOf(System.getProperty(CodegenConstants.GENERATE_ALL_MODELS)) :
+                getGeneratorPropertyDefaultSwitch(CodegenConstants.GENERATE_ALL_MODELS, false);
+
         // process models only
         for (String name : modelKeys) {
             try {
@@ -392,8 +396,13 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
                 // don't generate models that are not used as object (e.g. form parameters)
                 if (unusedModels.contains(name)) {
-                    LOGGER.debug("Model " + name + " not generated since it's marked as unused (due to form parameters)");
-                    continue;
+                    if (Boolean.TRUE.equals(generateAllModels)) {
+                        // if generateAllModels sets to true, still generate the model and log the result
+                        LOGGER.info("Model " + name + " (marked as unused due to form parameters) is generated due to generateAllModels=true");
+                    } else {
+                        LOGGER.debug("Model " + name + " not generated since it's marked as unused (due to form parameters)");
+                        continue;
+                    }
                 }
 
                 Schema schema = schemas.get(name);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To fix https://github.com/OpenAPITools/openapi-generator/issues/405

To enable, please use the following as stated in the updated doc:
```
java -DgenerateAllModels=true
```

