### PR TITLE
Update --skip-validate-spec option with "--validate-spec"

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -194,10 +194,10 @@ public class Generate implements Runnable {
             description = CodegenConstants.REMOVE_OPERATION_ID_PREFIX_DESC)
     private Boolean removeOperationIdPrefix;
 
-    @Option(name = {"--skip-validate-spec"},
-            title = "skip spec validation",
-            description = "Skips the default behavior of validating an input specification.")
-    private Boolean skipValidateSpec;
+    @Option(name = {"--validate-spec"},
+            title = "enable spec validation (true or false)",
+            description = "Enable validating an input specification and terminate if errors found. (default: true)")
+    private String validateSpec;
 
     @Override
     public void run() {
@@ -211,11 +211,14 @@ public class Generate implements Runnable {
             configurator = new CodegenConfigurator();
         }
 
-        // now override with any specified parameters
-        if (skipValidateSpec != null) {
+        // validateSpec not provided (null) or a true value is provided
+        if (validateSpec == null || Boolean.valueOf(validateSpec)) {
+            configurator.setValidateSpec(true);
+        } else {
             configurator.setValidateSpec(false);
         }
 
+        // now override with any specified parameters
         if (verbose != null) {
             configurator.setVerbose(verbose);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -536,7 +536,7 @@ public class CodegenConfigurator implements Serializable {
 
             if (this.isValidateSpec()) {
                 StringBuilder sb = new StringBuilder();
-                sb.append("There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).");
+                sb.append("There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --validate-spec (CLI).");
                 sb.append(System.lineSeparator());
                 SpecValidationException ex = new SpecValidationException(sb.toString());
                 ex.setErrors(validationMessages);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Update --skip-validate-spec option with "--validate-spec" to make consistent with the maven/gradle plug-in option. An improvement to https://github.com/OpenAPITools/openapi-generator/pull/251

@jimschubert please review to see if this change looks good to you.

