### PR TITLE
Remove x-nullable extension support to support nullable

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -77,8 +77,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCodegen.class);
@@ -1792,11 +1792,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (p.getWriteOnly() != null) {
             property.isWriteOnly = p.getWriteOnly();
         }
-
-        // use x-nullable
-        if (p.getExtensions() != null && p.getExtensions().get("x-nullable") != null) {
-            property.isNullable = Boolean.valueOf(p.getExtensions().get("x-nullable").toString());
-        } else if (p.getNullable() != null) { // use nullable defined in OAS3
+        if (p.getNullable() != null) {
             property.isNullable = p.getNullable();
         }
 
@@ -2743,10 +2739,7 @@ public class DefaultCodegen implements CodegenConfig {
                 parameterSchema = new StringSchema().description("//TODO automatically added by openapi-generator due to missing type definition.");
             }
 
-            // x-nullable extension in OAS2
-            if (parameter.getExtensions() != null && parameter.getExtensions().get("x-nullable") != null) {
-                codegenParameter.isNullable = Boolean.valueOf(parameter.getExtensions().get("x-nullable").toString());
-            } else if (Boolean.TRUE.equals(parameterSchema.getNullable())) { // use nullable defined in the spec
+            if (Boolean.TRUE.equals(parameterSchema.getNullable())) { // use nullable defined in the spec
                 codegenParameter.isNullable = true;
             }
 
@@ -4752,10 +4745,6 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     private void setParameterNullable(CodegenParameter parameter, CodegenProperty property) {
-        if (property.getVendorExtensions() != null && property.getVendorExtensions().get("x-nullable") != null) {
-            parameter.isNullable = Boolean.valueOf(property.getVendorExtensions().get("x-nullable").toString());
-        } else {
-            parameter.isNullable = property.isNullable;
-        }
+        parameter.isNullable = property.isNullable;
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -268,8 +268,7 @@ public class RubyClientCodegenTest {
         CodegenParameter name = op.formParams.get(0);
         Assert.assertFalse(name.isNullable);
         CodegenParameter status = op.formParams.get(1);
-        // TODO comment out the following as there seems to be an issue with swagger parser not brining over the
-        // vendor extensions of the form parameter when creating the schema
+        // TODO comment out the following until https://github.com/swagger-api/swagger-parser/issues/820 is solved
         //Assert.assertTrue(status.isNullable);
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @OpenAPITools/generator-core-team @OpenAPITools/openapi-generator-collaborators 

### Description of the PR

As discussed https://github.com/OpenAPITools/openapi-generator/pull/889#issuecomment-416980977, the implementation proposed in https://github.com/OpenAPITools/openapi-generator/pull/889 needs to be adapted.

Swagger-Parser is doing the conversion from `x-nullable` OASv2 to `nullable` OASv3.
See an example in https://github.com/swagger-api/swagger-parser/issues/810.

This PR removes reading `x-nullable` extension from our code, because the extension will only be available in OASv3. In v3 having them make no sense as pointed out by @wing328.


There is still an open issue: https://github.com/swagger-api/swagger-parser/issues/820 to have the formData parameter handled in swagger. I added a reference in near to the commented unit-test.

