### PR TITLE
[PHP] better operationId handling, add CI for PHP slim server

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -496,7 +496,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             operationId = "call_" + operationId;
         }
 
-	// operationId starts with a number
+        // operationId starts with a number
         if (operationId.matches("^\\d.*")) {
             LOGGER.warn(operationId + " (starting with a number) cannot be used as method name. Renamed to " + camelize(sanitizeName("call_" + operationId), true));
             operationId = "call_" + operationId;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -496,6 +496,12 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             operationId = "call_" + operationId;
         }
 
+	// operationId starts with a number
+        if (operationId.matches("^\\d.*")) {
+            LOGGER.warn(operationId + " (starting with a number) cannot be used as method name. Renamed to " + camelize(sanitizeName("call_" + operationId), true));
+            operationId = "call_" + operationId;
+        }
+
         return camelize(sanitizeName(operationId), true);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -981,8 +981,8 @@
                 <module>samples/server/petstore/jaxrs/jersey2-useTags</module>
                 <module>samples/server/petstore/spring-mvc</module>
                 <module>samples/server/petstore/spring-mvc-j8-async</module>
-		<module>samples/server/petstore/spring-mvc-j8-localdatetime</module>
-		<module>samples/server/petstore/php-slim</module>
+                <module>samples/server/petstore/spring-mvc-j8-localdatetime</module>
+                <module>samples/server/petstore/php-slim</module>
             </modules>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -981,7 +981,8 @@
                 <module>samples/server/petstore/jaxrs/jersey2-useTags</module>
                 <module>samples/server/petstore/spring-mvc</module>
                 <module>samples/server/petstore/spring-mvc-j8-async</module>
-                <module>samples/server/petstore/spring-mvc-j8-localdatetime</module>
+		<module>samples/server/petstore/spring-mvc-j8-localdatetime</module>
+		<module>samples/server/petstore/php-slim</module>
             </modules>
         </profile>
     </profiles>

