### PR TITLE
Adjust client response handler to be backwards compatible with older …

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -18,6 +18,7 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -553,7 +554,11 @@ public class ApiClient {
                             handleFileDownload(httpResponse, handler);
                             return;
                         } else {
-                            resultContent = Json.decodeValue(httpResponse.body(), returnType);
+                            try {
+                                resultContent = Json.mapper.readValue(httpResponse.bodyAsString(), returnType);
+                            } catch (Exception e) {
+                                throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+                            }
                         }
                         result = Future.succeededFuture(resultContent);
                     }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
@@ -18,6 +18,7 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -554,7 +555,11 @@ public class ApiClient {
                             handleFileDownload(httpResponse, handler);
                             return;
                         } else {
-                            resultContent = Json.decodeValue(httpResponse.body(), returnType);
+                            try {
+                                resultContent = Json.mapper.readValue(httpResponse.bodyAsString(), returnType);
+                            } catch (Exception e) {
+                                throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+                            }
                         }
                         result = Future.succeededFuture(resultContent);
                     }


### PR DESCRIPTION
Fix for #834  (Recreated pull request with proper commit author attribution)

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for #834

Adjusted client response handler to be backward compatible with older versions (< 3.5) of Vert.x.

@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @lopesmcc 