### PR TITLE
[all] add "x-enum-varnames" extension to control enum varname

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4027,10 +4027,9 @@ public class DefaultCodegen implements CodegenConfig {
     private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions) {
         if (vendorExtensions != null && vendorExtensions.containsKey("x-enum-varnames")) {
             List<String> alias = (List<String>) vendorExtensions.get("x-enum-varnames");
-            if (alias.size() == enumVars.size()) {
-                for (int i = 0; i < alias.size(); i++) {
-                    enumVars.get(i).put("name", alias.get(i));
-                }
+            int size = Math.min(enumVars.size(), alias.size());
+            for (int i = 0; i < size; i++) {
+                enumVars.get(i).put("name", alias.get(i));
             }
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -308,19 +308,44 @@ public class DefaultCodegenTest {
 
     @Test
     public void updateCodegenPropertyEnumWithExtention() {
-        final DefaultCodegen codegen = new DefaultCodegen();
-        CodegenProperty enumProperty = codegenPropertyWithXEnumVarName();
-
-        codegen.updateCodegenPropertyEnum(enumProperty);
-
-        List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
-        Assert.assertNotNull(enumVars);
-        Assert.assertNotNull(enumVars.get(0));
-        Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
-        Assert.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
-        Assert.assertNotNull(enumVars.get(1));
-        Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
-        Assert.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
+        {
+            CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("dog", "cat"), Arrays.asList("DOGVAR", "CATVAR"));
+            (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
+            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
+            Assert.assertNotNull(enumVars);
+            Assert.assertNotNull(enumVars.get(0));
+            Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "DOGVAR");
+            Assert.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"dog\"");
+            Assert.assertNotNull(enumVars.get(1));
+            Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "CATVAR");
+            Assert.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"cat\"");
+        }
+        {
+            CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("1", "2"), Arrays.asList("ONE", "TWO"));
+            (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
+            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
+            Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "ONE");
+            Assert.assertEquals(enumVars.get(0).getOrDefault("value", ""), "\"1\"");
+            Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "TWO");
+            Assert.assertEquals(enumVars.get(1).getOrDefault("value", ""), "\"2\"");
+        }
+        {
+            CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("a", "b", "c", "d"), Arrays.asList("FOO", "BAR"));
+            (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
+            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
+            Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "FOO");
+            Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "BAR");
+            Assert.assertEquals(enumVars.get(2).getOrDefault("name", ""), "C");
+            Assert.assertEquals(enumVars.get(3).getOrDefault("name", ""), "D");
+        }
+        {
+            CodegenProperty enumProperty = codegenPropertyWithXEnumVarName(Arrays.asList("a", "b"), Arrays.asList("FOO", "BAR", "BAZ"));
+            (new DefaultCodegen()).updateCodegenPropertyEnum(enumProperty);
+            List<Map<String, Object>> enumVars = (List<Map<String, Object>>) enumProperty.getAllowableValues().get("enumVars");
+            Assert.assertEquals(enumVars.get(0).getOrDefault("name", ""), "FOO");
+            Assert.assertEquals(enumVars.get(1).getOrDefault("name", ""), "BAR");
+            Assert.assertEquals(enumVars.size(), 2);
+        }
     }
 
     @Test
@@ -514,13 +539,12 @@ public class DefaultCodegenTest {
         return array;
     }
 
-    private CodegenProperty codegenPropertyWithXEnumVarName() {
+    private CodegenProperty codegenPropertyWithXEnumVarName(List<String> values, List<String> aliases) {
         final CodegenProperty var = new CodegenProperty();
         final HashMap<String, Object> allowableValues = new HashMap<>();
-        allowableValues.put("values", Arrays.asList("dog", "cat"));
+        allowableValues.put("values", values);
         var.setAllowableValues(allowableValues);
         var.dataType = "String";
-        final List<String> aliases = Arrays.asList("DOGVAR", "CATVAR");
         Map<String, Object> extentions = Collections.singletonMap("x-enum-varnames", aliases);
         var.setVendorExtensions(extentions);
         return var;


### PR DESCRIPTION


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

For issue #893 
Add "x-enum-varnames" vendor extension to control  names of generated enum properties.