--- a/samples/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/README.md
@@ -64,10 +64,10 @@ $apiInstance = new OpenAPI\Client\Api\AnotherFakeApi(
 $client = new \OpenAPI\Client\Model\Client(); // \OpenAPI\Client\Model\Client | client model
 
 try {
-    $result = $apiInstance->123testSpecialTags($client);
+    $result = $apiInstance->call123TestSpecialTags($client);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling AnotherFakeApi->123testSpecialTags: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling AnotherFakeApi->call123TestSpecialTags: ', $e->getMessage(), PHP_EOL;
 }
 
 ?>
@@ -79,7 +79,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**123testSpecialTags**](docs/Api/AnotherFakeApi.md#123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+*AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fakeOuterCompositeSerialize**](docs/Api/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fakeOuterNumberSerialize**](docs/Api/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/AnotherFakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/AnotherFakeApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**123testSpecialTags**](AnotherFakeApi.md#123testSpecialTags) | **PATCH** /another-fake/dummy | To test special tags
+[**call123TestSpecialTags**](AnotherFakeApi.md#call123TestSpecialTags) | **PATCH** /another-fake/dummy | To test special tags
 
 
-# **123testSpecialTags**
-> \OpenAPI\Client\Model\Client 123testSpecialTags($client)
+# **call123TestSpecialTags**
+> \OpenAPI\Client\Model\Client call123TestSpecialTags($client)
 
 To test special tags
 
@@ -27,10 +27,10 @@ $apiInstance = new OpenAPI\Client\Api\AnotherFakeApi(
 $client = new \OpenAPI\Client\Model\Client(); // \OpenAPI\Client\Model\Client | client model
 
 try {
-    $result = $apiInstance->123testSpecialTags($client);
+    $result = $apiInstance->call123TestSpecialTags($client);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling AnotherFakeApi->123testSpecialTags: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling AnotherFakeApi->call123TestSpecialTags: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -88,7 +88,7 @@ class AnotherFakeApi
     }
 
     /**
-     * Operation 123testSpecialTags
+     * Operation call123TestSpecialTags
      *
      * To test special tags
      *
@@ -98,14 +98,14 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function 123testSpecialTags($client)
+    public function call123TestSpecialTags($client)
     {
-        list($response) = $this->123testSpecialTagsWithHttpInfo($client);
+        list($response) = $this->call123TestSpecialTagsWithHttpInfo($client);
         return $response;
     }
 
     /**
-     * Operation 123testSpecialTagsWithHttpInfo
+     * Operation call123TestSpecialTagsWithHttpInfo
      *
      * To test special tags
      *
@@ -115,9 +115,9 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function 123testSpecialTagsWithHttpInfo($client)
+    public function call123TestSpecialTagsWithHttpInfo($client)
     {
-        $request = $this->123testSpecialTagsRequest($client);
+        $request = $this->call123TestSpecialTagsRequest($client);
 
         try {
             $options = $this->createHttpClientOption();
@@ -199,7 +199,7 @@ class AnotherFakeApi
     }
 
     /**
-     * Operation 123testSpecialTagsAsync
+     * Operation call123TestSpecialTagsAsync
      *
      * To test special tags
      *
@@ -208,9 +208,9 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function 123testSpecialTagsAsync($client)
+    public function call123TestSpecialTagsAsync($client)
     {
-        return $this->123testSpecialTagsAsyncWithHttpInfo($client)
+        return $this->call123TestSpecialTagsAsyncWithHttpInfo($client)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -219,7 +219,7 @@ class AnotherFakeApi
     }
 
     /**
-     * Operation 123testSpecialTagsAsyncWithHttpInfo
+     * Operation call123TestSpecialTagsAsyncWithHttpInfo
      *
      * To test special tags
      *
@@ -228,10 +228,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function 123testSpecialTagsAsyncWithHttpInfo($client)
+    public function call123TestSpecialTagsAsyncWithHttpInfo($client)
     {
         $returnType = '\OpenAPI\Client\Model\Client';
-        $request = $this->123testSpecialTagsRequest($client);
+        $request = $this->call123TestSpecialTagsRequest($client);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -271,19 +271,19 @@ class AnotherFakeApi
     }
 
     /**
-     * Create request for operation '123testSpecialTags'
+     * Create request for operation 'call123TestSpecialTags'
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function 123testSpecialTagsRequest($client)
+    protected function call123TestSpecialTagsRequest($client)
     {
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
             throw new \InvalidArgumentException(
-                'Missing the required parameter $client when calling 123testSpecialTags'
+                'Missing the required parameter $client when calling call123TestSpecialTags'
             );
         }
 

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/AnotherFakeApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/AnotherFakeApiTest.php
@@ -72,12 +72,12 @@ class AnotherFakeApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test case for 123testSpecialTags
+     * Test case for call123TestSpecialTags
      *
      * To test special tags.
      *
      */
-    public function test123testSpecialTags()
+    public function testCall123TestSpecialTags()
     {
     }
 }

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
@@ -64,10 +64,10 @@ $apiInstance = new OpenAPI\Client\Api\AnotherFakeApi(
 $client = new \OpenAPI\Client\Model\Client(); // \OpenAPI\Client\Model\Client | client model
 
 try {
-    $result = $apiInstance->123testSpecialTags($client);
+    $result = $apiInstance->call123TestSpecialTags($client);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling AnotherFakeApi->123testSpecialTags: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling AnotherFakeApi->call123TestSpecialTags: ', $e->getMessage(), PHP_EOL;
 }
 
 ?>
@@ -79,7 +79,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AnotherFakeApi* | [**123testSpecialTags**](docs/Api/AnotherFakeApi.md#123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
+*AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fakeOuterCompositeSerialize**](docs/Api/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fakeOuterNumberSerialize**](docs/Api/FakeApi.md#fakeouternumberserialize) | **POST** /fake/outer/number | 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/AnotherFakeApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**123testSpecialTags**](AnotherFakeApi.md#123testSpecialTags) | **PATCH** /another-fake/dummy | To test special tags
+[**call123TestSpecialTags**](AnotherFakeApi.md#call123TestSpecialTags) | **PATCH** /another-fake/dummy | To test special tags
 
 
-# **123testSpecialTags**
-> \OpenAPI\Client\Model\Client 123testSpecialTags($client)
+# **call123TestSpecialTags**
+> \OpenAPI\Client\Model\Client call123TestSpecialTags($client)
 
 To test special tags
 
@@ -27,10 +27,10 @@ $apiInstance = new OpenAPI\Client\Api\AnotherFakeApi(
 $client = new \OpenAPI\Client\Model\Client(); // \OpenAPI\Client\Model\Client | client model
 
 try {
-    $result = $apiInstance->123testSpecialTags($client);
+    $result = $apiInstance->call123TestSpecialTags($client);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling AnotherFakeApi->123testSpecialTags: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling AnotherFakeApi->call123TestSpecialTags: ', $e->getMessage(), PHP_EOL;
 }
 ?>
 ```

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -88,7 +88,7 @@ class AnotherFakeApi
     }
 
     /**
-     * Operation 123testSpecialTags
+     * Operation call123TestSpecialTags
      *
      * To test special tags
      *
@@ -98,14 +98,14 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function 123testSpecialTags($client)
+    public function call123TestSpecialTags($client)
     {
-        list($response) = $this->123testSpecialTagsWithHttpInfo($client);
+        list($response) = $this->call123TestSpecialTagsWithHttpInfo($client);
         return $response;
     }
 
     /**
-     * Operation 123testSpecialTagsWithHttpInfo
+     * Operation call123TestSpecialTagsWithHttpInfo
      *
      * To test special tags
      *
@@ -115,9 +115,9 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function 123testSpecialTagsWithHttpInfo($client)
+    public function call123TestSpecialTagsWithHttpInfo($client)
     {
-        $request = $this->123testSpecialTagsRequest($client);
+        $request = $this->call123TestSpecialTagsRequest($client);
 
         try {
             $options = $this->createHttpClientOption();
@@ -199,7 +199,7 @@ class AnotherFakeApi
     }
 
     /**
-     * Operation 123testSpecialTagsAsync
+     * Operation call123TestSpecialTagsAsync
      *
      * To test special tags
      *
@@ -208,9 +208,9 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function 123testSpecialTagsAsync($client)
+    public function call123TestSpecialTagsAsync($client)
     {
-        return $this->123testSpecialTagsAsyncWithHttpInfo($client)
+        return $this->call123TestSpecialTagsAsyncWithHttpInfo($client)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -219,7 +219,7 @@ class AnotherFakeApi
     }
 
     /**
-     * Operation 123testSpecialTagsAsyncWithHttpInfo
+     * Operation call123TestSpecialTagsAsyncWithHttpInfo
      *
      * To test special tags
      *
@@ -228,10 +228,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function 123testSpecialTagsAsyncWithHttpInfo($client)
+    public function call123TestSpecialTagsAsyncWithHttpInfo($client)
     {
         $returnType = '\OpenAPI\Client\Model\Client';
-        $request = $this->123testSpecialTagsRequest($client);
+        $request = $this->call123TestSpecialTagsRequest($client);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -271,19 +271,19 @@ class AnotherFakeApi
     }
 
     /**
-     * Create request for operation '123testSpecialTags'
+     * Create request for operation 'call123TestSpecialTags'
      *
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function 123testSpecialTagsRequest($client)
+    protected function call123TestSpecialTagsRequest($client)
     {
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
             throw new \InvalidArgumentException(
-                'Missing the required parameter $client when calling 123testSpecialTags'
+                'Missing the required parameter $client when calling call123TestSpecialTags'
             );
         }
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/AnotherFakeApiTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/AnotherFakeApiTest.php
@@ -72,12 +72,12 @@ class AnotherFakeApiTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test case for 123testSpecialTags
+     * Test case for call123TestSpecialTags
      *
      * To test special tags.
      *
      */
-    public function test123testSpecialTags()
+    public function testCall123TestSpecialTags()
     {
     }
 }

--- a/samples/server/petstore/php-lumen/lib/app/Http/Controllers/AnotherFakeApi.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/Controllers/AnotherFakeApi.php
@@ -27,14 +27,14 @@ class AnotherFakeApi extends Controller
     }
 
     /**
-     * Operation 123testSpecialTags
+     * Operation call123TestSpecialTags
      *
      * To test special tags.
      *
      *
      * @return Http response
      */
-    public function 123testSpecialTags()
+    public function call123TestSpecialTags()
     {
         $input = Request::all();
 
@@ -43,11 +43,11 @@ class AnotherFakeApi extends Controller
 
         //not path params validation
         if (!isset($input['client'])) {
-            throw new \InvalidArgumentException('Missing the required parameter $client when calling 123testSpecialTags');
+            throw new \InvalidArgumentException('Missing the required parameter $client when calling call123TestSpecialTags');
         }
         $client = $input['client'];
 
 
-        return response('How about implementing 123testSpecialTags as a patch method ?');
+        return response('How about implementing call123TestSpecialTags as a patch method ?');
     }
 }

--- a/samples/server/petstore/php-lumen/lib/app/Http/routes.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/routes.php
@@ -22,12 +22,12 @@ $app->get('/', function () use ($app) {
 });
 
 /**
- * patch 123testSpecialTags
+ * patch call123TestSpecialTags
  * Summary: To test special tags
  * Notes: To test special tags and operation ID starting with number
  * Output-Formats: [application/json]
  */
-$app->patch('/v2/another-fake/dummy', 'AnotherFakeApi@123testSpecialTags');
+$app->patch('/v2/another-fake/dummy', 'AnotherFakeApi@call123TestSpecialTags');
 /**
  * patch testClientModel
  * Summary: To test \&quot;client\&quot; model

--- a/samples/server/petstore/php-slim/lib/Api/AnotherFakeApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/AnotherFakeApi.php
@@ -40,7 +40,7 @@ use OpenAPIServer\AbstractApiController;
 class AnotherFakeApi extends AbstractApiController {
 
     /**
-     * PATCH 123testSpecialTags
+     * PATCH call123TestSpecialTags
      * Summary: To test special tags
      * Notes: To test special tags and operation ID starting with number
      * Output-Formats: [application/json]
@@ -49,9 +49,9 @@ class AnotherFakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function 123testSpecialTags($request, $response, $args) {
+    public function call123TestSpecialTags($request, $response, $args) {
         $body = $request->getParsedBody();
-        $response->write('How about implementing 123testSpecialTags as a PATCH method ?');
+        $response->write('How about implementing call123TestSpecialTags as a PATCH method ?');
         return $response;
     }
     

--- a/samples/server/petstore/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim/lib/SlimRouter.php
@@ -72,7 +72,7 @@ class SlimRouter {
         ]);
 
         $app->PATCH(
-            '/v2/another-fake/dummy', AnotherFakeApi::class . ':123testSpecialTags'
+            '/v2/another-fake/dummy', AnotherFakeApi::class . ':call123TestSpecialTags'
         );
         $app->POST(
             '/v2/fake/outer/boolean', FakeApi::class . ':fakeOuterBooleanSerialize'

--- a/samples/server/petstore/php-slim/php_syntax_checker.bash
+++ b/samples/server/petstore/php-slim/php_syntax_checker.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+# a simple script to perform a syntax check on php files using "php -l"
+
+for i in $( find . -name "*.php" ); do
+    result=`php -l $i | grep "No syntax errors detected"`
+    exit_status=$?
+    if [ $exit_status -eq 1 ]; then
+        echo "Syntax errors with $i"
+        exit 1;
+    fi
+done

--- a/samples/server/petstore/php-slim/pom.xml
+++ b/samples/server/petstore/php-slim/pom.xml
@@ -33,7 +33,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-			    <executable>./php_syntax_checker.bash</executable>
+                            <executable>./php_syntax_checker.bash</executable>
                         </configuration>
                     </execution>
                 </executions>

--- a/samples/server/petstore/php-slim/pom.xml
+++ b/samples/server/petstore/php-slim/pom.xml
@@ -1,0 +1,43 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.opoenapitools</groupId>
+    <artifactId>SlimPetstoreServerTests</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Slim Petstore Server</name>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>syntax-check</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+			    <executable>./php_syntax_checker.bash</executable>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/shippable.yml
+++ b/shippable.yml
@@ -26,7 +26,10 @@ build:
     - sudo apt-get install elixir
     # install rebar3
     - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3 && cp rebar3 /usr/bin
+    # install php
+    - apt-get install php
     # show version
+    - php -v
     - rebar3 -v
     - elixir --version
     - mix --version


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- better operationId handling (for operationId starting with a number)
- add CI for PHP slim server
