### PR TITLE
RFC: [go] define "any-type" schema as an empty interface in generated go code.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -83,7 +83,9 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                         "complex64",
                         "complex128",
                         "rune",
-                        "byte")
+                        "byte",
+                        "interface{}"
+                        )
         );
 
         instantiationTypes.clear();
@@ -298,12 +300,19 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
         if (ref != null && !ref.isEmpty()) {
             type = openAPIType;
-        } else if (typeMapping.containsKey(openAPIType)) {
-            type = typeMapping.get(openAPIType);
-            if (languageSpecificPrimitives.contains(type))
-                return (type);
-        } else
-            type = openAPIType;
+        } else {
+            // Handle "any type" as an empty interface
+            if (openAPIType == "object" && p != null && !ModelUtils.isObjectSchema(p) && !ModelUtils.isMapSchema(p)) {
+                return "interface{}";
+            }
+
+            if (typeMapping.containsKey(openAPIType)) {
+                type = typeMapping.get(openAPIType);
+                if (languageSpecificPrimitives.contains(type))
+                    return (type);
+            } else
+                type = openAPIType;
+        }
         return type;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -302,7 +302,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             type = openAPIType;
         } else {
             // Handle "any type" as an empty interface
-            if (openAPIType == "object" && p != null && !ModelUtils.isObjectSchema(p) && !ModelUtils.isMapSchema(p)) {
+            if (openAPIType.equals("object") && p != null && !ModelUtils.isObjectSchema(p) && !ModelUtils.isMapSchema(p)) {
                 return "interface{}";
             }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -47,15 +47,17 @@ public class GoModelTest {
                 .addProperties("id", new IntegerSchema().format(SchemaTypeUtil.INTEGER64_FORMAT))
                 .addProperties("name", new StringSchema())
                 .addProperties("createdAt", new DateTimeSchema())
+                .addProperties("anyValue", new Schema())
                 .addRequiredItem("id")
-                .addRequiredItem("name");
+                .addRequiredItem("name")
+                .addRequiredItem("anyValue");
         final DefaultCodegen codegen = new GoClientCodegen();
         final CodegenModel cm = codegen.fromModel("sample", model, Collections.singletonMap("sample", model));
 
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.description, "a sample model");
-        Assert.assertEquals(cm.vars.size(), 3);
+        Assert.assertEquals(cm.vars.size(), 4);
         Assert.assertEquals(cm.imports.size(), 1);
 
         final CodegenProperty property1 = cm.vars.get(0);
@@ -85,9 +87,20 @@ public class GoModelTest {
         Assert.assertEquals(property3.name, "CreatedAt");
         Assert.assertNull(property3.defaultValue);
         Assert.assertEquals(property3.baseType, "time.Time");
-        Assert.assertFalse(property3.hasMore);
+        Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
+
+        final CodegenProperty property4 = cm.vars.get(3);
+        Assert.assertEquals(property4.baseName, "anyValue");
+        Assert.assertEquals(property4.baseType, "interface{}");
+        Assert.assertEquals(property4.dataType, "interface{}");
+        Assert.assertTrue(property1.isPrimitiveType);
+        Assert.assertEquals(property4.name, "AnyValue");
+        Assert.assertNull(property4.defaultValue);
+        Assert.assertFalse(property4.hasMore);
+        Assert.assertTrue(property4.required);
     }
+
 
     @Test(description = "convert a model with list property")
     public void listPropertyTest() {


### PR DESCRIPTION
I could use some advice on this one.  The fix for https://github.com/OpenAPITools/openapi-generator/issues/51 (PR https://github.com/OpenAPITools/openapi-generator/pull/60) broke our use of the go generator because it now assumes unspecified (i.e. "any-type") schemas will be `map[string]interface{}` instead of `*interface{}`.  This change tries to restore the empty interface, albeit as `interface{}` instead of `*interface{}`.  I'm not sure what the intent of using a pointer to an interface was in the original code but maybe that would be preferred .  This code does not change the generated petshop code (but maybe petshop should be updated to include an "any-type" schema).

The "any-type" schema is mentioned at https://swagger.io/docs/specification/data-models/data-types/ which claims to be a guide to openapi 3.0, but I don't see it mentioned by name in the "open-api" spec.

Thanks for your help and for keeping this project moving forward.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

