### PR TITLE
[Slim] Add PHP CodeSniffer to check coding style

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -35,8 +35,11 @@ import java.util.Map;
 public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(PhpSlimServerCodegen.class);
 
+    public static final String PHPCS_STANDARD = "phpcsStandard";
+
     protected String groupId = "org.openapitools";
     protected String artifactId = "openapi-server";
+    protected String phpcsStandard = "PSR12";
 
     public PhpSlimServerCodegen() {
         super();
@@ -70,6 +73,9 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
                 break;
             }
         }
+
+        cliOptions.add(new CliOption(PHPCS_STANDARD, "PHP CodeSniffer <standard> option. Accepts name or path of the coding standard to use.")
+                .defaultValue("PSR12"));
     }
 
     @Override
@@ -109,6 +115,12 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     public void processOpts() {
         super.processOpts();
 
+        if (additionalProperties.containsKey(PHPCS_STANDARD)) {
+            this.setPhpcsStandard((String) additionalProperties.get(PHPCS_STANDARD));
+        } else {
+            additionalProperties.put(PHPCS_STANDARD, phpcsStandard);
+        }
+
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("composer.mustache", "", "composer.json"));
         supportingFiles.add(new SupportingFile("index.mustache", "", "index.php"));
@@ -146,6 +158,10 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
             });
         }
         return objs;
