### PR TITLE
Added server variable support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -23,6 +23,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
 
 import java.util.List;
 import java.util.Map;
@@ -113,6 +115,10 @@ public interface CodegenConfig {
 
     List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> schemas);
 
+    List<CodegenServer> fromServers(List<Server> servers);
+  
+    List<CodegenServerVariable> fromServerVariables(Map<String, ServerVariable> variables);
+    
     Set<String> defaultIncludes();
 
     Map<String, String> typeMapping();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServer.java
@@ -3,7 +3,7 @@ package org.openapitools.codegen;
 import java.util.List;
 
 public class CodegenServer {
-	public String url;
-	public String description;
-	public List<CodegenServerVariable> variables;
+    public String url;
+    public String description;
+    public List<CodegenServerVariable> variables;
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServer.java
@@ -1,0 +1,9 @@
+package org.openapitools.codegen;
+
+import java.util.List;
+
+public class CodegenServer {
+	public String url;
+	public String description;
+	public List<CodegenServerVariable> variables;
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServerVariable.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServerVariable.java
@@ -1,0 +1,10 @@
+package org.openapitools.codegen;
+
+import java.util.List;
+
+public class CodegenServerVariable {
+	public String name;
+	public String defaultValue;
+	public String description;
+	public List<String> enumValues;
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServerVariable.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenServerVariable.java
@@ -3,8 +3,8 @@ package org.openapitools.codegen;
 import java.util.List;
 
 public class CodegenServerVariable {
-	public String name;
-	public String defaultValue;
-	public String description;
-	public List<String> enumValues;
+    public String name;
+    public String defaultValue;
+    public String description;
+    public List<String> enumValues;
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -43,6 +43,8 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -64,6 +66,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -4588,4 +4591,38 @@ public class DefaultCodegen implements CodegenConfig {
     public boolean isDataTypeString(String dataType) {
         return "String".equals(dataType);
     }
+
+	@Override
+	public List<CodegenServer> fromServers(List<Server> servers) {
+		if (servers == null) {
+			return Collections.emptyList();
+		}
+		List<CodegenServer> codegenServers = new LinkedList<>();
+		for (Server server: servers) {
+			CodegenServer cs = new CodegenServer();
+			cs.description = server.getDescription();
+			cs.url = server.getUrl();
+			cs.variables = this.fromServerVariables(server.getVariables());
+			codegenServers.add(cs);
+		}
+		return codegenServers;
+	}
+
+	@Override
+	public List<CodegenServerVariable> fromServerVariables(Map<String, ServerVariable> variables) {
+		if (variables == null) {
+			return Collections.emptyList();
+		}
+		List<CodegenServerVariable> codegenServerVariables = new LinkedList<>();
+		for (Entry<String, ServerVariable> variableEntry: variables.entrySet()) {
+			CodegenServerVariable codegenServerVariable = new CodegenServerVariable();
+			ServerVariable variable = variableEntry.getValue();
+			codegenServerVariable.defaultValue = variable.getDefault();
+			codegenServerVariable.description = variable.getDescription();
+			codegenServerVariable.enumValues = variable.getEnum();
+			codegenServerVariable.name = variableEntry.getKey();
+			codegenServerVariables.add(codegenServerVariable);
+		}
+		return codegenServerVariables;
+	}
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4592,37 +4592,37 @@ public class DefaultCodegen implements CodegenConfig {
         return "String".equals(dataType);
     }
 
-	@Override
-	public List<CodegenServer> fromServers(List<Server> servers) {
-		if (servers == null) {
-			return Collections.emptyList();
-		}
-		List<CodegenServer> codegenServers = new LinkedList<>();
-		for (Server server: servers) {
-			CodegenServer cs = new CodegenServer();
-			cs.description = server.getDescription();
-			cs.url = server.getUrl();
-			cs.variables = this.fromServerVariables(server.getVariables());
-			codegenServers.add(cs);
-		}
-		return codegenServers;
-	}
+    @Override
+    public List<CodegenServer> fromServers(List<Server> servers) {
+        if (servers == null) {
+            return Collections.emptyList();
+        }
+        List<CodegenServer> codegenServers = new LinkedList<>();
+        for (Server server: servers) {
+            CodegenServer cs = new CodegenServer();
+            cs.description = server.getDescription();
+            cs.url = server.getUrl();
+            cs.variables = this.fromServerVariables(server.getVariables());
+            codegenServers.add(cs);
+        }
+        return codegenServers;
+    }
 
-	@Override
-	public List<CodegenServerVariable> fromServerVariables(Map<String, ServerVariable> variables) {
-		if (variables == null) {
-			return Collections.emptyList();
-		}
-		List<CodegenServerVariable> codegenServerVariables = new LinkedList<>();
-		for (Entry<String, ServerVariable> variableEntry: variables.entrySet()) {
-			CodegenServerVariable codegenServerVariable = new CodegenServerVariable();
-			ServerVariable variable = variableEntry.getValue();
-			codegenServerVariable.defaultValue = variable.getDefault();
-			codegenServerVariable.description = variable.getDescription();
-			codegenServerVariable.enumValues = variable.getEnum();
-			codegenServerVariable.name = variableEntry.getKey();
-			codegenServerVariables.add(codegenServerVariable);
-		}
-		return codegenServerVariables;
-	}
+    @Override
+    public List<CodegenServerVariable> fromServerVariables(Map<String, ServerVariable> variables) {
+        if (variables == null) {
+            return Collections.emptyList();
+        }
+        List<CodegenServerVariable> codegenServerVariables = new LinkedList<>();
+        for (Entry<String, ServerVariable> variableEntry: variables.entrySet()) {
+            CodegenServerVariable codegenServerVariable = new CodegenServerVariable();
+            ServerVariable variable = variableEntry.getValue();
+            codegenServerVariable.defaultValue = variable.getDefault();
+            codegenServerVariable.description = variable.getDescription();
+            codegenServerVariable.enumValues = variable.getEnum();
+            codegenServerVariable.name = variableEntry.getKey();
+            codegenServerVariables.add(codegenServerVariable);
+        }
+        return codegenServerVariables;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -756,8 +756,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         
         List<CodegenServer> servers = config.fromServers(openAPI.getServers());
         if (servers != null && !servers.isEmpty()) {
-        	bundle.put("servers", servers);
-        	bundle.put("hasServers", true);
+            bundle.put("servers", servers);
+            bundle.put("hasServers", true);
         }
 
         if (openAPI.getExternalDocs() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -753,6 +753,12 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             bundle.put("authMethods", authMethods);
             bundle.put("hasAuthMethods", true);
         }
+        
+        List<CodegenServer> servers = config.fromServers(openAPI.getServers());
+        if (servers != null && !servers.isEmpty()) {
+        	bundle.put("servers", servers);
+        	bundle.put("hasServers", true);
+        }
 
         if (openAPI.getExternalDocs() != null) {
             bundle.put("externalDocs", openAPI.getExternalDocs());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -50,7 +50,7 @@ public class URLPathUtils {
         return getServerURL(servers.get(0));
     }
 
-    static URL getServerURL(final Server server) {
+    public static URL getServerURL(final Server server) {
         String url = server.getUrl();
         ServerVariables variables = server.getVariables();
         if(variables == null) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

See #793 

I implemented a solution similar to `authMethods` in supportingFiles JSON (see generated json below).

Spec: https://gist.github.com/TiFu/0934b362f25c66bc2b758f33e15520fc
Generated Supporting Files JSON: https://gist.github.com/TiFu/919a8888837e4e24fd32a05dc8d289f9

Generated under the root object (use `-DdebugSupportingFiles` to print the full mustache template used):

```
 "servers" : [ {
    "url" : "http://petstore.swagger.io:{port}/{basePath}",
    "description" : "The production API server",
    "variables" : [ {
      "name" : "port",
      "defaultValue" : "8443",
      "enumValues" : [ "8443", "443" ]
    }, {
      "name" : "basePath",
      "defaultValue" : "v2"
    } ]
  }, {
    "url" : "http://petstore.swagger.io",
    "description" : "The production API server",
    "variables" : [ ]
  } ],
```
# Question

Do I have to regenerate any samples? This is a non-breaking change because I only added a new property to the JSON (which is passed to mustache) for supportingFiles.

CC @wing328  @jmini 