### PR TITLE
Create override for array schema default value when using the spring …

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -21,6 +21,7 @@ import com.samskivert.mustache.Mustache;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
@@ -34,6 +35,7 @@ import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.OptionalFeatures;
+import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.URLPathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,6 +131,14 @@ public class SpringCodegen extends AbstractJavaCodegen
         library.setDefault(SPRING_BOOT);
         library.setEnum(supportedLibraries);
         cliOptions.add(library);
+    }
+
+    @Override
+    public String toDefaultValue(Schema schema) {
+        if (ModelUtils.isArraySchema(schema) && schema.getDefault() != null) {
+            return schema.getDefault().toString();
+        }
+        return super.toDefaultValue(schema);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -19,6 +19,8 @@ package org.openapitools.codegen.java.spring;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
 
 import org.openapitools.codegen.CodegenConstants;
@@ -110,5 +112,17 @@ public class SpringCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(SpringCodegen.CONFIG_PACKAGE), "xyz.yyyyy.cccc.config");
         Assert.assertEquals(codegen.additionalProperties().get(SpringCodegen.TITLE), "someTest");
         Assert.assertEquals(codegen.additionalProperties().get(SpringCodegen.SERVER_PORT), "8088");
+    }
+
+    @Test
+    public void testArraySchemaDefaultValue() {
+        final SpringCodegen codegen = new SpringCodegen();
+
+        String schemaDefaultValue = "elem1,elem2,elem3";
+        Schema schema = new ArraySchema();
+        schema.setDefault(schemaDefaultValue);
+        String result = codegen.toDefaultValue(schema);
+
+        Assert.assertEquals(result, schemaDefaultValue);
     }
 }


### PR DESCRIPTION
…codegen.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] @bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger

### Description of the PR

Fix #890

### Note

There is an issue with the swagger-parser (https://github.com/swagger-api/swagger-parser/issues/814) where an empty string for the default field is parsed as null. This fix won't achieve the desired effect until that issue is resolved and released.

