### PR TITLE
[Java][Rest-assured] Fix generated javadoc and "swagger-annotations" improvement  

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -28,6 +28,7 @@ import {{invokerPackage}}.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "{{{baseName}}}")
 public class {{classname}} {
 
     private RequestSpecBuilder reqSpec;
@@ -44,10 +45,11 @@ public class {{classname}} {
 {{#operation}}
 
     @ApiOperation(value = "{{{summary}}}",
-                  notes = "{{{notes}}}",
-                  tags={ {{#tags}}{{#name}}"{{{name}}}"{{/name}}{{^-last}}, {{/-last}}{{/tags}} })
+            notes = "{{{notes}}}",
+            nickname = "{{{operationId}}}",
+            tags = { {{#tags}}{{#name}}"{{{name}}}"{{/name}}{{^-last}}, {{/-last}}{{/tags}} })
     @ApiResponses(value = { {{#responses}}
-        @ApiResponse(code = {{{code}}}, message = "{{{message}}}") {{#hasMore}},{{/hasMore}}{{/responses}} })
+            @ApiResponse(code = {{{code}}}, message = "{{{message}}}") {{#hasMore}},{{/hasMore}}{{/responses}} })
     {{#isDeprecated}}
     @Deprecated
     {{/isDeprecated}}
@@ -135,7 +137,7 @@ public class {{classname}} {
         {{#bodyParams}}
 
          /**
-         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper body({{{dataType}}} {{paramName}}) {
@@ -148,7 +150,7 @@ public class {{classname}} {
         public static final String {{#convert}}{{paramName}}{{/convert}}_HEADER = "{{baseName}}";
 
         /**
-         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Header(String {{paramName}}) {
@@ -161,7 +163,7 @@ public class {{classname}} {
         public static final String {{#convert}}{{paramName}}{{/convert}}_PATH = "{{baseName}}";
 
         /**
-         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Path(Object {{paramName}}) {
@@ -174,7 +176,7 @@ public class {{classname}} {
         public static final String {{#convert}}{{paramName}}{{/convert}}_QUERY = "{{baseName}}";
 
         /**
-         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
         public {{operationIdCamelCase}}Oper {{paramName}}Query(Object... {{paramName}}) {
@@ -188,7 +190,7 @@ public class {{classname}} {
          public static final String {{#convert}}{{paramName}}{{/convert}}_FORM = "{{baseName}}";
 
          /**
-         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
          public {{operationIdCamelCase}}Oper {{paramName}}Form(Object... {{paramName}}) {
@@ -203,7 +205,7 @@ public class {{classname}} {
          /**
          * It will assume that the control name is file and the &lt;content-type&gt; is &lt;application/octet-stream&gt;
          * @see #reqSpec for customise
-         * @param {{paramName}} ({{{dataType}}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+         * @param {{paramName}} ({{dataType}}) {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
          * @return operation
          */
          public {{operationIdCamelCase}}Oper {{paramName}}MultiPart({{{dataType}}} {{paramName}}) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -36,6 +36,7 @@ import org.openapitools.client.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "AnotherFake")
 public class AnotherFakeApi {
 
     private RequestSpecBuilder reqSpec;
@@ -50,10 +51,11 @@ public class AnotherFakeApi {
 
 
     @ApiOperation(value = "To test special tags",
-                  notes = "To test special tags and operation ID starting with number",
-                  tags={ "$another-fake?" })
+            notes = "To test special tags and operation ID starting with number",
+            nickname = "call123testSpecialTags",
+            tags = { "$another-fake?" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public Call123testSpecialTagsOper call123testSpecialTags() {
         return new Call123testSpecialTagsOper(reqSpec);
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -43,6 +43,7 @@ import org.openapitools.client.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "Fake")
 public class FakeApi {
 
     private RequestSpecBuilder reqSpec;
@@ -57,102 +58,113 @@ public class FakeApi {
 
 
     @ApiOperation(value = "",
-                  notes = "Test serialization of outer boolean types",
-                  tags={ "fake" })
+            notes = "Test serialization of outer boolean types",
+            nickname = "fakeOuterBooleanSerialize",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Output boolean")  })
+            @ApiResponse(code = 200, message = "Output boolean")  })
     public FakeOuterBooleanSerializeOper fakeOuterBooleanSerialize() {
         return new FakeOuterBooleanSerializeOper(reqSpec);
     }
 
     @ApiOperation(value = "",
-                  notes = "Test serialization of object with outer number type",
-                  tags={ "fake" })
+            notes = "Test serialization of object with outer number type",
+            nickname = "fakeOuterCompositeSerialize",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Output composite")  })
+            @ApiResponse(code = 200, message = "Output composite")  })
     public FakeOuterCompositeSerializeOper fakeOuterCompositeSerialize() {
         return new FakeOuterCompositeSerializeOper(reqSpec);
     }
 
     @ApiOperation(value = "",
-                  notes = "Test serialization of outer number types",
-                  tags={ "fake" })
+            notes = "Test serialization of outer number types",
+            nickname = "fakeOuterNumberSerialize",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Output number")  })
+            @ApiResponse(code = 200, message = "Output number")  })
     public FakeOuterNumberSerializeOper fakeOuterNumberSerialize() {
         return new FakeOuterNumberSerializeOper(reqSpec);
     }
 
     @ApiOperation(value = "",
-                  notes = "Test serialization of outer string types",
-                  tags={ "fake" })
+            notes = "Test serialization of outer string types",
+            nickname = "fakeOuterStringSerialize",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Output string")  })
+            @ApiResponse(code = 200, message = "Output string")  })
     public FakeOuterStringSerializeOper fakeOuterStringSerialize() {
         return new FakeOuterStringSerializeOper(reqSpec);
     }
 
     @ApiOperation(value = "",
-                  notes = "For this test, the body for this request much reference a schema named `File`.",
-                  tags={ "fake" })
+            notes = "For this test, the body for this request much reference a schema named `File`.",
+            nickname = "testBodyWithFileSchema",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Success")  })
+            @ApiResponse(code = 200, message = "Success")  })
     public TestBodyWithFileSchemaOper testBodyWithFileSchema() {
         return new TestBodyWithFileSchemaOper(reqSpec);
     }
 
     @ApiOperation(value = "",
-                  notes = "",
-                  tags={ "fake" })
+            notes = "",
+            nickname = "testBodyWithQueryParams",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Success")  })
+            @ApiResponse(code = 200, message = "Success")  })
     public TestBodyWithQueryParamsOper testBodyWithQueryParams() {
         return new TestBodyWithQueryParamsOper(reqSpec);
     }
 
     @ApiOperation(value = "To test \"client\" model",
-                  notes = "To test \"client\" model",
-                  tags={ "fake" })
+            notes = "To test \"client\" model",
+            nickname = "testClientModel",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public TestClientModelOper testClientModel() {
         return new TestClientModelOper(reqSpec);
     }
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ",
-                  notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ",
-                  tags={ "fake" })
+            notes = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ",
+            nickname = "testEndpointParameters",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid username supplied") ,
-        @ApiResponse(code = 404, message = "User not found")  })
+            @ApiResponse(code = 400, message = "Invalid username supplied") ,
+            @ApiResponse(code = 404, message = "User not found")  })
     public TestEndpointParametersOper testEndpointParameters() {
         return new TestEndpointParametersOper(reqSpec);
     }
 
     @ApiOperation(value = "To test enum parameters",
-                  notes = "To test enum parameters",
-                  tags={ "fake" })
+            notes = "To test enum parameters",
+            nickname = "testEnumParameters",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid request") ,
-        @ApiResponse(code = 404, message = "Not found")  })
+            @ApiResponse(code = 400, message = "Invalid request") ,
+            @ApiResponse(code = 404, message = "Not found")  })
     public TestEnumParametersOper testEnumParameters() {
         return new TestEnumParametersOper(reqSpec);
     }
 
     @ApiOperation(value = "test inline additionalProperties",
-                  notes = "",
-                  tags={ "fake" })
+            notes = "",
+            nickname = "testInlineAdditionalProperties",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public TestInlineAdditionalPropertiesOper testInlineAdditionalProperties() {
         return new TestInlineAdditionalPropertiesOper(reqSpec);
     }
 
     @ApiOperation(value = "test json serialization of form data",
-                  notes = "",
-                  tags={ "fake" })
+            notes = "",
+            nickname = "testJsonFormData",
+            tags = { "fake" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public TestJsonFormDataOper testJsonFormData() {
         return new TestJsonFormDataOper(reqSpec);
     }
@@ -913,7 +925,7 @@ public class FakeApi {
         public static final String ENUM_HEADER_STRING_ARRAY_HEADER = "enum_header_string_array";
 
         /**
-         * @param enumHeaderStringArray (List<String>) Header parameter enum test (string array) (optional)
+         * @param enumHeaderStringArray (List&lt;String&gt;) Header parameter enum test (string array) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumHeaderStringArrayHeader(String enumHeaderStringArray) {
@@ -935,7 +947,7 @@ public class FakeApi {
         public static final String ENUM_QUERY_STRING_ARRAY_QUERY = "enum_query_string_array";
 
         /**
-         * @param enumQueryStringArray (List<String>) Query parameter enum test (string array) (optional)
+         * @param enumQueryStringArray (List&lt;String&gt;) Query parameter enum test (string array) (optional)
          * @return operation
          */
         public TestEnumParametersOper enumQueryStringArrayQuery(Object... enumQueryStringArray) {
@@ -979,7 +991,7 @@ public class FakeApi {
          public static final String ENUM_FORM_STRING_ARRAY_FORM = "enum_form_string_array";
 
          /**
-         * @param enumFormStringArray (List<String>) Form parameter enum test (string array) (optional, default to $)
+         * @param enumFormStringArray (List&lt;String&gt;) Form parameter enum test (string array) (optional, default to $)
          * @return operation
          */
          public TestEnumParametersOper enumFormStringArrayForm(Object... enumFormStringArray) {
@@ -1050,7 +1062,7 @@ public class FakeApi {
         }
 
          /**
-         * @param requestBody (Map<String, String>) request body (required)
+         * @param requestBody (Map&lt;String, String&gt;) request body (required)
          * @return operation
          */
         public TestInlineAdditionalPropertiesOper body(Map<String, String> requestBody) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -36,6 +36,7 @@ import org.openapitools.client.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "FakeClassnameTags123")
 public class FakeClassnameTags123Api {
 
     private RequestSpecBuilder reqSpec;
@@ -50,10 +51,11 @@ public class FakeClassnameTags123Api {
 
 
     @ApiOperation(value = "To test class name in snake case",
-                  notes = "To test class name in snake case",
-                  tags={ "fake_classname_tags 123#$%^" })
+            notes = "To test class name in snake case",
+            nickname = "testClassname",
+            tags = { "fake_classname_tags 123#$%^" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public TestClassnameOper testClassname() {
         return new TestClassnameOper(reqSpec);
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
@@ -38,6 +38,7 @@ import org.openapitools.client.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "Pet")
 public class PetApi {
 
     private RequestSpecBuilder reqSpec;
@@ -52,89 +53,98 @@ public class PetApi {
 
 
     @ApiOperation(value = "Add a new pet to the store",
-                  notes = "",
-                  tags={ "pet" })
+            notes = "",
+            nickname = "addPet",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 405, message = "Invalid input")  })
+            @ApiResponse(code = 405, message = "Invalid input")  })
     public AddPetOper addPet() {
         return new AddPetOper(reqSpec);
     }
 
     @ApiOperation(value = "Deletes a pet",
-                  notes = "",
-                  tags={ "pet" })
+            notes = "",
+            nickname = "deletePet",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid pet value")  })
+            @ApiResponse(code = 400, message = "Invalid pet value")  })
     public DeletePetOper deletePet() {
         return new DeletePetOper(reqSpec);
     }
 
     @ApiOperation(value = "Finds Pets by status",
-                  notes = "Multiple status values can be provided with comma separated strings",
-                  tags={ "pet" })
+            notes = "Multiple status values can be provided with comma separated strings",
+            nickname = "findPetsByStatus",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid status value")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid status value")  })
     public FindPetsByStatusOper findPetsByStatus() {
         return new FindPetsByStatusOper(reqSpec);
     }
 
     @ApiOperation(value = "Finds Pets by tags",
-                  notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-                  tags={ "pet" })
+            notes = "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+            nickname = "findPetsByTags",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid tag value")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid tag value")  })
     @Deprecated
     public FindPetsByTagsOper findPetsByTags() {
         return new FindPetsByTagsOper(reqSpec);
     }
 
     @ApiOperation(value = "Find pet by ID",
-                  notes = "Returns a single pet",
-                  tags={ "pet" })
+            notes = "Returns a single pet",
+            nickname = "getPetById",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid ID supplied") ,
-        @ApiResponse(code = 404, message = "Pet not found")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid ID supplied") ,
+            @ApiResponse(code = 404, message = "Pet not found")  })
     public GetPetByIdOper getPetById() {
         return new GetPetByIdOper(reqSpec);
     }
 
     @ApiOperation(value = "Update an existing pet",
-                  notes = "",
-                  tags={ "pet" })
+            notes = "",
+            nickname = "updatePet",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid ID supplied") ,
-        @ApiResponse(code = 404, message = "Pet not found") ,
-        @ApiResponse(code = 405, message = "Validation exception")  })
+            @ApiResponse(code = 400, message = "Invalid ID supplied") ,
+            @ApiResponse(code = 404, message = "Pet not found") ,
+            @ApiResponse(code = 405, message = "Validation exception")  })
     public UpdatePetOper updatePet() {
         return new UpdatePetOper(reqSpec);
     }
 
     @ApiOperation(value = "Updates a pet in the store with form data",
-                  notes = "",
-                  tags={ "pet" })
+            notes = "",
+            nickname = "updatePetWithForm",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 405, message = "Invalid input")  })
+            @ApiResponse(code = 405, message = "Invalid input")  })
     public UpdatePetWithFormOper updatePetWithForm() {
         return new UpdatePetWithFormOper(reqSpec);
     }
 
     @ApiOperation(value = "uploads an image",
-                  notes = "",
-                  tags={ "pet" })
+            notes = "",
+            nickname = "uploadFile",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public UploadFileOper uploadFile() {
         return new UploadFileOper(reqSpec);
     }
 
     @ApiOperation(value = "uploads an image (required)",
-                  notes = "",
-                  tags={ "pet" })
+            notes = "",
+            nickname = "uploadFileWithRequiredFile",
+            tags = { "pet" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public UploadFileWithRequiredFileOper uploadFileWithRequiredFile() {
         return new UploadFileWithRequiredFileOper(reqSpec);
     }
@@ -326,7 +336,7 @@ public class PetApi {
         public static final String STATUS_QUERY = "status";
 
         /**
-         * @param status (List<String>) Status values that need to be considered for filter (required)
+         * @param status (List&lt;String&gt;) Status values that need to be considered for filter (required)
          * @return operation
          */
         public FindPetsByStatusOper statusQuery(Object... status) {
@@ -400,7 +410,7 @@ public class PetApi {
         public static final String TAGS_QUERY = "tags";
 
         /**
-         * @param tags (List<String>) Tags to filter by (required)
+         * @param tags (List&lt;String&gt;) Tags to filter by (required)
          * @return operation
          */
         public FindPetsByTagsOper tagsQuery(Object... tags) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -36,6 +36,7 @@ import org.openapitools.client.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "Store")
 public class StoreApi {
 
     private RequestSpecBuilder reqSpec;
@@ -50,41 +51,45 @@ public class StoreApi {
 
 
     @ApiOperation(value = "Delete purchase order by ID",
-                  notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
-                  tags={ "store" })
+            notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+            nickname = "deleteOrder",
+            tags = { "store" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid ID supplied") ,
-        @ApiResponse(code = 404, message = "Order not found")  })
+            @ApiResponse(code = 400, message = "Invalid ID supplied") ,
+            @ApiResponse(code = 404, message = "Order not found")  })
     public DeleteOrderOper deleteOrder() {
         return new DeleteOrderOper(reqSpec);
     }
 
     @ApiOperation(value = "Returns pet inventories by status",
-                  notes = "Returns a map of status codes to quantities",
-                  tags={ "store" })
+            notes = "Returns a map of status codes to quantities",
+            nickname = "getInventory",
+            tags = { "store" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation")  })
+            @ApiResponse(code = 200, message = "successful operation")  })
     public GetInventoryOper getInventory() {
         return new GetInventoryOper(reqSpec);
     }
 
     @ApiOperation(value = "Find purchase order by ID",
-                  notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
-                  tags={ "store" })
+            notes = "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+            nickname = "getOrderById",
+            tags = { "store" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid ID supplied") ,
-        @ApiResponse(code = 404, message = "Order not found")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid ID supplied") ,
+            @ApiResponse(code = 404, message = "Order not found")  })
     public GetOrderByIdOper getOrderById() {
         return new GetOrderByIdOper(reqSpec);
     }
 
     @ApiOperation(value = "Place an order for a pet",
-                  notes = "",
-                  tags={ "store" })
+            notes = "",
+            nickname = "placeOrder",
+            tags = { "store" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid Order")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid Order")  })
     public PlaceOrderOper placeOrder() {
         return new PlaceOrderOper(reqSpec);
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -36,6 +36,7 @@ import org.openapitools.client.JSON;
 
 import static io.restassured.http.Method.*;
 
+@Api(value = "User")
 public class UserApi {
 
     private RequestSpecBuilder reqSpec;
@@ -50,78 +51,86 @@ public class UserApi {
 
 
     @ApiOperation(value = "Create user",
-                  notes = "This can only be done by the logged in user.",
-                  tags={ "user" })
+            notes = "This can only be done by the logged in user.",
+            nickname = "createUser",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 0, message = "successful operation")  })
+            @ApiResponse(code = 0, message = "successful operation")  })
     public CreateUserOper createUser() {
         return new CreateUserOper(reqSpec);
     }
 
     @ApiOperation(value = "Creates list of users with given input array",
-                  notes = "",
-                  tags={ "user" })
+            notes = "",
+            nickname = "createUsersWithArrayInput",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 0, message = "successful operation")  })
+            @ApiResponse(code = 0, message = "successful operation")  })
     public CreateUsersWithArrayInputOper createUsersWithArrayInput() {
         return new CreateUsersWithArrayInputOper(reqSpec);
     }
 
     @ApiOperation(value = "Creates list of users with given input array",
-                  notes = "",
-                  tags={ "user" })
+            notes = "",
+            nickname = "createUsersWithListInput",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 0, message = "successful operation")  })
+            @ApiResponse(code = 0, message = "successful operation")  })
     public CreateUsersWithListInputOper createUsersWithListInput() {
         return new CreateUsersWithListInputOper(reqSpec);
     }
 
     @ApiOperation(value = "Delete user",
-                  notes = "This can only be done by the logged in user.",
-                  tags={ "user" })
+            notes = "This can only be done by the logged in user.",
+            nickname = "deleteUser",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid username supplied") ,
-        @ApiResponse(code = 404, message = "User not found")  })
+            @ApiResponse(code = 400, message = "Invalid username supplied") ,
+            @ApiResponse(code = 404, message = "User not found")  })
     public DeleteUserOper deleteUser() {
         return new DeleteUserOper(reqSpec);
     }
 
     @ApiOperation(value = "Get user by user name",
-                  notes = "",
-                  tags={ "user" })
+            notes = "",
+            nickname = "getUserByName",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid username supplied") ,
-        @ApiResponse(code = 404, message = "User not found")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid username supplied") ,
+            @ApiResponse(code = 404, message = "User not found")  })
     public GetUserByNameOper getUserByName() {
         return new GetUserByNameOper(reqSpec);
     }
 
     @ApiOperation(value = "Logs user into the system",
-                  notes = "",
-                  tags={ "user" })
+            notes = "",
+            nickname = "loginUser",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "successful operation") ,
-        @ApiResponse(code = 400, message = "Invalid username/password supplied")  })
+            @ApiResponse(code = 200, message = "successful operation") ,
+            @ApiResponse(code = 400, message = "Invalid username/password supplied")  })
     public LoginUserOper loginUser() {
         return new LoginUserOper(reqSpec);
     }
 
     @ApiOperation(value = "Logs out current logged in user session",
-                  notes = "",
-                  tags={ "user" })
+            notes = "",
+            nickname = "logoutUser",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 0, message = "successful operation")  })
+            @ApiResponse(code = 0, message = "successful operation")  })
     public LogoutUserOper logoutUser() {
         return new LogoutUserOper(reqSpec);
     }
 
     @ApiOperation(value = "Updated user",
-                  notes = "This can only be done by the logged in user.",
-                  tags={ "user" })
+            notes = "This can only be done by the logged in user.",
+            nickname = "updateUser",
+            tags = { "user" })
     @ApiResponses(value = { 
-        @ApiResponse(code = 400, message = "Invalid user supplied") ,
-        @ApiResponse(code = 404, message = "User not found")  })
+            @ApiResponse(code = 400, message = "Invalid user supplied") ,
+            @ApiResponse(code = 404, message = "User not found")  })
     public UpdateUserOper updateUser() {
         return new UpdateUserOper(reqSpec);
     }
@@ -228,7 +237,7 @@ public class UserApi {
         }
 
          /**
-         * @param user (List<User>) List of user object (required)
+         * @param user (List&lt;User&gt;) List of user object (required)
          * @return operation
          */
         public CreateUsersWithArrayInputOper body(List<User> user) {
@@ -288,7 +297,7 @@ public class UserApi {
         }
 
          /**
-         * @param user (List<User>) List of user object (required)
+         * @param user (List&lt;User&gt;) List of user object (required)
          * @return operation
          */
         public CreateUsersWithListInputOper body(List<User> user) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Hi,
I found problem with javadoc for params and fixed it.
Also I added "@Api" swagger annotation, "nickname" for "@ApiOperation".

