### PR TITLE
Trim trailing '/' from basePathWithoutHost

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -193,8 +193,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         }
 
         URL url = URLPathUtils.getServerURL(openAPI);
-        contextPath = config.escapeText(url.getPath());
-        basePathWithoutHost = contextPath.replaceAll("/$", ""); // for backward compatibility
+        contextPath = config.escapeText(url.getPath()).replaceAll("/$", ""); // for backward compatibility
+        basePathWithoutHost = contextPath;
         basePath = config.escapeText(URLPathUtils.getHost(openAPI)).replaceAll("/$", "");
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -194,14 +194,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
         URL url = URLPathUtils.getServerURL(openAPI);
         contextPath = config.escapeText(url.getPath());
-        basePathWithoutHost = contextPath; // for backward compatibility
-        basePath = config.escapeText(URLPathUtils.getHost(openAPI));
-        if ("/".equals(basePath.substring(basePath.length() - 1))) {
-            // remove trailing "/"
-            // https://host.example.com/ => https://host.example.com
-            basePath = basePath.substring(0, basePath.length() - 1);
-        }
-
+        basePathWithoutHost = contextPath.replaceAll("/$", ""); // for backward compatibility
+        basePath = config.escapeText(URLPathUtils.getHost(openAPI)).replaceAll("/$", "");
     }
 
     private void configureOpenAPIInfo() {

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -249,7 +249,7 @@ impl<F, C> Api<C> for Client<F> where
 
 
         let uri = format!(
-            "{}//dummy",
+            "{}/dummy",
             self.base_path
         );
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -35,7 +35,7 @@ mod mimetypes;
 
 pub use swagger::{ApiError, ContextWrapper};
 
-pub const BASE_PATH: &'static str = "/";
+pub const BASE_PATH: &'static str = "";
 pub const API_VERSION: &'static str = "1.0.0";
 
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -51,7 +51,7 @@ mod paths {
 
     lazy_static! {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(&[
-            r"^//dummy$"
+            r"^/dummy$"
         ]).unwrap();
     }
     pub static ID_DUMMY: usize = 0;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

`basePath` has its trailing `/` trimmed if present. This PR does the same thing for `basePathWithoutHost` as well. This fixes the common use of `{{{basePathWithoutHost}}}{{{path}}}` in the presence of trailing `/`.

This is now necessary as a result of #951, which causes `basePathWithoutHost` to otherwise default to `/`. This breaks `rust-server` (and probably other generators as well), which assumes that it can safely perform a string concatenation of `basePathWithoutHost` and `path`.