### PR TITLE
[cpprestsdk] Fix broken non-mockable builds due to conflicting destructors

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-header.mustache
@@ -51,7 +51,7 @@ public:
     ~{{classname}}() override;
     {{/gmockApis}}
     {{^gmockApis}}
-    virtual ~{{classname}}() = default;
+    virtual ~{{classname}}();
     {{/gmockApis}}
 
     {{#operation}}

--- a/samples/client/petstore/cpp-restsdk/api/PetApi.h
+++ b/samples/client/petstore/cpp-restsdk/api/PetApi.h
@@ -43,7 +43,7 @@ public:
 
     explicit PetApi( std::shared_ptr<ApiClient> apiClient );
 
-    virtual ~PetApi() = default;
+    virtual ~PetApi();
 
     /// <summary>
     /// Add a new pet to the store

--- a/samples/client/petstore/cpp-restsdk/api/StoreApi.h
+++ b/samples/client/petstore/cpp-restsdk/api/StoreApi.h
@@ -42,7 +42,7 @@ public:
 
     explicit StoreApi( std::shared_ptr<ApiClient> apiClient );
 
-    virtual ~StoreApi() = default;
+    virtual ~StoreApi();
 
     /// <summary>
     /// Delete purchase order by ID

--- a/samples/client/petstore/cpp-restsdk/api/UserApi.h
+++ b/samples/client/petstore/cpp-restsdk/api/UserApi.h
@@ -42,7 +42,7 @@ public:
 
     explicit UserApi( std::shared_ptr<ApiClient> apiClient );
 
-    virtual ~UserApi() = default;
+    virtual ~UserApi();
 
     /// <summary>
     /// Create user


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Seems like #595 might have broken cpprestsdk builds when non-gmockable api is selected as it declares explicitly-defaulted api class destructor, but at the same time the destructor itself is unconditionally defined in api source.

@ravinikam @stkrwork @fvarose @etherealjoy @MartinDelille
