### PR TITLE
Remove duplicate variable declaration

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpLaravelServerCodegen.java
@@ -17,31 +17,13 @@
 
 package org.openapitools.codegen.languages;
 
-import io.swagger.models.properties.*;
-import io.swagger.v3.oas.models.*;
-import io.swagger.v3.oas.models.media.*;
-import io.swagger.v3.oas.models.parameters.*;
 import org.openapitools.codegen.*;
 
 import java.io.File;
 import java.util.*;
 
-import io.swagger.v3.oas.models.media.*;
-import io.swagger.v3.oas.models.PathItem;
-import io.swagger.v3.oas.models.PathItem.HttpMethod;
-import io.swagger.v3.oas.models.*;
-import io.swagger.v3.oas.models.parameters.*;
-import io.swagger.v3.core.util.Yaml;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-
 public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
-    @SuppressWarnings("hiding")
     protected String apiVersion = "1.0.0";
-    protected String variableNamingConvention = "camelCase";
 
     /**
      * Configures the type of generator.
@@ -80,6 +62,7 @@ public class PhpLaravelServerCodegen extends AbstractPhpCodegen {
         super();
 
         embeddedTemplateDir = templateDir = "php-laravel";
+        variableNamingConvention = "camelCase";
 
         /*
          * packPath


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

**Small code review:** Introduced with #574, this PR fixes following error:

> The field PhpLaravelServerCodegen.variableNamingConvention is hiding a field from type AbstractPhpCodegen

We decided to not use fields hiding other in child classes, because this is a bad practice in Java. 

cc: @renepardon, @wing328, @ackintosh 

---

There is an open issue (#33) to integrate a static code analysis tool to automate detection of those cases. 