+    }
+
+    public void setPhpcsStandard(String phpcsStandard) {
+        this.phpcsStandard = phpcsStandard;
     }
 
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/AbstractApiController.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/AbstractApiController.mustache
@@ -44,7 +44,8 @@ namespace {{invokerPackage}};
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-abstract class AbstractApiController {
+abstract class AbstractApiController
+{
 
     /**
      * @var \Interop\Container\ContainerInterface Slim app container instance
@@ -56,8 +57,8 @@ abstract class AbstractApiController {
      *
      * @param \Interop\Container\ContainerInterface $container Slim app container instance
      */
-    public function __construct($container) {
+    public function __construct($container)
+    {
         $this->container = $container;
     }
-
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/README.mustache
@@ -30,15 +30,17 @@ $ php -S localhost:8888 -t php-slim-server
 
 ## Run tests
 
-This package uses PHPUnit 4.8 for unit testing.
+This package uses PHPUnit 4.8 for unit testing and PHP Codesniffer to check source code against user defined coding standard(`phpcsStandard` generator config option).
 [Test folder]({{testBasePath}}) contains templates which you can fill with real test assertions.
 How to write tests read at [PHPUnit Manual - Chapter 2. Writing Tests for PHPUnit](https://phpunit.de/manual/4.8/en/writing-tests-for-phpunit.html).
+How to configure PHP CodeSniffer read at [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
 
 Command | Tool | Target
 ---- | ---- | ----
 `$ composer test` | PHPUnit | All tests
 `$ composer run test-apis` | PHPUnit | Apis tests
 `$ composer run test-models` | PHPUnit | Models tests
+`$ composer run phpcs` | PHP CodeSniffer | All files
 
 {{#generateApiDocs}}
 ## API Endpoints

--- a/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
@@ -10,7 +10,7 @@
  * @link     https://github.com/openapitools/openapi-generator
  */
 
-/**{{#apiInfo}}{{#appName}} 
+/**{{#apiInfo}}{{#appName}}
  * {{{appName}}}
  *
  {{/appName}}
@@ -51,7 +51,8 @@ use Tuupola\Middleware\HttpBasicAuthentication;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class SlimRouter {
+class SlimRouter
+{
 
     /**
      * @var $slimApp Slim\App instance
@@ -64,7 +65,8 @@ class SlimRouter {
      * @param ContainerInterface|array $container Either a ContainerInterface or an associative array of app settings
      * @throws InvalidArgumentException when no container is provided that implements ContainerInterface
      */
-    public function __construct($container = []) {
+    public function __construct($container = [])
+    {
         $app = new App($container);
 
         $basicAuth = new HttpBasicAuthentication([
@@ -80,7 +82,8 @@ class SlimRouter {
         {{#operations}}
         {{#operation}}
         $app->{{httpMethod}}(
-            '{{{basePathWithoutHost}}}{{{path}}}', {{classname}}::class . ':{{operationId}}'
+            '{{{basePathWithoutHost}}}{{{path}}}',
+            {{classname}}::class . ':{{operationId}}'
 {{#hasAuthMethods}}
 {{#authMethods}}
 {{#isBasic}}
@@ -101,7 +104,8 @@ class SlimRouter {
      * Returns Slim Framework instance
      * @return App
      */
-    public function getSlimApp() {
+    public function getSlimApp()
+    {
         return $this->slimApp;
     }
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/api.mustache
@@ -46,14 +46,19 @@ use {{invokerPackage}}\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class {{classname}} extends AbstractApiController {
-
+class {{classname}} extends AbstractApiController
+{
     {{#operations}}
     {{#operation}}
+    
     /**
      * {{httpMethod}} {{operationId}}
+     {{#summary}}
      * Summary: {{summary}}
+     {{/summary}}
+     {{#notes}}
      * Notes: {{notes}}
+     {{/notes}}
      {{#hasProduces}}
      * Output-Formats: [{{#produces}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/produces}}]
      {{/hasProduces}}
@@ -62,7 +67,8 @@ class {{classname}} extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function {{operationId}}($request, $response, $args) {
+    public function {{operationId}}($request, $response, $args)
+    {
         {{#hasHeaderParams}}
         $headers = $request->getHeaders();
         {{#headerParams}}
@@ -96,7 +102,6 @@ class {{classname}} extends AbstractApiController {
         $response->write('How about implementing {{nickname}} as a {{httpMethod}} method ?');
         return $response;
     }
-    {{#hasMore}}{{/hasMore}}
     {{/operation}}
     {{/operations}}
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/api_test.mustache
@@ -45,34 +45,35 @@ use {{apiPackage}}\{{classname}};
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \{{modelPackage}}\{{classname}}
  */
-{{#operations}}class {{classname}}Test extends \PHPUnit_Framework_TestCase {
+{{#operations}}class {{classname}}Test extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
     {{#operation}}
 
@@ -82,8 +83,8 @@ use {{apiPackage}}\{{classname}};
      * {{{summary}}}.
      * @covers ::{{{operationId}}}
      */
-    public function test{{operationIdCamelCase}}() {
-
+    public function test{{operationIdCamelCase}}()
+    {
     }
     {{/operation}}
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/composer.mustache
@@ -22,6 +22,6 @@
     ],
     "test-apis": "phpunit --testsuite Apis",
     "test-models": "phpunit --testsuite Models",
-    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0"
+    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0 --standard={{phpcsStandard}}"
   }
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/composer.mustache
@@ -6,7 +6,8 @@
     "tuupola/slim-basic-auth": "^3.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8",
+    "squizlabs/php_codesniffer": "^3.0"
   },
   "autoload": {
     "psr-4": { "{{escapedInvokerPackage}}\\": "{{srcBasePath}}/" }
@@ -20,6 +21,7 @@
       "@test-models"
     ],
     "test-apis": "phpunit --testsuite Apis",
-    "test-models": "phpunit --testsuite Models"
+    "test-models": "phpunit --testsuite Models",
+    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0"
   }
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model.mustache
@@ -7,12 +7,12 @@ namespace {{modelPackage}};
 /**
  * {{classname}}
  */
-class {{classname}} {
-
+class {{classname}}
+{
     {{#vars}}
+    
     /** @var {{dataType}} ${{name}} {{#description}}{{description}}{{/description}}*/
     private ${{name}};
-
     {{/vars}}
 }
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/php-slim-server/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/model_test.mustache
@@ -47,40 +47,42 @@ use {{modelPackage}}\{{classname}};
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \{{modelPackage}}\{{classname}}
  */
-class {{classname}}Test extends \PHPUnit_Framework_TestCase {
+class {{classname}}Test extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "{{classname}}"
      */
-    public function test{{classname}}() {
+    public function test{{classname}}()
+    {
         $test{{classname}} = new {{classname}}();
     }
 {{#vars}}
@@ -88,8 +90,8 @@ class {{classname}}Test extends \PHPUnit_Framework_TestCase {
     /**
      * Test attribute "{{name}}"
      */
-    public function testProperty{{nameInCamelCase}}() {
-
+    public function testProperty{{nameInCamelCase}}()
+    {
     }
 {{/vars}}
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
@@ -19,6 +19,7 @@ package org.openapitools.codegen.options;
 
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
+import org.openapitools.codegen.languages.PhpSlimServerCodegen;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -38,6 +39,7 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
+    public static final String PHPCS_STANDARD_VALUE = "PSR12";
 
     @Override
     public String getLanguage() {
@@ -60,6 +62,7 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
+                .put(PhpSlimServerCodegen.PHPCS_STANDARD, PHPCS_STANDARD_VALUE)
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
@@ -63,6 +63,8 @@ public class PhpSlimServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlimServerOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
+            clientCodegen.setPhpcsStandard(PhpSlimServerOptionsProvider.PHPCS_STANDARD_VALUE);
+            times = 1;
         }};
     }
 }

--- a/samples/server/petstore-security-test/php-slim/README.md
+++ b/samples/server/petstore-security-test/php-slim/README.md
@@ -30,15 +30,17 @@ $ php -S localhost:8888 -t php-slim-server
 
 ## Run tests
 
-This package uses PHPUnit 4.8 for unit testing.
+This package uses PHPUnit 4.8 for unit testing and PHP Codesniffer to check source code against user defined coding standard(`phpcsStandard` generator config option).
 [Test folder](test) contains templates which you can fill with real test assertions.
 How to write tests read at [PHPUnit Manual - Chapter 2. Writing Tests for PHPUnit](https://phpunit.de/manual/4.8/en/writing-tests-for-phpunit.html).
+How to configure PHP CodeSniffer read at [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
 
 Command | Tool | Target
 ---- | ---- | ----
 `$ composer test` | PHPUnit | All tests
 `$ composer run test-apis` | PHPUnit | Apis tests
 `$ composer run test-models` | PHPUnit | Models tests
+`$ composer run phpcs` | PHP CodeSniffer | All files
 
 ## API Endpoints
 

--- a/samples/server/petstore-security-test/php-slim/composer.json
+++ b/samples/server/petstore-security-test/php-slim/composer.json
@@ -6,7 +6,8 @@
     "tuupola/slim-basic-auth": "^3.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8",
+    "squizlabs/php_codesniffer": "^3.0"
   },
   "autoload": {
     "psr-4": { "OpenAPIServer\\": "lib/" }
@@ -20,6 +21,7 @@
       "@test-models"
     ],
     "test-apis": "phpunit --testsuite Apis",
-    "test-models": "phpunit --testsuite Models"
+    "test-models": "phpunit --testsuite Models",
+    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0 --standard=PSR12"
   }
 }

--- a/samples/server/petstore-security-test/php-slim/lib/AbstractApiController.php
+++ b/samples/server/petstore-security-test/php-slim/lib/AbstractApiController.php
@@ -36,7 +36,8 @@ namespace OpenAPIServer;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-abstract class AbstractApiController {
+abstract class AbstractApiController
+{
 
     /**
      * @var \Interop\Container\ContainerInterface Slim app container instance
@@ -48,8 +49,8 @@ abstract class AbstractApiController {
      *
      * @param \Interop\Container\ContainerInterface $container Slim app container instance
      */
-    public function __construct($container) {
+    public function __construct($container)
+    {
         $this->container = $container;
     }
-
 }

--- a/samples/server/petstore-security-test/php-slim/lib/Api/FakeApi.php
+++ b/samples/server/petstore-security-test/php-slim/lib/Api/FakeApi.php
@@ -38,8 +38,9 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class FakeApi extends AbstractApiController {
-
+class FakeApi extends AbstractApiController
+{
+    
     /**
      * PUT testCodeInjectEndRnNR
      * Summary: To test code injection *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r
@@ -49,10 +50,10 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testCodeInjectEndRnNR($request, $response, $args) {
+    public function testCodeInjectEndRnNR($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing testCodeInjectEndRnNR as a PUT method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore-security-test/php-slim/lib/Model/ModelReturn.php
+++ b/samples/server/petstore-security-test/php-slim/lib/Model/ModelReturn.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * ModelReturn
  */
-class ModelReturn {
-
+class ModelReturn
+{
+    
     /** @var int $return property description  *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r*/
     private $return;
-
 }

--- a/samples/server/petstore-security-test/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore-security-test/php-slim/lib/SlimRouter.php
@@ -10,7 +10,7 @@
  * @link     https://github.com/openapitools/openapi-generator
  */
 
-/** 
+/**
  * OpenAPI Petstore *_/ ' \" =end -- \\r\\n \\n \\r
  *
  * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\  *_/ ' \" =end --
@@ -42,7 +42,8 @@ use Tuupola\Middleware\HttpBasicAuthentication;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class SlimRouter {
+class SlimRouter
+{
 
     /**
      * @var $slimApp Slim\App instance
@@ -55,7 +56,8 @@ class SlimRouter {
      * @param ContainerInterface|array $container Either a ContainerInterface or an associative array of app settings
      * @throws InvalidArgumentException when no container is provided that implements ContainerInterface
      */
-    public function __construct($container = []) {
+    public function __construct($container = [])
+    {
         $app = new App($container);
 
         $basicAuth = new HttpBasicAuthentication([
@@ -68,7 +70,8 @@ class SlimRouter {
         ]);
 
         $app->PUT(
-            '/ ' \" =end -- \\r\\n \\n \\r/v2 *_/ ' \" =end -- \\r\\n \\n \\r/fake', FakeApi::class . ':testCodeInjectEndRnNR'
+            '/ ' \" =end -- \\r\\n \\n \\r/v2 *_/ ' \" =end -- \\r\\n \\n \\r/fake',
+            FakeApi::class . ':testCodeInjectEndRnNR'
         );
 
         $this->slimApp = $app;
@@ -78,7 +81,8 @@ class SlimRouter {
      * Returns Slim Framework instance
      * @return App
      */
-    public function getSlimApp() {
+    public function getSlimApp()
+    {
         return $this->slimApp;
     }
 }

--- a/samples/server/petstore-security-test/php-slim/test/Api/FakeApiTest.php
+++ b/samples/server/petstore-security-test/php-slim/test/Api/FakeApiTest.php
@@ -37,34 +37,35 @@ use OpenAPIServer\Api\FakeApi;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\FakeApi
  */
-class FakeApiTest extends \PHPUnit_Framework_TestCase {
+class FakeApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
@@ -73,7 +74,7 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * To test code injection *_/ ' \" =end -- \\r\\n \\n \\r.
      * @covers ::testCodeInjectEndRnNR
      */
-    public function testTestCodeInjectEndRnNR() {
-
+    public function testTestCodeInjectEndRnNR()
+    {
     }
 }

--- a/samples/server/petstore-security-test/php-slim/test/Model/ModelReturnTest.php
+++ b/samples/server/petstore-security-test/php-slim/test/Model/ModelReturnTest.php
@@ -37,48 +37,49 @@ use OpenAPIServer\Model\ModelReturn;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ModelReturn
  */
-class ModelReturnTest extends \PHPUnit_Framework_TestCase {
+class ModelReturnTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ModelReturn"
      */
-    public function testModelReturn() {
+    public function testModelReturn()
+    {
         $testModelReturn = new ModelReturn();
     }
 
     /**
      * Test attribute "return"
      */
-    public function testPropertyReturn() {
-
+    public function testPropertyReturn()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/README.md
+++ b/samples/server/petstore/php-slim/README.md
@@ -30,15 +30,17 @@ $ php -S localhost:8888 -t php-slim-server
 
 ## Run tests
 
-This package uses PHPUnit 4.8 for unit testing.
+This package uses PHPUnit 4.8 for unit testing and PHP Codesniffer to check source code against user defined coding standard(`phpcsStandard` generator config option).
 [Test folder](test) contains templates which you can fill with real test assertions.
 How to write tests read at [PHPUnit Manual - Chapter 2. Writing Tests for PHPUnit](https://phpunit.de/manual/4.8/en/writing-tests-for-phpunit.html).
+How to configure PHP CodeSniffer read at [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
 
 Command | Tool | Target
 ---- | ---- | ----
 `$ composer test` | PHPUnit | All tests
 `$ composer run test-apis` | PHPUnit | Apis tests
 `$ composer run test-models` | PHPUnit | Models tests
+`$ composer run phpcs` | PHP CodeSniffer | All files
 
 ## API Endpoints
 

--- a/samples/server/petstore/php-slim/composer.json
+++ b/samples/server/petstore/php-slim/composer.json
@@ -6,7 +6,8 @@
     "tuupola/slim-basic-auth": "^3.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8",
+    "squizlabs/php_codesniffer": "^3.0"
   },
   "autoload": {
     "psr-4": { "OpenAPIServer\\": "lib/" }
@@ -20,6 +21,7 @@
       "@test-models"
     ],
     "test-apis": "phpunit --testsuite Apis",
-    "test-models": "phpunit --testsuite Models"
+    "test-models": "phpunit --testsuite Models",
+    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0 --standard=PSR12"
   }
 }

--- a/samples/server/petstore/php-slim/lib/AbstractApiController.php
+++ b/samples/server/petstore/php-slim/lib/AbstractApiController.php
@@ -35,7 +35,8 @@ namespace OpenAPIServer;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-abstract class AbstractApiController {
+abstract class AbstractApiController
+{
 
     /**
      * @var \Interop\Container\ContainerInterface Slim app container instance
@@ -47,8 +48,8 @@ abstract class AbstractApiController {
      *
      * @param \Interop\Container\ContainerInterface $container Slim app container instance
      */
-    public function __construct($container) {
+    public function __construct($container)
+    {
         $this->container = $container;
     }
-
 }

--- a/samples/server/petstore/php-slim/lib/Api/AnotherFakeApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/AnotherFakeApi.php
@@ -37,8 +37,9 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class AnotherFakeApi extends AbstractApiController {
-
+class AnotherFakeApi extends AbstractApiController
+{
+    
     /**
      * PATCH call123TestSpecialTags
      * Summary: To test special tags
@@ -49,10 +50,10 @@ class AnotherFakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function call123TestSpecialTags($request, $response, $args) {
+    public function call123TestSpecialTags($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing call123TestSpecialTags as a PATCH method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore/php-slim/lib/Api/FakeApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/FakeApi.php
@@ -37,11 +37,11 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class FakeApi extends AbstractApiController {
-
+class FakeApi extends AbstractApiController
+{
+    
     /**
      * POST fakeOuterBooleanSerialize
-     * Summary: 
      * Notes: Test serialization of outer boolean types
      * Output-Formats: [*_/_*]
      *
@@ -49,7 +49,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function fakeOuterBooleanSerialize($request, $response, $args) {
+    public function fakeOuterBooleanSerialize($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing fakeOuterBooleanSerialize as a POST method ?');
         return $response;
@@ -57,7 +58,6 @@ class FakeApi extends AbstractApiController {
     
     /**
      * POST fakeOuterCompositeSerialize
-     * Summary: 
      * Notes: Test serialization of object with outer number type
      * Output-Formats: [*_/_*]
      *
@@ -65,7 +65,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function fakeOuterCompositeSerialize($request, $response, $args) {
+    public function fakeOuterCompositeSerialize($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing fakeOuterCompositeSerialize as a POST method ?');
         return $response;
@@ -73,7 +74,6 @@ class FakeApi extends AbstractApiController {
     
     /**
      * POST fakeOuterNumberSerialize
-     * Summary: 
      * Notes: Test serialization of outer number types
      * Output-Formats: [*_/_*]
      *
@@ -81,7 +81,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function fakeOuterNumberSerialize($request, $response, $args) {
+    public function fakeOuterNumberSerialize($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing fakeOuterNumberSerialize as a POST method ?');
         return $response;
@@ -89,7 +90,6 @@ class FakeApi extends AbstractApiController {
     
     /**
      * POST fakeOuterStringSerialize
-     * Summary: 
      * Notes: Test serialization of outer string types
      * Output-Formats: [*_/_*]
      *
@@ -97,7 +97,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function fakeOuterStringSerialize($request, $response, $args) {
+    public function fakeOuterStringSerialize($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing fakeOuterStringSerialize as a POST method ?');
         return $response;
@@ -105,14 +106,14 @@ class FakeApi extends AbstractApiController {
     
     /**
      * PUT testBodyWithFileSchema
-     * Summary: 
      * Notes: For this test, the body for this request much reference a schema named &#x60;File&#x60;.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testBodyWithFileSchema($request, $response, $args) {
+    public function testBodyWithFileSchema($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing testBodyWithFileSchema as a PUT method ?');
         return $response;
@@ -120,14 +121,13 @@ class FakeApi extends AbstractApiController {
     
     /**
      * PUT testBodyWithQueryParams
-     * Summary: 
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testBodyWithQueryParams($request, $response, $args) {
+    public function testBodyWithQueryParams($request, $response, $args)
+    {
         $queryParams = $request->getQueryParams();
         $query = $request->getQueryParam('query');
         $body = $request->getParsedBody();
@@ -145,7 +145,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testClientModel($request, $response, $args) {
+    public function testClientModel($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing testClientModel as a PATCH method ?');
         return $response;
@@ -160,7 +161,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testEndpointParameters($request, $response, $args) {
+    public function testEndpointParameters($request, $response, $args)
+    {
         $integer = $request->getParsedBodyParam('integer');
         $int32 = $request->getParsedBodyParam('int32');
         $int64 = $request->getParsedBodyParam('int64');
@@ -188,7 +190,8 @@ class FakeApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testEnumParameters($request, $response, $args) {
+    public function testEnumParameters($request, $response, $args)
+    {
         $headers = $request->getHeaders();
         $enumHeaderStringArray = $request->hasHeader('enum_header_string_array') ? $headers['enum_header_string_array'] : null;
         $enumHeaderString = $request->hasHeader('enum_header_string') ? $headers['enum_header_string'] : null;
@@ -206,13 +209,13 @@ class FakeApi extends AbstractApiController {
     /**
      * POST testInlineAdditionalProperties
      * Summary: test inline additionalProperties
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testInlineAdditionalProperties($request, $response, $args) {
+    public function testInlineAdditionalProperties($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing testInlineAdditionalProperties as a POST method ?');
         return $response;
@@ -221,17 +224,16 @@ class FakeApi extends AbstractApiController {
     /**
      * GET testJsonFormData
      * Summary: test json serialization of form data
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testJsonFormData($request, $response, $args) {
+    public function testJsonFormData($request, $response, $args)
+    {
         $param = $request->getParsedBodyParam('param');
         $param2 = $request->getParsedBodyParam('param2');
         $response->write('How about implementing testJsonFormData as a GET method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore/php-slim/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/server/petstore/php-slim/lib/Api/FakeClassnameTags123Api.php
@@ -37,8 +37,9 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class FakeClassnameTags123Api extends AbstractApiController {
-
+class FakeClassnameTags123Api extends AbstractApiController
+{
+    
     /**
      * PATCH testClassname
      * Summary: To test class name in snake case
@@ -49,10 +50,10 @@ class FakeClassnameTags123Api extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function testClassname($request, $response, $args) {
+    public function testClassname($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing testClassname as a PATCH method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore/php-slim/lib/Api/PetApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/PetApi.php
@@ -37,18 +37,19 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class PetApi extends AbstractApiController {
-
+class PetApi extends AbstractApiController
+{
+    
     /**
      * POST addPet
      * Summary: Add a new pet to the store
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function addPet($request, $response, $args) {
+    public function addPet($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing addPet as a POST method ?');
         return $response;
@@ -57,13 +58,13 @@ class PetApi extends AbstractApiController {
     /**
      * DELETE deletePet
      * Summary: Deletes a pet
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function deletePet($request, $response, $args) {
+    public function deletePet($request, $response, $args)
+    {
         $headers = $request->getHeaders();
         $apiKey = $request->hasHeader('api_key') ? $headers['api_key'] : null;
         $petId = $args['petId'];
@@ -81,7 +82,8 @@ class PetApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function findPetsByStatus($request, $response, $args) {
+    public function findPetsByStatus($request, $response, $args)
+    {
         $queryParams = $request->getQueryParams();
         $status = $request->getQueryParam('status');
         $response->write('How about implementing findPetsByStatus as a GET method ?');
@@ -98,7 +100,8 @@ class PetApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function findPetsByTags($request, $response, $args) {
+    public function findPetsByTags($request, $response, $args)
+    {
         $queryParams = $request->getQueryParams();
         $tags = $request->getQueryParam('tags');
         $response->write('How about implementing findPetsByTags as a GET method ?');
@@ -115,7 +118,8 @@ class PetApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function getPetById($request, $response, $args) {
+    public function getPetById($request, $response, $args)
+    {
         $petId = $args['petId'];
         $response->write('How about implementing getPetById as a GET method ?');
         return $response;
@@ -124,13 +128,13 @@ class PetApi extends AbstractApiController {
     /**
      * PUT updatePet
      * Summary: Update an existing pet
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function updatePet($request, $response, $args) {
+    public function updatePet($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing updatePet as a PUT method ?');
         return $response;
@@ -139,13 +143,13 @@ class PetApi extends AbstractApiController {
     /**
      * POST updatePetWithForm
      * Summary: Updates a pet in the store with form data
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function updatePetWithForm($request, $response, $args) {
+    public function updatePetWithForm($request, $response, $args)
+    {
         $petId = $args['petId'];
         $name = $request->getParsedBodyParam('name');
         $status = $request->getParsedBodyParam('status');
@@ -156,14 +160,14 @@ class PetApi extends AbstractApiController {
     /**
      * POST uploadFile
      * Summary: uploads an image
-     * Notes: 
      * Output-Formats: [application/json]
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function uploadFile($request, $response, $args) {
+    public function uploadFile($request, $response, $args)
+    {
         $petId = $args['petId'];
         $additionalMetadata = $request->getParsedBodyParam('additionalMetadata');
         $file = (key_exists('file', $request->getUploadedFiles())) ? $request->getUploadedFiles()['file'] : null;
@@ -174,19 +178,18 @@ class PetApi extends AbstractApiController {
     /**
      * POST uploadFileWithRequiredFile
      * Summary: uploads an image (required)
-     * Notes: 
      * Output-Formats: [application/json]
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function uploadFileWithRequiredFile($request, $response, $args) {
+    public function uploadFileWithRequiredFile($request, $response, $args)
+    {
         $petId = $args['petId'];
         $additionalMetadata = $request->getParsedBodyParam('additionalMetadata');
         $requiredFile = (key_exists('requiredFile', $request->getUploadedFiles())) ? $request->getUploadedFiles()['requiredFile'] : null;
         $response->write('How about implementing uploadFileWithRequiredFile as a POST method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore/php-slim/lib/Api/StoreApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/StoreApi.php
@@ -37,8 +37,9 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class StoreApi extends AbstractApiController {
-
+class StoreApi extends AbstractApiController
+{
+    
     /**
      * DELETE deleteOrder
      * Summary: Delete purchase order by ID
@@ -48,7 +49,8 @@ class StoreApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function deleteOrder($request, $response, $args) {
+    public function deleteOrder($request, $response, $args)
+    {
         $orderId = $args['order_id'];
         $response->write('How about implementing deleteOrder as a DELETE method ?');
         return $response;
@@ -64,7 +66,8 @@ class StoreApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function getInventory($request, $response, $args) {
+    public function getInventory($request, $response, $args)
+    {
         $response->write('How about implementing getInventory as a GET method ?');
         return $response;
     }
@@ -79,7 +82,8 @@ class StoreApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function getOrderById($request, $response, $args) {
+    public function getOrderById($request, $response, $args)
+    {
         $orderId = $args['order_id'];
         $response->write('How about implementing getOrderById as a GET method ?');
         return $response;
@@ -88,17 +92,16 @@ class StoreApi extends AbstractApiController {
     /**
      * POST placeOrder
      * Summary: Place an order for a pet
-     * Notes: 
      * Output-Formats: [application/xml, application/json]
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function placeOrder($request, $response, $args) {
+    public function placeOrder($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing placeOrder as a POST method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore/php-slim/lib/Api/UserApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/UserApi.php
@@ -37,8 +37,9 @@ use OpenAPIServer\AbstractApiController;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class UserApi extends AbstractApiController {
-
+class UserApi extends AbstractApiController
+{
+    
     /**
      * POST createUser
      * Summary: Create user
@@ -48,7 +49,8 @@ class UserApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function createUser($request, $response, $args) {
+    public function createUser($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing createUser as a POST method ?');
         return $response;
@@ -57,13 +59,13 @@ class UserApi extends AbstractApiController {
     /**
      * POST createUsersWithArrayInput
      * Summary: Creates list of users with given input array
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function createUsersWithArrayInput($request, $response, $args) {
+    public function createUsersWithArrayInput($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing createUsersWithArrayInput as a POST method ?');
         return $response;
@@ -72,13 +74,13 @@ class UserApi extends AbstractApiController {
     /**
      * POST createUsersWithListInput
      * Summary: Creates list of users with given input array
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function createUsersWithListInput($request, $response, $args) {
+    public function createUsersWithListInput($request, $response, $args)
+    {
         $body = $request->getParsedBody();
         $response->write('How about implementing createUsersWithListInput as a POST method ?');
         return $response;
@@ -93,7 +95,8 @@ class UserApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function deleteUser($request, $response, $args) {
+    public function deleteUser($request, $response, $args)
+    {
         $username = $args['username'];
         $response->write('How about implementing deleteUser as a DELETE method ?');
         return $response;
@@ -102,14 +105,14 @@ class UserApi extends AbstractApiController {
     /**
      * GET getUserByName
      * Summary: Get user by user name
-     * Notes: 
      * Output-Formats: [application/xml, application/json]
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function getUserByName($request, $response, $args) {
+    public function getUserByName($request, $response, $args)
+    {
         $username = $args['username'];
         $response->write('How about implementing getUserByName as a GET method ?');
         return $response;
@@ -118,14 +121,14 @@ class UserApi extends AbstractApiController {
     /**
      * GET loginUser
      * Summary: Logs user into the system
-     * Notes: 
      * Output-Formats: [application/xml, application/json]
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function loginUser($request, $response, $args) {
+    public function loginUser($request, $response, $args)
+    {
         $queryParams = $request->getQueryParams();
         $username = $request->getQueryParam('username');
         $password = $request->getQueryParam('password');
@@ -136,13 +139,13 @@ class UserApi extends AbstractApiController {
     /**
      * GET logoutUser
      * Summary: Logs out current logged in user session
-     * Notes: 
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request  Request
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function logoutUser($request, $response, $args) {
+    public function logoutUser($request, $response, $args)
+    {
         $response->write('How about implementing logoutUser as a GET method ?');
         return $response;
     }
@@ -156,11 +159,11 @@ class UserApi extends AbstractApiController {
      * @param \Psr\Http\Message\ResponseInterface      $response Response
      * @param array|null                               $args     Path arguments
      */
-    public function updateUser($request, $response, $args) {
+    public function updateUser($request, $response, $args)
+    {
         $username = $args['username'];
         $body = $request->getParsedBody();
         $response->write('How about implementing updateUser as a PUT method ?');
         return $response;
     }
-    
 }

--- a/samples/server/petstore/php-slim/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/AdditionalPropertiesClass.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * AdditionalPropertiesClass
  */
-class AdditionalPropertiesClass {
-
+class AdditionalPropertiesClass
+{
+    
     /** @var map[string,string] $mapProperty */
     private $mapProperty;
-
+    
     /** @var map[string,map[string,string]] $mapOfMapProperty */
     private $mapOfMapProperty;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Animal.php
+++ b/samples/server/petstore/php-slim/lib/Model/Animal.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * Animal
  */
-class Animal {
-
+class Animal
+{
+    
     /** @var string $className */
     private $className;
-
+    
     /** @var string $color */
     private $color;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/AnimalFarm.php
+++ b/samples/server/petstore/php-slim/lib/Model/AnimalFarm.php
@@ -7,6 +7,6 @@ namespace OpenAPIServer\Model;
 /**
  * AnimalFarm
  */
-class AnimalFarm {
-
+class AnimalFarm
+{
 }

--- a/samples/server/petstore/php-slim/lib/Model/ApiResponse.php
+++ b/samples/server/petstore/php-slim/lib/Model/ApiResponse.php
@@ -7,15 +7,15 @@ namespace OpenAPIServer\Model;
 /**
  * ApiResponse
  */
-class ApiResponse {
-
+class ApiResponse
+{
+    
     /** @var int $code */
     private $code;
-
+    
     /** @var string $type */
     private $type;
-
+    
     /** @var string $message */
     private $message;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * ArrayOfArrayOfNumberOnly
  */
-class ArrayOfArrayOfNumberOnly {
-
+class ArrayOfArrayOfNumberOnly
+{
+    
     /** @var float[][] $arrayArrayNumber */
     private $arrayArrayNumber;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/ArrayOfNumberOnly.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * ArrayOfNumberOnly
  */
-class ArrayOfNumberOnly {
-
+class ArrayOfNumberOnly
+{
+    
     /** @var float[] $arrayNumber */
     private $arrayNumber;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ArrayTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/ArrayTest.php
@@ -7,15 +7,15 @@ namespace OpenAPIServer\Model;
 /**
  * ArrayTest
  */
-class ArrayTest {
-
+class ArrayTest
+{
+    
     /** @var string[] $arrayOfString */
     private $arrayOfString;
-
+    
     /** @var int[][] $arrayArrayOfInteger */
     private $arrayArrayOfInteger;
-
+    
     /** @var \OpenAPIServer\Model\ReadOnlyFirst[][] $arrayArrayOfModel */
     private $arrayArrayOfModel;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Capitalization.php
+++ b/samples/server/petstore/php-slim/lib/Model/Capitalization.php
@@ -7,24 +7,24 @@ namespace OpenAPIServer\Model;
 /**
  * Capitalization
  */
-class Capitalization {
-
+class Capitalization
+{
+    
     /** @var string $smallCamel */
     private $smallCamel;
-
+    
     /** @var string $capitalCamel */
     private $capitalCamel;
-
+    
     /** @var string $smallSnake */
     private $smallSnake;
-
+    
     /** @var string $capitalSnake */
     private $capitalSnake;
-
+    
     /** @var string $sCAETHFlowPoints */
     private $sCAETHFlowPoints;
-
+    
     /** @var string $aTTNAME Name of the pet*/
     private $aTTNAME;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Cat.php
+++ b/samples/server/petstore/php-slim/lib/Model/Cat.php
@@ -7,15 +7,15 @@ namespace OpenAPIServer\Model;
 /**
  * Cat
  */
-class Cat {
-
+class Cat
+{
+    
     /** @var string $className */
     private $className;
-
+    
     /** @var string $color */
     private $color;
-
+    
     /** @var bool $declawed */
     private $declawed;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Category.php
+++ b/samples/server/petstore/php-slim/lib/Model/Category.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * Category
  */
-class Category {
-
+class Category
+{
+    
     /** @var int $id */
     private $id;
-
+    
     /** @var string $name */
     private $name;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ClassModel.php
+++ b/samples/server/petstore/php-slim/lib/Model/ClassModel.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * ClassModel
  */
-class ClassModel {
-
+class ClassModel
+{
+    
     /** @var string $class */
     private $class;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Client.php
+++ b/samples/server/petstore/php-slim/lib/Model/Client.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * Client
  */
-class Client {
-
+class Client
+{
+    
     /** @var string $client */
     private $client;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Dog.php
+++ b/samples/server/petstore/php-slim/lib/Model/Dog.php
@@ -7,15 +7,15 @@ namespace OpenAPIServer\Model;
 /**
  * Dog
  */
-class Dog {
-
+class Dog
+{
+    
     /** @var string $className */
     private $className;
-
+    
     /** @var string $color */
     private $color;
-
+    
     /** @var string $breed */
     private $breed;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/EnumArrays.php
+++ b/samples/server/petstore/php-slim/lib/Model/EnumArrays.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * EnumArrays
  */
-class EnumArrays {
-
+class EnumArrays
+{
+    
     /** @var string $justSymbol */
     private $justSymbol;
-
+    
     /** @var string[] $arrayEnum */
     private $arrayEnum;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/EnumClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/EnumClass.php
@@ -7,6 +7,6 @@ namespace OpenAPIServer\Model;
 /**
  * EnumClass
  */
-class EnumClass {
-
+class EnumClass
+{
 }

--- a/samples/server/petstore/php-slim/lib/Model/EnumTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/EnumTest.php
@@ -7,21 +7,21 @@ namespace OpenAPIServer\Model;
 /**
  * EnumTest
  */
-class EnumTest {
-
+class EnumTest
+{
+    
     /** @var string $enumString */
     private $enumString;
-
+    
     /** @var string $enumStringRequired */
     private $enumStringRequired;
-
+    
     /** @var int $enumInteger */
     private $enumInteger;
-
+    
     /** @var double $enumNumber */
     private $enumNumber;
-
+    
     /** @var \OpenAPIServer\Model\OuterEnum $outerEnum */
     private $outerEnum;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/File.php
+++ b/samples/server/petstore/php-slim/lib/Model/File.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * File
  */
-class File {
-
+class File
+{
+    
     /** @var string $sourceURI Test capitalization*/
     private $sourceURI;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/FileSchemaTestClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/FileSchemaTestClass.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * FileSchemaTestClass
  */
-class FileSchemaTestClass {
-
+class FileSchemaTestClass
+{
+    
     /** @var \OpenAPIServer\Model\File $file */
     private $file;
-
+    
     /** @var \OpenAPIServer\Model\File[] $files */
     private $files;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/FormatTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/FormatTest.php
@@ -7,45 +7,45 @@ namespace OpenAPIServer\Model;
 /**
  * FormatTest
  */
-class FormatTest {
-
+class FormatTest
+{
+    
     /** @var int $integer */
     private $integer;
-
+    
     /** @var int $int32 */
     private $int32;
-
+    
     /** @var int $int64 */
     private $int64;
-
+    
     /** @var float $number */
     private $number;
-
+    
     /** @var float $float */
     private $float;
-
+    
     /** @var double $double */
     private $double;
-
+    
     /** @var string $string */
     private $string;
-
+    
     /** @var string $byte */
     private $byte;
-
+    
     /** @var \SplFileObject $binary */
     private $binary;
-
+    
     /** @var \DateTime $date */
     private $date;
-
+    
     /** @var \DateTime $dateTime */
     private $dateTime;
-
+    
     /** @var string $uuid */
     private $uuid;
-
+    
     /** @var string $password */
     private $password;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/HasOnlyReadOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/HasOnlyReadOnly.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * HasOnlyReadOnly
  */
-class HasOnlyReadOnly {
-
+class HasOnlyReadOnly
+{
+    
     /** @var string $bar */
     private $bar;
-
+    
     /** @var string $foo */
     private $foo;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/MapTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/MapTest.php
@@ -7,18 +7,18 @@ namespace OpenAPIServer\Model;
 /**
  * MapTest
  */
-class MapTest {
-
+class MapTest
+{
+    
     /** @var map[string,map[string,string]] $mapMapOfString */
     private $mapMapOfString;
-
+    
     /** @var map[string,string] $mapOfEnumString */
     private $mapOfEnumString;
-
+    
     /** @var map[string,bool] $directMap */
     private $directMap;
-
+    
     /** @var \OpenAPIServer\Model\StringBooleanMap $indirectMap */
     private $indirectMap;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/server/petstore/php-slim/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -7,15 +7,15 @@ namespace OpenAPIServer\Model;
 /**
  * MixedPropertiesAndAdditionalPropertiesClass
  */
-class MixedPropertiesAndAdditionalPropertiesClass {
-
+class MixedPropertiesAndAdditionalPropertiesClass
+{
+    
     /** @var string $uuid */
     private $uuid;
-
+    
     /** @var \DateTime $dateTime */
     private $dateTime;
-
+    
     /** @var map[string,\OpenAPIServer\Model\Animal] $map */
     private $map;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Model200Response.php
+++ b/samples/server/petstore/php-slim/lib/Model/Model200Response.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * Model200Response
  */
-class Model200Response {
-
+class Model200Response
+{
+    
     /** @var int $name */
     private $name;
-
+    
     /** @var string $class */
     private $class;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ModelList.php
+++ b/samples/server/petstore/php-slim/lib/Model/ModelList.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * ModelList
  */
-class ModelList {
-
+class ModelList
+{
+    
     /** @var string $_123list */
     private $_123list;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ModelReturn.php
+++ b/samples/server/petstore/php-slim/lib/Model/ModelReturn.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * ModelReturn
  */
-class ModelReturn {
-
+class ModelReturn
+{
+    
     /** @var int $return */
     private $return;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Name.php
+++ b/samples/server/petstore/php-slim/lib/Model/Name.php
@@ -7,18 +7,18 @@ namespace OpenAPIServer\Model;
 /**
  * Name
  */
-class Name {
-
+class Name
+{
+    
     /** @var int $name */
     private $name;
-
+    
     /** @var int $snakeCase */
     private $snakeCase;
-
+    
     /** @var string $property */
     private $property;
-
+    
     /** @var int $_123number */
     private $_123number;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/NumberOnly.php
+++ b/samples/server/petstore/php-slim/lib/Model/NumberOnly.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * NumberOnly
  */
-class NumberOnly {
-
+class NumberOnly
+{
+    
     /** @var float $justNumber */
     private $justNumber;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/Order.php
+++ b/samples/server/petstore/php-slim/lib/Model/Order.php
@@ -7,24 +7,24 @@ namespace OpenAPIServer\Model;
 /**
  * Order
  */
-class Order {
-
+class Order
+{
+    
     /** @var int $id */
     private $id;
-
+    
     /** @var int $petId */
     private $petId;
-
+    
     /** @var int $quantity */
     private $quantity;
-
+    
     /** @var \DateTime $shipDate */
     private $shipDate;
-
+    
     /** @var string $status Order Status*/
     private $status;
-
+    
     /** @var bool $complete */
     private $complete;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/OuterComposite.php
+++ b/samples/server/petstore/php-slim/lib/Model/OuterComposite.php
@@ -7,15 +7,15 @@ namespace OpenAPIServer\Model;
 /**
  * OuterComposite
  */
-class OuterComposite {
-
+class OuterComposite
+{
+    
     /** @var float $myNumber */
     private $myNumber;
-
+    
     /** @var string $myString */
     private $myString;
-
+    
     /** @var bool $myBoolean */
     private $myBoolean;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/OuterEnum.php
+++ b/samples/server/petstore/php-slim/lib/Model/OuterEnum.php
@@ -7,6 +7,6 @@ namespace OpenAPIServer\Model;
 /**
  * OuterEnum
  */
-class OuterEnum {
-
+class OuterEnum
+{
 }

--- a/samples/server/petstore/php-slim/lib/Model/Pet.php
+++ b/samples/server/petstore/php-slim/lib/Model/Pet.php
@@ -7,24 +7,24 @@ namespace OpenAPIServer\Model;
 /**
  * Pet
  */
-class Pet {
-
+class Pet
+{
+    
     /** @var int $id */
     private $id;
-
+    
     /** @var \OpenAPIServer\Model\Category $category */
     private $category;
-
+    
     /** @var string $name */
     private $name;
-
+    
     /** @var string[] $photoUrls */
     private $photoUrls;
-
+    
     /** @var \OpenAPIServer\Model\Tag[] $tags */
     private $tags;
-
+    
     /** @var string $status pet status in the store*/
     private $status;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/ReadOnlyFirst.php
+++ b/samples/server/petstore/php-slim/lib/Model/ReadOnlyFirst.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * ReadOnlyFirst
  */
-class ReadOnlyFirst {
-
+class ReadOnlyFirst
+{
+    
     /** @var string $bar */
     private $bar;
-
+    
     /** @var string $baz */
     private $baz;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/SpecialModelName.php
+++ b/samples/server/petstore/php-slim/lib/Model/SpecialModelName.php
@@ -7,9 +7,9 @@ namespace OpenAPIServer\Model;
 /**
  * SpecialModelName
  */
-class SpecialModelName {
-
+class SpecialModelName
+{
+    
     /** @var int $specialPropertyName */
     private $specialPropertyName;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/StringBooleanMap.php
+++ b/samples/server/petstore/php-slim/lib/Model/StringBooleanMap.php
@@ -7,6 +7,6 @@ namespace OpenAPIServer\Model;
 /**
  * StringBooleanMap
  */
-class StringBooleanMap {
-
+class StringBooleanMap
+{
 }

--- a/samples/server/petstore/php-slim/lib/Model/Tag.php
+++ b/samples/server/petstore/php-slim/lib/Model/Tag.php
@@ -7,12 +7,12 @@ namespace OpenAPIServer\Model;
 /**
  * Tag
  */
-class Tag {
-
+class Tag
+{
+    
     /** @var int $id */
     private $id;
-
+    
     /** @var string $name */
     private $name;
-
 }

--- a/samples/server/petstore/php-slim/lib/Model/User.php
+++ b/samples/server/petstore/php-slim/lib/Model/User.php
@@ -7,30 +7,30 @@ namespace OpenAPIServer\Model;
 /**
  * User
  */
-class User {
-
+class User
+{
+    
     /** @var int $id */
     private $id;
-
+    
     /** @var string $username */
     private $username;
-
+    
     /** @var string $firstName */
     private $firstName;
-
+    
     /** @var string $lastName */
     private $lastName;
-
+    
     /** @var string $email */
     private $email;
-
+    
     /** @var string $password */
     private $password;
-
+    
     /** @var string $phone */
     private $phone;
-
+    
     /** @var int $userStatus User Status*/
     private $userStatus;
-
 }

--- a/samples/server/petstore/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim/lib/SlimRouter.php
@@ -10,7 +10,7 @@
  * @link     https://github.com/openapitools/openapi-generator
  */
 
-/** 
+/**
  * OpenAPI Petstore
  *
  * This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\
@@ -46,7 +46,8 @@ use Tuupola\Middleware\HttpBasicAuthentication;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class SlimRouter {
+class SlimRouter
+{
 
     /**
      * @var $slimApp Slim\App instance
@@ -59,7 +60,8 @@ class SlimRouter {
      * @param ContainerInterface|array $container Either a ContainerInterface or an associative array of app settings
      * @throws InvalidArgumentException when no container is provided that implements ContainerInterface
      */
-    public function __construct($container = []) {
+    public function __construct($container = [])
+    {
         $app = new App($container);
 
         $basicAuth = new HttpBasicAuthentication([
@@ -72,108 +74,142 @@ class SlimRouter {
         ]);
 
         $app->PATCH(
-            '/v2/another-fake/dummy', AnotherFakeApi::class . ':call123TestSpecialTags'
+            '/v2/another-fake/dummy',
+            AnotherFakeApi::class . ':call123TestSpecialTags'
         );
         $app->POST(
-            '/v2/fake/outer/boolean', FakeApi::class . ':fakeOuterBooleanSerialize'
+            '/v2/fake/outer/boolean',
+            FakeApi::class . ':fakeOuterBooleanSerialize'
         );
         $app->POST(
-            '/v2/fake/outer/composite', FakeApi::class . ':fakeOuterCompositeSerialize'
+            '/v2/fake/outer/composite',
+            FakeApi::class . ':fakeOuterCompositeSerialize'
         );
         $app->POST(
-            '/v2/fake/outer/number', FakeApi::class . ':fakeOuterNumberSerialize'
+            '/v2/fake/outer/number',
+            FakeApi::class . ':fakeOuterNumberSerialize'
         );
         $app->POST(
-            '/v2/fake/outer/string', FakeApi::class . ':fakeOuterStringSerialize'
+            '/v2/fake/outer/string',
+            FakeApi::class . ':fakeOuterStringSerialize'
         );
         $app->PUT(
-            '/v2/fake/body-with-file-schema', FakeApi::class . ':testBodyWithFileSchema'
+            '/v2/fake/body-with-file-schema',
+            FakeApi::class . ':testBodyWithFileSchema'
         );
         $app->PUT(
-            '/v2/fake/body-with-query-params', FakeApi::class . ':testBodyWithQueryParams'
+            '/v2/fake/body-with-query-params',
+            FakeApi::class . ':testBodyWithQueryParams'
         );
         $app->PATCH(
-            '/v2/fake', FakeApi::class . ':testClientModel'
+            '/v2/fake',
+            FakeApi::class . ':testClientModel'
         );
         $app->POST(
-            '/v2/fake', FakeApi::class . ':testEndpointParameters'
+            '/v2/fake',
+            FakeApi::class . ':testEndpointParameters'
         )->add(
             $basicAuth
         );
         $app->GET(
-            '/v2/fake', FakeApi::class . ':testEnumParameters'
+            '/v2/fake',
+            FakeApi::class . ':testEnumParameters'
         );
         $app->POST(
-            '/v2/fake/inline-additionalProperties', FakeApi::class . ':testInlineAdditionalProperties'
+            '/v2/fake/inline-additionalProperties',
+            FakeApi::class . ':testInlineAdditionalProperties'
         );
         $app->GET(
-            '/v2/fake/jsonFormData', FakeApi::class . ':testJsonFormData'
+            '/v2/fake/jsonFormData',
+            FakeApi::class . ':testJsonFormData'
         );
         $app->PATCH(
-            '/v2/fake_classname_test', FakeClassnameTags123Api::class . ':testClassname'
+            '/v2/fake_classname_test',
+            FakeClassnameTags123Api::class . ':testClassname'
         );
         $app->POST(
-            '/v2/pet', PetApi::class . ':addPet'
+            '/v2/pet',
+            PetApi::class . ':addPet'
         );
         $app->GET(
-            '/v2/pet/findByStatus', PetApi::class . ':findPetsByStatus'
+            '/v2/pet/findByStatus',
+            PetApi::class . ':findPetsByStatus'
         );
         $app->GET(
-            '/v2/pet/findByTags', PetApi::class . ':findPetsByTags'
+            '/v2/pet/findByTags',
+            PetApi::class . ':findPetsByTags'
         );
         $app->PUT(
-            '/v2/pet', PetApi::class . ':updatePet'
+            '/v2/pet',
+            PetApi::class . ':updatePet'
         );
         $app->DELETE(
-            '/v2/pet/{petId}', PetApi::class . ':deletePet'
+            '/v2/pet/{petId}',
+            PetApi::class . ':deletePet'
         );
         $app->GET(
-            '/v2/pet/{petId}', PetApi::class . ':getPetById'
+            '/v2/pet/{petId}',
+            PetApi::class . ':getPetById'
         );
         $app->POST(
-            '/v2/pet/{petId}', PetApi::class . ':updatePetWithForm'
+            '/v2/pet/{petId}',
+            PetApi::class . ':updatePetWithForm'
         );
         $app->POST(
-            '/v2/pet/{petId}/uploadImage', PetApi::class . ':uploadFile'
+            '/v2/pet/{petId}/uploadImage',
+            PetApi::class . ':uploadFile'
         );
         $app->POST(
-            '/v2/fake/{petId}/uploadImageWithRequiredFile', PetApi::class . ':uploadFileWithRequiredFile'
+            '/v2/fake/{petId}/uploadImageWithRequiredFile',
+            PetApi::class . ':uploadFileWithRequiredFile'
         );
         $app->GET(
-            '/v2/store/inventory', StoreApi::class . ':getInventory'
+            '/v2/store/inventory',
+            StoreApi::class . ':getInventory'
         );
         $app->POST(
-            '/v2/store/order', StoreApi::class . ':placeOrder'
+            '/v2/store/order',
+            StoreApi::class . ':placeOrder'
         );
         $app->DELETE(
-            '/v2/store/order/{order_id}', StoreApi::class . ':deleteOrder'
+            '/v2/store/order/{order_id}',
+            StoreApi::class . ':deleteOrder'
         );
         $app->GET(
-            '/v2/store/order/{order_id}', StoreApi::class . ':getOrderById'
+            '/v2/store/order/{order_id}',
+            StoreApi::class . ':getOrderById'
         );
         $app->POST(
-            '/v2/user', UserApi::class . ':createUser'
+            '/v2/user',
+            UserApi::class . ':createUser'
         );
         $app->POST(
-            '/v2/user/createWithArray', UserApi::class . ':createUsersWithArrayInput'
+            '/v2/user/createWithArray',
+            UserApi::class . ':createUsersWithArrayInput'
         );
         $app->POST(
-            '/v2/user/createWithList', UserApi::class . ':createUsersWithListInput'
+            '/v2/user/createWithList',
+            UserApi::class . ':createUsersWithListInput'
         );
         $app->GET(
-            '/v2/user/login', UserApi::class . ':loginUser'
+            '/v2/user/login',
+            UserApi::class . ':loginUser'
         );
         $app->GET(
-            '/v2/user/logout', UserApi::class . ':logoutUser'
+            '/v2/user/logout',
+            UserApi::class . ':logoutUser'
         );
         $app->DELETE(
-            '/v2/user/{username}', UserApi::class . ':deleteUser'
+            '/v2/user/{username}',
+            UserApi::class . ':deleteUser'
         );
         $app->GET(
-            '/v2/user/{username}', UserApi::class . ':getUserByName'
+            '/v2/user/{username}',
+            UserApi::class . ':getUserByName'
         );
         $app->PUT(
-            '/v2/user/{username}', UserApi::class . ':updateUser'
+            '/v2/user/{username}',
+            UserApi::class . ':updateUser'
         );
 
         $this->slimApp = $app;
@@ -183,7 +219,8 @@ class SlimRouter {
      * Returns Slim Framework instance
      * @return App
      */
-    public function getSlimApp() {
+    public function getSlimApp()
+    {
         return $this->slimApp;
     }
 }

--- a/samples/server/petstore/php-slim/test/Api/AnotherFakeApiTest.php
+++ b/samples/server/petstore/php-slim/test/Api/AnotherFakeApiTest.php
@@ -36,43 +36,44 @@ use OpenAPIServer\Api\AnotherFakeApi;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\AnotherFakeApi
  */
-class AnotherFakeApiTest extends \PHPUnit_Framework_TestCase {
+class AnotherFakeApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
-     * Test case for testSpecialTags
+     * Test case for call123TestSpecialTags
      *
      * To test special tags.
-     * @covers ::testSpecialTags
+     * @covers ::call123TestSpecialTags
      */
-    public function testTestSpecialTags() {
-
+    public function testCall123TestSpecialTags()
+    {
     }
 }

--- a/samples/server/petstore/php-slim/test/Api/FakeApiTest.php
+++ b/samples/server/petstore/php-slim/test/Api/FakeApiTest.php
@@ -36,34 +36,35 @@ use OpenAPIServer\Api\FakeApi;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\FakeApi
  */
-class FakeApiTest extends \PHPUnit_Framework_TestCase {
+class FakeApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
@@ -72,8 +73,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * .
      * @covers ::fakeOuterBooleanSerialize
      */
-    public function testFakeOuterBooleanSerialize() {
-
+    public function testFakeOuterBooleanSerialize()
+    {
     }
 
     /**
@@ -82,8 +83,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * .
      * @covers ::fakeOuterCompositeSerialize
      */
-    public function testFakeOuterCompositeSerialize() {
-
+    public function testFakeOuterCompositeSerialize()
+    {
     }
 
     /**
@@ -92,8 +93,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * .
      * @covers ::fakeOuterNumberSerialize
      */
-    public function testFakeOuterNumberSerialize() {
-
+    public function testFakeOuterNumberSerialize()
+    {
     }
 
     /**
@@ -102,8 +103,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * .
      * @covers ::fakeOuterStringSerialize
      */
-    public function testFakeOuterStringSerialize() {
-
+    public function testFakeOuterStringSerialize()
+    {
     }
 
     /**
@@ -112,8 +113,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * .
      * @covers ::testBodyWithFileSchema
      */
-    public function testTestBodyWithFileSchema() {
-
+    public function testTestBodyWithFileSchema()
+    {
     }
 
     /**
@@ -122,8 +123,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * .
      * @covers ::testBodyWithQueryParams
      */
-    public function testTestBodyWithQueryParams() {
-
+    public function testTestBodyWithQueryParams()
+    {
     }
 
     /**
@@ -132,8 +133,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * To test \"client\" model.
      * @covers ::testClientModel
      */
-    public function testTestClientModel() {
-
+    public function testTestClientModel()
+    {
     }
 
     /**
@@ -142,8 +143,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트.
      * @covers ::testEndpointParameters
      */
-    public function testTestEndpointParameters() {
-
+    public function testTestEndpointParameters()
+    {
     }
 
     /**
@@ -152,8 +153,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * To test enum parameters.
      * @covers ::testEnumParameters
      */
-    public function testTestEnumParameters() {
-
+    public function testTestEnumParameters()
+    {
     }
 
     /**
@@ -162,8 +163,8 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * test inline additionalProperties.
      * @covers ::testInlineAdditionalProperties
      */
-    public function testTestInlineAdditionalProperties() {
-
+    public function testTestInlineAdditionalProperties()
+    {
     }
 
     /**
@@ -172,7 +173,7 @@ class FakeApiTest extends \PHPUnit_Framework_TestCase {
      * test json serialization of form data.
      * @covers ::testJsonFormData
      */
-    public function testTestJsonFormData() {
-
+    public function testTestJsonFormData()
+    {
     }
 }

--- a/samples/server/petstore/php-slim/test/Api/FakeClassnameTags123ApiTest.php
+++ b/samples/server/petstore/php-slim/test/Api/FakeClassnameTags123ApiTest.php
@@ -36,34 +36,35 @@ use OpenAPIServer\Api\FakeClassnameTags123Api;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\FakeClassnameTags123Api
  */
-class FakeClassnameTags123ApiTest extends \PHPUnit_Framework_TestCase {
+class FakeClassnameTags123ApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
@@ -72,7 +73,7 @@ class FakeClassnameTags123ApiTest extends \PHPUnit_Framework_TestCase {
      * To test class name in snake case.
      * @covers ::testClassname
      */
-    public function testTestClassname() {
-
+    public function testTestClassname()
+    {
     }
 }

--- a/samples/server/petstore/php-slim/test/Api/PetApiTest.php
+++ b/samples/server/petstore/php-slim/test/Api/PetApiTest.php
@@ -36,34 +36,35 @@ use OpenAPIServer\Api\PetApi;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\PetApi
  */
-class PetApiTest extends \PHPUnit_Framework_TestCase {
+class PetApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
@@ -72,8 +73,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Add a new pet to the store.
      * @covers ::addPet
      */
-    public function testAddPet() {
-
+    public function testAddPet()
+    {
     }
 
     /**
@@ -82,8 +83,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Deletes a pet.
      * @covers ::deletePet
      */
-    public function testDeletePet() {
-
+    public function testDeletePet()
+    {
     }
 
     /**
@@ -92,8 +93,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Finds Pets by status.
      * @covers ::findPetsByStatus
      */
-    public function testFindPetsByStatus() {
-
+    public function testFindPetsByStatus()
+    {
     }
 
     /**
@@ -102,8 +103,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Finds Pets by tags.
      * @covers ::findPetsByTags
      */
-    public function testFindPetsByTags() {
-
+    public function testFindPetsByTags()
+    {
     }
 
     /**
@@ -112,8 +113,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Find pet by ID.
      * @covers ::getPetById
      */
-    public function testGetPetById() {
-
+    public function testGetPetById()
+    {
     }
 
     /**
@@ -122,8 +123,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Update an existing pet.
      * @covers ::updatePet
      */
-    public function testUpdatePet() {
-
+    public function testUpdatePet()
+    {
     }
 
     /**
@@ -132,8 +133,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * Updates a pet in the store with form data.
      * @covers ::updatePetWithForm
      */
-    public function testUpdatePetWithForm() {
-
+    public function testUpdatePetWithForm()
+    {
     }
 
     /**
@@ -142,8 +143,8 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * uploads an image.
      * @covers ::uploadFile
      */
-    public function testUploadFile() {
-
+    public function testUploadFile()
+    {
     }
 
     /**
@@ -152,7 +153,7 @@ class PetApiTest extends \PHPUnit_Framework_TestCase {
      * uploads an image (required).
      * @covers ::uploadFileWithRequiredFile
      */
-    public function testUploadFileWithRequiredFile() {
-
+    public function testUploadFileWithRequiredFile()
+    {
     }
 }

--- a/samples/server/petstore/php-slim/test/Api/StoreApiTest.php
+++ b/samples/server/petstore/php-slim/test/Api/StoreApiTest.php
@@ -36,34 +36,35 @@ use OpenAPIServer\Api\StoreApi;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\StoreApi
  */
-class StoreApiTest extends \PHPUnit_Framework_TestCase {
+class StoreApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
@@ -72,8 +73,8 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase {
      * Delete purchase order by ID.
      * @covers ::deleteOrder
      */
-    public function testDeleteOrder() {
-
+    public function testDeleteOrder()
+    {
     }
 
     /**
@@ -82,8 +83,8 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase {
      * Returns pet inventories by status.
      * @covers ::getInventory
      */
-    public function testGetInventory() {
-
+    public function testGetInventory()
+    {
     }
 
     /**
@@ -92,8 +93,8 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase {
      * Find purchase order by ID.
      * @covers ::getOrderById
      */
-    public function testGetOrderById() {
-
+    public function testGetOrderById()
+    {
     }
 
     /**
@@ -102,7 +103,7 @@ class StoreApiTest extends \PHPUnit_Framework_TestCase {
      * Place an order for a pet.
      * @covers ::placeOrder
      */
-    public function testPlaceOrder() {
-
+    public function testPlaceOrder()
+    {
     }
 }

--- a/samples/server/petstore/php-slim/test/Api/UserApiTest.php
+++ b/samples/server/petstore/php-slim/test/Api/UserApiTest.php
@@ -36,34 +36,35 @@ use OpenAPIServer\Api\UserApi;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\UserApi
  */
-class UserApiTest extends \PHPUnit_Framework_TestCase {
+class UserApiTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
@@ -72,8 +73,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Create user.
      * @covers ::createUser
      */
-    public function testCreateUser() {
-
+    public function testCreateUser()
+    {
     }
 
     /**
@@ -82,8 +83,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Creates list of users with given input array.
      * @covers ::createUsersWithArrayInput
      */
-    public function testCreateUsersWithArrayInput() {
-
+    public function testCreateUsersWithArrayInput()
+    {
     }
 
     /**
@@ -92,8 +93,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Creates list of users with given input array.
      * @covers ::createUsersWithListInput
      */
-    public function testCreateUsersWithListInput() {
-
+    public function testCreateUsersWithListInput()
+    {
     }
 
     /**
@@ -102,8 +103,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Delete user.
      * @covers ::deleteUser
      */
-    public function testDeleteUser() {
-
+    public function testDeleteUser()
+    {
     }
 
     /**
@@ -112,8 +113,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Get user by user name.
      * @covers ::getUserByName
      */
-    public function testGetUserByName() {
-
+    public function testGetUserByName()
+    {
     }
 
     /**
@@ -122,8 +123,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Logs user into the system.
      * @covers ::loginUser
      */
-    public function testLoginUser() {
-
+    public function testLoginUser()
+    {
     }
 
     /**
@@ -132,8 +133,8 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Logs out current logged in user session.
      * @covers ::logoutUser
      */
-    public function testLogoutUser() {
-
+    public function testLogoutUser()
+    {
     }
 
     /**
@@ -142,7 +143,7 @@ class UserApiTest extends \PHPUnit_Framework_TestCase {
      * Updated user.
      * @covers ::updateUser
      */
-    public function testUpdateUser() {
-
+    public function testUpdateUser()
+    {
     }
 }

--- a/samples/server/petstore/php-slim/test/Model/AdditionalPropertiesClassTest.php
+++ b/samples/server/petstore/php-slim/test/Model/AdditionalPropertiesClassTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\AdditionalPropertiesClass;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\AdditionalPropertiesClass
  */
-class AdditionalPropertiesClassTest extends \PHPUnit_Framework_TestCase {
+class AdditionalPropertiesClassTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "AdditionalPropertiesClass"
      */
-    public function testAdditionalPropertiesClass() {
+    public function testAdditionalPropertiesClass()
+    {
         $testAdditionalPropertiesClass = new AdditionalPropertiesClass();
     }
 
     /**
      * Test attribute "mapProperty"
      */
-    public function testPropertyMapProperty() {
-
+    public function testPropertyMapProperty()
+    {
     }
 
     /**
      * Test attribute "mapOfMapProperty"
      */
-    public function testPropertyMapOfMapProperty() {
-
+    public function testPropertyMapOfMapProperty()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/AnimalFarmTest.php
+++ b/samples/server/petstore/php-slim/test/Model/AnimalFarmTest.php
@@ -36,41 +36,42 @@ use OpenAPIServer\Model\AnimalFarm;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\AnimalFarm
  */
-class AnimalFarmTest extends \PHPUnit_Framework_TestCase {
+class AnimalFarmTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "AnimalFarm"
      */
-    public function testAnimalFarm() {
+    public function testAnimalFarm()
+    {
         $testAnimalFarm = new AnimalFarm();
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/AnimalTest.php
+++ b/samples/server/petstore/php-slim/test/Model/AnimalTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\Animal;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Animal
  */
-class AnimalTest extends \PHPUnit_Framework_TestCase {
+class AnimalTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Animal"
      */
-    public function testAnimal() {
+    public function testAnimal()
+    {
         $testAnimal = new Animal();
     }
 
     /**
      * Test attribute "className"
      */
-    public function testPropertyClassName() {
-
+    public function testPropertyClassName()
+    {
     }
 
     /**
      * Test attribute "color"
      */
-    public function testPropertyColor() {
-
+    public function testPropertyColor()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ApiResponseTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ApiResponseTest.php
@@ -36,62 +36,63 @@ use OpenAPIServer\Model\ApiResponse;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ApiResponse
  */
-class ApiResponseTest extends \PHPUnit_Framework_TestCase {
+class ApiResponseTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ApiResponse"
      */
-    public function testApiResponse() {
+    public function testApiResponse()
+    {
         $testApiResponse = new ApiResponse();
     }
 
     /**
      * Test attribute "code"
      */
-    public function testPropertyCode() {
-
+    public function testPropertyCode()
+    {
     }
 
     /**
      * Test attribute "type"
      */
-    public function testPropertyType() {
-
+    public function testPropertyType()
+    {
     }
 
     /**
      * Test attribute "message"
      */
-    public function testPropertyMessage() {
-
+    public function testPropertyMessage()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ArrayOfArrayOfNumberOnlyTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ArrayOfArrayOfNumberOnlyTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\ArrayOfArrayOfNumberOnly;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ArrayOfArrayOfNumberOnly
  */
-class ArrayOfArrayOfNumberOnlyTest extends \PHPUnit_Framework_TestCase {
+class ArrayOfArrayOfNumberOnlyTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ArrayOfArrayOfNumberOnly"
      */
-    public function testArrayOfArrayOfNumberOnly() {
+    public function testArrayOfArrayOfNumberOnly()
+    {
         $testArrayOfArrayOfNumberOnly = new ArrayOfArrayOfNumberOnly();
     }
 
     /**
      * Test attribute "arrayArrayNumber"
      */
-    public function testPropertyArrayArrayNumber() {
-
+    public function testPropertyArrayArrayNumber()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ArrayOfNumberOnlyTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ArrayOfNumberOnlyTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\ArrayOfNumberOnly;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ArrayOfNumberOnly
  */
-class ArrayOfNumberOnlyTest extends \PHPUnit_Framework_TestCase {
+class ArrayOfNumberOnlyTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ArrayOfNumberOnly"
      */
-    public function testArrayOfNumberOnly() {
+    public function testArrayOfNumberOnly()
+    {
         $testArrayOfNumberOnly = new ArrayOfNumberOnly();
     }
 
     /**
      * Test attribute "arrayNumber"
      */
-    public function testPropertyArrayNumber() {
-
+    public function testPropertyArrayNumber()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ArrayTestTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ArrayTestTest.php
@@ -36,62 +36,63 @@ use OpenAPIServer\Model\ArrayTest;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ArrayTest
  */
-class ArrayTestTest extends \PHPUnit_Framework_TestCase {
+class ArrayTestTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ArrayTest"
      */
-    public function testArrayTest() {
+    public function testArrayTest()
+    {
         $testArrayTest = new ArrayTest();
     }
 
     /**
      * Test attribute "arrayOfString"
      */
-    public function testPropertyArrayOfString() {
-
+    public function testPropertyArrayOfString()
+    {
     }
 
     /**
      * Test attribute "arrayArrayOfInteger"
      */
-    public function testPropertyArrayArrayOfInteger() {
-
+    public function testPropertyArrayArrayOfInteger()
+    {
     }
 
     /**
      * Test attribute "arrayArrayOfModel"
      */
-    public function testPropertyArrayArrayOfModel() {
-
+    public function testPropertyArrayArrayOfModel()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/CapitalizationTest.php
+++ b/samples/server/petstore/php-slim/test/Model/CapitalizationTest.php
@@ -36,83 +36,84 @@ use OpenAPIServer\Model\Capitalization;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Capitalization
  */
-class CapitalizationTest extends \PHPUnit_Framework_TestCase {
+class CapitalizationTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Capitalization"
      */
-    public function testCapitalization() {
+    public function testCapitalization()
+    {
         $testCapitalization = new Capitalization();
     }
 
     /**
      * Test attribute "smallCamel"
      */
-    public function testPropertySmallCamel() {
-
+    public function testPropertySmallCamel()
+    {
     }
 
     /**
      * Test attribute "capitalCamel"
      */
-    public function testPropertyCapitalCamel() {
-
+    public function testPropertyCapitalCamel()
+    {
     }
 
     /**
      * Test attribute "smallSnake"
      */
-    public function testPropertySmallSnake() {
-
+    public function testPropertySmallSnake()
+    {
     }
 
     /**
      * Test attribute "capitalSnake"
      */
-    public function testPropertyCapitalSnake() {
-
+    public function testPropertyCapitalSnake()
+    {
     }
 
     /**
      * Test attribute "sCAETHFlowPoints"
      */
-    public function testPropertySCAETHFlowPoints() {
-
+    public function testPropertySCAETHFlowPoints()
+    {
     }
 
     /**
      * Test attribute "aTTNAME"
      */
-    public function testPropertyATTNAME() {
-
+    public function testPropertyATTNAME()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/CatTest.php
+++ b/samples/server/petstore/php-slim/test/Model/CatTest.php
@@ -36,62 +36,63 @@ use OpenAPIServer\Model\Cat;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Cat
  */
-class CatTest extends \PHPUnit_Framework_TestCase {
+class CatTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Cat"
      */
-    public function testCat() {
+    public function testCat()
+    {
         $testCat = new Cat();
     }
 
     /**
      * Test attribute "className"
      */
-    public function testPropertyClassName() {
-
+    public function testPropertyClassName()
+    {
     }
 
     /**
      * Test attribute "color"
      */
-    public function testPropertyColor() {
-
+    public function testPropertyColor()
+    {
     }
 
     /**
      * Test attribute "declawed"
      */
-    public function testPropertyDeclawed() {
-
+    public function testPropertyDeclawed()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/CategoryTest.php
+++ b/samples/server/petstore/php-slim/test/Model/CategoryTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\Category;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Category
  */
-class CategoryTest extends \PHPUnit_Framework_TestCase {
+class CategoryTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Category"
      */
-    public function testCategory() {
+    public function testCategory()
+    {
         $testCategory = new Category();
     }
 
     /**
      * Test attribute "id"
      */
-    public function testPropertyId() {
-
+    public function testPropertyId()
+    {
     }
 
     /**
      * Test attribute "name"
      */
-    public function testPropertyName() {
-
+    public function testPropertyName()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ClassModelTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ClassModelTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\ClassModel;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ClassModel
  */
-class ClassModelTest extends \PHPUnit_Framework_TestCase {
+class ClassModelTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ClassModel"
      */
-    public function testClassModel() {
+    public function testClassModel()
+    {
         $testClassModel = new ClassModel();
     }
 
     /**
      * Test attribute "class"
      */
-    public function testPropertyClass() {
-
+    public function testPropertyClass()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ClientTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ClientTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\Client;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Client
  */
-class ClientTest extends \PHPUnit_Framework_TestCase {
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Client"
      */
-    public function testClient() {
+    public function testClient()
+    {
         $testClient = new Client();
     }
 
     /**
      * Test attribute "client"
      */
-    public function testPropertyClient() {
-
+    public function testPropertyClient()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/DogTest.php
+++ b/samples/server/petstore/php-slim/test/Model/DogTest.php
@@ -36,62 +36,63 @@ use OpenAPIServer\Model\Dog;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Dog
  */
-class DogTest extends \PHPUnit_Framework_TestCase {
+class DogTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Dog"
      */
-    public function testDog() {
+    public function testDog()
+    {
         $testDog = new Dog();
     }
 
     /**
      * Test attribute "className"
      */
-    public function testPropertyClassName() {
-
+    public function testPropertyClassName()
+    {
     }
 
     /**
      * Test attribute "color"
      */
-    public function testPropertyColor() {
-
+    public function testPropertyColor()
+    {
     }
 
     /**
      * Test attribute "breed"
      */
-    public function testPropertyBreed() {
-
+    public function testPropertyBreed()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/EnumArraysTest.php
+++ b/samples/server/petstore/php-slim/test/Model/EnumArraysTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\EnumArrays;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\EnumArrays
  */
-class EnumArraysTest extends \PHPUnit_Framework_TestCase {
+class EnumArraysTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "EnumArrays"
      */
-    public function testEnumArrays() {
+    public function testEnumArrays()
+    {
         $testEnumArrays = new EnumArrays();
     }
 
     /**
      * Test attribute "justSymbol"
      */
-    public function testPropertyJustSymbol() {
-
+    public function testPropertyJustSymbol()
+    {
     }
 
     /**
      * Test attribute "arrayEnum"
      */
-    public function testPropertyArrayEnum() {
-
+    public function testPropertyArrayEnum()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/EnumClassTest.php
+++ b/samples/server/petstore/php-slim/test/Model/EnumClassTest.php
@@ -36,41 +36,42 @@ use OpenAPIServer\Model\EnumClass;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\EnumClass
  */
-class EnumClassTest extends \PHPUnit_Framework_TestCase {
+class EnumClassTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "EnumClass"
      */
-    public function testEnumClass() {
+    public function testEnumClass()
+    {
         $testEnumClass = new EnumClass();
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/EnumTestTest.php
+++ b/samples/server/petstore/php-slim/test/Model/EnumTestTest.php
@@ -36,76 +36,77 @@ use OpenAPIServer\Model\EnumTest;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\EnumTest
  */
-class EnumTestTest extends \PHPUnit_Framework_TestCase {
+class EnumTestTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "EnumTest"
      */
-    public function testEnumTest() {
+    public function testEnumTest()
+    {
         $testEnumTest = new EnumTest();
     }
 
     /**
      * Test attribute "enumString"
      */
-    public function testPropertyEnumString() {
-
+    public function testPropertyEnumString()
+    {
     }
 
     /**
      * Test attribute "enumStringRequired"
      */
-    public function testPropertyEnumStringRequired() {
-
+    public function testPropertyEnumStringRequired()
+    {
     }
 
     /**
      * Test attribute "enumInteger"
      */
-    public function testPropertyEnumInteger() {
-
+    public function testPropertyEnumInteger()
+    {
     }
 
     /**
      * Test attribute "enumNumber"
      */
-    public function testPropertyEnumNumber() {
-
+    public function testPropertyEnumNumber()
+    {
     }
 
     /**
      * Test attribute "outerEnum"
      */
-    public function testPropertyOuterEnum() {
-
+    public function testPropertyOuterEnum()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/FileSchemaTestClassTest.php
+++ b/samples/server/petstore/php-slim/test/Model/FileSchemaTestClassTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\FileSchemaTestClass;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\FileSchemaTestClass
  */
-class FileSchemaTestClassTest extends \PHPUnit_Framework_TestCase {
+class FileSchemaTestClassTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "FileSchemaTestClass"
      */
-    public function testFileSchemaTestClass() {
+    public function testFileSchemaTestClass()
+    {
         $testFileSchemaTestClass = new FileSchemaTestClass();
     }
 
     /**
      * Test attribute "file"
      */
-    public function testPropertyFile() {
-
+    public function testPropertyFile()
+    {
     }
 
     /**
      * Test attribute "files"
      */
-    public function testPropertyFiles() {
-
+    public function testPropertyFiles()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/FileTest.php
+++ b/samples/server/petstore/php-slim/test/Model/FileTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\File;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\File
  */
-class FileTest extends \PHPUnit_Framework_TestCase {
+class FileTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "File"
      */
-    public function testFile() {
+    public function testFile()
+    {
         $testFile = new File();
     }
 
     /**
      * Test attribute "sourceURI"
      */
-    public function testPropertySourceURI() {
-
+    public function testPropertySourceURI()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/FormatTestTest.php
+++ b/samples/server/petstore/php-slim/test/Model/FormatTestTest.php
@@ -36,132 +36,133 @@ use OpenAPIServer\Model\FormatTest;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\FormatTest
  */
-class FormatTestTest extends \PHPUnit_Framework_TestCase {
+class FormatTestTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "FormatTest"
      */
-    public function testFormatTest() {
+    public function testFormatTest()
+    {
         $testFormatTest = new FormatTest();
     }
 
     /**
      * Test attribute "integer"
      */
-    public function testPropertyInteger() {
-
+    public function testPropertyInteger()
+    {
     }
 
     /**
      * Test attribute "int32"
      */
-    public function testPropertyInt32() {
-
+    public function testPropertyInt32()
+    {
     }
 
     /**
      * Test attribute "int64"
      */
-    public function testPropertyInt64() {
-
+    public function testPropertyInt64()
+    {
     }
 
     /**
      * Test attribute "number"
      */
-    public function testPropertyNumber() {
-
+    public function testPropertyNumber()
+    {
     }
 
     /**
      * Test attribute "float"
      */
-    public function testPropertyFloat() {
-
+    public function testPropertyFloat()
+    {
     }
 
     /**
      * Test attribute "double"
      */
-    public function testPropertyDouble() {
-
+    public function testPropertyDouble()
+    {
     }
 
     /**
      * Test attribute "string"
      */
-    public function testPropertyString() {
-
+    public function testPropertyString()
+    {
     }
 
     /**
      * Test attribute "byte"
      */
-    public function testPropertyByte() {
-
+    public function testPropertyByte()
+    {
     }
 
     /**
      * Test attribute "binary"
      */
-    public function testPropertyBinary() {
-
+    public function testPropertyBinary()
+    {
     }
 
     /**
      * Test attribute "date"
      */
-    public function testPropertyDate() {
-
+    public function testPropertyDate()
+    {
     }
 
     /**
      * Test attribute "dateTime"
      */
-    public function testPropertyDateTime() {
-
+    public function testPropertyDateTime()
+    {
     }
 
     /**
      * Test attribute "uuid"
      */
-    public function testPropertyUuid() {
-
+    public function testPropertyUuid()
+    {
     }
 
     /**
      * Test attribute "password"
      */
-    public function testPropertyPassword() {
-
+    public function testPropertyPassword()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/HasOnlyReadOnlyTest.php
+++ b/samples/server/petstore/php-slim/test/Model/HasOnlyReadOnlyTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\HasOnlyReadOnly;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\HasOnlyReadOnly
  */
-class HasOnlyReadOnlyTest extends \PHPUnit_Framework_TestCase {
+class HasOnlyReadOnlyTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "HasOnlyReadOnly"
      */
-    public function testHasOnlyReadOnly() {
+    public function testHasOnlyReadOnly()
+    {
         $testHasOnlyReadOnly = new HasOnlyReadOnly();
     }
 
     /**
      * Test attribute "bar"
      */
-    public function testPropertyBar() {
-
+    public function testPropertyBar()
+    {
     }
 
     /**
      * Test attribute "foo"
      */
-    public function testPropertyFoo() {
-
+    public function testPropertyFoo()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/MapTestTest.php
+++ b/samples/server/petstore/php-slim/test/Model/MapTestTest.php
@@ -36,69 +36,70 @@ use OpenAPIServer\Model\MapTest;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\MapTest
  */
-class MapTestTest extends \PHPUnit_Framework_TestCase {
+class MapTestTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "MapTest"
      */
-    public function testMapTest() {
+    public function testMapTest()
+    {
         $testMapTest = new MapTest();
     }
 
     /**
      * Test attribute "mapMapOfString"
      */
-    public function testPropertyMapMapOfString() {
-
+    public function testPropertyMapMapOfString()
+    {
     }
 
     /**
      * Test attribute "mapOfEnumString"
      */
-    public function testPropertyMapOfEnumString() {
-
+    public function testPropertyMapOfEnumString()
+    {
     }
 
     /**
      * Test attribute "directMap"
      */
-    public function testPropertyDirectMap() {
-
+    public function testPropertyDirectMap()
+    {
     }
 
     /**
      * Test attribute "indirectMap"
      */
-    public function testPropertyIndirectMap() {
-
+    public function testPropertyIndirectMap()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
+++ b/samples/server/petstore/php-slim/test/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
@@ -36,62 +36,63 @@ use OpenAPIServer\Model\MixedPropertiesAndAdditionalPropertiesClass;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\MixedPropertiesAndAdditionalPropertiesClass
  */
-class MixedPropertiesAndAdditionalPropertiesClassTest extends \PHPUnit_Framework_TestCase {
+class MixedPropertiesAndAdditionalPropertiesClassTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "MixedPropertiesAndAdditionalPropertiesClass"
      */
-    public function testMixedPropertiesAndAdditionalPropertiesClass() {
+    public function testMixedPropertiesAndAdditionalPropertiesClass()
+    {
         $testMixedPropertiesAndAdditionalPropertiesClass = new MixedPropertiesAndAdditionalPropertiesClass();
     }
 
     /**
      * Test attribute "uuid"
      */
-    public function testPropertyUuid() {
-
+    public function testPropertyUuid()
+    {
     }
 
     /**
      * Test attribute "dateTime"
      */
-    public function testPropertyDateTime() {
-
+    public function testPropertyDateTime()
+    {
     }
 
     /**
      * Test attribute "map"
      */
-    public function testPropertyMap() {
-
+    public function testPropertyMap()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/Model200ResponseTest.php
+++ b/samples/server/petstore/php-slim/test/Model/Model200ResponseTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\Model200Response;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Model200Response
  */
-class Model200ResponseTest extends \PHPUnit_Framework_TestCase {
+class Model200ResponseTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Model200Response"
      */
-    public function testModel200Response() {
+    public function testModel200Response()
+    {
         $testModel200Response = new Model200Response();
     }
 
     /**
      * Test attribute "name"
      */
-    public function testPropertyName() {
-
+    public function testPropertyName()
+    {
     }
 
     /**
      * Test attribute "class"
      */
-    public function testPropertyClass() {
-
+    public function testPropertyClass()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ModelListTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ModelListTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\ModelList;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ModelList
  */
-class ModelListTest extends \PHPUnit_Framework_TestCase {
+class ModelListTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ModelList"
      */
-    public function testModelList() {
+    public function testModelList()
+    {
         $testModelList = new ModelList();
     }
 
     /**
      * Test attribute "_123list"
      */
-    public function testProperty123list() {
-
+    public function testProperty123list()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ModelReturnTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ModelReturnTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\ModelReturn;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ModelReturn
  */
-class ModelReturnTest extends \PHPUnit_Framework_TestCase {
+class ModelReturnTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ModelReturn"
      */
-    public function testModelReturn() {
+    public function testModelReturn()
+    {
         $testModelReturn = new ModelReturn();
     }
 
     /**
      * Test attribute "return"
      */
-    public function testPropertyReturn() {
-
+    public function testPropertyReturn()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/NameTest.php
+++ b/samples/server/petstore/php-slim/test/Model/NameTest.php
@@ -36,69 +36,70 @@ use OpenAPIServer\Model\Name;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Name
  */
-class NameTest extends \PHPUnit_Framework_TestCase {
+class NameTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Name"
      */
-    public function testName() {
+    public function testName()
+    {
         $testName = new Name();
     }
 
     /**
      * Test attribute "name"
      */
-    public function testPropertyName() {
-
+    public function testPropertyName()
+    {
     }
 
     /**
      * Test attribute "snakeCase"
      */
-    public function testPropertySnakeCase() {
-
+    public function testPropertySnakeCase()
+    {
     }
 
     /**
      * Test attribute "property"
      */
-    public function testPropertyProperty() {
-
+    public function testPropertyProperty()
+    {
     }
 
     /**
      * Test attribute "_123number"
      */
-    public function testProperty123number() {
-
+    public function testProperty123number()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/NumberOnlyTest.php
+++ b/samples/server/petstore/php-slim/test/Model/NumberOnlyTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\NumberOnly;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\NumberOnly
  */
-class NumberOnlyTest extends \PHPUnit_Framework_TestCase {
+class NumberOnlyTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "NumberOnly"
      */
-    public function testNumberOnly() {
+    public function testNumberOnly()
+    {
         $testNumberOnly = new NumberOnly();
     }
 
     /**
      * Test attribute "justNumber"
      */
-    public function testPropertyJustNumber() {
-
+    public function testPropertyJustNumber()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/OrderTest.php
+++ b/samples/server/petstore/php-slim/test/Model/OrderTest.php
@@ -36,83 +36,84 @@ use OpenAPIServer\Model\Order;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Order
  */
-class OrderTest extends \PHPUnit_Framework_TestCase {
+class OrderTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Order"
      */
-    public function testOrder() {
+    public function testOrder()
+    {
         $testOrder = new Order();
     }
 
     /**
      * Test attribute "id"
      */
-    public function testPropertyId() {
-
+    public function testPropertyId()
+    {
     }
 
     /**
      * Test attribute "petId"
      */
-    public function testPropertyPetId() {
-
+    public function testPropertyPetId()
+    {
     }
 
     /**
      * Test attribute "quantity"
      */
-    public function testPropertyQuantity() {
-
+    public function testPropertyQuantity()
+    {
     }
 
     /**
      * Test attribute "shipDate"
      */
-    public function testPropertyShipDate() {
-
+    public function testPropertyShipDate()
+    {
     }
 
     /**
      * Test attribute "status"
      */
-    public function testPropertyStatus() {
-
+    public function testPropertyStatus()
+    {
     }
 
     /**
      * Test attribute "complete"
      */
-    public function testPropertyComplete() {
-
+    public function testPropertyComplete()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/OuterCompositeTest.php
+++ b/samples/server/petstore/php-slim/test/Model/OuterCompositeTest.php
@@ -36,62 +36,63 @@ use OpenAPIServer\Model\OuterComposite;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\OuterComposite
  */
-class OuterCompositeTest extends \PHPUnit_Framework_TestCase {
+class OuterCompositeTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "OuterComposite"
      */
-    public function testOuterComposite() {
+    public function testOuterComposite()
+    {
         $testOuterComposite = new OuterComposite();
     }
 
     /**
      * Test attribute "myNumber"
      */
-    public function testPropertyMyNumber() {
-
+    public function testPropertyMyNumber()
+    {
     }
 
     /**
      * Test attribute "myString"
      */
-    public function testPropertyMyString() {
-
+    public function testPropertyMyString()
+    {
     }
 
     /**
      * Test attribute "myBoolean"
      */
-    public function testPropertyMyBoolean() {
-
+    public function testPropertyMyBoolean()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/OuterEnumTest.php
+++ b/samples/server/petstore/php-slim/test/Model/OuterEnumTest.php
@@ -36,41 +36,42 @@ use OpenAPIServer\Model\OuterEnum;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\OuterEnum
  */
-class OuterEnumTest extends \PHPUnit_Framework_TestCase {
+class OuterEnumTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "OuterEnum"
      */
-    public function testOuterEnum() {
+    public function testOuterEnum()
+    {
         $testOuterEnum = new OuterEnum();
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/PetTest.php
+++ b/samples/server/petstore/php-slim/test/Model/PetTest.php
@@ -36,83 +36,84 @@ use OpenAPIServer\Model\Pet;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Pet
  */
-class PetTest extends \PHPUnit_Framework_TestCase {
+class PetTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Pet"
      */
-    public function testPet() {
+    public function testPet()
+    {
         $testPet = new Pet();
     }
 
     /**
      * Test attribute "id"
      */
-    public function testPropertyId() {
-
+    public function testPropertyId()
+    {
     }
 
     /**
      * Test attribute "category"
      */
-    public function testPropertyCategory() {
-
+    public function testPropertyCategory()
+    {
     }
 
     /**
      * Test attribute "name"
      */
-    public function testPropertyName() {
-
+    public function testPropertyName()
+    {
     }
 
     /**
      * Test attribute "photoUrls"
      */
-    public function testPropertyPhotoUrls() {
-
+    public function testPropertyPhotoUrls()
+    {
     }
 
     /**
      * Test attribute "tags"
      */
-    public function testPropertyTags() {
-
+    public function testPropertyTags()
+    {
     }
 
     /**
      * Test attribute "status"
      */
-    public function testPropertyStatus() {
-
+    public function testPropertyStatus()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/ReadOnlyFirstTest.php
+++ b/samples/server/petstore/php-slim/test/Model/ReadOnlyFirstTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\ReadOnlyFirst;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\ReadOnlyFirst
  */
-class ReadOnlyFirstTest extends \PHPUnit_Framework_TestCase {
+class ReadOnlyFirstTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "ReadOnlyFirst"
      */
-    public function testReadOnlyFirst() {
+    public function testReadOnlyFirst()
+    {
         $testReadOnlyFirst = new ReadOnlyFirst();
     }
 
     /**
      * Test attribute "bar"
      */
-    public function testPropertyBar() {
-
+    public function testPropertyBar()
+    {
     }
 
     /**
      * Test attribute "baz"
      */
-    public function testPropertyBaz() {
-
+    public function testPropertyBaz()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/SpecialModelNameTest.php
+++ b/samples/server/petstore/php-slim/test/Model/SpecialModelNameTest.php
@@ -36,48 +36,49 @@ use OpenAPIServer\Model\SpecialModelName;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\SpecialModelName
  */
-class SpecialModelNameTest extends \PHPUnit_Framework_TestCase {
+class SpecialModelNameTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "SpecialModelName"
      */
-    public function testSpecialModelName() {
+    public function testSpecialModelName()
+    {
         $testSpecialModelName = new SpecialModelName();
     }
 
     /**
      * Test attribute "specialPropertyName"
      */
-    public function testPropertySpecialPropertyName() {
-
+    public function testPropertySpecialPropertyName()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/StringBooleanMapTest.php
+++ b/samples/server/petstore/php-slim/test/Model/StringBooleanMapTest.php
@@ -36,41 +36,42 @@ use OpenAPIServer\Model\StringBooleanMap;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\StringBooleanMap
  */
-class StringBooleanMapTest extends \PHPUnit_Framework_TestCase {
+class StringBooleanMapTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "StringBooleanMap"
      */
-    public function testStringBooleanMap() {
+    public function testStringBooleanMap()
+    {
         $testStringBooleanMap = new StringBooleanMap();
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/TagTest.php
+++ b/samples/server/petstore/php-slim/test/Model/TagTest.php
@@ -36,55 +36,56 @@ use OpenAPIServer\Model\Tag;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\Tag
  */
-class TagTest extends \PHPUnit_Framework_TestCase {
+class TagTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "Tag"
      */
-    public function testTag() {
+    public function testTag()
+    {
         $testTag = new Tag();
     }
 
     /**
      * Test attribute "id"
      */
-    public function testPropertyId() {
-
+    public function testPropertyId()
+    {
     }
 
     /**
      * Test attribute "name"
      */
-    public function testPropertyName() {
-
+    public function testPropertyName()
+    {
     }
 }
-

--- a/samples/server/petstore/php-slim/test/Model/UserTest.php
+++ b/samples/server/petstore/php-slim/test/Model/UserTest.php
@@ -36,97 +36,98 @@ use OpenAPIServer\Model\User;
  * @link     https://github.com/openapitools/openapi-generator
  * @coversDefaultClass \OpenAPIServer\Model\User
  */
-class UserTest extends \PHPUnit_Framework_TestCase {
+class UserTest extends \PHPUnit_Framework_TestCase
+{
 
     /**
      * Setup before running any test cases
      */
-    public static function setUpBeforeClass() {
-
+    public static function setUpBeforeClass()
+    {
     }
 
     /**
      * Setup before running each test case
      */
-    public function setUp() {
-
+    public function setUp()
+    {
     }
 
     /**
      * Clean up after running each test case
      */
-    public function tearDown() {
-
+    public function tearDown()
+    {
     }
 
     /**
      * Clean up after running all test cases
      */
-    public static function tearDownAfterClass() {
-
+    public static function tearDownAfterClass()
+    {
     }
 
     /**
      * Test "User"
      */
-    public function testUser() {
+    public function testUser()
+    {
         $testUser = new User();
     }
 
     /**
      * Test attribute "id"
      */
-    public function testPropertyId() {
-
+    public function testPropertyId()
+    {
     }
 
     /**
      * Test attribute "username"
      */
-    public function testPropertyUsername() {
-
+    public function testPropertyUsername()
+    {
     }
 
     /**
      * Test attribute "firstName"
      */
-    public function testPropertyFirstName() {
-
+    public function testPropertyFirstName()
+    {
     }
 
     /**
      * Test attribute "lastName"
      */
-    public function testPropertyLastName() {
-
+    public function testPropertyLastName()
+    {
     }
 
     /**
      * Test attribute "email"
      */
-    public function testPropertyEmail() {
-
+    public function testPropertyEmail()
+    {
     }
 
     /**
      * Test attribute "password"
      */
-    public function testPropertyPassword() {
-
+    public function testPropertyPassword()
+    {
     }
 
     /**
      * Test attribute "phone"
      */
-    public function testPropertyPhone() {
-
+    public function testPropertyPhone()
+    {
     }
 
     /**
      * Test attribute "userStatus"
      */
-    public function testPropertyUserStatus() {
-
+    public function testPropertyUserStatus()
+    {
     }
 }
-


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As defined in guide of contributing, PHP templates should meet [PSR-2 coding style](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).

I've added [PHP CodeSniffer package](https://github.com/squizlabs/PHP_CodeSniffer/wiki) to check source code on violations against user defined standard. User can change coding standard with `phpcsStandard` config option. `'PSR12'` is default(checks against PSR-1 and PSR-2)

I think it's perfect time to add linters and code formatters while generator is small like Slim now. It will be easier to update templates and check them automatically every next PR. By this reason I suggest to merge this PR before #735.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh
