### PR TITLE
[Java][Webclient] Init authentication on ApiClient instanciation

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -86,8 +86,9 @@ public class ApiClient {
 
 
     public ApiClient() {
-        this.dateFormat = createDefaultDateFormat();
-        this.webClient = buildWebClient(new ObjectMapper(), this.dateFormat);
+        DateFormat dateFormat = createDefaultDateFormat();
+        
+        this(buildWebClient(new ObjectMapper(), dateFormat), dateFormat);
     }
 
     public ApiClient(ObjectMapper mapper, DateFormat format) {
@@ -97,6 +98,8 @@ public class ApiClient {
     private ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
+
+        init();
     }
 
     public DateFormat createDefaultDateFormat() {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -87,7 +87,7 @@ public class ApiClient {
 
     public ApiClient() {
         DateFormat dateFormat = createDefaultDateFormat();
-        
+
         this(buildWebClient(new ObjectMapper(), dateFormat), dateFormat);
     }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -86,8 +86,9 @@ public class ApiClient {
 
 
     public ApiClient() {
-        this.dateFormat = createDefaultDateFormat();
-        this.webClient = buildWebClient(new ObjectMapper(), this.dateFormat);
+        DateFormat dateFormat = createDefaultDateFormat();
+        
+        this(buildWebClient(new ObjectMapper(), dateFormat), dateFormat);
     }
 
     public ApiClient(ObjectMapper mapper, DateFormat format) {
@@ -97,6 +98,8 @@ public class ApiClient {
     private ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
+
+        init();
     }
 
     public DateFormat createDefaultDateFormat() {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR
Fixes #872 .

I changed ApiClient() declaration for DRY.

Testing is being discussed in #689 

