### PR TITLE
:memo: Remove swagger comment, fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ export PATH=${JAVA_HOME}/bin:$PATH
 
 ### Launcher Script
 
-One downside to manual jar downloads is that you don't keep up-to-date with the latest released version. We have a Bash launcher script at [bin/utils/openapi-generator.cli.sh](./bin/utils/openapi-generator.cli.sh) which resolves this issue.
+One downside to manual jar downloads is that you don't keep up-to-date with the latest released version. We have a Bash launcher script at [bin/utils/openapi-generator.cli.sh](./bin/utils/openapi-generator-cli.sh) which resolves this issue.
 
 To install the launcher script, copy the contents of the script to a location on your path and make the script executable.
 

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -475,7 +475,7 @@ $ ./gradlew openApiValidate --input=/Users/jim/projects/openapi-generator/module
 If you want to perform multiple generation tasks, you'd want to create a task that inherits from the `GenerateTask`.
 Examples can be found in https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle[samples/local-spec/build.gradle].
 
-To match the example you are using for that old swagger based plugin:
+You can define any number of generator tasks; the generated code does _not_ need to be a JVM language.
 
 ```gradle
 task buildGoClient(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask){
@@ -517,8 +517,8 @@ If you want to simplify the execution, you could create a new task with `depends
 task codegen(dependsOn: ['buildGoClient', 'buildKotlinClient'])
 ```
 
-Or, if you're generating the code on compile, you can add these as a dependency to `compileJava` or any other existing task:
-
+Or, if you're generating the code on compile, you can add these as a dependency to `compileJava` or any other existing task.
+You can also mix the default task `openApiGenerate` with custom tasks:
 
 ```gradle
 compileJava.dependsOn buildKotlinClient, tasks.openApiGenerate


### PR DESCRIPTION
I had previously copied the multi-task description in the gradle
plugin's docs from a response made in an issue. The reference to 'the
old swagger plugin' have no context in the gradle plugin README, so I've
updated that wording.

Also, I found that the link to openapi-generator-cli.sh in the root
README was broken. It pointed to openapi-generator.cli.sh instead of
openapi-generator-cli.sh.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
