### PR TITLE
Generate a Gemfile.lock for the Ruby client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -216,6 +216,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("Rakefile.mustache", "", "Rakefile"));
         supportingFiles.add(new SupportingFile("Gemfile.mustache", "", "Gemfile"));
+        supportingFiles.add(new SupportingFile("Gemfile.lock.mustache", "", "Gemfile.lock"));
         supportingFiles.add(new SupportingFile("rubocop.mustache", "", ".rubocop.yml"));
 
         // test files should not be overwritten

--- a/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.lock.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.lock.mustache
@@ -1,0 +1,69 @@
+PATH
+  remote: .
+  specs:
+    {{gemName}}{{^gemName}}{{{appName}}}{{/gemName}} ({{gemVersion}})
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.11.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    autotest (4.4.6)
+      ZenTest (>= 4.4.1)
+    autotest-fsevent (0.2.13)
+      sys-uname
+    autotest-growl (0.2.16)
+    autotest-rails-pure (4.1.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
+    ffi (1.9.25)
+    hashdiff (0.3.7)
+    json (2.1.0)
+    public_suffix (3.0.3)
+    rake (12.0.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    safe_yaml (1.0.4)
+    sys-uname (1.0.3)
+      ffi (>= 1.0.0)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
+    vcr (3.0.3)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  autotest (~> 4.4, >= 4.4.6)
+  autotest-fsevent (~> 0.2, >= 0.2.12)
+  autotest-growl (~> 0.2, >= 0.2.16)
+  autotest-rails-pure (~> 4.1, >= 4.1.2)
+  {{gemName}}{{^gemName}}{{{appName}}}{{/gemName}}!
+  rake (~> 12.0.0)
+  rspec (~> 3.6, >= 3.6.0)
+  vcr (~> 3.0, >= 3.0.1)
+  webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
This keeps the versions consistent when a developer is testing the client locally or running some automated tests on CI.

I ran `./bin/ruby-client-petstore.sh`, and it produces an identical `Gemfile.lock` at `samples/client/petstore/ruby/Gemfile.lock`.