### PR TITLE
[cpprestsdk] Add localVar prefix to parameterized functions variables in cpprestsd…

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
@@ -36,55 +36,55 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     }
 {{/isContainer}}{{/isPrimitiveType}}{{/required}}{{/allParams}}
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("{{{path}}}");
-    {{#pathParams}}boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("{{baseName}}") + utility::conversions::to_string_t("}"), ApiClient::parameterToString({{{paramName}}}));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("{{{path}}}");
+    {{#pathParams}}boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("{{baseName}}") + utility::conversions::to_string_t("}"), ApiClient::parameterToString({{{paramName}}}));
     {{/pathParams}}
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
     {{#produces}}
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("{{{mediaType}}}") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("{{{mediaType}}}") );
     {{/produces}}
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
         {{#vendorExtensions.x-codegen-response.isString}}
-        responseHttpContentType = utility::conversions::to_string_t("text/plain");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("text/plain");
         {{/vendorExtensions.x-codegen-response.isString}}
         {{^vendorExtensions.x-codegen-response.isString}}
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
         {{/vendorExtensions.x-codegen-response.isString}}
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     {{#vendorExtensions.x-codegen-response.isString}}
     // plain text
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("text/plain");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     {{/vendorExtensions.x-codegen-response.isString}}
     {{#vendorExtensions.x-codegen-response-ishttpcontent}}
     else
     {
         //It's going to be binary, so just use the first one.
-        responseHttpContentType = *responseHttpContentTypes.begin();
+        localVarResponseHttpContentType = *localVarResponseHttpContentTypes.begin();
     }
     {{/vendorExtensions.x-codegen-response-ishttpcontent}}
     {{^vendorExtensions.x-codegen-response-ishttpcontent}}
@@ -94,11 +94,11 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     }
     {{/vendorExtensions.x-codegen-response-ishttpcontent}}
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
     {{#consumes}}
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("{{{mediaType}}}") );
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("{{{mediaType}}}") );
     {{/consumes}}
 
     {{#allParams}}
@@ -131,17 +131,17 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{/required}}
     {
         {{#isQueryParam}}
-        queryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
+        localVarQueryParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
         {{/isQueryParam}}
         {{#isHeaderParam}}
-        headerParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
+        localVarHeaderParams[utility::conversions::to_string_t("{{baseName}}")] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
         {{/isHeaderParam}}
         {{#isFormParam}}
         {{#isFile}}
-        fileParams[ utility::conversions::to_string_t("{{baseName}}") ] = {{^required}}*{{/required}}{{paramName}};
+        localVarFileParams[ utility::conversions::to_string_t("{{baseName}}") ] = {{^required}}*{{/required}}{{paramName}};
         {{/isFile}}
         {{^isFile}}
-        formParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
+        localVarFormParams[ utility::conversions::to_string_t("{{baseName}}") ] = ApiClient::parameterToString({{^required}}*{{/required}}{{paramName}});
         {{/isFile}}
         {{/isFormParam}}
     }
@@ -149,77 +149,77 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{/isBodyParam}}
     {{/allParams}}
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
         {{#bodyParam}}
-        web::json::value json;
+        web::json::value localVarJson;
 
         {{#isPrimitiveType}}
-        json = ModelBase::toJson({{paramName}});
+        localVarJson = ModelBase::toJson({{paramName}});
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isListContainer}}
         {
-            std::vector<web::json::value> jsonArray;
-            for( auto& item : {{paramName}} )
+            std::vector<web::json::value> localVarJsonArray;
+            for( auto& localVarItem : {{paramName}} )
             {
-                {{#items.isPrimitiveType}}jsonArray.push_back(ModelBase::toJson(item));
-                {{/items.isPrimitiveType}}{{^items.isPrimitiveType}}{{#items.isString}}jsonArray.push_back(ModelBase::toJson(item));
-                {{/items.isString}}{{^items.isString}}{{#items.isDateTime}}jsonArray.push_back(ModelBase::toJson(item));
-                {{/items.isDateTime}}{{^items.isDateTime}}jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
+                {{#items.isPrimitiveType}}localVarJsonArray.push_back(ModelBase::toJson(localVarItem));
+                {{/items.isPrimitiveType}}{{^items.isPrimitiveType}}{{#items.isString}}localVarJsonArray.push_back(ModelBase::toJson(localVarItem));
+                {{/items.isString}}{{^items.isString}}{{#items.isDateTime}}localVarJsonArray.push_back(ModelBase::toJson(localVarItem));
+                {{/items.isDateTime}}{{^items.isDateTime}}localVarJsonArray.push_back( localVarItem.get() ? localVarItem->toJson() : web::json::value::null() );
                 {{/items.isDateTime}}{{/items.isString}}{{/items.isPrimitiveType}}
             }
-            json = web::json::value::array(jsonArray);
+            localVarJson = web::json::value::array(localVarJsonArray);
         }
         {{/isListContainer}}
-        {{^isListContainer}}{{#required}}json = ModelBase::toJson({{paramName}});
+        {{^isListContainer}}{{#required}}localVarJson = ModelBase::toJson({{paramName}});
         {{/required}}{{^required}}if ({{paramName}})
-            json = ModelBase::toJson(*{{paramName}});{{/required}}
+            localVarJson = ModelBase::toJson(*{{paramName}});{{/required}}
         {{/isListContainer}}
         {{/isPrimitiveType}}
 
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
         {{/bodyParam}}
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
         {{#bodyParam}}
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
         {{#isPrimitiveType}}
-        multipart->add(ModelBase::toHttpContent("{{paramName}}", {{paramName}}));
+        localVarMultipart->add(ModelBase::toHttpContent("{{paramName}}", {{paramName}}));
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isListContainer}}
         {
-            std::vector<web::json::value> jsonArray;
-            for( auto& item : {{paramName}} )
+            std::vector<web::json::value> localVarJsonArray;
+            for( auto& localVarItem : {{paramName}} )
             {
-                {{#items.isPrimitiveType}}jsonArray.push_back(ModelBase::toJson(item));
-                {{/items.isPrimitiveType}}{{^items.isPrimitiveType}}{{#items.isString}}jsonArray.push_back(ModelBase::toJson(item));
-                {{/items.isString}}{{^items.isString}}{{#items.isDateTime}}jsonArray.push_back(ModelBase::toJson(item));
-                {{/items.isDateTime}}{{^items.isDateTime}}jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
+                {{#items.isPrimitiveType}}localVarJsonArray.push_back(ModelBase::toJson(localVarItem));
+                {{/items.isPrimitiveType}}{{^items.isPrimitiveType}}{{#items.isString}}localVarJsonArray.push_back(ModelBase::toJson(localVarItem));
+                {{/items.isString}}{{^items.isString}}{{#items.isDateTime}}localVarJsonArray.push_back(ModelBase::toJson(localVarItem));
+                {{/items.isDateTime}}{{^items.isDateTime}}localVarJsonArray.push_back( localVarItem.get() ? localVarItem->toJson() : web::json::value::null() );
                 {{/items.isDateTime}}{{/items.isString}}{{/items.isPrimitiveType}}
             }
-            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
+            localVarMultipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), web::json::value::array(localVarJsonArray), utility::conversions::to_string_t("application/json")));
         }{{/isListContainer}}
-        {{^isListContainer}}{{#isString}}multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), {{paramName}}));
+        {{^isListContainer}}{{#isString}}localVarMultipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("{{paramName}}"), {{paramName}}));
         {{/isString}}{{^isString}}if({{^required}}{{paramName}} && (*{{paramName}}){{/required}}{{#required}}{{paramName}}{{/required}}.get())
         {
-            {{^required}}(*{{/required}}{{paramName}}{{^required}}){{/required}}->toMultipart(multipart, utility::conversions::to_string_t("{{paramName}}"));
+            {{^required}}(*{{/required}}{{paramName}}{{^required}}){{/required}}->toMultipart(localVarMultipart, utility::conversions::to_string_t("{{paramName}}"));
         }
         {{/isString}}
         {{/isListContainer}}
         {{/isPrimitiveType}}
 
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
         {{/bodyParam}}
     }
     else
@@ -232,19 +232,19 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{#isApiKey}}
     {{#isKeyInHeader}}
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
-        if ( apiKey.size() > 0 )
+        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
+        if ( localVarApiKey.size() > 0 )
         {
-            headerParams[utility::conversions::to_string_t("{{keyParamName}}")] = apiKey;
+            localVarHeaderParams[utility::conversions::to_string_t("{{keyParamName}}")] = localVarApiKey;
         }
     }
     {{/isKeyInHeader}}
     {{#isKeyInQuery}}
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
-        if ( apiKey.size() > 0 )
+        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
+        if ( localVarApiKey.size() > 0 )
         {
-            queryParams[utility::conversions::to_string_t("{{keyParamName}}")] = apiKey;
+            localVarQueryParams[utility::conversions::to_string_t("{{keyParamName}}")] = localVarApiKey;
         }
     }
     {{/isKeyInQuery}}
@@ -257,91 +257,91 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     {{/isOAuth}}
     {{/authMethods}}
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("{{httpMethod}}"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("{{httpMethod}}"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling {{operationId}}: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling {{operationId}}: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling {{operationId}}: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling {{operationId}}: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
         {{#vendorExtensions.x-codegen-response-ishttpcontent}}
-        return response.extract_vector();
+        return localVarResponse.extract_vector();
     })
-    .then([=](std::vector<unsigned char> response)
+    .then([=](std::vector<unsigned char> localVarResponse)
     {
-        HttpContent result;
-        std::shared_ptr<std::stringstream> stream = std::make_shared<std::stringstream>(std::string(response.begin(), response.end()));
-        result.setData(stream);
-        return result;
+        HttpContent localVarResult;
+        std::shared_ptr<std::stringstream> stream = std::make_shared<std::stringstream>(std::string(localVarResponse.begin(), localVarResponse.end()));
+        localVarResult.setData(stream);
+        return localVarResult;
         {{/vendorExtensions.x-codegen-response-ishttpcontent}}
         {{^vendorExtensions.x-codegen-response-ishttpcontent}}
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         {{^returnType}}
         return void();
         {{/returnType}}
         {{#returnType}}
         {{#returnContainer}}
-        {{{returnType}}} result;
+        {{{returnType}}} localVarResult;
         {{/returnContainer}}
         {{^returnContainer}}
-        {{{returnType}}} result({{{defaultResponse}}});
+        {{{returnType}}} localVarResult({{{defaultResponse}}});
         {{/returnContainer}}
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            {{#isListContainer}}for( auto& item : json.as_array() )
+            {{#isListContainer}}for( auto& localVarItem : localVarJson.as_array() )
             {
-                {{#vendorExtensions.x-codegen-response.items.isPrimitiveType}}result.push_back(ModelBase::{{vendorExtensions.x-codegen-response.items.datatype}}FromJson(item));
-                {{/vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.items.isString}}result.push_back(ModelBase::stringFromJson(item));
-                {{/vendorExtensions.x-codegen-response.items.isString}}{{^vendorExtensions.x-codegen-response.items.isString}}{{{vendorExtensions.x-codegen-response.items.datatype}}} itemObj({{{vendorExtensions.x-codegen-response.items.defaultValue}}});
-                itemObj->fromJson(item);
-                result.push_back(itemObj);
+                {{#vendorExtensions.x-codegen-response.items.isPrimitiveType}}localVarResult.push_back(ModelBase::{{vendorExtensions.x-codegen-response.items.datatype}}FromJson(localVarItem));
+                {{/vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.items.isString}}localVarResult.push_back(ModelBase::stringFromJson(localVarItem));
+                {{/vendorExtensions.x-codegen-response.items.isString}}{{^vendorExtensions.x-codegen-response.items.isString}}{{{vendorExtensions.x-codegen-response.items.datatype}}} localVarItemObj({{{vendorExtensions.x-codegen-response.items.defaultValue}}});
+                localVarItemObj->fromJson(localVarItem);
+                localVarResult.push_back(localVarItemObj);
                 {{/vendorExtensions.x-codegen-response.items.isString}}{{/vendorExtensions.x-codegen-response.items.isPrimitiveType}}
             }
-            {{/isListContainer}}{{^isListContainer}}{{#isMapContainer}}for( auto& item : json.as_object() )
+            {{/isListContainer}}{{^isListContainer}}{{#isMapContainer}}for( auto& localVarItem : localVarJson.as_object() )
             {
-                {{#vendorExtensions.x-codegen-response.items.isPrimitiveType}}result[item.first] = ModelBase::{{vendorExtensions.x-codegen-response.items.datatype}}FromJson(item.second);
-                {{/vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.items.isString}}result[item.first] = ModelBase::stringFromJson(item.second);
-                {{/vendorExtensions.x-codegen-response.items.isString}}{{^vendorExtensions.x-codegen-response.items.isString}}{{{vendorExtensions.x-codegen-response.items.datatype}}} itemObj({{{vendorExtensions.x-codegen-response.items.defaultValue}}});
-                itemObj->fromJson(item.second);
-                result[item.first] = itemObj;
+                {{#vendorExtensions.x-codegen-response.items.isPrimitiveType}}localVarResult[localVarItem.first] = ModelBase::{{vendorExtensions.x-codegen-response.items.datatype}}FromJson(localVarItem.second);
+                {{/vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.items.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.items.isString}}localVarResult[localVarItem.first] = ModelBase::stringFromJson(localVarItem.second);
+                {{/vendorExtensions.x-codegen-response.items.isString}}{{^vendorExtensions.x-codegen-response.items.isString}}{{{vendorExtensions.x-codegen-response.items.datatype}}} localVarItemObj({{{vendorExtensions.x-codegen-response.items.defaultValue}}});
+                localVarItemObj->fromJson(localVarItem.second);
+                localVarResult[localVarItem.first] = localVarItemObj;
                 {{/vendorExtensions.x-codegen-response.items.isString}}{{/vendorExtensions.x-codegen-response.items.isPrimitiveType}}
             }
-            {{/isMapContainer}}{{^isMapContainer}}{{#vendorExtensions.x-codegen-response.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.items.datatype}}result = ModelBase::{{vendorExtensions.x-codegen-response.items.datatype}}FromJson(json);
-            {{/vendorExtensions.x-codegen-response.items.datatype}}{{^vendorExtensions.x-codegen-response.items.datatype}}result = ModelBase::{{vendorExtensions.x-codegen-response.datatype}}FromJson(json);
-            {{/vendorExtensions.x-codegen-response.items.datatype}}{{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.isString}}result = ModelBase::stringFromJson(json);
-            {{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}result->fromJson(json);{{/vendorExtensions.x-codegen-response.isString}}{{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{/isMapContainer}}{{/isListContainer}}
+            {{/isMapContainer}}{{^isMapContainer}}{{#vendorExtensions.x-codegen-response.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.items.datatype}}localVarResult = ModelBase::{{vendorExtensions.x-codegen-response.items.datatype}}FromJson(localVarJson);
+            {{/vendorExtensions.x-codegen-response.items.datatype}}{{^vendorExtensions.x-codegen-response.items.datatype}}localVarResult = ModelBase::{{vendorExtensions.x-codegen-response.datatype}}FromJson(localVarJson);
+            {{/vendorExtensions.x-codegen-response.items.datatype}}{{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{^vendorExtensions.x-codegen-response.isPrimitiveType}}{{#vendorExtensions.x-codegen-response.isString}}localVarResult = ModelBase::stringFromJson(localVarJson);
+            {{/vendorExtensions.x-codegen-response.isString}}{{^vendorExtensions.x-codegen-response.isString}}localVarResult->fromJson(localVarJson);{{/vendorExtensions.x-codegen-response.isString}}{{/vendorExtensions.x-codegen-response.isPrimitiveType}}{{/isMapContainer}}{{/isListContainer}}
         }{{#vendorExtensions.x-codegen-response.isString}}
-        else if(responseHttpContentType == utility::conversions::to_string_t("text/plain"))
+        else if(localVarResponseHttpContentType == utility::conversions::to_string_t("text/plain"))
         {
-            result = response;
+            localVarResult = localVarResponse;
         }{{/vendorExtensions.x-codegen-response.isString}}
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -351,7 +351,7 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
                 , utility::conversions::to_string_t("error calling {{operationId}}: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
         {{/returnType}}
         {{/vendorExtensions.x-codegen-response-ishttpcontent}}
     });

--- a/samples/client/petstore/cpp-restsdk/api/PetApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/api/PetApi.cpp
@@ -45,72 +45,72 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> pet)
     }
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->addPet does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
-        json = ModelBase::toJson(pet);
+        localVarJson = ModelBase::toJson(pet);
         
 
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
 
         if(pet.get())
         {
-            pet->toMultipart(multipart, utility::conversions::to_string_t("pet"));
+            pet->toMultipart(localVarMultipart, utility::conversions::to_string_t("pet"));
         }
 
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -120,36 +120,36 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> pet)
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling addPet: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling addPet: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling addPet: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling addPet: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -158,60 +158,60 @@ pplx::task<void> PetApi::deletePet(int64_t petId, boost::optional<utility::strin
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet/{petId}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->deletePet does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
     if (apiKey)
     {
-        headerParams[utility::conversions::to_string_t("api_key")] = ApiClient::parameterToString(*apiKey);
+        localVarHeaderParams[utility::conversions::to_string_t("api_key")] = ApiClient::parameterToString(*apiKey);
     }
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -221,36 +221,36 @@ pplx::task<void> PetApi::deletePet(int64_t petId, boost::optional<utility::strin
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("DELETE"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling deletePet: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling deletePet: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling deletePet: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling deletePet: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -259,60 +259,60 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet/findByStatus");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet/findByStatus");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->findPetsByStatus does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
     {
-        queryParams[utility::conversions::to_string_t("status")] = ApiClient::parameterToString(status);
+        localVarQueryParams[utility::conversions::to_string_t("status")] = ApiClient::parameterToString(status);
     }
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -322,53 +322,53 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling findPetsByStatus: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling findPetsByStatus: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling findPetsByStatus: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling findPetsByStatus: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::vector<std::shared_ptr<Pet>> result;
+        std::vector<std::shared_ptr<Pet>> localVarResult;
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            for( auto& item : json.as_array() )
+            for( auto& localVarItem : localVarJson.as_array() )
             {
-                std::shared_ptr<Pet> itemObj(new Pet());
-                itemObj->fromJson(item);
-                result.push_back(itemObj);
+                std::shared_ptr<Pet> localVarItemObj(new Pet());
+                localVarItemObj->fromJson(localVarItem);
+                localVarResult.push_back(localVarItemObj);
                 
             }
             
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -378,67 +378,67 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
                 , utility::conversions::to_string_t("error calling findPetsByStatus: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector<utility::string_t> tags)
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet/findByTags");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet/findByTags");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->findPetsByTags does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
     {
-        queryParams[utility::conversions::to_string_t("tags")] = ApiClient::parameterToString(tags);
+        localVarQueryParams[utility::conversions::to_string_t("tags")] = ApiClient::parameterToString(tags);
     }
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -448,53 +448,53 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling findPetsByTags: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling findPetsByTags: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling findPetsByTags: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling findPetsByTags: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::vector<std::shared_ptr<Pet>> result;
+        std::vector<std::shared_ptr<Pet>> localVarResult;
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            for( auto& item : json.as_array() )
+            for( auto& localVarItem : localVarJson.as_array() )
             {
-                std::shared_ptr<Pet> itemObj(new Pet());
-                itemObj->fromJson(item);
-                result.push_back(itemObj);
+                std::shared_ptr<Pet> localVarItemObj(new Pet());
+                localVarItemObj->fromJson(localVarItem);
+                localVarResult.push_back(localVarItemObj);
                 
             }
             
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -504,65 +504,65 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
                 , utility::conversions::to_string_t("error calling findPetsByTags: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet/{petId}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->getPetById does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -571,53 +571,53 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
 
     // authentication (api_key) required
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("api_key"));
-        if ( apiKey.size() > 0 )
+        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("api_key"));
+        if ( localVarApiKey.size() > 0 )
         {
-            headerParams[utility::conversions::to_string_t("api_key")] = apiKey;
+            localVarHeaderParams[utility::conversions::to_string_t("api_key")] = localVarApiKey;
         }
     }
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling getPetById: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling getPetById: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling getPetById: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling getPetById: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::shared_ptr<Pet> result(new Pet());
+        std::shared_ptr<Pet> localVarResult(new Pet());
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            result->fromJson(json);
+            localVarResult->fromJson(localVarJson);
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -627,7 +627,7 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
                 , utility::conversions::to_string_t("error calling getPetById: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> pet)
@@ -640,72 +640,72 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> pet)
     }
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->updatePet does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
-        json = ModelBase::toJson(pet);
+        localVarJson = ModelBase::toJson(pet);
         
 
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
 
         if(pet.get())
         {
-            pet->toMultipart(multipart, utility::conversions::to_string_t("pet"));
+            pet->toMultipart(localVarMultipart, utility::conversions::to_string_t("pet"));
         }
 
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -715,36 +715,36 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> pet)
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("PUT"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling updatePet: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling updatePet: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling updatePet: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling updatePet: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -753,65 +753,65 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, boost::optional<utilit
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet/{petId}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->updatePetWithForm does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("application/x-www-form-urlencoded") );
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("application/x-www-form-urlencoded") );
 
     if (name)
     {
-        formParams[ utility::conversions::to_string_t("name") ] = ApiClient::parameterToString(*name);
+        localVarFormParams[ utility::conversions::to_string_t("name") ] = ApiClient::parameterToString(*name);
     }
     if (status)
     {
-        formParams[ utility::conversions::to_string_t("status") ] = ApiClient::parameterToString(*status);
+        localVarFormParams[ utility::conversions::to_string_t("status") ] = ApiClient::parameterToString(*status);
     }
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -821,36 +821,36 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, boost::optional<utilit
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling updatePetWithForm: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling updatePetWithForm: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling updatePetWithForm: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling updatePetWithForm: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -859,66 +859,66 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, boost
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/pet/{petId}/uploadImage");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/pet/{petId}/uploadImage");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("petId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(petId));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("PetApi->uploadFile does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
-    consumeHttpContentTypes.insert( utility::conversions::to_string_t("multipart/form-data") );
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
+    localVarConsumeHttpContentTypes.insert( utility::conversions::to_string_t("multipart/form-data") );
 
     if (additionalMetadata)
     {
-        formParams[ utility::conversions::to_string_t("additionalMetadata") ] = ApiClient::parameterToString(*additionalMetadata);
+        localVarFormParams[ utility::conversions::to_string_t("additionalMetadata") ] = ApiClient::parameterToString(*additionalMetadata);
     }
     if (file && *file != nullptr)
     {
-        fileParams[ utility::conversions::to_string_t("file") ] = *file;
+        localVarFileParams[ utility::conversions::to_string_t("file") ] = *file;
     }
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -928,46 +928,46 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, boost
     // authentication (petstore_auth) required
     // oauth2 authentication is added automatically as part of the http_client_config
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling uploadFile: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling uploadFile: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling uploadFile: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling uploadFile: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::shared_ptr<ApiResponse> result(new ApiResponse());
+        std::shared_ptr<ApiResponse> localVarResult(new ApiResponse());
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            result->fromJson(json);
+            localVarResult->fromJson(localVarJson);
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -977,7 +977,7 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, boost
                 , utility::conversions::to_string_t("error calling uploadFile: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 

--- a/samples/client/petstore/cpp-restsdk/api/StoreApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/api/StoreApi.cpp
@@ -39,56 +39,56 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/store/order/{orderId}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("orderId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(orderId));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/store/order/{orderId}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("orderId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(orderId));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("StoreApi->deleteOrder does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -96,36 +96,36 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("DELETE"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling deleteOrder: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling deleteOrder: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling deleteOrder: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling deleteOrder: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -134,56 +134,56 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/store/inventory");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/store/inventory");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("StoreApi->getInventory does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -192,58 +192,58 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
 
     // authentication (api_key) required
     {
-        utility::string_t apiKey = apiConfiguration->getApiKey(utility::conversions::to_string_t("api_key"));
-        if ( apiKey.size() > 0 )
+        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("api_key"));
+        if ( localVarApiKey.size() > 0 )
         {
-            headerParams[utility::conversions::to_string_t("api_key")] = apiKey;
+            localVarHeaderParams[utility::conversions::to_string_t("api_key")] = localVarApiKey;
         }
     }
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling getInventory: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling getInventory: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling getInventory: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling getInventory: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::map<utility::string_t, int32_t> result;
+        std::map<utility::string_t, int32_t> localVarResult;
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            for( auto& item : json.as_object() )
+            for( auto& localVarItem : localVarJson.as_object() )
             {
-                result[item.first] = ModelBase::int32_tFromJson(item.second);
+                localVarResult[localVarItem.first] = ModelBase::int32_tFromJson(localVarItem.second);
                 
             }
             
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -253,65 +253,65 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
                 , utility::conversions::to_string_t("error calling getInventory: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/store/order/{orderId}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("orderId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(orderId));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/store/order/{orderId}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("orderId") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(orderId));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("StoreApi->getOrderById does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -319,46 +319,46 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling getOrderById: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling getOrderById: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling getOrderById: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling getOrderById: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::shared_ptr<Order> result(new Order());
+        std::shared_ptr<Order> localVarResult(new Order());
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            result->fromJson(json);
+            localVarResult->fromJson(localVarJson);
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -368,7 +368,7 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
                 , utility::conversions::to_string_t("error calling getOrderById: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> order)
@@ -381,72 +381,72 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> o
     }
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/store/order");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/store/order");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("StoreApi->placeOrder does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
-        json = ModelBase::toJson(order);
+        localVarJson = ModelBase::toJson(order);
         
 
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
 
         if(order.get())
         {
-            order->toMultipart(multipart, utility::conversions::to_string_t("order"));
+            order->toMultipart(localVarMultipart, utility::conversions::to_string_t("order"));
         }
 
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -454,46 +454,46 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> o
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling placeOrder: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling placeOrder: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling placeOrder: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling placeOrder: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::shared_ptr<Order> result(new Order());
+        std::shared_ptr<Order> localVarResult(new Order());
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            result->fromJson(json);
+            localVarResult->fromJson(localVarJson);
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -503,7 +503,7 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> o
                 , utility::conversions::to_string_t("error calling placeOrder: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 

--- a/samples/client/petstore/cpp-restsdk/api/UserApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/api/UserApi.cpp
@@ -45,70 +45,70 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> user)
     }
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->createUser does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
-        json = ModelBase::toJson(user);
+        localVarJson = ModelBase::toJson(user);
         
 
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
 
         if(user.get())
         {
-            user->toMultipart(multipart, utility::conversions::to_string_t("user"));
+            user->toMultipart(localVarMultipart, utility::conversions::to_string_t("user"));
         }
 
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -116,36 +116,36 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> user)
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling createUser: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling createUser: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling createUser: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling createUser: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -154,81 +154,81 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/createWithArray");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/createWithArray");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->createUsersWithArrayInput does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
         {
-            std::vector<web::json::value> jsonArray;
-            for( auto& item : user )
+            std::vector<web::json::value> localVarJsonArray;
+            for( auto& localVarItem : user )
             {
-                jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
+                localVarJsonArray.push_back( localVarItem.get() ? localVarItem->toJson() : web::json::value::null() );
                 
             }
-            json = web::json::value::array(jsonArray);
+            localVarJson = web::json::value::array(localVarJsonArray);
         }
         
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
         {
-            std::vector<web::json::value> jsonArray;
-            for( auto& item : user )
+            std::vector<web::json::value> localVarJsonArray;
+            for( auto& localVarItem : user )
             {
-                jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
+                localVarJsonArray.push_back( localVarItem.get() ? localVarItem->toJson() : web::json::value::null() );
                 
             }
-            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("user"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
+            localVarMultipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("user"), web::json::value::array(localVarJsonArray), utility::conversions::to_string_t("application/json")));
         }
         
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -236,36 +236,36 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling createUsersWithArrayInput: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling createUsersWithArrayInput: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling createUsersWithArrayInput: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling createUsersWithArrayInput: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -274,81 +274,81 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/createWithList");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/createWithList");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->createUsersWithListInput does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
         {
-            std::vector<web::json::value> jsonArray;
-            for( auto& item : user )
+            std::vector<web::json::value> localVarJsonArray;
+            for( auto& localVarItem : user )
             {
-                jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
+                localVarJsonArray.push_back( localVarItem.get() ? localVarItem->toJson() : web::json::value::null() );
                 
             }
-            json = web::json::value::array(jsonArray);
+            localVarJson = web::json::value::array(localVarJsonArray);
         }
         
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
         {
-            std::vector<web::json::value> jsonArray;
-            for( auto& item : user )
+            std::vector<web::json::value> localVarJsonArray;
+            for( auto& localVarItem : user )
             {
-                jsonArray.push_back( item.get() ? item->toJson() : web::json::value::null() );
+                localVarJsonArray.push_back( localVarItem.get() ? localVarItem->toJson() : web::json::value::null() );
                 
             }
-            multipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("user"), web::json::value::array(jsonArray), utility::conversions::to_string_t("application/json")));
+            localVarMultipart->add(ModelBase::toHttpContent(utility::conversions::to_string_t("user"), web::json::value::array(localVarJsonArray), utility::conversions::to_string_t("application/json")));
         }
         
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -356,36 +356,36 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("POST"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling createUsersWithListInput: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling createUsersWithListInput: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling createUsersWithListInput: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling createUsersWithListInput: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -394,56 +394,56 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/{username}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/{username}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->deleteUser does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -451,36 +451,36 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("DELETE"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("DELETE"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling deleteUser: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling deleteUser: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling deleteUser: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling deleteUser: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -489,58 +489,58 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/{username}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/{username}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->getUserByName does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -548,46 +548,46 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling getUserByName: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling getUserByName: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling getUserByName: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling getUserByName: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        std::shared_ptr<User> result(new User());
+        std::shared_ptr<User> localVarResult(new User());
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            result->fromJson(json);
+            localVarResult->fromJson(localVarJson);
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -597,75 +597,75 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
                 , utility::conversions::to_string_t("error calling getUserByName: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, utility::string_t password)
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/login");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/login");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
-    responseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/xml") );
+    localVarResponseHttpContentTypes.insert( utility::conversions::to_string_t("application/json") );
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("text/plain");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     // plain text
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("text/plain")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("text/plain");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("text/plain");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->loginUser does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
     {
-        queryParams[utility::conversions::to_string_t("username")] = ApiClient::parameterToString(username);
+        localVarQueryParams[utility::conversions::to_string_t("username")] = ApiClient::parameterToString(username);
     }
     {
-        queryParams[utility::conversions::to_string_t("password")] = ApiClient::parameterToString(password);
+        localVarQueryParams[utility::conversions::to_string_t("password")] = ApiClient::parameterToString(password);
     }
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -673,51 +673,51 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling loginUser: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling loginUser: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling loginUser: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling loginUser: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
-        utility::string_t result(utility::conversions::to_string_t(""));
+        utility::string_t localVarResult(utility::conversions::to_string_t(""));
 
-        if(responseHttpContentType == utility::conversions::to_string_t("application/json"))
+        if(localVarResponseHttpContentType == utility::conversions::to_string_t("application/json"))
         {
-            web::json::value json = web::json::value::parse(response);
+            web::json::value localVarJson = web::json::value::parse(localVarResponse);
 
-            result = ModelBase::stringFromJson(json);
+            localVarResult = ModelBase::stringFromJson(localVarJson);
             
         }
-        else if(responseHttpContentType == utility::conversions::to_string_t("text/plain"))
+        else if(localVarResponseHttpContentType == utility::conversions::to_string_t("text/plain"))
         {
-            result = response;
+            localVarResult = localVarResponse;
         }
-        // else if(responseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
+        // else if(localVarResponseHttpContentType == utility::conversions::to_string_t("multipart/form-data"))
         // {
         // TODO multipart response parsing
         // }
@@ -727,62 +727,62 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
                 , utility::conversions::to_string_t("error calling loginUser: unsupported response type"));
         }
 
-        return result;
+        return localVarResult;
     });
 }
 pplx::task<void> UserApi::logoutUser()
 {
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/logout");
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/logout");
     
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->logoutUser does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
@@ -790,36 +790,36 @@ pplx::task<void> UserApi::logoutUser()
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("GET"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling logoutUser: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling logoutUser: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling logoutUser: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling logoutUser: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });
@@ -834,71 +834,71 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     }
 
 
-    std::shared_ptr<ApiConfiguration> apiConfiguration( m_ApiClient->getConfiguration() );
-    utility::string_t path = utility::conversions::to_string_t("/user/{username}");
-    boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
+    std::shared_ptr<ApiConfiguration> localVarApiConfiguration( m_ApiClient->getConfiguration() );
+    utility::string_t localVarPath = utility::conversions::to_string_t("/user/{username}");
+    boost::replace_all(localVarPath, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("username") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(username));
 
-    std::map<utility::string_t, utility::string_t> queryParams;
-    std::map<utility::string_t, utility::string_t> headerParams( apiConfiguration->getDefaultHeaders() );
-    std::map<utility::string_t, utility::string_t> formParams;
-    std::map<utility::string_t, std::shared_ptr<HttpContent>> fileParams;
+    std::map<utility::string_t, utility::string_t> localVarQueryParams;
+    std::map<utility::string_t, utility::string_t> localVarHeaderParams( localVarApiConfiguration->getDefaultHeaders() );
+    std::map<utility::string_t, utility::string_t> localVarFormParams;
+    std::map<utility::string_t, std::shared_ptr<HttpContent>> localVarFileParams;
 
-    std::unordered_set<utility::string_t> responseHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarResponseHttpContentTypes;
 
-    utility::string_t responseHttpContentType;
+    utility::string_t localVarResponseHttpContentType;
 
     // use JSON if possible
-    if ( responseHttpContentTypes.size() == 0 )
+    if ( localVarResponseHttpContentTypes.size() == 0 )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // JSON
-    else if ( responseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != responseHttpContentTypes.end() )
+    else if ( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("application/json");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("application/json");
     }
     // multipart formdata
-    else if( responseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != responseHttpContentTypes.end() )
+    else if( localVarResponseHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarResponseHttpContentTypes.end() )
     {
-        responseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        localVarResponseHttpContentType = utility::conversions::to_string_t("multipart/form-data");
     }
     else
     {
         throw ApiException(400, utility::conversions::to_string_t("UserApi->updateUser does not produce any supported media type"));
     }
 
-    headerParams[utility::conversions::to_string_t("Accept")] = responseHttpContentType;
+    localVarHeaderParams[utility::conversions::to_string_t("Accept")] = localVarResponseHttpContentType;
 
-    std::unordered_set<utility::string_t> consumeHttpContentTypes;
+    std::unordered_set<utility::string_t> localVarConsumeHttpContentTypes;
 
 
-    std::shared_ptr<IHttpBody> httpBody;
-    utility::string_t requestHttpContentType;
+    std::shared_ptr<IHttpBody> localVarHttpBody;
+    utility::string_t localVarRequestHttpContentType;
 
     // use JSON if possible
-    if ( consumeHttpContentTypes.size() == 0 || consumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != consumeHttpContentTypes.end() )
+    if ( localVarConsumeHttpContentTypes.size() == 0 || localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("application/json")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("application/json");
-        web::json::value json;
+        localVarRequestHttpContentType = utility::conversions::to_string_t("application/json");
+        web::json::value localVarJson;
 
-        json = ModelBase::toJson(user);
+        localVarJson = ModelBase::toJson(user);
         
 
-        httpBody = std::shared_ptr<IHttpBody>( new JsonBody( json ) );
+        localVarHttpBody = std::shared_ptr<IHttpBody>( new JsonBody( localVarJson ) );
     }
     // multipart formdata
-    else if( consumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != consumeHttpContentTypes.end() )
+    else if( localVarConsumeHttpContentTypes.find(utility::conversions::to_string_t("multipart/form-data")) != localVarConsumeHttpContentTypes.end() )
     {
-        requestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
-        std::shared_ptr<MultipartFormData> multipart(new MultipartFormData);
+        localVarRequestHttpContentType = utility::conversions::to_string_t("multipart/form-data");
+        std::shared_ptr<MultipartFormData> localVarMultipart(new MultipartFormData);
 
         if(user.get())
         {
-            user->toMultipart(multipart, utility::conversions::to_string_t("user"));
+            user->toMultipart(localVarMultipart, utility::conversions::to_string_t("user"));
         }
 
-        httpBody = multipart;
-        requestHttpContentType += utility::conversions::to_string_t("; boundary=") + multipart->getBoundary();
+        localVarHttpBody = localVarMultipart;
+        localVarRequestHttpContentType += utility::conversions::to_string_t("; boundary=") + localVarMultipart->getBoundary();
     }
     else
     {
@@ -906,36 +906,36 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     }
 
 
-    return m_ApiClient->callApi(path, utility::conversions::to_string_t("PUT"), queryParams, httpBody, headerParams, formParams, fileParams, requestHttpContentType)
-    .then([=](web::http::http_response response)
+    return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("PUT"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
+    .then([=](web::http::http_response localVarResponse)
     {
         // 1xx - informational : OK
         // 2xx - successful       : OK
         // 3xx - redirection   : OK
         // 4xx - client error  : not OK
         // 5xx - client error  : not OK
-        if (response.status_code() >= 400)
+        if (localVarResponse.status_code() >= 400)
         {
-            throw ApiException(response.status_code()
-                , utility::conversions::to_string_t("error calling updateUser: ") + response.reason_phrase()
-                , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+            throw ApiException(localVarResponse.status_code()
+                , utility::conversions::to_string_t("error calling updateUser: ") + localVarResponse.reason_phrase()
+                , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
         }
 
         // check response content type
-        if(response.headers().has(utility::conversions::to_string_t("Content-Type")))
+        if(localVarResponse.headers().has(utility::conversions::to_string_t("Content-Type")))
         {
-            utility::string_t contentType = response.headers()[utility::conversions::to_string_t("Content-Type")];
-            if( contentType.find(responseHttpContentType) == std::string::npos )
+            utility::string_t localVarContentType = localVarResponse.headers()[utility::conversions::to_string_t("Content-Type")];
+            if( localVarContentType.find(localVarResponseHttpContentType) == std::string::npos )
             {
                 throw ApiException(500
-                    , utility::conversions::to_string_t("error calling updateUser: unexpected response type: ") + contentType
-                    , std::make_shared<std::stringstream>(response.extract_utf8string(true).get()));
+                    , utility::conversions::to_string_t("error calling updateUser: unexpected response type: ") + localVarContentType
+                    , std::make_shared<std::stringstream>(localVarResponse.extract_utf8string(true).get()));
             }
         }
 
-        return response.extract_string();
+        return localVarResponse.extract_string();
     })
-    .then([=](utility::string_t response)
+    .then([=](utility::string_t localVarResponse)
     {
         return void();
     });


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Proposed solution for #660 rename local variables to have prefix localVar in api-source.mustache.
Petstore api source files has hanged so I am adding them into the same commit.

@ravinikam @stkrwork @fvarose @etherealjoy @martindelille