### PR TITLE
[build] create jar without version in openapi-generator-online

### DIFF
--- a/.hub.online.dockerfile
+++ b/.hub.online.dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p ${TARGET_DIR}
 
 WORKDIR ${TARGET_DIR}
 
-COPY --from=builder ${GEN_DIR}/modules/openapi-generator-online/target/openapi-generator-*.jar ${TARGET_DIR}/openapi-generator-online.jar
+COPY --from=builder ${GEN_DIR}/modules/openapi-generator-online/target/openapi-generator.jar ${TARGET_DIR}/openapi-generator-online.jar
 
 ENV GENERATOR_HOST=http://localhost
 

--- a/bin/utils/release_version_update.sh
+++ b/bin/utils/release_version_update.sh
@@ -45,7 +45,6 @@ declare -a files=("CI/pom.xml.bash"
                   "modules/openapi-generator-maven-plugin/pom.xml"
                   "modules/openapi-generator-online/pom.xml"
                   "modules/openapi-generator/pom.xml"
-                  "modules/openapi-generator-online/Dockerfile"
                   "pom.xml")
 
 for filename in "${files[@]}"; do

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jre-alpine
 
 WORKDIR /generator
 
-COPY target/openapi-generator-online-3.2.3-SNAPSHOT.jar /generator/openapi-generator-online.jar
+COPY target/openapi-generator-online.jar /generator/openapi-generator-online.jar
 
 ENV GENERATOR_HOST=http://localhost
 

--- a/modules/openapi-generator-online/pom.xml
+++ b/modules/openapi-generator-online/pom.xml
@@ -27,6 +27,7 @@
         </dependencies>
     </dependencyManagement>
     <build>
+        <finalName>openapi-generator-online</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>


### PR DESCRIPTION
Instead of:
```
modules/openapi-generator-online/target/openapi-generator-online-3.2.3-SNAPSHOT.jar
```

The `openapi-generator-online` artifact is locally generated at:
```
modules/openapi-generator-online/target/openapi-generator-online.jar
```

This is much simpler for other scripts and Dockerfiles, relying on this jar.

---

This way we are consistent with the `openapi-generator-cli` artifact.


