### PR TITLE
[Slim] Models constructor

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
@@ -3,20 +3,22 @@
  * {{classname}}
  */
 namespace {{modelPackage}};
+
 use \InvalidArgumentException;
 
 /**
  * {{classname}}
  */
-class {{classname}} {
+class {{classname}}
+{
 
     {{#requiredVars}}
-    /** @var {{dataType}} ${{name}} {{#description}}{{description}} {{/description}}*/
+    /** @var {{dataType}} ${{name}}{{#description}} {{description}}{{/description}} */
     private ${{name}};
 
     {{/requiredVars}}
     {{#optionalVars}}
-    /** @var {{dataType}} ${{name}} (optional) {{#description}}{{description}} {{/description}}{{#defaultValue}}Default {{{defaultValue}}} {{/defaultValue}}*/
+    /** @var {{dataType}} ${{name}} (optional){{#description}} {{description}}{{/description}}{{#defaultValue}} Default {{{defaultValue}}}{{/defaultValue}} */
     private ${{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}};
 
     {{/optionalVars}}
@@ -25,10 +27,10 @@ class {{classname}} {
     {{#hasVars}}
      *
     {{#requiredVars}}
-     * @param {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}
+     * @param {{dataType}} ${{name}}{{#description}} {{description}}{{/description}}
     {{/requiredVars}}
     {{#optionalVars}}
-     * @param {{dataType}}|null ${{name}} (optional) {{#description}}{{description}} {{/description}}{{#defaultValue}}Default {{{defaultValue}}} {{/defaultValue}}
+     * @param {{dataType}}|null ${{name}} (optional){{#description}} {{description}}{{/description}}{{#defaultValue}} Default {{{defaultValue}}}{{/defaultValue}}
     {{/optionalVars}}
     {{/hasVars}}
      */
@@ -43,7 +45,8 @@ class {{classname}} {
     ) {
     {{/hasVars}}
     {{^hasVars}}
-    public function __construct() {
+    public function __construct()
+    {
     {{/hasVars}}
         {{#allVars}}
         $this->{{name}} = ${{name}};
@@ -59,9 +62,12 @@ class {{classname}} {
      *
      * @return {{classname}}
      */
-    public static function createFromObject(array $data = null) {
+    public static function createFromObject(array $data = null)
+    {
     {{#requiredVars}}
-        if ($data['{{baseName}}'] === null) throw new InvalidArgumentException("'{{baseName}}' can't be null");
+        if ($data['{{baseName}}'] === null) {
+            throw new InvalidArgumentException("'{{baseName}}' can't be null");
+        }
         ${{name}} = $data['{{baseName}}'];
     {{/requiredVars}}
     {{#optionalVars}}

--- a/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
@@ -11,13 +11,13 @@ use \InvalidArgumentException;
 class {{classname}} {
 
     {{#requiredVars}}
-    /** @var {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}*/
+    /** @var {{dataType}} ${{name}} {{#description}}{{description}} {{/description}}*/
     private ${{name}};
 
     {{/requiredVars}}
     {{#optionalVars}}
-    /** @var {{dataType}} ${{name}} (optional) {{#description}}{{description}}{{/description}}*/
-    private ${{name}};
+    /** @var {{dataType}} ${{name}} (optional) {{#description}}{{description}} {{/description}}{{#defaultValue}}Default {{{defaultValue}}} {{/defaultValue}}*/
+    private ${{name}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}};
 
     {{/optionalVars}}
     /**
@@ -28,7 +28,7 @@ class {{classname}} {
      * @param {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}
     {{/requiredVars}}
     {{#optionalVars}}
-     * @param {{dataType}}|null ${{name}} (optional) {{#description}}{{description}}{{/description}}
+     * @param {{dataType}}|null ${{name}} (optional) {{#description}}{{description}} {{/description}}{{#defaultValue}}Default {{{defaultValue}}} {{/defaultValue}}
     {{/optionalVars}}
     {{/hasVars}}
      */
@@ -38,7 +38,7 @@ class {{classname}} {
         ${{name}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#hasOptional}},{{/hasOptional}}{{/hasMore}}
         {{/requiredVars}}
         {{#optionalVars}}
-        ${{name}} = null{{#hasMore}},{{/hasMore}}
+        ${{name}} = {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{#hasMore}},{{/hasMore}}
         {{/optionalVars}}
     ) {
     {{/hasVars}}
@@ -65,7 +65,7 @@ class {{classname}} {
         ${{name}} = $data['{{baseName}}'];
     {{/requiredVars}}
     {{#optionalVars}}
-        ${{name}} = (isset($data['{{baseName}}'])) ? $data['{{baseName}}'] : null;
+        ${{name}} = (isset($data['{{baseName}}'])) ? $data['{{baseName}}'] : {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}};
     {{/optionalVars}}
         return new {{classname}}({{^hasVars}});{{/hasVars}}
     {{#hasVars}}

--- a/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
@@ -9,10 +9,44 @@ namespace {{modelPackage}};
  */
 class {{classname}} {
 
-    {{#vars}}
+    {{#requiredVars}}
     /** @var {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}*/
     private ${{name}};
 
-    {{/vars}}
+    {{/requiredVars}}
+    {{#optionalVars}}
+    /** @var {{dataType}} ${{name}} (optional) {{#description}}{{description}}{{/description}}*/
+    private ${{name}};
+
+    {{/optionalVars}}
+    /**
+     * {{classname}} constructor
+    {{#hasVars}}
+     *
+    {{#requiredVars}}
+     * @param {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}
+    {{/requiredVars}}
+    {{#optionalVars}}
+     * @param {{dataType}}|null ${{name}} (optional) {{#description}}{{description}}{{/description}}
+    {{/optionalVars}}
+    {{/hasVars}}
+     */
+    {{#hasVars}}
+    public function __construct(
+        {{#requiredVars}}
+        ${{name}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#hasOptional}},{{/hasOptional}}{{/hasMore}}
+        {{/requiredVars}}
+        {{#optionalVars}}
+        ${{name}} = null{{#hasMore}},{{/hasMore}}
+        {{/optionalVars}}
+    ) {
+    {{/hasVars}}
+    {{^hasVars}}
+    public function __construct() {
+    {{/hasVars}}
+        {{#allVars}}
+        $this->{{name}} = ${{name}};
+        {{/allVars}}
+    }
 }
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
@@ -3,6 +3,7 @@
  * {{classname}}
  */
 namespace {{modelPackage}};
+use \InvalidArgumentException;
 
 /**
  * {{classname}}
@@ -47,6 +48,35 @@ class {{classname}} {
         {{#allVars}}
         $this->{{name}} = ${{name}};
         {{/allVars}}
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example ${{classVarName}} = {{classname}}::createFromObject({{#hasVars}}[ {{#vars}}{{#-first}}'{{baseName}}' => 'foobar'{{/-first}}{{/vars}} ]{{/hasVars}});
+     *
+     * @return {{classname}}
+     */
+    public static function createFromObject(array $data = null) {
+    {{#requiredVars}}
+        if ($data['{{baseName}}'] === null) throw new InvalidArgumentException("'{{baseName}}' can't be null");
+        ${{name}} = $data['{{baseName}}'];
+    {{/requiredVars}}
+    {{#optionalVars}}
+        ${{name}} = (isset($data['{{baseName}}'])) ? $data['{{baseName}}'] : null;
+    {{/optionalVars}}
+        return new {{classname}}({{^hasVars}});{{/hasVars}}
+    {{#hasVars}}
+        {{#requiredVars}}
+            ${{name}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#hasOptional}},{{/hasOptional}}{{/hasMore}}
+        {{/requiredVars}}
+        {{#optionalVars}}
+            ${{name}}{{#hasMore}},{{/hasMore}}
+        {{/optionalVars}}
+        );
+    {{/hasVars}}
     }
 }
 {{/model}}{{/models}}

--- a/samples/server/petstore/php-slim/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/AdditionalPropertiesClass.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * AdditionalPropertiesClass
  */
-class AdditionalPropertiesClass {
+class AdditionalPropertiesClass
+{
 
-    /** @var map[string,string] $mapProperty */
+    /** @var map[string,string] $mapProperty (optional) */
     private $mapProperty;
 
-    /** @var map[string,map[string,string]] $mapOfMapProperty */
+    /** @var map[string,map[string,string]] $mapOfMapProperty (optional) */
     private $mapOfMapProperty;
 
+    /**
+     * AdditionalPropertiesClass constructor
+     *
+     * @param map[string,string]|null $mapProperty (optional)
+     * @param map[string,map[string,string]]|null $mapOfMapProperty (optional)
+     */
+    public function __construct(
+        $mapProperty = null,
+        $mapOfMapProperty = null
+    ) {
+        $this->mapProperty = $mapProperty;
+        $this->mapOfMapProperty = $mapOfMapProperty;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $additionalPropertiesClass = AdditionalPropertiesClass::createFromObject([ 'map_property' => 'foobar' ]);
+     *
+     * @return AdditionalPropertiesClass
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $mapProperty = (isset($data['map_property'])) ? $data['map_property'] : null;
+        $mapOfMapProperty = (isset($data['map_of_map_property'])) ? $data['map_of_map_property'] : null;
+        return new AdditionalPropertiesClass(
+            $mapProperty,
+            $mapOfMapProperty
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Animal.php
+++ b/samples/server/petstore/php-slim/lib/Model/Animal.php
@@ -4,15 +4,53 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Animal
  */
-class Animal {
+class Animal
+{
 
     /** @var string $className */
     private $className;
 
-    /** @var string $color */
-    private $color;
+    /** @var string $color (optional) Default 'red' */
+    private $color = 'red';
 
+    /**
+     * Animal constructor
+     *
+     * @param string $className
+     * @param string|null $color (optional) Default 'red'
+     */
+    public function __construct(
+        $className,
+        $color = 'red'
+    ) {
+        $this->className = $className;
+        $this->color = $color;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $animal = Animal::createFromObject([ 'className' => 'foobar' ]);
+     *
+     * @return Animal
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['className'] === null) {
+            throw new InvalidArgumentException("'className' can't be null");
+        }
+        $className = $data['className'];
+        $color = (isset($data['color'])) ? $data['color'] : 'red';
+        return new Animal(
+            $className,
+            $color
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/AnimalFarm.php
+++ b/samples/server/petstore/php-slim/lib/Model/AnimalFarm.php
@@ -4,9 +4,32 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * AnimalFarm
  */
-class AnimalFarm {
+class AnimalFarm
+{
 
+    /**
+     * AnimalFarm constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $animalFarm = AnimalFarm::createFromObject();
+     *
+     * @return AnimalFarm
+     */
+    public static function createFromObject(array $data = null)
+    {
+        return new AnimalFarm();
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ApiResponse.php
+++ b/samples/server/petstore/php-slim/lib/Model/ApiResponse.php
@@ -4,18 +4,58 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ApiResponse
  */
-class ApiResponse {
+class ApiResponse
+{
 
-    /** @var int $code */
+    /** @var int $code (optional) */
     private $code;
 
-    /** @var string $type */
+    /** @var string $type (optional) */
     private $type;
 
-    /** @var string $message */
+    /** @var string $message (optional) */
     private $message;
 
+    /**
+     * ApiResponse constructor
+     *
+     * @param int|null $code (optional)
+     * @param string|null $type (optional)
+     * @param string|null $message (optional)
+     */
+    public function __construct(
+        $code = null,
+        $type = null,
+        $message = null
+    ) {
+        $this->code = $code;
+        $this->type = $type;
+        $this->message = $message;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $apiResponse = ApiResponse::createFromObject([ 'code' => 'foobar' ]);
+     *
+     * @return ApiResponse
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $code = (isset($data['code'])) ? $data['code'] : null;
+        $type = (isset($data['type'])) ? $data['type'] : null;
+        $message = (isset($data['message'])) ? $data['message'] : null;
+        return new ApiResponse(
+            $code,
+            $type,
+            $message
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ArrayOfArrayOfNumberOnly
  */
-class ArrayOfArrayOfNumberOnly {
+class ArrayOfArrayOfNumberOnly
+{
 
-    /** @var float[][] $arrayArrayNumber */
+    /** @var float[][] $arrayArrayNumber (optional) */
     private $arrayArrayNumber;
 
+    /**
+     * ArrayOfArrayOfNumberOnly constructor
+     *
+     * @param float[][]|null $arrayArrayNumber (optional)
+     */
+    public function __construct(
+        $arrayArrayNumber = null
+    ) {
+        $this->arrayArrayNumber = $arrayArrayNumber;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $arrayOfArrayOfNumberOnly = ArrayOfArrayOfNumberOnly::createFromObject([ 'ArrayArrayNumber' => 'foobar' ]);
+     *
+     * @return ArrayOfArrayOfNumberOnly
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $arrayArrayNumber = (isset($data['ArrayArrayNumber'])) ? $data['ArrayArrayNumber'] : null;
+        return new ArrayOfArrayOfNumberOnly(
+            $arrayArrayNumber
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/ArrayOfNumberOnly.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ArrayOfNumberOnly
  */
-class ArrayOfNumberOnly {
+class ArrayOfNumberOnly
+{
 
-    /** @var float[] $arrayNumber */
+    /** @var float[] $arrayNumber (optional) */
     private $arrayNumber;
 
+    /**
+     * ArrayOfNumberOnly constructor
+     *
+     * @param float[]|null $arrayNumber (optional)
+     */
+    public function __construct(
+        $arrayNumber = null
+    ) {
+        $this->arrayNumber = $arrayNumber;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $arrayOfNumberOnly = ArrayOfNumberOnly::createFromObject([ 'ArrayNumber' => 'foobar' ]);
+     *
+     * @return ArrayOfNumberOnly
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $arrayNumber = (isset($data['ArrayNumber'])) ? $data['ArrayNumber'] : null;
+        return new ArrayOfNumberOnly(
+            $arrayNumber
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ArrayTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/ArrayTest.php
@@ -4,18 +4,58 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ArrayTest
  */
-class ArrayTest {
+class ArrayTest
+{
 
-    /** @var string[] $arrayOfString */
+    /** @var string[] $arrayOfString (optional) */
     private $arrayOfString;
 
-    /** @var int[][] $arrayArrayOfInteger */
+    /** @var int[][] $arrayArrayOfInteger (optional) */
     private $arrayArrayOfInteger;
 
-    /** @var \OpenAPIServer\Model\ReadOnlyFirst[][] $arrayArrayOfModel */
+    /** @var \OpenAPIServer\Model\ReadOnlyFirst[][] $arrayArrayOfModel (optional) */
     private $arrayArrayOfModel;
 
+    /**
+     * ArrayTest constructor
+     *
+     * @param string[]|null $arrayOfString (optional)
+     * @param int[][]|null $arrayArrayOfInteger (optional)
+     * @param \OpenAPIServer\Model\ReadOnlyFirst[][]|null $arrayArrayOfModel (optional)
+     */
+    public function __construct(
+        $arrayOfString = null,
+        $arrayArrayOfInteger = null,
+        $arrayArrayOfModel = null
+    ) {
+        $this->arrayOfString = $arrayOfString;
+        $this->arrayArrayOfInteger = $arrayArrayOfInteger;
+        $this->arrayArrayOfModel = $arrayArrayOfModel;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $arrayTest = ArrayTest::createFromObject([ 'array_of_string' => 'foobar' ]);
+     *
+     * @return ArrayTest
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $arrayOfString = (isset($data['array_of_string'])) ? $data['array_of_string'] : null;
+        $arrayArrayOfInteger = (isset($data['array_array_of_integer'])) ? $data['array_array_of_integer'] : null;
+        $arrayArrayOfModel = (isset($data['array_array_of_model'])) ? $data['array_array_of_model'] : null;
+        return new ArrayTest(
+            $arrayOfString,
+            $arrayArrayOfInteger,
+            $arrayArrayOfModel
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Capitalization.php
+++ b/samples/server/petstore/php-slim/lib/Model/Capitalization.php
@@ -4,27 +4,82 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Capitalization
  */
-class Capitalization {
+class Capitalization
+{
 
-    /** @var string $smallCamel */
+    /** @var string $smallCamel (optional) */
     private $smallCamel;
 
-    /** @var string $capitalCamel */
+    /** @var string $capitalCamel (optional) */
     private $capitalCamel;
 
-    /** @var string $smallSnake */
+    /** @var string $smallSnake (optional) */
     private $smallSnake;
 
-    /** @var string $capitalSnake */
+    /** @var string $capitalSnake (optional) */
     private $capitalSnake;
 
-    /** @var string $sCAETHFlowPoints */
+    /** @var string $sCAETHFlowPoints (optional) */
     private $sCAETHFlowPoints;
 
-    /** @var string $aTTNAME Name of the pet*/
+    /** @var string $aTTNAME (optional) Name of the pet */
     private $aTTNAME;
 
+    /**
+     * Capitalization constructor
+     *
+     * @param string|null $smallCamel (optional)
+     * @param string|null $capitalCamel (optional)
+     * @param string|null $smallSnake (optional)
+     * @param string|null $capitalSnake (optional)
+     * @param string|null $sCAETHFlowPoints (optional)
+     * @param string|null $aTTNAME (optional) Name of the pet
+     */
+    public function __construct(
+        $smallCamel = null,
+        $capitalCamel = null,
+        $smallSnake = null,
+        $capitalSnake = null,
+        $sCAETHFlowPoints = null,
+        $aTTNAME = null
+    ) {
+        $this->smallCamel = $smallCamel;
+        $this->capitalCamel = $capitalCamel;
+        $this->smallSnake = $smallSnake;
+        $this->capitalSnake = $capitalSnake;
+        $this->sCAETHFlowPoints = $sCAETHFlowPoints;
+        $this->aTTNAME = $aTTNAME;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $capitalization = Capitalization::createFromObject([ 'smallCamel' => 'foobar' ]);
+     *
+     * @return Capitalization
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $smallCamel = (isset($data['smallCamel'])) ? $data['smallCamel'] : null;
+        $capitalCamel = (isset($data['CapitalCamel'])) ? $data['CapitalCamel'] : null;
+        $smallSnake = (isset($data['small_Snake'])) ? $data['small_Snake'] : null;
+        $capitalSnake = (isset($data['Capital_Snake'])) ? $data['Capital_Snake'] : null;
+        $sCAETHFlowPoints = (isset($data['SCA_ETH_Flow_Points'])) ? $data['SCA_ETH_Flow_Points'] : null;
+        $aTTNAME = (isset($data['ATT_NAME'])) ? $data['ATT_NAME'] : null;
+        return new Capitalization(
+            $smallCamel,
+            $capitalCamel,
+            $smallSnake,
+            $capitalSnake,
+            $sCAETHFlowPoints,
+            $aTTNAME
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Cat.php
+++ b/samples/server/petstore/php-slim/lib/Model/Cat.php
@@ -4,18 +4,61 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Cat
  */
-class Cat {
+class Cat
+{
 
     /** @var string $className */
     private $className;
 
-    /** @var string $color */
-    private $color;
+    /** @var string $color (optional) Default 'red' */
+    private $color = 'red';
 
-    /** @var bool $declawed */
+    /** @var bool $declawed (optional) */
     private $declawed;
 
+    /**
+     * Cat constructor
+     *
+     * @param string $className
+     * @param string|null $color (optional) Default 'red'
+     * @param bool|null $declawed (optional)
+     */
+    public function __construct(
+        $className,
+        $color = 'red',
+        $declawed = null
+    ) {
+        $this->className = $className;
+        $this->color = $color;
+        $this->declawed = $declawed;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $cat = Cat::createFromObject([ 'className' => 'foobar' ]);
+     *
+     * @return Cat
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['className'] === null) {
+            throw new InvalidArgumentException("'className' can't be null");
+        }
+        $className = $data['className'];
+        $color = (isset($data['color'])) ? $data['color'] : 'red';
+        $declawed = (isset($data['declawed'])) ? $data['declawed'] : null;
+        return new Cat(
+            $className,
+            $color,
+            $declawed
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Category.php
+++ b/samples/server/petstore/php-slim/lib/Model/Category.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Category
  */
-class Category {
+class Category
+{
 
-    /** @var int $id */
+    /** @var int $id (optional) */
     private $id;
 
-    /** @var string $name */
+    /** @var string $name (optional) */
     private $name;
 
+    /**
+     * Category constructor
+     *
+     * @param int|null $id (optional)
+     * @param string|null $name (optional)
+     */
+    public function __construct(
+        $id = null,
+        $name = null
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $category = Category::createFromObject([ 'id' => 'foobar' ]);
+     *
+     * @return Category
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $id = (isset($data['id'])) ? $data['id'] : null;
+        $name = (isset($data['name'])) ? $data['name'] : null;
+        return new Category(
+            $id,
+            $name
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ClassModel.php
+++ b/samples/server/petstore/php-slim/lib/Model/ClassModel.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ClassModel
  */
-class ClassModel {
+class ClassModel
+{
 
-    /** @var string $class */
+    /** @var string $class (optional) */
     private $class;
 
+    /**
+     * ClassModel constructor
+     *
+     * @param string|null $class (optional)
+     */
+    public function __construct(
+        $class = null
+    ) {
+        $this->class = $class;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $classModel = ClassModel::createFromObject([ '_class' => 'foobar' ]);
+     *
+     * @return ClassModel
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $class = (isset($data['_class'])) ? $data['_class'] : null;
+        return new ClassModel(
+            $class
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Client.php
+++ b/samples/server/petstore/php-slim/lib/Model/Client.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Client
  */
-class Client {
+class Client
+{
 
-    /** @var string $client */
+    /** @var string $client (optional) */
     private $client;
 
+    /**
+     * Client constructor
+     *
+     * @param string|null $client (optional)
+     */
+    public function __construct(
+        $client = null
+    ) {
+        $this->client = $client;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $client = Client::createFromObject([ 'client' => 'foobar' ]);
+     *
+     * @return Client
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $client = (isset($data['client'])) ? $data['client'] : null;
+        return new Client(
+            $client
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Dog.php
+++ b/samples/server/petstore/php-slim/lib/Model/Dog.php
@@ -4,18 +4,61 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Dog
  */
-class Dog {
+class Dog
+{
 
     /** @var string $className */
     private $className;
 
-    /** @var string $color */
-    private $color;
+    /** @var string $color (optional) Default 'red' */
+    private $color = 'red';
 
-    /** @var string $breed */
+    /** @var string $breed (optional) */
     private $breed;
 
+    /**
+     * Dog constructor
+     *
+     * @param string $className
+     * @param string|null $color (optional) Default 'red'
+     * @param string|null $breed (optional)
+     */
+    public function __construct(
+        $className,
+        $color = 'red',
+        $breed = null
+    ) {
+        $this->className = $className;
+        $this->color = $color;
+        $this->breed = $breed;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $dog = Dog::createFromObject([ 'className' => 'foobar' ]);
+     *
+     * @return Dog
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['className'] === null) {
+            throw new InvalidArgumentException("'className' can't be null");
+        }
+        $className = $data['className'];
+        $color = (isset($data['color'])) ? $data['color'] : 'red';
+        $breed = (isset($data['breed'])) ? $data['breed'] : null;
+        return new Dog(
+            $className,
+            $color,
+            $breed
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/EnumArrays.php
+++ b/samples/server/petstore/php-slim/lib/Model/EnumArrays.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * EnumArrays
  */
-class EnumArrays {
+class EnumArrays
+{
 
-    /** @var string $justSymbol */
+    /** @var string $justSymbol (optional) */
     private $justSymbol;
 
-    /** @var string[] $arrayEnum */
+    /** @var string[] $arrayEnum (optional) */
     private $arrayEnum;
 
+    /**
+     * EnumArrays constructor
+     *
+     * @param string|null $justSymbol (optional)
+     * @param string[]|null $arrayEnum (optional)
+     */
+    public function __construct(
+        $justSymbol = null,
+        $arrayEnum = null
+    ) {
+        $this->justSymbol = $justSymbol;
+        $this->arrayEnum = $arrayEnum;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $enumArrays = EnumArrays::createFromObject([ 'just_symbol' => 'foobar' ]);
+     *
+     * @return EnumArrays
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $justSymbol = (isset($data['just_symbol'])) ? $data['just_symbol'] : null;
+        $arrayEnum = (isset($data['array_enum'])) ? $data['array_enum'] : null;
+        return new EnumArrays(
+            $justSymbol,
+            $arrayEnum
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/EnumClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/EnumClass.php
@@ -4,9 +4,32 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * EnumClass
  */
-class EnumClass {
+class EnumClass
+{
 
+    /**
+     * EnumClass constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $enumClass = EnumClass::createFromObject();
+     *
+     * @return EnumClass
+     */
+    public static function createFromObject(array $data = null)
+    {
+        return new EnumClass();
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/EnumTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/EnumTest.php
@@ -4,24 +4,77 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * EnumTest
  */
-class EnumTest {
-
-    /** @var string $enumString */
-    private $enumString;
+class EnumTest
+{
 
     /** @var string $enumStringRequired */
     private $enumStringRequired;
 
-    /** @var int $enumInteger */
+    /** @var string $enumString (optional) */
+    private $enumString;
+
+    /** @var int $enumInteger (optional) */
     private $enumInteger;
 
-    /** @var double $enumNumber */
+    /** @var double $enumNumber (optional) */
     private $enumNumber;
 
-    /** @var \OpenAPIServer\Model\OuterEnum $outerEnum */
+    /** @var \OpenAPIServer\Model\OuterEnum $outerEnum (optional) */
     private $outerEnum;
 
+    /**
+     * EnumTest constructor
+     *
+     * @param string $enumStringRequired
+     * @param string|null $enumString (optional)
+     * @param int|null $enumInteger (optional)
+     * @param double|null $enumNumber (optional)
+     * @param \OpenAPIServer\Model\OuterEnum|null $outerEnum (optional)
+     */
+    public function __construct(
+        $enumStringRequired,
+        $enumString = null,
+        $enumInteger = null,
+        $enumNumber = null,
+        $outerEnum = null
+    ) {
+        $this->enumString = $enumString;
+        $this->enumStringRequired = $enumStringRequired;
+        $this->enumInteger = $enumInteger;
+        $this->enumNumber = $enumNumber;
+        $this->outerEnum = $outerEnum;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $enumTest = EnumTest::createFromObject([ 'enum_string' => 'foobar' ]);
+     *
+     * @return EnumTest
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['enum_string_required'] === null) {
+            throw new InvalidArgumentException("'enum_string_required' can't be null");
+        }
+        $enumStringRequired = $data['enum_string_required'];
+        $enumString = (isset($data['enum_string'])) ? $data['enum_string'] : null;
+        $enumInteger = (isset($data['enum_integer'])) ? $data['enum_integer'] : null;
+        $enumNumber = (isset($data['enum_number'])) ? $data['enum_number'] : null;
+        $outerEnum = (isset($data['outerEnum'])) ? $data['outerEnum'] : null;
+        return new EnumTest(
+            $enumStringRequired,
+            $enumString,
+            $enumInteger,
+            $enumNumber,
+            $outerEnum
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/File.php
+++ b/samples/server/petstore/php-slim/lib/Model/File.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * File
  */
-class File {
+class File
+{
 
-    /** @var string $sourceURI Test capitalization*/
+    /** @var string $sourceURI (optional) Test capitalization */
     private $sourceURI;
 
+    /**
+     * File constructor
+     *
+     * @param string|null $sourceURI (optional) Test capitalization
+     */
+    public function __construct(
+        $sourceURI = null
+    ) {
+        $this->sourceURI = $sourceURI;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $file = File::createFromObject([ 'sourceURI' => 'foobar' ]);
+     *
+     * @return File
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $sourceURI = (isset($data['sourceURI'])) ? $data['sourceURI'] : null;
+        return new File(
+            $sourceURI
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/FileSchemaTestClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/FileSchemaTestClass.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * FileSchemaTestClass
  */
-class FileSchemaTestClass {
+class FileSchemaTestClass
+{
 
-    /** @var \OpenAPIServer\Model\File $file */
+    /** @var \OpenAPIServer\Model\File $file (optional) */
     private $file;
 
-    /** @var \OpenAPIServer\Model\File[] $files */
+    /** @var \OpenAPIServer\Model\File[] $files (optional) */
     private $files;
 
+    /**
+     * FileSchemaTestClass constructor
+     *
+     * @param \OpenAPIServer\Model\File|null $file (optional)
+     * @param \OpenAPIServer\Model\File[]|null $files (optional)
+     */
+    public function __construct(
+        $file = null,
+        $files = null
+    ) {
+        $this->file = $file;
+        $this->files = $files;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $fileSchemaTestClass = FileSchemaTestClass::createFromObject([ 'file' => 'foobar' ]);
+     *
+     * @return FileSchemaTestClass
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $file = (isset($data['file'])) ? $data['file'] : null;
+        $files = (isset($data['files'])) ? $data['files'] : null;
+        return new FileSchemaTestClass(
+            $file,
+            $files
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/FormatTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/FormatTest.php
@@ -4,48 +4,150 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * FormatTest
  */
-class FormatTest {
-
-    /** @var int $integer */
-    private $integer;
-
-    /** @var int $int32 */
-    private $int32;
-
-    /** @var int $int64 */
-    private $int64;
+class FormatTest
+{
 
     /** @var float $number */
     private $number;
 
-    /** @var float $float */
-    private $float;
-
-    /** @var double $double */
-    private $double;
-
-    /** @var string $string */
-    private $string;
-
     /** @var string $byte */
     private $byte;
-
-    /** @var \SplFileObject $binary */
-    private $binary;
 
     /** @var \DateTime $date */
     private $date;
 
-    /** @var \DateTime $dateTime */
-    private $dateTime;
-
-    /** @var string $uuid */
-    private $uuid;
-
     /** @var string $password */
     private $password;
 
+    /** @var int $integer (optional) */
+    private $integer;
+
+    /** @var int $int32 (optional) */
+    private $int32;
+
+    /** @var int $int64 (optional) */
+    private $int64;
+
+    /** @var float $float (optional) */
+    private $float;
+
+    /** @var double $double (optional) */
+    private $double;
+
+    /** @var string $string (optional) */
+    private $string;
+
+    /** @var \SplFileObject $binary (optional) */
+    private $binary;
+
+    /** @var \DateTime $dateTime (optional) */
+    private $dateTime;
+
+    /** @var string $uuid (optional) */
+    private $uuid;
+
+    /**
+     * FormatTest constructor
+     *
+     * @param float $number
+     * @param string $byte
+     * @param \DateTime $date
+     * @param string $password
+     * @param int|null $integer (optional)
+     * @param int|null $int32 (optional)
+     * @param int|null $int64 (optional)
+     * @param float|null $float (optional)
+     * @param double|null $double (optional)
+     * @param string|null $string (optional)
+     * @param \SplFileObject|null $binary (optional)
+     * @param \DateTime|null $dateTime (optional)
+     * @param string|null $uuid (optional)
+     */
+    public function __construct(
+        $number,
+        $byte,
+        $date,
+        $password,
+        $integer = null,
+        $int32 = null,
+        $int64 = null,
+        $float = null,
+        $double = null,
+        $string = null,
+        $binary = null,
+        $dateTime = null,
+        $uuid = null,
+    ) {
+        $this->integer = $integer;
+        $this->int32 = $int32;
+        $this->int64 = $int64;
+        $this->number = $number;
+        $this->float = $float;
+        $this->double = $double;
+        $this->string = $string;
+        $this->byte = $byte;
+        $this->binary = $binary;
+        $this->date = $date;
+        $this->dateTime = $dateTime;
+        $this->uuid = $uuid;
+        $this->password = $password;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $formatTest = FormatTest::createFromObject([ 'integer' => 'foobar' ]);
+     *
+     * @return FormatTest
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['number'] === null) {
+            throw new InvalidArgumentException("'number' can't be null");
+        }
+        $number = $data['number'];
+        if ($data['byte'] === null) {
+            throw new InvalidArgumentException("'byte' can't be null");
+        }
+        $byte = $data['byte'];
+        if ($data['date'] === null) {
+            throw new InvalidArgumentException("'date' can't be null");
+        }
+        $date = $data['date'];
+        if ($data['password'] === null) {
+            throw new InvalidArgumentException("'password' can't be null");
+        }
+        $password = $data['password'];
+        $integer = (isset($data['integer'])) ? $data['integer'] : null;
+        $int32 = (isset($data['int32'])) ? $data['int32'] : null;
+        $int64 = (isset($data['int64'])) ? $data['int64'] : null;
+        $float = (isset($data['float'])) ? $data['float'] : null;
+        $double = (isset($data['double'])) ? $data['double'] : null;
+        $string = (isset($data['string'])) ? $data['string'] : null;
+        $binary = (isset($data['binary'])) ? $data['binary'] : null;
+        $dateTime = (isset($data['dateTime'])) ? $data['dateTime'] : null;
+        $uuid = (isset($data['uuid'])) ? $data['uuid'] : null;
+        return new FormatTest(
+            $number,
+            $byte,
+            $date,
+            $password,
+            $integer,
+            $int32,
+            $int64,
+            $float,
+            $double,
+            $string,
+            $binary,
+            $dateTime,
+            $uuid,
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/HasOnlyReadOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/HasOnlyReadOnly.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * HasOnlyReadOnly
  */
-class HasOnlyReadOnly {
+class HasOnlyReadOnly
+{
 
-    /** @var string $bar */
+    /** @var string $bar (optional) */
     private $bar;
 
-    /** @var string $foo */
+    /** @var string $foo (optional) */
     private $foo;
 
+    /**
+     * HasOnlyReadOnly constructor
+     *
+     * @param string|null $bar (optional)
+     * @param string|null $foo (optional)
+     */
+    public function __construct(
+        $bar = null,
+        $foo = null
+    ) {
+        $this->bar = $bar;
+        $this->foo = $foo;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $hasOnlyReadOnly = HasOnlyReadOnly::createFromObject([ 'bar' => 'foobar' ]);
+     *
+     * @return HasOnlyReadOnly
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $bar = (isset($data['bar'])) ? $data['bar'] : null;
+        $foo = (isset($data['foo'])) ? $data['foo'] : null;
+        return new HasOnlyReadOnly(
+            $bar,
+            $foo
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/MapTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/MapTest.php
@@ -4,21 +4,66 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * MapTest
  */
-class MapTest {
+class MapTest
+{
 
-    /** @var map[string,map[string,string]] $mapMapOfString */
+    /** @var map[string,map[string,string]] $mapMapOfString (optional) */
     private $mapMapOfString;
 
-    /** @var map[string,string] $mapOfEnumString */
+    /** @var map[string,string] $mapOfEnumString (optional) */
     private $mapOfEnumString;
 
-    /** @var map[string,bool] $directMap */
+    /** @var map[string,bool] $directMap (optional) */
     private $directMap;
 
-    /** @var \OpenAPIServer\Model\StringBooleanMap $indirectMap */
+    /** @var \OpenAPIServer\Model\StringBooleanMap $indirectMap (optional) */
     private $indirectMap;
 
+    /**
+     * MapTest constructor
+     *
+     * @param map[string,map[string,string]]|null $mapMapOfString (optional)
+     * @param map[string,string]|null $mapOfEnumString (optional)
+     * @param map[string,bool]|null $directMap (optional)
+     * @param \OpenAPIServer\Model\StringBooleanMap|null $indirectMap (optional)
+     */
+    public function __construct(
+        $mapMapOfString = null,
+        $mapOfEnumString = null,
+        $directMap = null,
+        $indirectMap = null
+    ) {
+        $this->mapMapOfString = $mapMapOfString;
+        $this->mapOfEnumString = $mapOfEnumString;
+        $this->directMap = $directMap;
+        $this->indirectMap = $indirectMap;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $mapTest = MapTest::createFromObject([ 'map_map_of_string' => 'foobar' ]);
+     *
+     * @return MapTest
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $mapMapOfString = (isset($data['map_map_of_string'])) ? $data['map_map_of_string'] : null;
+        $mapOfEnumString = (isset($data['map_of_enum_string'])) ? $data['map_of_enum_string'] : null;
+        $directMap = (isset($data['direct_map'])) ? $data['direct_map'] : null;
+        $indirectMap = (isset($data['indirect_map'])) ? $data['indirect_map'] : null;
+        return new MapTest(
+            $mapMapOfString,
+            $mapOfEnumString,
+            $directMap,
+            $indirectMap
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -4,18 +4,58 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * MixedPropertiesAndAdditionalPropertiesClass
  */
-class MixedPropertiesAndAdditionalPropertiesClass {
+class MixedPropertiesAndAdditionalPropertiesClass
+{
 
-    /** @var string $uuid */
+    /** @var string $uuid (optional) */
     private $uuid;
 
-    /** @var \DateTime $dateTime */
+    /** @var \DateTime $dateTime (optional) */
     private $dateTime;
 
-    /** @var map[string,\OpenAPIServer\Model\Animal] $map */
+    /** @var map[string,\OpenAPIServer\Model\Animal] $map (optional) */
     private $map;
 
+    /**
+     * MixedPropertiesAndAdditionalPropertiesClass constructor
+     *
+     * @param string|null $uuid (optional)
+     * @param \DateTime|null $dateTime (optional)
+     * @param map[string,\OpenAPIServer\Model\Animal]|null $map (optional)
+     */
+    public function __construct(
+        $uuid = null,
+        $dateTime = null,
+        $map = null
+    ) {
+        $this->uuid = $uuid;
+        $this->dateTime = $dateTime;
+        $this->map = $map;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $mixedPropertiesAndAdditionalPropertiesClass = MixedPropertiesAndAdditionalPropertiesClass::createFromObject([ 'uuid' => 'foobar' ]);
+     *
+     * @return MixedPropertiesAndAdditionalPropertiesClass
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $uuid = (isset($data['uuid'])) ? $data['uuid'] : null;
+        $dateTime = (isset($data['dateTime'])) ? $data['dateTime'] : null;
+        $map = (isset($data['map'])) ? $data['map'] : null;
+        return new MixedPropertiesAndAdditionalPropertiesClass(
+            $uuid,
+            $dateTime,
+            $map
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Model200Response.php
+++ b/samples/server/petstore/php-slim/lib/Model/Model200Response.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Model200Response
  */
-class Model200Response {
+class Model200Response
+{
 
-    /** @var int $name */
+    /** @var int $name (optional) */
     private $name;
 
-    /** @var string $class */
+    /** @var string $class (optional) */
     private $class;
 
+    /**
+     * Model200Response constructor
+     *
+     * @param int|null $name (optional)
+     * @param string|null $class (optional)
+     */
+    public function __construct(
+        $name = null,
+        $class = null
+    ) {
+        $this->name = $name;
+        $this->class = $class;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $_200response = Model200Response::createFromObject([ 'name' => 'foobar' ]);
+     *
+     * @return Model200Response
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $name = (isset($data['name'])) ? $data['name'] : null;
+        $class = (isset($data['class'])) ? $data['class'] : null;
+        return new Model200Response(
+            $name,
+            $class
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ModelList.php
+++ b/samples/server/petstore/php-slim/lib/Model/ModelList.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ModelList
  */
-class ModelList {
+class ModelList
+{
 
-    /** @var string $_123list */
+    /** @var string $_123list (optional) */
     private $_123list;
 
+    /**
+     * ModelList constructor
+     *
+     * @param string|null $_123list (optional)
+     */
+    public function __construct(
+        $_123list = null
+    ) {
+        $this->_123list = $_123list;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $list = ModelList::createFromObject([ '123-list' => 'foobar' ]);
+     *
+     * @return ModelList
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $_123list = (isset($data['123-list'])) ? $data['123-list'] : null;
+        return new ModelList(
+            $_123list
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ModelReturn.php
+++ b/samples/server/petstore/php-slim/lib/Model/ModelReturn.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ModelReturn
  */
-class ModelReturn {
+class ModelReturn
+{
 
-    /** @var int $return */
+    /** @var int $return (optional) */
     private $return;
 
+    /**
+     * ModelReturn constructor
+     *
+     * @param int|null $return (optional)
+     */
+    public function __construct(
+        $return = null
+    ) {
+        $this->return = $return;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $return = ModelReturn::createFromObject([ 'return' => 'foobar' ]);
+     *
+     * @return ModelReturn
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $return = (isset($data['return'])) ? $data['return'] : null;
+        return new ModelReturn(
+            $return
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Name.php
+++ b/samples/server/petstore/php-slim/lib/Model/Name.php
@@ -4,21 +4,69 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Name
  */
-class Name {
+class Name
+{
 
     /** @var int $name */
     private $name;
 
-    /** @var int $snakeCase */
+    /** @var int $snakeCase (optional) */
     private $snakeCase;
 
-    /** @var string $property */
+    /** @var string $property (optional) */
     private $property;
 
-    /** @var int $_123number */
+    /** @var int $_123number (optional) */
     private $_123number;
 
+    /**
+     * Name constructor
+     *
+     * @param int $name
+     * @param int|null $snakeCase (optional)
+     * @param string|null $property (optional)
+     * @param int|null $_123number (optional)
+     */
+    public function __construct(
+        $name,
+        $snakeCase = null,
+        $property = null,
+        $_123number = null
+    ) {
+        $this->name = $name;
+        $this->snakeCase = $snakeCase;
+        $this->property = $property;
+        $this->_123number = $_123number;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $name = Name::createFromObject([ 'name' => 'foobar' ]);
+     *
+     * @return Name
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['name'] === null) {
+            throw new InvalidArgumentException("'name' can't be null");
+        }
+        $name = $data['name'];
+        $snakeCase = (isset($data['snake_case'])) ? $data['snake_case'] : null;
+        $property = (isset($data['property'])) ? $data['property'] : null;
+        $_123number = (isset($data['123Number'])) ? $data['123Number'] : null;
+        return new Name(
+            $name,
+            $snakeCase,
+            $property,
+            $_123number
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/NumberOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/NumberOnly.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * NumberOnly
  */
-class NumberOnly {
+class NumberOnly
+{
 
-    /** @var float $justNumber */
+    /** @var float $justNumber (optional) */
     private $justNumber;
 
+    /**
+     * NumberOnly constructor
+     *
+     * @param float|null $justNumber (optional)
+     */
+    public function __construct(
+        $justNumber = null
+    ) {
+        $this->justNumber = $justNumber;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $numberOnly = NumberOnly::createFromObject([ 'JustNumber' => 'foobar' ]);
+     *
+     * @return NumberOnly
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $justNumber = (isset($data['JustNumber'])) ? $data['JustNumber'] : null;
+        return new NumberOnly(
+            $justNumber
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Order.php
+++ b/samples/server/petstore/php-slim/lib/Model/Order.php
@@ -4,27 +4,82 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Order
  */
-class Order {
+class Order
+{
 
-    /** @var int $id */
+    /** @var int $id (optional) */
     private $id;
 
-    /** @var int $petId */
+    /** @var int $petId (optional) */
     private $petId;
 
-    /** @var int $quantity */
+    /** @var int $quantity (optional) */
     private $quantity;
 
-    /** @var \DateTime $shipDate */
+    /** @var \DateTime $shipDate (optional) */
     private $shipDate;
 
-    /** @var string $status Order Status*/
+    /** @var string $status (optional) Order Status */
     private $status;
 
-    /** @var bool $complete */
-    private $complete;
+    /** @var bool $complete (optional) Default false */
+    private $complete = false;
 
+    /**
+     * Order constructor
+     *
+     * @param int|null $id (optional)
+     * @param int|null $petId (optional)
+     * @param int|null $quantity (optional)
+     * @param \DateTime|null $shipDate (optional)
+     * @param string|null $status (optional) Order Status
+     * @param bool|null $complete (optional) Default false
+     */
+    public function __construct(
+        $id = null,
+        $petId = null,
+        $quantity = null,
+        $shipDate = null,
+        $status = null,
+        $complete = false
+    ) {
+        $this->id = $id;
+        $this->petId = $petId;
+        $this->quantity = $quantity;
+        $this->shipDate = $shipDate;
+        $this->status = $status;
+        $this->complete = $complete;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $order = Order::createFromObject([ 'id' => 'foobar' ]);
+     *
+     * @return Order
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $id = (isset($data['id'])) ? $data['id'] : null;
+        $petId = (isset($data['petId'])) ? $data['petId'] : null;
+        $quantity = (isset($data['quantity'])) ? $data['quantity'] : null;
+        $shipDate = (isset($data['shipDate'])) ? $data['shipDate'] : null;
+        $status = (isset($data['status'])) ? $data['status'] : null;
+        $complete = (isset($data['complete'])) ? $data['complete'] : false;
+        return new Order(
+            $id,
+            $petId,
+            $quantity,
+            $shipDate,
+            $status,
+            $complete
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/OuterComposite.php
+++ b/samples/server/petstore/php-slim/lib/Model/OuterComposite.php
@@ -4,18 +4,58 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * OuterComposite
  */
-class OuterComposite {
+class OuterComposite
+{
 
-    /** @var float $myNumber */
+    /** @var float $myNumber (optional) */
     private $myNumber;
 
-    /** @var string $myString */
+    /** @var string $myString (optional) */
     private $myString;
 
-    /** @var bool $myBoolean */
+    /** @var bool $myBoolean (optional) */
     private $myBoolean;
 
+    /**
+     * OuterComposite constructor
+     *
+     * @param float|null $myNumber (optional)
+     * @param string|null $myString (optional)
+     * @param bool|null $myBoolean (optional)
+     */
+    public function __construct(
+        $myNumber = null,
+        $myString = null,
+        $myBoolean = null
+    ) {
+        $this->myNumber = $myNumber;
+        $this->myString = $myString;
+        $this->myBoolean = $myBoolean;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $outerComposite = OuterComposite::createFromObject([ 'my_number' => 'foobar' ]);
+     *
+     * @return OuterComposite
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $myNumber = (isset($data['my_number'])) ? $data['my_number'] : null;
+        $myString = (isset($data['my_string'])) ? $data['my_string'] : null;
+        $myBoolean = (isset($data['my_boolean'])) ? $data['my_boolean'] : null;
+        return new OuterComposite(
+            $myNumber,
+            $myString,
+            $myBoolean
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/OuterEnum.php
+++ b/samples/server/petstore/php-slim/lib/Model/OuterEnum.php
@@ -4,9 +4,32 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * OuterEnum
  */
-class OuterEnum {
+class OuterEnum
+{
 
+    /**
+     * OuterEnum constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $outerEnum = OuterEnum::createFromObject();
+     *
+     * @return OuterEnum
+     */
+    public static function createFromObject(array $data = null)
+    {
+        return new OuterEnum();
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Pet.php
+++ b/samples/server/petstore/php-slim/lib/Model/Pet.php
@@ -4,16 +4,13 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Pet
  */
-class Pet {
-
-    /** @var int $id */
-    private $id;
-
-    /** @var \OpenAPIServer\Model\Category $category */
-    private $category;
+class Pet
+{
 
     /** @var string $name */
     private $name;
@@ -21,10 +18,74 @@ class Pet {
     /** @var string[] $photoUrls */
     private $photoUrls;
 
-    /** @var \OpenAPIServer\Model\Tag[] $tags */
+    /** @var int $id (optional) */
+    private $id;
+
+    /** @var \OpenAPIServer\Model\Category $category (optional) */
+    private $category;
+
+    /** @var \OpenAPIServer\Model\Tag[] $tags (optional) */
     private $tags;
 
-    /** @var string $status pet status in the store*/
+    /** @var string $status (optional) pet status in the store */
     private $status;
 
+    /**
+     * Pet constructor
+     *
+     * @param string $name
+     * @param string[] $photoUrls
+     * @param int|null $id (optional)
+     * @param \OpenAPIServer\Model\Category|null $category (optional)
+     * @param \OpenAPIServer\Model\Tag[]|null $tags (optional)
+     * @param string|null $status (optional) pet status in the store
+     */
+    public function __construct(
+        $name,
+        $photoUrls,
+        $id = null,
+        $category = null,
+        $tags = null,
+        $status = null
+    ) {
+        $this->id = $id;
+        $this->category = $category;
+        $this->name = $name;
+        $this->photoUrls = $photoUrls;
+        $this->tags = $tags;
+        $this->status = $status;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $pet = Pet::createFromObject([ 'id' => 'foobar' ]);
+     *
+     * @return Pet
+     */
+    public static function createFromObject(array $data = null)
+    {
+        if ($data['name'] === null) {
+            throw new InvalidArgumentException("'name' can't be null");
+        }
+        $name = $data['name'];
+        if ($data['photoUrls'] === null) {
+            throw new InvalidArgumentException("'photoUrls' can't be null");
+        }
+        $photoUrls = $data['photoUrls'];
+        $id = (isset($data['id'])) ? $data['id'] : null;
+        $category = (isset($data['category'])) ? $data['category'] : null;
+        $tags = (isset($data['tags'])) ? $data['tags'] : null;
+        $status = (isset($data['status'])) ? $data['status'] : null;
+        return new Pet(
+            $name,
+            $photoUrls,
+            $id,
+            $category,
+            $tags,
+            $status
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/ReadOnlyFirst.php
+++ b/samples/server/petstore/php-slim/lib/Model/ReadOnlyFirst.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * ReadOnlyFirst
  */
-class ReadOnlyFirst {
+class ReadOnlyFirst
+{
 
-    /** @var string $bar */
+    /** @var string $bar (optional) */
     private $bar;
 
-    /** @var string $baz */
+    /** @var string $baz (optional) */
     private $baz;
 
+    /**
+     * ReadOnlyFirst constructor
+     *
+     * @param string|null $bar (optional)
+     * @param string|null $baz (optional)
+     */
+    public function __construct(
+        $bar = null,
+        $baz = null
+    ) {
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $readOnlyFirst = ReadOnlyFirst::createFromObject([ 'bar' => 'foobar' ]);
+     *
+     * @return ReadOnlyFirst
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $bar = (isset($data['bar'])) ? $data['bar'] : null;
+        $baz = (isset($data['baz'])) ? $data['baz'] : null;
+        return new ReadOnlyFirst(
+            $bar,
+            $baz
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/SpecialModelName.php
+++ b/samples/server/petstore/php-slim/lib/Model/SpecialModelName.php
@@ -4,12 +4,42 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * SpecialModelName
  */
-class SpecialModelName {
+class SpecialModelName
+{
 
-    /** @var int $specialPropertyName */
+    /** @var int $specialPropertyName (optional) */
     private $specialPropertyName;
 
+    /**
+     * SpecialModelName constructor
+     *
+     * @param int|null $specialPropertyName (optional)
+     */
+    public function __construct(
+        $specialPropertyName = null
+    ) {
+        $this->specialPropertyName = $specialPropertyName;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $specialModelName = SpecialModelName::createFromObject([ '$special[property.name]' => 'foobar' ]);
+     *
+     * @return SpecialModelName
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $specialPropertyName = (isset($data['$special[property.name]'])) ? $data['$special[property.name]'] : null;
+        return new SpecialModelName(
+            $specialPropertyName
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/StringBooleanMap.php
+++ b/samples/server/petstore/php-slim/lib/Model/StringBooleanMap.php
@@ -4,9 +4,32 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * StringBooleanMap
  */
-class StringBooleanMap {
+class StringBooleanMap
+{
 
+    /**
+     * StringBooleanMap constructor
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $stringBooleanMap = StringBooleanMap::createFromObject();
+     *
+     * @return StringBooleanMap
+     */
+    public static function createFromObject(array $data = null)
+    {
+        return new StringBooleanMap();
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/Tag.php
+++ b/samples/server/petstore/php-slim/lib/Model/Tag.php
@@ -4,15 +4,50 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * Tag
  */
-class Tag {
+class Tag
+{
 
-    /** @var int $id */
+    /** @var int $id (optional) */
     private $id;
 
-    /** @var string $name */
+    /** @var string $name (optional) */
     private $name;
 
+    /**
+     * Tag constructor
+     *
+     * @param int|null $id (optional)
+     * @param string|null $name (optional)
+     */
+    public function __construct(
+        $id = null,
+        $name = null
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $tag = Tag::createFromObject([ 'id' => 'foobar' ]);
+     *
+     * @return Tag
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $id = (isset($data['id'])) ? $data['id'] : null;
+        $name = (isset($data['name'])) ? $data['name'] : null;
+        return new Tag(
+            $id,
+            $name
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/lib/Model/User.php
+++ b/samples/server/petstore/php-slim/lib/Model/User.php
@@ -4,33 +4,98 @@
  */
 namespace OpenAPIServer\Model;
 
+use \InvalidArgumentException;
+
 /**
  * User
  */
-class User {
+class User
+{
 
-    /** @var int $id */
+    /** @var int $id (optional) */
     private $id;
 
-    /** @var string $username */
+    /** @var string $username (optional) */
     private $username;
 
-    /** @var string $firstName */
+    /** @var string $firstName (optional) */
     private $firstName;
 
-    /** @var string $lastName */
+    /** @var string $lastName (optional) */
     private $lastName;
 
-    /** @var string $email */
+    /** @var string $email (optional) */
     private $email;
 
-    /** @var string $password */
+    /** @var string $password (optional) */
     private $password;
 
-    /** @var string $phone */
+    /** @var string $phone (optional) */
     private $phone;
 
-    /** @var int $userStatus User Status*/
+    /** @var int $userStatus (optional) User Status */
     private $userStatus;
 
+    /**
+     * User constructor
+     *
+     * @param int|null $id (optional)
+     * @param string|null $username (optional)
+     * @param string|null $firstName (optional)
+     * @param string|null $lastName (optional)
+     * @param string|null $email (optional)
+     * @param string|null $password (optional)
+     * @param string|null $phone (optional)
+     * @param int|null $userStatus (optional) User Status
+     */
+    public function __construct(
+        $id = null,
+        $username = null,
+        $firstName = null,
+        $lastName = null,
+        $email = null,
+        $password = null,
+        $phone = null,
+        $userStatus = null
+    ) {
+        $this->id = $id;
+        $this->username = $username;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+        $this->email = $email;
+        $this->password = $password;
+        $this->phone = $phone;
+        $this->userStatus = $userStatus;
+    }
+
+    /**
+     * Alternative static class constructor
+     *
+     * @param mixed[]|null $data Associated array of property values initializing the model
+     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
+     * @example $user = User::createFromObject([ 'id' => 'foobar' ]);
+     *
+     * @return User
+     */
+    public static function createFromObject(array $data = null)
+    {
+        $id = (isset($data['id'])) ? $data['id'] : null;
+        $username = (isset($data['username'])) ? $data['username'] : null;
+        $firstName = (isset($data['firstName'])) ? $data['firstName'] : null;
+        $lastName = (isset($data['lastName'])) ? $data['lastName'] : null;
+        $email = (isset($data['email'])) ? $data['email'] : null;
+        $password = (isset($data['password'])) ? $data['password'] : null;
+        $phone = (isset($data['phone'])) ? $data['phone'] : null;
+        $userStatus = (isset($data['userStatus'])) ? $data['userStatus'] : null;
+        return new User(
+            $id,
+            $username,
+            $firstName,
+            $lastName,
+            $email,
+            $password,
+            $phone,
+            $userStatus
+        );
+    }
 }

--- a/samples/server/petstore/php-slim/phpunit.xml.dist
+++ b/samples/server/petstore/php-slim/phpunit.xml.dist
@@ -19,8 +19,8 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./lib/Api</directory>
-            <directory suffix=".php">./lib/Model</directory>
+            <directory suffix=".php">./lib//Api</directory>
+            <directory suffix=".php">./lib//Model</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
New model template generates file like:
```php
class Animal
{

    /** @var string $className */
    private $className;

    /** @var string $color (optional) Default 'red' */
    private $color = 'red';

    /**
     * Animal constructor
     *
     * @param string $className
     * @param string|null $color (optional) Default 'red'
     */
    public function __construct(
        $className,
        $color = 'red'
    ) {
        $this->className = $className;
        $this->color = $color;
    }

    /**
     * Alternative static class constructor
     *
     * @param mixed[]|null $data Associated array of property values initializing the model
     * @throws InvalidArgumentException when $data doesn't contain required constructor arguments
     * @example $animal = Animal::createFromObject([ 'className' => 'foobar' ]);
     *
     * @return Animal
     */
    public static function createFromObject(array $data = null)
    {
        if ($data['className'] === null) {
            throw new InvalidArgumentException("'className' can't be null");
        }
        $className = $data['className'];
        $color = (isset($data['color'])) ? $data['color'] : 'red';
        return new Animal(
            $className,
            $color
        );
    }
}
```

### Why that way and not another

**Why I think that `private $className` and `private $color` is better than single `$container` from PHPClient codegen:**
1. It's more common and expected for developers, more descriptive, you can say what properties exists with a quick look
2. Most of time developer needs to query database and map result to related model class. For this case there is [PDOStatement::fetchObject()](http://php.net/manual/en/pdostatement.fetchobject.php). Other database drivers(mysqli) has similar methods too.
3. I've quickly checked popular ORMs. [Eloquent](https://laravel.com/docs/5.1/eloquent) have builtin generator to produce models and doesn't follow approuch from this PR. [Doctrine](https://www.doctrine-project.org/) however, creates similar models, example [User.php](https://github.com/1ma/Slim-Doctrine-Demo/blob/master/src/Domain/User.php). The last one [Atlas](http://atlasphp.io/) claims own persistence models with optional fallback to domain models. That domain models looks similar to that PR, example [Map From Persistence To Domain](http://atlasphp.io/cassini/orm/domain.html#1-1-11-5)
4. PhpSymfonyCodegen already produces that kind of [models](https://github.com/OpenAPITools/openapi-generator/blob/master/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php) and it looks like a stable implementation, correct me if I'm wrong

**Why I've added both traditional and associative array constructor in the same class:**
1. I cannot choose one, so I've decided to add `createFromObject` static method when you want to parse JSON and get new model instance as result. I like classic constructor with arguments list more, but I understand that sometimes it doesn't fit.
2. With classic constructor you can see required and optional variables right away.

### Unresolved question to discuss
I can't say for sure that force user to set required arguments is a good idea. I mean sometimes you receive messy JSON object without required fields, if you'll try to parse it via `createFromObject` method your code will die with uncatched exception. From another point, it's very usefull during development to notice missed properties instantly. 
PHPClient throws exceptions when you're trying to set property with setter method, but it gives no exceptions within constructor even if you don't provide any props at all. It doesn't make sense to me. :confused: 
**The question is, should we split arguments to required and optional and throw exceptions right from constructor method OR set all arguments optional and validates them silently with special method `valid()` only when user ask for it?**

### Issues found in process
1. Parser optionalVars.hasMore in models, #710 :bug: 
2. [Slim] Security samples script fails, #734

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh