### PR TITLE
[rust-server] Cope with base paths with trailing '/'

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -24,7 +24,7 @@ use swagger::{self, ApiError, XSpanId, XSpanIdString, Has, AuthData};
 {{#apiUsesUuid}}use uuid;
 {{/apiUsesUuid}}use std::borrow::Cow;
 #[allow(unused_imports)]
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error;
 use std::fmt;
 use std::io::{Error, ErrorKind, Read};
@@ -47,9 +47,9 @@ define_encode_set! {
     pub ID_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | {'|'}
 }
 
-/// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
-fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
-    // First convert to Uri, since a base path is a subset of Uri.
+/// Convert input into a base URL, e.g. "http://example:123". Also checks the scheme as it goes.
+fn into_base_url(input: &str, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
+    // First convert to Uri, since a base URL is a subset of Uri.
     let uri = Uri::from_str(input)?;
 
     let scheme = uri.scheme().ok_or(ClientInitError::InvalidScheme)?;
@@ -70,13 +70,13 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
     client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
-    base_path: String,
+    base_url: String,
 }
 
 impl<F> fmt::Debug for Client<F> where
    F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Client {{ base_path: {} }}", self.base_path)
+        write!(f, "Client {{ base_url: {} }}", self.base_url)
     }
 }
 
@@ -85,7 +85,7 @@ impl<F> Clone for Client<F> where
     fn clone(&self) -> Self {
         Client {
             client_service: self.client_service.clone(),
-            base_path: self.base_path.clone()
+            base_url: self.base_url.clone()
         }
     }
 }
