### PR TITLE
Fix unescaped description in requestBody

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2369,7 +2369,7 @@ public class DefaultCodegen implements CodegenConfig {
                     bodyParameterName = (String) op.vendorExtensions.get("x-codegen-request-body-name");
                 }
                 bodyParam = fromRequestBody(requestBody, schemas, imports, bodyParameterName);
-                bodyParam.description = requestBody.getDescription();
+                bodyParam.description = escapeText(requestBody.getDescription());
                 postProcessParameter(bodyParam);
 
                 bodyParams.add(bodyParam);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This is a very small fix and re-uses existing functionality. It solves a glitch in OpenAPI 3 generation where the `description` of a `requestBody` of a `POST` operation was not escaped and caused code generators to have line breaks where no line breaks are allowed. Example:

```yml
    post:
      description: |
        Creates a new Job in the
        repository
      operationId: createJob
      requestBody:
        description: |
          Job to add to the 
          repository
```

was resulting in (lines 9-11):

```java
    @ApiOperation(value = "", nickname = "createJob", notes = "Creates a new Job in the repository ", response = Job.class, tags={  })
    @ApiResponses(value = { 
        @ApiResponse(code = 201, message = "job response ", response = Job.class),
        @ApiResponse(code = 500, message = "unexpected error ", response = Error.class) })
    @RequestMapping(value = "/jobs",
        produces = { "application/json" }, 
        consumes = { "application/json" },
        method = RequestMethod.POST)
    default ResponseEntity<Job> createJob(@ApiParam(value = "Job to add to the
repository
",required=true)  @Valid @RequestBody Job job
) {
```

The fix is to re-use the existing `escapeText` method in `DefaultCodegen`.