### PR TITLE
[docker] Fixes hub dockerfile for online project

### DIFF
--- a/.hub.online.dockerfile
+++ b/.hub.online.dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p ${TARGET_DIR}
 
 WORKDIR ${TARGET_DIR}
 
-COPY --from=builder ${GEN_DIR}/modules/openapi-generator-online/target/openapi-generator.jar ${TARGET_DIR}/openapi-generator-online.jar
+COPY --from=builder ${GEN_DIR}/modules/openapi-generator-online/target/openapi-generator-online.jar ${TARGET_DIR}/openapi-generator-online.jar
 
 ENV GENERATOR_HOST=http://localhost
 


### PR DESCRIPTION
An update was made in #876 to remove version from the generated artifact
for openapi-generator-online. The change is missing the -online suffix.
My original glob pattern put the * in the wrong place for
maintainability.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
