### PR TITLE
Use thread safe manager store dictionary

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift4/AlamofireImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/AlamofireImplementations.mustache
@@ -17,8 +17,37 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
+private struct SynchronizedDictionary<K: Hashable, V> {
+
+     private var dictionary = [K: V]()
+     private let queue = DispatchQueue(
+         label: "SynchronizedDictionary",
+         qos: DispatchQoS.userInitiated,
+         attributes: [DispatchQueue.Attributes.concurrent],
+         autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit,
+         target: nil
+     )
+
+     public subscript(key: K) -> V? {
+         get {
+             var value: V?
+
+             queue.sync {
+                 value = self.dictionary[key]
+             }
+
+             return value
+         }
+         set {
+             queue.sync(flags: DispatchWorkItemFlags.barrier) {
+                 self.dictionary[key] = newValue
+             }
+         }
+     }
+ }
+
 // Store manager to retain its reference
-private var managerStore: [String: Alamofire.SessionManager] = [:]
+private var managerStore = SynchronizedDictionary<String, Alamofire.SessionManager>()
 
 open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
     required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
@@ -112,7 +141,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()
@@ -314,7 +343,7 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/AlamofireImplementations.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/AlamofireImplementations.swift
@@ -17,8 +17,37 @@ class AlamofireRequestBuilderFactory: RequestBuilderFactory {
     }
 }
 
+private struct SynchronizedDictionary<K: Hashable, V> {
+
+     private var dictionary = [K: V]()
+     private let queue = DispatchQueue(
+         label: "SynchronizedDictionary",
+         qos: DispatchQoS.userInitiated,
+         attributes: [DispatchQueue.Attributes.concurrent],
+         autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency.inherit,
+         target: nil
+     )
+
+     public subscript(key: K) -> V? {
+         get {
+             var value: V?
+
+             queue.sync {
+                 value = self.dictionary[key]
+             }
+
+             return value
+         }
+         set {
+             queue.sync(flags: DispatchWorkItemFlags.barrier) {
+                 self.dictionary[key] = newValue
+             }
+         }
+     }
+ }
+
 // Store manager to retain its reference
-private var managerStore: [String: Alamofire.SessionManager] = [:]
+private var managerStore = SynchronizedDictionary<String, Alamofire.SessionManager>()
 
 open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
     required public init(method: String, URLString: String, parameters: [String : Any]?, isBody: Bool, headers: [String : String] = [:]) {
@@ -112,7 +141,7 @@ open class AlamofireRequestBuilder<T>: RequestBuilder<T> {
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()
@@ -314,7 +343,7 @@ open class AlamofireDecodableRequestBuilder<T:Decodable>: AlamofireRequestBuilde
         }
 
         let cleanupRequest = {
-            _ = managerStore.removeValue(forKey: managerId)
+            managerStore[managerId] = nil
         }
 
         let validatedRequest = request.validate()


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use thread safe manager store dictionary
Fix crash due to concurrent access of managerStore dictionary.
Swift2 and Swift3 had been enhanced respectively with the following
pull requests: #3873 #5610