### PR TITLE
[rust-server] Restore support for nullable

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -145,19 +145,19 @@ pub struct {{{classname}}} {
 {{/description}}{{#isEnum}}    // Note: inline enums are not fully supported by openapi-generator
 {{/isEnum}}    #[serde(rename = "{{{baseName}}}")]{{#vendorExtensions}}{{#itemXmlName}}
     #[serde(serialize_with = "wrap_in_{{{itemXmlName}}}")]{{/itemXmlName}}{{/vendorExtensions}}{{#required}}
-    pub {{{name}}}: {{#vendorExtensions}}{{#x-nullable}}swagger::Nullable<{{/x-nullable}}{{/vendorExtensions}}{{{dataType}}}{{#vendorExtensions}}{{#x-nullable}}>{{/x-nullable}}{{/vendorExtensions}},
-{{/required}}{{^required}}{{#vendorExtensions}}{{#x-nullable}}    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
-    #[serde(default = "swagger::nullable_format::default_optional_nullable")]
-{{/x-nullable}}{{/vendorExtensions}}
+    pub {{{name}}}: {{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}},
+{{/required}}{{^required}}{{#isNullable}}
+    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
+    #[serde(default = "swagger::nullable_format::default_optional_nullable")]{{/isNullable}}
     #[serde(skip_serializing_if="Option::is_none")]
-    pub {{{name}}}: Option<{{#vendorExtensions}}{{#x-nullable}}swagger::Nullable<{{/x-nullable}}{{/vendorExtensions}}{{#isListContainer}}Vec<{{#items}}{{{dataType}}}{{/items}}>{{/isListContainer}}{{^isListContainer}}{{{dataType}}}{{/isListContainer}}{{#vendorExtensions}}{{#x-nullable}}>{{/x-nullable}}{{/vendorExtensions}}>,
+    pub {{{name}}}: Option<{{#isNullable}}swagger::Nullable<{{/isNullable}}{{#isListContainer}}Vec<{{#items}}{{{dataType}}}{{/items}}>{{/isListContainer}}{{^isListContainer}}{{{dataType}}}{{/isListContainer}}{{#isNullable}}>{{/isNullable}}>,
 {{/required}}
 
 {{/vars}}
 }
 
 impl {{{classname}}} {
-    pub fn new({{#vars}}{{^defaultValue}}{{{name}}}: {{#vendorExtensions}}{{#x-nullable}}swagger::Nullable<{{/x-nullable}}{{/vendorExtensions}}{{{dataType}}}{{#vendorExtensions}}{{#x-nullable}}>{{/x-nullable}}{{/vendorExtensions}}, {{/defaultValue}}{{/vars}}) -> {{{classname}}} {
+    pub fn new({{#vars}}{{^defaultValue}}{{{name}}}: {{#isNullable}}swagger::Nullable<{{/isNullable}}{{{dataType}}}{{#isNullable}}>{{/isNullable}}, {{/defaultValue}}{{/vars}}) -> {{{classname}}} {
         {{{classname}}} {
 {{#vars}}            {{{name}}}: {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}{{{name}}}{{/defaultValue}},
 {{/vars}}

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -19,3 +19,9 @@ definitions:
     additionalProperties:
       type: string
     example: "foo"
+  aNullableContainer:
+    type: object
+    properties:
+      NullableThing:
+        type: string
+        x-nullable: true

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -25,3 +25,8 @@ definitions:
       NullableThing:
         type: string
         x-nullable: true
+      RequiredNullableThing:
+        type: string
+        x-nullable: true
+    required:
+      - RequiredNullableThing

--- a/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
@@ -24,5 +24,10 @@ components:
         NullableThing:
           nullable: true
           type: string
+        RequiredNullableThing:
+          nullable: true
+          type: string
+      required:
+      - RequiredNullableThing
       type: object
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
@@ -19,4 +19,10 @@ components:
       description: An additionalPropertiesObject
       example: foo
       type: object
+    aNullableContainer:
+      properties:
+        NullableThing:
+          nullable: true
+          type: string
+      type: object
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -18,12 +18,16 @@ pub struct ANullableContainer {
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_thing: Option<swagger::Nullable<String>>,
 
+    #[serde(rename = "RequiredNullableThing")]
+    pub required_nullable_thing: swagger::Nullable<String>,
+
 }
 
 impl ANullableContainer {
-    pub fn new() -> ANullableContainer {
+    pub fn new(required_nullable_thing: swagger::Nullable<String>, ) -> ANullableContainer {
         ANullableContainer {
             nullable_thing: None,
+            required_nullable_thing: required_nullable_thing,
         }
     }
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -10,6 +10,24 @@ use models;
 use swagger;
 
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ANullableContainer {
+    #[serde(rename = "NullableThing")]
+    #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
+    #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub nullable_thing: Option<swagger::Nullable<String>>,
+
+}
+
+impl ANullableContainer {
+    pub fn new() -> ANullableContainer {
+        ANullableContainer {
+            nullable_thing: None,
+        }
+    }
+}
+
 /// An additionalPropertiesObject
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AdditionalPropertiesObject {


### PR DESCRIPTION
Accounts for changes in https://github.com/OpenAPITools/openapi-generator/pull/930. Adds a nullable field to the sample to reduce the risk of this regressing again in future.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @farcaller @frol 

### Description of the PR

Accounts for changes in #930. Adds a nullable field to the sample to reduce the risk of this regressing in future.

This PR  basically renames `x-nullable` to `isNullable` in the mustache template. 