### PR TITLE
Make release script cross-compatible between Mac and Linux

### DIFF
--- a/bin/utils/release_version_update.sh
+++ b/bin/utils/release_version_update.sh
@@ -31,8 +31,6 @@ else
     exit 1;
 fi
 
-
-echo "IMPORTANT: this script works on Mac only"
 echo "Release preparation: replacing $FROM with $TO in different files"
 
 declare -a files=("CI/pom.xml.bash"
@@ -48,10 +46,15 @@ declare -a files=("CI/pom.xml.bash"
                   "samples/meta-codegen/lib/pom.xml"
                   "pom.xml")
 
+sedi () {
+  # Cross-platform version of sed -i that works both on Mac and Linux
+  sed --version >/dev/null 2>&1 && sed -i -e "$@" || sed -i "" "$@"
+}
+
 for filename in "${files[@]}"; do
   # e.g. sed -i '' "s/3.0.1-SNAPSHOT/3.0.1/g" CI/pom.xml.bash
   #echo "Running command: sed -i '' "s/$FROM/$TO/g" $filename"
-  if sed -i '' "s/$FROM/$TO/g" $filename; then
+  if sedi "s/$FROM/$TO/g" $filename; then
     echo "Updated $filename successfully!"
   else
     echo "ERROR: Failed to update $filename with the following command"

--- a/bin/utils/release_version_update_docs.sh
+++ b/bin/utils/release_version_update_docs.sh
@@ -31,8 +31,6 @@ else
     exit 1;
 fi
 
-
-echo "IMPORTANT: this script works on Mac only"
 echo "Release preparation: replacing $FROM with $TO in different files"
 
 declare -a files=("modules/openapi-generator-maven-plugin/README.md"
@@ -45,10 +43,15 @@ declare -a files=("modules/openapi-generator-maven-plugin/README.md"
                   "modules/openapi-generator-gradle-plugin/samples/local-spec/README.md"
                   "README.md")
 
+sedi () {
+  # Cross-platform version of sed -i that works both on Mac and Linux
+  sed --version >/dev/null 2>&1 && sed -i -e "$@" || sed -i "" "$@"
+}
+
 for filename in "${files[@]}"; do
   # e.g. sed -i '' "s/3.0.1-SNAPSHOT/3.0.1/g" CI/pom.xml.bash
   #echo "Running command: sed -i '' "s/$FROM/$TO/g" $filename"
-  if sed -i '' "s/$FROM/$TO/g" $filename; then
+  if sedi "s/$FROM/$TO/g" $filename; then
     echo "Updated $filename successfully!"
   else
     echo "ERROR: Failed to update $filename with the following command"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I tested on Linux. Can someone test on Mac ?
