### PR TITLE
Move "ensure-up-to-date" execution to CircleCI

### DIFF
--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -10,7 +10,6 @@ if [ "$NODE_INDEX" = "1" ]; then
   mvn --quiet verify -Psamples
 elif [ "$NODE_INDEX" = "2" ]; then
   echo "Running node $NODE_INDEX to test ensure-up-to-date"
-  mvn clean package -DskipTests -Dmaven.javadoc.skip=true
   ./bin/utils/ensure-up-to-date
 else
   echo "Running node $NODE_INDEX to test CI/pom.xml.circleci.java7 ..."

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -8,6 +8,10 @@ if [ "$NODE_INDEX" = "1" ]; then
   cp CI/pom.xml.circleci pom.xml
   java -version
   mvn --quiet verify -Psamples
+elif [ "$NODE_INDEX" = "2" ]; then
+  echo "Running node $NODE_INDEX to test ensure-up-to-date"
+  mvn clean package -DskipTests -Dmaven.javadoc.skip=true
+  ./bin/utils/ensure-up-to-date
 else
   echo "Running node $NODE_INDEX to test CI/pom.xml.circleci.java7 ..."
   sudo update-java-alternatives -s java-1.7.0-openjdk-amd64

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
     machine:
       docker_layer_caching: true
     working_directory: ~/OpenAPITools/openapi-generator
-    parallelism: 2
+    parallelism: 3
     shell: /bin/bash --login
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
@@ -10,7 +10,7 @@
  * Do not edit the class manually.
  */
 
-
+//XXXXXXX Modification that should be catched by ensure-up-to-date !!
 package org.openapitools.client;
 
 import org.openapitools.client.api.*;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
@@ -10,7 +10,7 @@
  * Do not edit the class manually.
  */
 
-//XXXXXXX Modification that should be catched by ensure-up-to-date !!
+
 package org.openapitools.client;
 
 import org.openapitools.client.api.*;

--- a/shippable.yml
+++ b/shippable.yml
@@ -12,7 +12,7 @@ build:
   ci:
     - mvn --quiet clean install
     # ensure all modifications created by 'mature' generators are in the git repo
-    - ./bin/utils/ensure-up-to-date
+    # moved to CircleCI ./bin/utils/ensure-up-to-date 
     # prepare environment for tests
     - sudo apt-get update -qq
     # install stack


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Extracted from PR #929:
@wing328 proposed to move execution of `ensure-up-to-date` (see #80) to CircleCI.

This PR does the change and I will perform some checks to ensure that it works as expected.



