### PR TITLE
[DefaultGenerator] Consider referenced headers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -506,8 +506,8 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public CodegenResponse fromResponse(String responseCode, ApiResponse resp) {
-        final CodegenResponse response = super.fromResponse(responseCode, resp);
+    public CodegenResponse fromResponse(OpenAPI openAPI, String responseCode, ApiResponse resp) {
+        final CodegenResponse response = super.fromResponse(openAPI, responseCode, resp);
         if (response.dataType != null) {
             addEncoderAndDecoder(response.vendorExtensions, response.dataType, response.isMapContainer, response.primitiveType);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -20,6 +20,7 @@ package org.openapitools.codegen.utils;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BinarySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
@@ -670,4 +671,25 @@ public class ModelUtils {
         return null;
     }
 
+    public static Header getReferencedHeader(OpenAPI openAPI, Header header) {
+        if (header != null && StringUtils.isNotEmpty(header.get$ref())) {
+            String name = getSimpleRef(header.get$ref());
+            Header referencedheader = getHeader(openAPI, name);
+            if (referencedheader != null) {
+                return referencedheader;
+            }
+        }
+        return header;
+    }
+
+    public static Header getHeader(OpenAPI openAPI, String name) {
+        if (name == null) {
+            return null;
+        }
+
+        if (openAPI != null && openAPI.getComponents() != null && openAPI.getComponents().getHeaders() != null) {
+            return openAPI.getComponents().getHeaders().get(name);
+        }
+        return null;
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -31,18 +31,12 @@ import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenParameter;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.MockDefaultGenerator;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.MockDefaultGenerator.WrittenTemplateBasedFile;
-import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -303,6 +297,20 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(templateBasedFile.getTemplateData().get("classname"), "DefaultApi");
 
         output.deleteOnExit();
+    }
+
+    @Test
+    public void testReferencedHeader() {
+        final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/issue855.yaml", null, new ParseOptions()).getOpenAPI();
+        JavaClientCodegen codegen = new JavaClientCodegen();
+
+        ApiResponse ok_200 = openAPI.getComponents().getResponses().get("OK_200");
+        CodegenResponse response = codegen.fromResponse(openAPI, "200", ok_200);
+
+        Assert.assertEquals(1, response.headers.size());
+        CodegenProperty header = response.headers.get(0);
+        Assert.assertEquals("UUID", header.dataType);
+        Assert.assertEquals("Request", header.baseName);
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/issue855.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue855.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.1
+info:
+  title: Issue 855 example
+  version: 1.0.0
+components:
+  headers:
+    Request:
+      description: ID of the request, unique to the call, as determined by the initiating party.
+      required: true
+      example: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
+      schema:
+        type: string
+        format: uuid
+
+  responses:
+    OK_200:
+      description: OK
+      headers:
+        Request:
+          $ref: "#/components/headers/Request"
+
+paths:
+  /ping:
+    get:
+      summary: Get Payment Information
+      description: Returns the content of a payment object
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200"


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

ping @jmini for fix issue #855

### Description of the PR

Fix for an unimplemented part of OAS 3: $ref were not followed in the case of headers, I added some methods in ModelUtils to follow the ref to the /components/headers