@@ -96,12 +96,12 @@ impl Client<hyper::client::FutureResponse> {
     ///
     /// # Arguments
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
-    pub fn try_new_http(handle: Handle, base_path: &str) -> Result<Client<hyper::client::FutureResponse>, ClientInitError> {
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
+    pub fn try_new_http(handle: Handle, base_url: &str) -> Result<Client<hyper::client::FutureResponse>, ClientInitError> {
         let http_connector = swagger::http_connector();
         Self::try_new_with_connector::<hyper::client::HttpConnector>(
             handle,
-            base_path,
+            base_url,
             Some("http"),
             http_connector,
         )
@@ -111,11 +111,11 @@ impl Client<hyper::client::FutureResponse> {
     ///
     /// # Arguments
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
     /// * `ca_certificate` - Path to CA certificate used to authenticate the server
     pub fn try_new_https<CA>(
         handle: Handle,
-        base_path: &str,
+        base_url: &str,
         ca_certificate: CA,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
@@ -124,7 +124,7 @@ impl Client<hyper::client::FutureResponse> {
         let https_connector = swagger::https_connector(ca_certificate);
         Self::try_new_with_connector::<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>(
             handle,
-            base_path,
+            base_url,
             Some("https"),
             https_connector,
         )
@@ -134,13 +134,13 @@ impl Client<hyper::client::FutureResponse> {
     ///
     /// # Arguments
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
     /// * `ca_certificate` - Path to CA certificate used to authenticate the server
     /// * `client_key` - Path to the client private key
     /// * `client_certificate` - Path to the client's public certificate associated with the private key
     pub fn try_new_https_mutual<CA, K, C>(
         handle: Handle,
-        base_path: &str,
+        base_url: &str,
         ca_certificate: CA,
         client_key: K,
         client_certificate: C,
@@ -154,7 +154,7 @@ impl Client<hyper::client::FutureResponse> {
             swagger::https_mutual_connector(ca_certificate, client_key, client_certificate);
         Self::try_new_with_connector::<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>(
             handle,
-            base_path,
+            base_url,
             Some("https"),
             https_connector,
         )
@@ -173,12 +173,12 @@ impl Client<hyper::client::FutureResponse> {
     /// # Arguments
     ///
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
     /// * `protocol` - Which protocol to use when constructing the request url, e.g. `Some("http")`
     /// * `connector_fn` - Function which returns an implementation of `hyper::client::Connect`
     pub fn try_new_with_connector<C>(
         handle: Handle,
-        base_path: &str,
+        base_url: &str,
         protocol: Option<&'static str>,
         connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -192,7 +192,7 @@ impl Client<hyper::client::FutureResponse> {
 
         Ok(Client {
             client_service: Arc::new(client_service),
-            base_path: into_base_path(base_path, protocol)?,
+            base_url: into_base_url(base_url, protocol)?,
         })
     }
 
@@ -209,12 +209,12 @@ impl Client<hyper::client::FutureResponse> {
     pub fn try_new_with_hyper_client(
         hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
-        base_path: &str
+        base_url: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     {
         Ok(Client {
             client_service: hyper_client,
-            base_path: into_base_path(base_path, None)?,
+            base_url: into_base_url(base_url, None)?,
         })
     }
 }
@@ -227,12 +227,12 @@ impl<F> Client<F> where
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
     pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
-                                       base_path: &str)
+                                       base_url: &str)
                                     -> Result<Client<F>, ClientInitError>
     {
         Ok(Client {
             client_service: client_service,
-            base_path: into_base_path(base_path, None)?,
+            base_url: into_base_url(base_url, None)?,
         })
     }
 }
@@ -250,7 +250,7 @@ impl<F, C> Api<C> for Client<F> where
 
         let uri = format!(
             "{host}{base_path}{{path}}{{#queryParams}}{{#-first}}?{{/-first}}{{=<% %>=}}{<% paramName %>}<%={{ }}=%>{{/queryParams}}",
-            host=self.base_path,
+            host=self.base_url,
             base_path=*BASE_PATH{{#pathParams}},
             {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}{{#queryParams}},
             {{{paramName}}}=utf8_percent_encode(&query_{{{paramName}}}, QUERY_ENCODE_SET){{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -1,42 +1,37 @@
 #![allow(unused_extern_crates)]
-extern crate tokio_core;
-extern crate native_tls;
-extern crate hyper_tls;
-extern crate openssl;
-extern crate mime;
 extern crate chrono;
+extern crate hyper_tls;
+extern crate mime;
+extern crate native_tls;
+extern crate openssl;
+{{#usesUrlEncodedForm}}extern crate serde_urlencoded;
+{{/usesUrlEncodedForm}}extern crate tokio_core;
 extern crate url;
-{{#usesUrlEncodedForm}}extern crate serde_urlencoded;{{/usesUrlEncodedForm}}
 
-{{#apiUsesUuid}}use uuid;{{/apiUsesUuid}}
-use hyper;
-use hyper::header::{Headers, ContentType};
-use hyper::Uri;
+use self::tokio_core::reactor::Handle;
 use self::url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET};
 use futures;
-use futures::{Future, Stream};
 use futures::{future, stream};
-use self::tokio_core::reactor::Handle;
-use std::borrow::Cow;
-use std::io::{Read, Error, ErrorKind};
+use futures::{Future, Stream};
+use hyper;
+use hyper::header::{ContentType, Headers};
+use hyper::Uri;
+use mimetypes;
+use serde_json;
+{{#usesXml}}use serde_xml_rs;
+{{/usesXml}}#[allow(unused_imports)]
+use swagger::{self, ApiError, XSpanId, XSpanIdString, Has, AuthData};
+{{#apiUsesUuid}}use uuid;
+{{/apiUsesUuid}}use std::borrow::Cow;
+#[allow(unused_imports)]
+use std::collections::BTreeMap;
 use std::error;
 use std::fmt;
+use std::io::{Error, ErrorKind, Read};
 use std::path::Path;
-use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
-
-use mimetypes;
-
-use serde_json;
-{{#usesXml}}use serde_xml_rs;{{/usesXml}}
-
-#[allow(unused_imports)]
-use std::collections::{HashMap, BTreeMap};
-#[allow(unused_imports)]
-use swagger;
-
-use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
+use std::sync::Arc;
 
 use {BASE_PATH,
      Api{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},

--- a/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-mod.mustache
@@ -38,7 +38,8 @@ use swagger;
 
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
 
-use {Api{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
+use {BASE_PATH,
+     Api{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}},
      {{{operationId}}}Response{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
      };
 use models;
@@ -253,8 +254,10 @@ impl<F, C> Api<C> for Client<F> where
 {{/required}}{{/queryParams}}
 
         let uri = format!(
-            "{}{{{basePathWithoutHost}}}{{path}}{{#queryParams}}{{#-first}}?{{/-first}}{{=<% %>=}}{<% paramName %>}<%={{ }}=%>{{/queryParams}}",
-            self.base_path{{#pathParams}}, {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}{{#queryParams}},
+            "{host}{base_path}{{path}}{{#queryParams}}{{#-first}}?{{/-first}}{{=<% %>=}}{<% paramName %>}<%={{ }}=%>{{/queryParams}}",
+            host=self.base_path,
+            base_path=*BASE_PATH{{#pathParams}},
+            {{{baseName}}}=utf8_percent_encode(&param_{{{paramName}}}.to_string(), ID_ENCODE_SET){{/pathParams}}{{#queryParams}},
             {{{paramName}}}=utf8_percent_encode(&query_{{{paramName}}}, QUERY_ENCODE_SET){{/queryParams}}
         );
 

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -35,7 +35,10 @@ mod mimetypes;
 
 pub use swagger::{ApiError, ContextWrapper};
 
-pub const BASE_PATH: &'static str = "{{{basePathWithoutHost}}}";
+lazy_static!{
+    /// Base path (without host) with trailing '/'s removed.
+    pub static ref BASE_PATH: &'static str = "{{{basePathWithoutHost}}}".trim_right_matches('/');
+}
 pub const API_VERSION: &'static str = "{{{appVersion}}}";
 
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}

--- a/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-mod.mustache
@@ -49,10 +49,12 @@ header! { (Warning, "Warning") => [String] }
 mod paths {
     extern crate regex;
 
+    use BASE_PATH;
+
     lazy_static! {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(&[
 {{#pathSet}}
-            r"^{{{basePathWithoutHost}}}{{{pathRegEx}}}"{{^-last}},{{/-last}}
+            format!(r"^{}{{{pathRegEx}}}", *BASE_PATH),
 {{/pathSet}}
         ]).unwrap();
     }
@@ -60,7 +62,7 @@ mod paths {
     pub static ID_{{{PATH_ID}}}: usize = {{{index}}};
 {{#hasPathParams}}
     lazy_static! {
-        pub static ref REGEX_{{{PATH_ID}}}: regex::Regex = regex::Regex::new(r"^{{{basePathWithoutHost}}}{{{pathRegEx}}}").unwrap();
+        pub static ref REGEX_{{{PATH_ID}}}: regex::Regex = regex::Regex::new(&format!(r"^{}{{{pathRegEx}}}", *BASE_PATH),).unwrap();
     }
 {{/hasPathParams}}
 {{/pathSet}}

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -1,42 +1,36 @@
 #![allow(unused_extern_crates)]
-extern crate tokio_core;
-extern crate native_tls;
-extern crate hyper_tls;
-extern crate openssl;
-extern crate mime;
 extern crate chrono;
-extern crate url;
+extern crate hyper_tls;
+extern crate mime;
+extern crate native_tls;
+extern crate openssl;
 extern crate serde_urlencoded;
+extern crate tokio_core;
+extern crate url;
 
-
-use hyper;
-use hyper::header::{Headers, ContentType};
-use hyper::Uri;
+use self::tokio_core::reactor::Handle;
 use self::url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET};
 use futures;
-use futures::{Future, Stream};
 use futures::{future, stream};
-use self::tokio_core::reactor::Handle;
-use std::borrow::Cow;
-use std::io::{Read, Error, ErrorKind};
-use std::error;
-use std::fmt;
-use std::path::Path;
-use std::sync::Arc;
-use std::str;
-use std::str::FromStr;
-
+use futures::{Future, Stream};
+use hyper;
+use hyper::header::{ContentType, Headers};
+use hyper::Uri;
 use mimetypes;
-
 use serde_json;
 use serde_xml_rs;
-
 #[allow(unused_imports)]
-use std::collections::{HashMap, BTreeMap};
+use swagger::{self, ApiError, XSpanId, XSpanIdString, Has, AuthData};
+use std::borrow::Cow;
 #[allow(unused_imports)]
-use swagger;
-
-use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
+use std::collections::BTreeMap;
+use std::error;
+use std::fmt;
+use std::io::{Error, ErrorKind, Read};
+use std::path::Path;
+use std::str;
+use std::str::FromStr;
+use std::sync::Arc;
 
 use {BASE_PATH,
      Api,

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -38,7 +38,8 @@ use swagger;
 
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
 
-use {Api,
+use {BASE_PATH,
+     Api,
      TestSpecialTagsResponse,
      FakeOuterBooleanSerializeResponse,
      FakeOuterCompositeSerializeResponse,
@@ -280,8 +281,9 @@ impl<F, C> Api<C> for Client<F> where
 
 
         let uri = format!(
-            "{}/v2/another-fake/dummy",
-            self.base_path
+            "{host}{base_path}/another-fake/dummy",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -355,8 +357,9 @@ impl<F, C> Api<C> for Client<F> where
 
 
         let uri = format!(
-            "{}/v2/fake/outer/boolean",
-            self.base_path
+            "{host}{base_path}/fake/outer/boolean",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -432,8 +435,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake/outer/composite",
-            self.base_path
+            "{host}{base_path}/fake/outer/composite",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -507,8 +511,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake/outer/number",
-            self.base_path
+            "{host}{base_path}/fake/outer/number",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -582,8 +587,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake/outer/string",
-            self.base_path
+            "{host}{base_path}/fake/outer/string",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -660,8 +666,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake/body-with-query-params?{query}",
-            self.base_path,
+            "{host}{base_path}/fake/body-with-query-params?{query}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
             query=utf8_percent_encode(&query_query, QUERY_ENCODE_SET)
         );
 
@@ -724,8 +731,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake",
-            self.base_path
+            "{host}{base_path}/fake",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -797,8 +805,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake",
-            self.base_path
+            "{host}{base_path}/fake",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -894,8 +903,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake?{enum_query_string_array}{enum_query_string}{enum_query_integer}{enum_query_double}",
-            self.base_path,
+            "{host}{base_path}/fake?{enum_query_string_array}{enum_query_string}{enum_query_integer}{enum_query_double}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
             enum_query_string_array=utf8_percent_encode(&query_enum_query_string_array, QUERY_ENCODE_SET),
             enum_query_string=utf8_percent_encode(&query_enum_query_string, QUERY_ENCODE_SET),
             enum_query_integer=utf8_percent_encode(&query_enum_query_integer, QUERY_ENCODE_SET),
@@ -976,8 +986,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake/inline-additionalProperties",
-            self.base_path
+            "{host}{base_path}/fake/inline-additionalProperties",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1039,8 +1050,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake/jsonFormData",
-            self.base_path
+            "{host}{base_path}/fake/jsonFormData",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1103,8 +1115,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/fake_classname_test",
-            self.base_path
+            "{host}{base_path}/fake_classname_test",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1178,8 +1191,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet",
-            self.base_path
+            "{host}{base_path}/pet",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1243,8 +1257,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet/{petId}",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/pet/{petId}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1307,8 +1323,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet/findByStatus?{status}",
-            self.base_path,
+            "{host}{base_path}/pet/findByStatus?{status}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
             status=utf8_percent_encode(&query_status, QUERY_ENCODE_SET)
         );
 
@@ -1389,8 +1406,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet/findByTags?{tags}",
-            self.base_path,
+            "{host}{base_path}/pet/findByTags?{tags}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
             tags=utf8_percent_encode(&query_tags, QUERY_ENCODE_SET)
         );
 
@@ -1468,8 +1486,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet/{petId}",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/pet/{petId}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1555,8 +1575,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet",
-            self.base_path
+            "{host}{base_path}/pet",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1636,8 +1657,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet/{petId}",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/pet/{petId}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1700,8 +1723,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/pet/{petId}/uploadImage",
-            self.base_path, petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/pet/{petId}/uploadImage",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            petId=utf8_percent_encode(&param_pet_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1774,8 +1799,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/store/order/{order_id}",
-            self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/store/order/{order_id}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1840,8 +1867,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/store/inventory",
-            self.base_path
+            "{host}{base_path}/store/inventory",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1907,8 +1935,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/store/order/{order_id}",
-            self.base_path, order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/store/order/{order_id}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            order_id=utf8_percent_encode(&param_order_id.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -1994,8 +2024,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/store/order",
-            self.base_path
+            "{host}{base_path}/store/order",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2078,8 +2109,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user",
-            self.base_path
+            "{host}{base_path}/user",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2143,8 +2175,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/createWithArray",
-            self.base_path
+            "{host}{base_path}/user/createWithArray",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2206,8 +2239,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/createWithList",
-            self.base_path
+            "{host}{base_path}/user/createWithList",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2269,8 +2303,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/{username}",
-            self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/user/{username}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2335,8 +2371,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/{username}",
-            self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/user/{username}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2426,8 +2464,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/login?{username}{password}",
-            self.base_path,
+            "{host}{base_path}/user/login?{username}{password}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
             username=utf8_percent_encode(&query_username, QUERY_ENCODE_SET),
             password=utf8_percent_encode(&query_password, QUERY_ENCODE_SET)
         );
@@ -2516,8 +2555,9 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/logout",
-            self.base_path
+            "{host}{base_path}/user/logout",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {
@@ -2573,8 +2613,10 @@ if let Some(body) = body {
 
 
         let uri = format!(
-            "{}/v2/user/{username}",
-            self.base_path, username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
+            "{host}{base_path}/user/{username}",
+            host=self.base_path,
+            base_path=*BASE_PATH,
+            username=utf8_percent_encode(&param_username.to_string(), ID_ENCODE_SET)
         );
 
         let uri = match Uri::from_str(&uri) {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -35,7 +35,10 @@ mod mimetypes;
 
 pub use swagger::{ApiError, ContextWrapper};
 
-pub const BASE_PATH: &'static str = "/v2";
+lazy_static!{
+    /// Base path (without host) with trailing '/'s removed.
+    pub static ref BASE_PATH: &'static str = "/v2".trim_right_matches('/');
+}
 pub const API_VERSION: &'static str = "1.0.0";
 
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -80,32 +80,34 @@ header! { (Warning, "Warning") => [String] }
 mod paths {
     extern crate regex;
 
+    use BASE_PATH;
+
     lazy_static! {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(&[
-            r"^/v2/another-fake/dummy$",
-            r"^/v2/fake$",
-            r"^/v2/fake/body-with-query-params$",
-            r"^/v2/fake/inline-additionalProperties$",
-            r"^/v2/fake/jsonFormData$",
-            r"^/v2/fake/outer/boolean$",
-            r"^/v2/fake/outer/composite$",
-            r"^/v2/fake/outer/number$",
-            r"^/v2/fake/outer/string$",
-            r"^/v2/fake_classname_test$",
-            r"^/v2/pet$",
-            r"^/v2/pet/findByStatus$",
-            r"^/v2/pet/findByTags$",
-            r"^/v2/pet/(?P<petId>[^/?#]*)$",
-            r"^/v2/pet/(?P<petId>[^/?#]*)/uploadImage$",
-            r"^/v2/store/inventory$",
-            r"^/v2/store/order$",
-            r"^/v2/store/order/(?P<order_id>[^/?#]*)$",
-            r"^/v2/user$",
-            r"^/v2/user/createWithArray$",
-            r"^/v2/user/createWithList$",
-            r"^/v2/user/login$",
-            r"^/v2/user/logout$",
-            r"^/v2/user/(?P<username>[^/?#]*)$"
+            format!(r"^{}/another-fake/dummy$", *BASE_PATH),
+            format!(r"^{}/fake$", *BASE_PATH),
+            format!(r"^{}/fake/body-with-query-params$", *BASE_PATH),
+            format!(r"^{}/fake/inline-additionalProperties$", *BASE_PATH),
+            format!(r"^{}/fake/jsonFormData$", *BASE_PATH),
+            format!(r"^{}/fake/outer/boolean$", *BASE_PATH),
+            format!(r"^{}/fake/outer/composite$", *BASE_PATH),
+            format!(r"^{}/fake/outer/number$", *BASE_PATH),
+            format!(r"^{}/fake/outer/string$", *BASE_PATH),
+            format!(r"^{}/fake_classname_test$", *BASE_PATH),
+            format!(r"^{}/pet$", *BASE_PATH),
+            format!(r"^{}/pet/findByStatus$", *BASE_PATH),
+            format!(r"^{}/pet/findByTags$", *BASE_PATH),
+            format!(r"^{}/pet/(?P<petId>[^/?#]*)$", *BASE_PATH),
+            format!(r"^{}/pet/(?P<petId>[^/?#]*)/uploadImage$", *BASE_PATH),
+            format!(r"^{}/store/inventory$", *BASE_PATH),
+            format!(r"^{}/store/order$", *BASE_PATH),
+            format!(r"^{}/store/order/(?P<order_id>[^/?#]*)$", *BASE_PATH),
+            format!(r"^{}/user$", *BASE_PATH),
+            format!(r"^{}/user/createWithArray$", *BASE_PATH),
+            format!(r"^{}/user/createWithList$", *BASE_PATH),
+            format!(r"^{}/user/login$", *BASE_PATH),
+            format!(r"^{}/user/logout$", *BASE_PATH),
+            format!(r"^{}/user/(?P<username>[^/?#]*)$", *BASE_PATH),
         ]).unwrap();
     }
     pub static ID_ANOTHER_FAKE_DUMMY: usize = 0;
@@ -123,17 +125,17 @@ mod paths {
     pub static ID_PET_FINDBYTAGS: usize = 12;
     pub static ID_PET_PETID: usize = 13;
     lazy_static! {
-        pub static ref REGEX_PET_PETID: regex::Regex = regex::Regex::new(r"^/v2/pet/(?P<petId>[^/?#]*)$").unwrap();
+        pub static ref REGEX_PET_PETID: regex::Regex = regex::Regex::new(&format!(r"^{}/pet/(?P<petId>[^/?#]*)$", *BASE_PATH),).unwrap();
     }
     pub static ID_PET_PETID_UPLOADIMAGE: usize = 14;
     lazy_static! {
-        pub static ref REGEX_PET_PETID_UPLOADIMAGE: regex::Regex = regex::Regex::new(r"^/v2/pet/(?P<petId>[^/?#]*)/uploadImage$").unwrap();
+        pub static ref REGEX_PET_PETID_UPLOADIMAGE: regex::Regex = regex::Regex::new(&format!(r"^{}/pet/(?P<petId>[^/?#]*)/uploadImage$", *BASE_PATH),).unwrap();
     }
     pub static ID_STORE_INVENTORY: usize = 15;
     pub static ID_STORE_ORDER: usize = 16;
     pub static ID_STORE_ORDER_ORDER_ID: usize = 17;
     lazy_static! {
-        pub static ref REGEX_STORE_ORDER_ORDER_ID: regex::Regex = regex::Regex::new(r"^/v2/store/order/(?P<order_id>[^/?#]*)$").unwrap();
+        pub static ref REGEX_STORE_ORDER_ORDER_ID: regex::Regex = regex::Regex::new(&format!(r"^{}/store/order/(?P<order_id>[^/?#]*)$", *BASE_PATH),).unwrap();
     }
     pub static ID_USER: usize = 18;
     pub static ID_USER_CREATEWITHARRAY: usize = 19;
@@ -142,7 +144,7 @@ mod paths {
     pub static ID_USER_LOGOUT: usize = 22;
     pub static ID_USER_USERNAME: usize = 23;
     lazy_static! {
-        pub static ref REGEX_USER_USERNAME: regex::Regex = regex::Regex::new(r"^/v2/user/(?P<username>[^/?#]*)$").unwrap();
+        pub static ref REGEX_USER_USERNAME: regex::Regex = regex::Regex::new(&format!(r"^{}/user/(?P<username>[^/?#]*)$", *BASE_PATH),).unwrap();
     }
 }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -1,42 +1,34 @@
 #![allow(unused_extern_crates)]
-extern crate tokio_core;
-extern crate native_tls;
-extern crate hyper_tls;
-extern crate openssl;
-extern crate mime;
 extern crate chrono;
+extern crate hyper_tls;
+extern crate mime;
+extern crate native_tls;
+extern crate openssl;
+extern crate tokio_core;
 extern crate url;
 
-
-
-use hyper;
-use hyper::header::{Headers, ContentType};
-use hyper::Uri;
+use self::tokio_core::reactor::Handle;
 use self::url::percent_encoding::{utf8_percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET};
 use futures;
-use futures::{Future, Stream};
 use futures::{future, stream};
-use self::tokio_core::reactor::Handle;
+use futures::{Future, Stream};
+use hyper;
+use hyper::header::{ContentType, Headers};
+use hyper::Uri;
+use mimetypes;
+use serde_json;
+#[allow(unused_imports)]
+use swagger::{self, ApiError, XSpanId, XSpanIdString, Has, AuthData};
 use std::borrow::Cow;
-use std::io::{Read, Error, ErrorKind};
+#[allow(unused_imports)]
+use std::collections::BTreeMap;
 use std::error;
 use std::fmt;
+use std::io::{Error, ErrorKind, Read};
 use std::path::Path;
-use std::sync::Arc;
 use std::str;
 use std::str::FromStr;
-
-use mimetypes;
-
-use serde_json;
-
-
-#[allow(unused_imports)]
-use std::collections::{HashMap, BTreeMap};
-#[allow(unused_imports)]
-use swagger;
-
-use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
+use std::sync::Arc;
 
 use {BASE_PATH,
      Api,

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -38,7 +38,8 @@ use swagger;
 
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
 
-use {Api,
+use {BASE_PATH,
+     Api,
      DummyGetResponse
      };
 use models;
@@ -249,8 +250,9 @@ impl<F, C> Api<C> for Client<F> where
 
 
         let uri = format!(
-            "{}//dummy",
-            self.base_path
+            "{host}{base_path}/dummy",
+            host=self.base_path,
+            base_path=*BASE_PATH
         );
 
         let uri = match Uri::from_str(&uri) {

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -21,7 +21,7 @@ use serde_json;
 use swagger::{self, ApiError, XSpanId, XSpanIdString, Has, AuthData};
 use std::borrow::Cow;
 #[allow(unused_imports)]
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error;
 use std::fmt;
 use std::io::{Error, ErrorKind, Read};
@@ -44,9 +44,9 @@ define_encode_set! {
     pub ID_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | {'|'}
 }
 
-/// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
-fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
-    // First convert to Uri, since a base path is a subset of Uri.
+/// Convert input into a base URL, e.g. "http://example:123". Also checks the scheme as it goes.
+fn into_base_url(input: &str, correct_scheme: Option<&'static str>) -> Result<String, ClientInitError> {
+    // First convert to Uri, since a base URL is a subset of Uri.
     let uri = Uri::from_str(input)?;
 
     let scheme = uri.scheme().ok_or(ClientInitError::InvalidScheme)?;
@@ -67,13 +67,13 @@ fn into_base_path(input: &str, correct_scheme: Option<&'static str>) -> Result<S
 pub struct Client<F> where
   F: Future<Item=hyper::Response, Error=hyper::Error> + 'static {
     client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
-    base_path: String,
+    base_url: String,
 }
 
 impl<F> fmt::Debug for Client<F> where
    F: Future<Item=hyper::Response, Error=hyper::Error>  + 'static {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Client {{ base_path: {} }}", self.base_path)
+        write!(f, "Client {{ base_url: {} }}", self.base_url)
     }
 }
 
@@ -82,7 +82,7 @@ impl<F> Clone for Client<F> where
     fn clone(&self) -> Self {
         Client {
             client_service: self.client_service.clone(),
-            base_path: self.base_path.clone()
+            base_url: self.base_url.clone()
         }
     }
 }
@@ -93,12 +93,12 @@ impl Client<hyper::client::FutureResponse> {
     ///
     /// # Arguments
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
-    pub fn try_new_http(handle: Handle, base_path: &str) -> Result<Client<hyper::client::FutureResponse>, ClientInitError> {
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
+    pub fn try_new_http(handle: Handle, base_url: &str) -> Result<Client<hyper::client::FutureResponse>, ClientInitError> {
         let http_connector = swagger::http_connector();
         Self::try_new_with_connector::<hyper::client::HttpConnector>(
             handle,
-            base_path,
+            base_url,
             Some("http"),
             http_connector,
         )
@@ -108,11 +108,11 @@ impl Client<hyper::client::FutureResponse> {
     ///
     /// # Arguments
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
     /// * `ca_certificate` - Path to CA certificate used to authenticate the server
     pub fn try_new_https<CA>(
         handle: Handle,
-        base_path: &str,
+        base_url: &str,
         ca_certificate: CA,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     where
@@ -121,7 +121,7 @@ impl Client<hyper::client::FutureResponse> {
         let https_connector = swagger::https_connector(ca_certificate);
         Self::try_new_with_connector::<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>(
             handle,
-            base_path,
+            base_url,
             Some("https"),
             https_connector,
         )
@@ -131,13 +131,13 @@ impl Client<hyper::client::FutureResponse> {
     ///
     /// # Arguments
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
     /// * `ca_certificate` - Path to CA certificate used to authenticate the server
     /// * `client_key` - Path to the client private key
     /// * `client_certificate` - Path to the client's public certificate associated with the private key
     pub fn try_new_https_mutual<CA, K, C>(
         handle: Handle,
-        base_path: &str,
+        base_url: &str,
         ca_certificate: CA,
         client_key: K,
         client_certificate: C,
@@ -151,7 +151,7 @@ impl Client<hyper::client::FutureResponse> {
             swagger::https_mutual_connector(ca_certificate, client_key, client_certificate);
         Self::try_new_with_connector::<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>(
             handle,
-            base_path,
+            base_url,
             Some("https"),
             https_connector,
         )
@@ -170,12 +170,12 @@ impl Client<hyper::client::FutureResponse> {
     /// # Arguments
     ///
     /// * `handle` - tokio reactor handle to use for execution
-    /// * `base_path` - base path of the client API, i.e. "www.my-api-implementation.com"
+    /// * `base_url` - base URL of the client API, i.e. "www.my-api-implementation.com"
     /// * `protocol` - Which protocol to use when constructing the request url, e.g. `Some("http")`
     /// * `connector_fn` - Function which returns an implementation of `hyper::client::Connect`
     pub fn try_new_with_connector<C>(
         handle: Handle,
-        base_path: &str,
+        base_url: &str,
         protocol: Option<&'static str>,
         connector_fn: Box<Fn(&Handle) -> C + Send + Sync>,
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
@@ -189,7 +189,7 @@ impl Client<hyper::client::FutureResponse> {
 
         Ok(Client {
             client_service: Arc::new(client_service),
-            base_path: into_base_path(base_path, protocol)?,
+            base_url: into_base_url(base_url, protocol)?,
         })
     }
 
@@ -206,12 +206,12 @@ impl Client<hyper::client::FutureResponse> {
     pub fn try_new_with_hyper_client(
         hyper_client: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=hyper::client::FutureResponse>>>,
         handle: Handle,
-        base_path: &str
+        base_url: &str
     ) -> Result<Client<hyper::client::FutureResponse>, ClientInitError>
     {
         Ok(Client {
             client_service: hyper_client,
-            base_path: into_base_path(base_path, None)?,
+            base_url: into_base_url(base_url, None)?,
         })
     }
 }
@@ -224,12 +224,12 @@ impl<F> Client<F> where
     /// This allows adding custom wrappers around the underlying transport, for example for logging.
     pub fn try_new_with_client_service(client_service: Arc<Box<hyper::client::Service<Request=hyper::Request<hyper::Body>, Response=hyper::Response, Error=hyper::Error, Future=F>>>,
                                        handle: Handle,
-                                       base_path: &str)
+                                       base_url: &str)
                                     -> Result<Client<F>, ClientInitError>
     {
         Ok(Client {
             client_service: client_service,
-            base_path: into_base_path(base_path, None)?,
+            base_url: into_base_url(base_url, None)?,
         })
     }
 }
@@ -243,7 +243,7 @@ impl<F, C> Api<C> for Client<F> where
 
         let uri = format!(
             "{host}{base_path}/dummy",
-            host=self.base_path,
+            host=self.base_url,
             base_path=*BASE_PATH
         );
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -35,7 +35,10 @@ mod mimetypes;
 
 pub use swagger::{ApiError, ContextWrapper};
 
-pub const BASE_PATH: &'static str = "/";
+lazy_static!{
+    /// Base path (without host) with trailing '/'s removed.
+    pub static ref BASE_PATH: &'static str = "/".trim_right_matches('/');
+}
 pub const API_VERSION: &'static str = "1.0.0";
 
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -49,9 +49,11 @@ header! { (Warning, "Warning") => [String] }
 mod paths {
     extern crate regex;
 
+    use BASE_PATH;
+
     lazy_static! {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(&[
-            r"^//dummy$"
+            format!(r"^{}/dummy$", *BASE_PATH),
         ]).unwrap();
     }
     pub static ID_DUMMY: usize = 0;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

Since we're concatenating URL path segments as strings, we need to strip any trailing '/'. 

Of course, the correct fix would be to use the `Url` type and perform the concatenation correctly. This is just a quick fix to ensure that `rust-server` stops mangling the URL when no base_path is provided (we've been exposed by the recent update to swagger-parser - see #951).

I've also renamed `base_path` to `base_url` in a file where it was actually a URL being referenced, and tidied up some imports.

The renaming is a change to the public API. However, it's fully back-compatible.