### PR TITLE
Fixed the generation of model properties whose data type is a composed (allOf) schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -648,7 +648,7 @@ public class ModelUtils {
             } else if (isStringSchema(ref) && (ref.getEnum() != null && !ref.getEnum().isEmpty())) {
                 // top-level enum class
                 return schema;
-            } else if (isMapSchema(ref) || isArraySchema(ref)) { // map/array def should be created as models
+            } else if (isMapSchema(ref) || isArraySchema(ref) || isComposedSchema(ref)) { // map/array def should be created as models
                 return schema;
             } else {
                 return unaliasSchema(allSchemas, allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref())));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -19,10 +19,7 @@ package org.openapitools.codegen.utils;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.IntegerSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -32,7 +29,10 @@ import org.openapitools.codegen.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ModelUtilsTest {
 
@@ -173,4 +173,24 @@ public class ModelUtilsTest {
         Parameter result2 = ModelUtils.getReferencedParameter(openAPI, new Parameter().$ref("#/components/parameters/OtherParameter"));
         Assert.assertEquals(result2, otherParameter);
     }
+	
+    /**
+     * Issue https://github.com/OpenAPITools/openapi-generator/issues/582.
+     * Composed schemas should not get unaliased when generating model properties, in order to properly
+     * generate the property data type name.
+     */
+    @Test
+    public void testComposedSchemasAreNotUnaliased() {
+        ComposedSchema composedSchema = new ComposedSchema().allOf(Arrays.asList(
+                new Schema<>().$ref("#/components/schemas/SomeSchema"),
+                new ObjectSchema()
+        ));
+        Schema refToComposedSchema = new Schema().$ref("#/components/schemas/SomeComposedSchema");
+
+
+        Map<String, Schema> allSchemas = new HashMap<>();
+        allSchemas.put("SomeComposedSchema", composedSchema);
+
+        Assert.assertEquals(refToComposedSchema, ModelUtils.unaliasSchema(allSchemas, refToComposedSchema));
+    }	
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -173,7 +173,7 @@ public class ModelUtilsTest {
         Parameter result2 = ModelUtils.getReferencedParameter(openAPI, new Parameter().$ref("#/components/parameters/OtherParameter"));
         Assert.assertEquals(result2, otherParameter);
     }
-	
+
     /**
      * Issue https://github.com/OpenAPITools/openapi-generator/issues/582.
      * Composed schemas should not get unaliased when generating model properties, in order to properly
@@ -192,5 +192,5 @@ public class ModelUtilsTest {
         allSchemas.put("SomeComposedSchema", composedSchema);
 
         Assert.assertEquals(refToComposedSchema, ModelUtils.unaliasSchema(allSchemas, refToComposedSchema));
-    }	
+    }
 }

--- a/samples/server/petstore/php-slim/phpunit.xml.dist
+++ b/samples/server/petstore/php-slim/phpunit.xml.dist
@@ -19,8 +19,8 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./lib//Api</directory>
-            <directory suffix=".php">./lib//Model</directory>
+            <directory suffix=".php">./lib/Api</directory>
+            <directory suffix=".php">./lib/Model</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixed issue #582. The problem came from the https://github.com/OpenAPITools/openapi-generator/commit/a897feef50989d8b0d0238c067eebaef4f7f6c70 commit in the https://github.com/OpenAPITools/openapi-generator/pull/360 pull request. After that commit, the generation of model properties whose data type is a composed (allOf) schema was broken: the data type name of the generated property was that of the first model participating in the allOf clause. 

After this fix the property data type is again as expected: the one of the composed schema and not one of its parents (models involved in an allOf clause).

cc @jmini @wing328 


