### PR TITLE
[CI] use regex to check if TRAVIS_BRANCH is a working branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ after_success:
         ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
         echo "Finished ./gradlew uploadArchives";
         popd;
-      elif ([ "$TRAVIS_BRANCH" == "4.0.x" ]) ; then
+      elif ([[ "$TRAVIS_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]) ; then
         mvn clean deploy --settings CI/settings.xml;
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;


### PR DESCRIPTION
For our working branches `3.3.x`, `4.0.x`...
A `mvn clean deploy` should be performed to push the artifacts to the remote maven repository. 

This PR changes the check: instead of looking for a specific name, a regex pattern is used.