### PR TITLE
Add support for Api key in cookie for Symfony

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
@@ -87,6 +87,10 @@ class {{controllerName}} extends Controller
         // Set key with prefix in query string
         $security{{name}} = $request->query->get('{{keyParamName}}');
         {{/isKeyInQuery}}
+        {{#isKeyInCookie}}
+        // Set key with prefix in cookies
+        $security{{name}} = $request->cookies->get('{{keyParamName}}');
+        {{/isKeyInCookie}}
         {{/isApiKey}}
         {{#isBasic}}
         // HTTP basic authentication required


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for #875

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko

Related, but not entirely sure if I need to regenerate something for the samples. I found how to build sample of v3, yet, it does not seem something that needs to be done in changeset. @wing328 can you advise me on this please?
