### PR TITLE
[gradle] Support nullable system property values

### DIFF
--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -41,6 +41,9 @@ openApiGenerate {
     configOptions = [
             dateLibrary: "java8"
     ]
+    systemProperties = [
+            modelDocs: "false"
+    ]
 }
 
 task buildGoSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask){


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The gradle plugin sets all System properties before generation, then
reverts them back to their original state.

System.getProperty/setProperty return null if the property was not
previously set. The Kotlin map was defined with non-nullable key/value
constraints, so setting something not commonly set (modelDocs: "false")
would result in an runtime exception.

This changes the map to support nullable values, and rather than setting
a null System property at the end, it clears those which previously had
no value.

See #551

