### PR TITLE
Set swagger-parser to version 2.0.4

### DIFF
--- a/CI/pom.xml.bash
+++ b/CI/pom.xml.bash
@@ -920,8 +920,8 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
-        <swagger-core-version>2.0.1</swagger-core-version>
+        <swagger-parser-version>2.0.4</swagger-parser-version>
+        <swagger-core-version>2.0.4</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
         <commons-io-version>2.4</commons-io-version>

--- a/CI/pom.xml.circleci
+++ b/CI/pom.xml.circleci
@@ -1030,8 +1030,8 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
-        <swagger-core-version>2.0.1</swagger-core-version>
+        <swagger-parser-version>2.0.4</swagger-parser-version>
+        <swagger-core-version>2.0.4</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
         <commons-io-version>2.4</commons-io-version>

--- a/CI/pom.xml.circleci.java7
+++ b/CI/pom.xml.circleci.java7
@@ -1000,8 +1000,8 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
-        <swagger-core-version>2.0.1</swagger-core-version>
+        <swagger-parser-version>2.0.4</swagger-parser-version>
+        <swagger-core-version>2.0.4</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
         <commons-io-version>2.4</commons-io-version>

--- a/CI/pom.xml.ios
+++ b/CI/pom.xml.ios
@@ -928,8 +928,8 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
-        <swagger-core-version>2.0.1</swagger-core-version>
+        <swagger-parser-version>2.0.4</swagger-parser-version>
+        <swagger-core-version>2.0.4</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
         <commons-io-version>2.4</commons-io-version>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -203,8 +203,8 @@
             <artifactId>swagger-core</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
-        <dependency> 
-            <groupId>org.openapitools.swagger.parser</groupId>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
             <version>${swagger-parser-version}</version>
         </dependency> 

--- a/pom.xml
+++ b/pom.xml
@@ -1147,8 +1147,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
-        <swagger-core-version>2.0.1</swagger-core-version>
+        <swagger-parser-version>2.0.4</swagger-parser-version>
+        <swagger-core-version>2.0.4</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>
         <commons-io-version>2.4</commons-io-version>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team 

### Description of the PR

With #696 swagger-parser was updated to a custom version.
This PR set it to the official `2.0.2` version (see https://github.com/swagger-api/swagger-parser/issues/780)

