### PR TITLE
[generator] Cleanup debugOpenAPI usage/display text

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -169,13 +169,14 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         if (!generateApiTests && !generateModelTests) {
             config.additionalProperties().put(CodegenConstants.EXCLUDE_TESTS, true);
         }
-        // for backward compatibility
-        if (System.getProperty("debugSwagger") != null) {
-            LOGGER.info("Please use system property 'debugOpenAPI' instead of 'debugSwagger'.");
-            Json.prettyPrint(openAPI);
-        }
+
 
         if (System.getProperty("debugOpenAPI") != null) {
+            Json.prettyPrint(openAPI);
+        } else if (System.getProperty("debugSwagger") != null) {
+            // This exists for backward compatibility
+            // We fall to this block only if debugOpenAPI is null. No need to dump this twice.
+            LOGGER.info("Please use system property 'debugOpenAPI' instead of 'debugSwagger'.");
             Json.prettyPrint(openAPI);
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -596,12 +596,12 @@ public class CodegenConfigurator implements Serializable {
             return;
         }
         LOGGER.info("\nVERBOSE MODE: ON. Additional debug options are injected" +
-                "\n - [debugSwagger] prints the openapi specification as interpreted by the codegen" +
+                "\n - [debugOpenAPI] prints the OpenAPI specification as interpreted by the codegen" +
                 "\n - [debugModels] prints models passed to the template engine" +
                 "\n - [debugOperations] prints operations passed to the template engine" +
                 "\n - [debugSupportingFiles] prints additional data passed to the template engine");
 
-        System.setProperty("debugSwagger", "");
+        System.setProperty("debugOpenAPI", "");
         System.setProperty("debugModels", "");
         System.setProperty("debugOperations", "");
         System.setProperty("debugSupportingFiles", "");

--- a/modules/openapi-generator/src/main/resources/codegen/README.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/README.mustache
@@ -62,7 +62,7 @@ the object you have available during client generation:
 
 ```
 # The following additional debug options are available for all codegen targets:
-# -DdebugSwagger prints the OpenAPI Specification as interpreted by the codegen
+# -DdebugOpenAPI prints the OpenAPI Specification as interpreted by the codegen
 # -DdebugModels prints models passed to the template engine
 # -DdebugOperations prints operations passed to the template engine
 # -DdebugSupportingFiles prints additional data passed to the template engine


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Prevents spec from getting dumped twice. Displays help text with new debug key rather than debugSwagger.

