### PR TITLE
Fix Elm CI issue due to new version (0.19) installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y -v
   # required when sudo: required for the Ruby petstore tests
   - gem install bundler
+  - gem environment
   - npm install -g typescript
   - npm install -g npm
   - npm install -g elm@0.18.0-exp5

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ cache:
   - $HOME/.cargo
   - $HOME/.stack
   - $HOME/samples/server/petstore/cpp-pistache/pistache
+  - $HOME/.npm  
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
   - gem install bundler
   - npm install -g typescript
   - npm install -g npm
-  - npm install -g elm
+  - npm install -g elm@0.18.0-exp5
   - npm config set registry http://registry.npmjs.org/
   # set python 3.6.3 as default
   - source ~/virtualenv/python3.6/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ cache:
   - $HOME/.stack
   - $HOME/samples/server/petstore/cpp-pistache/pistache
   - $HOME/.npm  
+  - $HOME/.rvm/gems/ruby-2.4.1
 
 services:
   - docker
@@ -56,7 +57,6 @@ before_install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y -v
   # required when sudo: required for the Ruby petstore tests
   - gem install bundler
-  - gem environment
   - npm install -g typescript
   - npm install -g npm
   - npm install -g elm@0.18.0-exp5

--- a/samples/client/petstore/elm/elm-compile-test
+++ b/samples/client/petstore/elm/elm-compile-test
@@ -4,8 +4,7 @@
 for ELM in `find src -name "*.elm"`
 do
     echo "Compiling $ELM"
-    elm make --help
-    elm make $ELM --yes --output /dev/null
+    elm make $ELM --output /dev/null
     rc=$?
     if [[ $rc != 0 ]]
     then

--- a/samples/client/petstore/elm/elm-compile-test
+++ b/samples/client/petstore/elm/elm-compile-test
@@ -4,7 +4,7 @@
 for ELM in `find src -name "*.elm"`
 do
     echo "Compiling $ELM"
-    elm make $ELM --output /dev/null
+    elm make $ELM --output /dev/null --yes
     rc=$?
     if [[ $rc != 0 ]]
     then

--- a/samples/client/petstore/elm/elm-compile-test
+++ b/samples/client/petstore/elm/elm-compile-test
@@ -4,7 +4,8 @@
 for ELM in `find src -name "*.elm"`
 do
     echo "Compiling $ELM"
-    elm make $ELM --output /dev/null --yes
+    elm make --help
+    elm make $ELM --yes --output /dev/null
     rc=$?
     if [[ $rc != 0 ]]
     then


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- hardcoded elm installation to v0.18
- add cache directories (npm, gem) (not related to the issue, simply for CI build performance)
