### PR TITLE
[Ruby] Better handling of operationID starting with a number

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -462,6 +462,12 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
             return newOperationId;
         }
 
+        // operationId starts with a number
+        if (operationId.matches("^\\d.*")) {
+            LOGGER.warn(operationId + " (starting with a number) cannot be used as method name. Renamed to " + underscore(sanitizeName("call_" + operationId)));
+            operationId = "call_" + operationId;
+        }
+
         return underscore(sanitizeName(operationId));
     }
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/rubocop.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/rubocop.mustache
@@ -136,7 +136,7 @@ Style/UnneededPercentQ:
 
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
   AutoCorrect: true

--- a/samples/client/petstore/ruby/.rubocop.yml
+++ b/samples/client/petstore/ruby/.rubocop.yml
@@ -136,7 +136,7 @@ Style/UnneededPercentQ:
 
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
   AutoCorrect: true

--- a/samples/client/petstore/ruby/README.md
+++ b/samples/client/petstore/ruby/README.md
@@ -59,10 +59,10 @@ client = Petstore::Client.new # Client | client model
 
 begin
   #To test special tags
-  result = api_instance.test_special_tags(client)
+  result = api_instance.call_123_test_special_tags(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling AnotherFakeApi->test_special_tags: #{e}"
+  puts "Exception when calling AnotherFakeApi->call_123_test_special_tags: #{e}"
 end
 
 ```
@@ -73,7 +73,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*Petstore::AnotherFakeApi* | [**test_special_tags**](docs/AnotherFakeApi.md#test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
+*Petstore::AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 *Petstore::FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *Petstore::FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 *Petstore::FakeApi* | [**fake_outer_number_serialize**](docs/FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 

--- a/samples/client/petstore/ruby/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/ruby/docs/AnotherFakeApi.md
@@ -4,15 +4,15 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**test_special_tags**](AnotherFakeApi.md#test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
+[**call_123_test_special_tags**](AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 
 
-# **test_special_tags**
-> Client test_special_tags(client)
-
-To test special tags
+# **call_123_test_special_tags**
+> Client call_123_test_special_tags(client)
 
 To test special tags
+
+To test special tags and operation ID starting with number
 
 ### Example
 ```ruby
@@ -24,10 +24,10 @@ client = Petstore::Client.new # Client | client model
 
 begin
   #To test special tags
-  result = api_instance.test_special_tags(client)
+  result = api_instance.call_123_test_special_tags(client)
   p result
 rescue Petstore::ApiError => e
-  puts "Exception when calling AnotherFakeApi->test_special_tags: #{e}"
+  puts "Exception when calling AnotherFakeApi->call_123_test_special_tags: #{e}"
 end
 ```
 

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -20,27 +20,27 @@ module Petstore
       @api_client = api_client
     end
     # To test special tags
-    # To test special tags
+    # To test special tags and operation ID starting with number
     # @param client client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
-    def test_special_tags(client, opts = {})
-      data, _status_code, _headers = test_special_tags_with_http_info(client, opts)
+    def call_123_test_special_tags(client, opts = {})
+      data, _status_code, _headers = call_123_test_special_tags_with_http_info(client, opts)
       data
     end
 
     # To test special tags
-    # To test special tags
+    # To test special tags and operation ID starting with number
     # @param client client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
-    def test_special_tags_with_http_info(client, opts = {})
+    def call_123_test_special_tags_with_http_info(client, opts = {})
       if @api_client.config.debugging
-        @api_client.config.logger.debug 'Calling API: AnotherFakeApi.test_special_tags ...'
+        @api_client.config.logger.debug 'Calling API: AnotherFakeApi.call_123_test_special_tags ...'
       end
       # verify the required parameter 'client' is set
       if @api_client.config.client_side_validation && client.nil?
-        fail ArgumentError, "Missing the required parameter 'client' when calling AnotherFakeApi.test_special_tags"
+        fail ArgumentError, "Missing the required parameter 'client' when calling AnotherFakeApi.call_123_test_special_tags"
       end
       # resource path
       local_var_path = '/another-fake/dummy'
@@ -69,7 +69,7 @@ module Petstore
         :auth_names => auth_names,
         :return_type => 'Client')
       if @api_client.config.debugging
-        @api_client.config.logger.debug "API called: AnotherFakeApi#test_special_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+        @api_client.config.logger.debug "API called: AnotherFakeApi#call_123_test_special_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Better handling of operationID starting with a number
- Update Rubocup to use Layout

cc @cliffano @zlx 