### PR TITLE
Improve Symfony 4.1 compatibility

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "symfony/validator": "*",
         "jms/serializer-bundle": "*",
-        "symfony/framework-bundle": "^2.3|^3.0"
+        "symfony/framework-bundle": "^2.3|^3.0|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
@@ -14,10 +14,10 @@ services:
         class: {{modelPackage}}\ModelSerializer
 
     {{bundleAlias}}.service.serializer:
-        class: %{{bundleAlias}}.serializer%
+        class: '%{{bundleAlias}}.serializer%'
 
     {{bundleAlias}}.service.validator:
-        class: %{{bundleAlias}}.validator%
+        class: '%{{bundleAlias}}.validator%'
 
 {{#apiInfo}}
 {{#apis}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
@@ -14,10 +14,10 @@ services:
         class: OpenAPI\Server\Model\ModelSerializer
 
     open_apiserver.service.serializer:
-        class: %open_apiserver.serializer%
+        class: '%open_apiserver.serializer%'
 
     open_apiserver.service.validator:
-        class: %open_apiserver.validator%
+        class: '%open_apiserver.validator%'
 
     open_apiserver.controller.pet:
         class: OpenAPI\Server\Controller\PetController

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -22,7 +22,7 @@
         "ext-mbstring": "*",
         "symfony/validator": "*",
         "jms/serializer-bundle": "*",
-        "symfony/framework-bundle": "^2.3|^3.0"
+        "symfony/framework-bundle": "^2.3|^3.0|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Allow for Symfony 4.1 dependency and quote container params.
Both changes should be safe, bc compatible changes.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko 