### PR TITLE
[CI] Change the way gradle uploadArchives works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,21 +118,25 @@ after_success:
   # push to maven repo
   - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       if [ "$TRAVIS_BRANCH" = "master" ]; then
-        mvn clean deploy -DskipTests=true -B -U -P release --settings CI/settings.xml;
-        echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
+        mvn clean install -DskipTests=true -U;
+        echo "Finished mvn clean install for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
-        echo "Finished ./gradlew uploadArchives";
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" uploadArchives --no-daemon;
+        echo "Finished ./gradlew uploadArchives for $TRAVIS_BRANCH";
         popd;
+        mvn deploy -DskipTests=true -B -U -P release --settings CI/settings.xml;
+        echo "Finished mvn deploy for $TRAVIS_BRANCH";
       elif ([[ "$TRAVIS_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]) ; then
-        mvn clean deploy --settings CI/settings.xml;
-        echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
+        mvn clean install -DskipTests=true;
+        echo "Finished mvn clean install for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
-        ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
-        echo "Finished ./gradlew uploadArchives";
+        ./gradlew uploadArchives --no-daemon;
+        echo "Finished ./gradlew uploadArchives for $TRAVIS_BRANCH";
         popd;
+        mvn deploy -DskipTests=true --settings CI/settings.xml;
+        echo "Finished mvn deploy for $TRAVIS_BRANCH";
       fi;
     fi;
   ## docker: build and push openapi-generator-online to DockerHub

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -155,12 +155,7 @@ uploadArchives {
         // or stored in ~/.gradle/gradle.properties as key=value pairs
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
+            repository(url: "file:../../target/nexus-staging/deferred/")
 
             pom.withXml {
                 def root = asNode()


### PR DESCRIPTION
As described in #411 the deployment of the `openapi-generator-gradle-plugin` artefact is always an issue during the release.

This PR changes the way the `openapi-generator-gradle-plugin` is deployed (`uploadArchives`)

**PREVIOUS WORKFLOW:**

1. Call `mvn clean deploy` on the maven root pom, this do not use the regular deploy plugin for each modules, but is using `nexus-staging-maven-plugin` that put each artefacts under `<repo>/target/nexus-staging/deferred/`. As final step of the build, this folder gets uploaded.
2. Call `.gradlew uploadArchives` that uploads the `openapi-generator-gradle-plugin` to the distant maven repository.


Related PR where this `deferred` folder is explained : #366 


**NEW WORKFLOW**

1. Call `mvn clean install` to build all the maven modules and to install them in the local maven repository.
2. The `uploadArchives` gradle task is modified to publish the gradle plugin into `<repo>/target/nexus-staging/deferred/`.
3. Call `mvn deploy` to publish each artefacts to the `deferred` folder. The final step will synchronise all artefacts present in this folder (in particular also the gradle plugin created at step 2).