### PR TITLE
Add callback model

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenCallback.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenCallback.java
@@ -1,0 +1,63 @@
+package org.openapitools.codegen;
+
+import java.util.*;
+
+public class CodegenCallback {
+    public String name;
+    public boolean hasMore;
+    public List<Url> urls = new ArrayList<>();
+    public Map<String, Object> vendorExtensions = new HashMap<>();
+
+    public static class Url {
+        public String expression;
+        public boolean hasMore;
+        public List<CodegenOperation> requests = new ArrayList<>();
+        public Map<String, Object> vendorExtensions = new HashMap<>();
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Url that = (Url) o;
+            return Objects.equals(that.expression, expression) && Objects.equals(that.hasMore, hasMore) &&
+                    Objects.equals(that.requests, requests) && Objects.equals(that.vendorExtensions, vendorExtensions);
+        }
+        @Override
+        public int hashCode() {
+            return Objects.hash(expression, hasMore, requests, vendorExtensions);
+        }
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("CodegenCallback.Urls {\n");
+            sb.append("    expression: ").append(expression).append("\n");
+            requests.forEach(r -> sb.append("   ").append(r).append("\n"));
+            sb.append("}");
+            return sb.toString();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CodegenCallback that = (CodegenCallback) o;
+        return Objects.equals(that.name, name) && Objects.equals(that.hasMore, hasMore) &&
+                Objects.equals(that.urls, urls) && Objects.equals(that.vendorExtensions, vendorExtensions);
+    }
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, hasMore, urls, vendorExtensions);
+    }
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CodegenCallback {\n");
+        sb.append("    name: ").append(name).append("\n");
+        urls.forEach(u -> sb.append("   ").append(u).append("\n"));
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenCallback.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenCallback.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen;
 
 import java.util.*;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -36,7 +36,7 @@ public class CodegenOperation {
             isListContainer, isMultipart, hasMore = true,
             isResponseBinary = false, isResponseFile = false, hasReference = false,
             isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
-            isRestful, isDeprecated;
+            isRestful, isDeprecated, isCallbackRequest;
     public String path, operationId, returnType, httpMethod, returnBaseType,
             returnContainer, summary, unescapedNotes, notes, baseName, defaultResponse; 
     public CodegenDiscriminator discriminator;
@@ -54,6 +54,7 @@ public class CodegenOperation {
     public List<CodegenSecurity> authMethods;
     public List<Tag> tags;
     public List<CodegenResponse> responses = new ArrayList<CodegenResponse>();
+    public List<CodegenCallback> callbacks = new ArrayList<>();
     public Set<String> imports = new HashSet<String>();
     public List<Map<String, String>> examples;
     public List<Map<String, String>> requestBodyExamples;
@@ -293,6 +294,8 @@ public class CodegenOperation {
             return false;
         if (isDeprecated != that.isDeprecated)
             return false;
+        if (isCallbackRequest != that.isCallbackRequest)
+            return false;
         if (path != null ? !path.equals(that.path) : that.path != null)
             return false;
         if (operationId != null ? !operationId.equals(that.operationId) : that.operationId != null)
@@ -347,6 +350,8 @@ public class CodegenOperation {
             return false;
         if (responses != null ? !responses.equals(that.responses) : that.responses != null)
             return false;
+        if (callbacks != null ? !callbacks.equals(that.callbacks) : that.callbacks != null)
+            return false;
         if (imports != null ? !imports.equals(that.imports) : that.imports != null)
             return false;
         if (examples != null ? !examples.equals(that.examples) : that.examples != null)
@@ -386,6 +391,7 @@ public class CodegenOperation {
         result = 31 * result + (isResponseFile ? 13:31);
         result = 31 * result + (hasReference ? 13:31);
         result = 31 * result + (isDeprecated ? 13:31);
+        result = 31 * result + (isCallbackRequest ? 13:31);
         result = 31 * result + (path != null ? path.hashCode() : 0);
         result = 31 * result + (operationId != null ? operationId.hashCode() : 0);
         result = 31 * result + (returnType != null ? returnType.hashCode() : 0);
@@ -413,6 +419,7 @@ public class CodegenOperation {
         result = 31 * result + (authMethods != null ? authMethods.hashCode() : 0);
         result = 31 * result + (tags != null ? tags.hashCode() : 0);
         result = 31 * result + (responses != null ? responses.hashCode() : 0);
+        result = 31 * result + (callbacks != null ? callbacks.hashCode() : 0);
         result = 31 * result + (imports != null ? imports.hashCode() : 0);
         result = 31 * result + (examples != null ? examples.hashCode() : 0);
         result = 31 * result + (externalDocs != null ? externalDocs.hashCode() : 0);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -38,12 +38,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class DefaultCodegenTest {
@@ -443,19 +438,20 @@ public class DefaultCodegenTest {
 
         urlA.requests.forEach(req -> {
             Assert.assertTrue(req.isCallbackRequest);
-            Assert.assertNull(req.operationId);
             Assert.assertNotNull(req.bodyParam);
             Assert.assertEquals(req.responses.size(), 2);
 
-            switch (req.httpMethod.toLowerCase()) {
+            switch (req.httpMethod.toLowerCase(Locale.getDefault())) {
             case "post":
+                Assert.assertEquals(req.operationId, "onDataDataPost");
                 Assert.assertEquals(req.bodyParam.dataType, "NewNotificationData");
                 break;
             case "delete":
+                Assert.assertEquals(req.operationId, "onDataDataDelete");
                 Assert.assertEquals(req.bodyParam.dataType, "DeleteNotificationData");
                 break;
             default:
-                Assert.fail(String.format("invalid callback request http method '%s'", req.httpMethod));
+                Assert.fail(String.format(Locale.getDefault(), "invalid callback request http method '%s'", req.httpMethod));
             }
         });
     }

--- a/modules/openapi-generator/src/test/resources/3_0/callbacks.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/callbacks.yaml
@@ -1,0 +1,85 @@
+openapi: 3.0.0
+info:
+  title: Callback Example
+  version: 1.0.0
+paths:
+  /streams:
+    post:
+      description: subscribes a client to receive out-of-band data
+      parameters:
+        - name: callbackUrl
+          in: query
+          required: true
+          description: |
+            the location where data will be sent.  Must be network accessible
+            by the source server
+          schema:
+            type: string
+            format: uri
+            example: https://tonys-server.com
+      responses:
+        '201':
+          description: subscription successfully created
+          content:
+            application/json:
+              schema:
+                description: subscription information
+                required:
+                  - subscriptionId
+                properties:
+                  subscriptionId:
+                    description: this unique identifier allows management of the subscription
+                    type: string
+                    example: 2531329f-fb09-4ef7-887e-84e648214436
+      callbacks:
+        onData:
+          '{$request.query.callbackUrl}/data':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/NewNotificationData'
+              responses:
+                '202':
+                  description: |
+                    Your server implementation should return this HTTP status code
+                    if the data was received successfully
+                '204':
+                  description: |
+                    Your server should return this HTTP status code if no longer interested
+                    in further updates
+            delete:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/DeleteNotificationData'
+              responses:
+                '202':
+                  description: |
+                    Your server implementation should return this HTTP status code
+                    if the data was received successfully
+                '204':
+                  description: |
+                    Your server should return this HTTP status code if no longer interested
+                    in further updates
+          '{$request.query.callbackUrl}/test': {}
+        dummy: {}
+
+components:
+  schemas:
+    NewNotificationData:
+      description: subscription payload
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        userData:
+          type: string
+    DeleteNotificationData:
+      description: subscription payload
+      properties:
+        timestamp:
+          type: string
+          format: date-time


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This adds a new `CodegenCallback` class, a list of which is now present in `CodegenOperation`. `CodegenOperation` now also includes a `isCallbackRequest` boolean since `fromCallback()` (the method added to `DefaultCodegen` to process callbacks in OpenAPI operations) uses CodegenOperation as the model for a callback request.

A `CodegenOperation` which represents a callback request will have a `null` operation id.

A test is included for this new model.

(See #372)