### PR TITLE
Correct URL for openapi-generator.cli.sh in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ An example of setting this up (NOTE: Always evaluate scripts curled from externa
 
 ```
 mkdir -p ~/bin/openapitools
-curl https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator.cli.sh > ~/bin/openapitools/openapi-generator-cli
+curl https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator-cli.sh > ~/bin/openapitools/openapi-generator-cli
 chmod u+x ~/bin/openapitools/openapi-generator-cli
 export PATH=$PATH:~/bin/openapitools/
 ```


### PR DESCRIPTION
The URL for openapi-generator.cli.sh in README.md was incorrect, and this PR corrects it