### PR TITLE
[Spring] Fix reactive + delegatePattern option

### DIFF
--- a/bin/springboot-petstore-server-reactive.sh
+++ b/bin/springboot-petstore-server-reactive.sh
@@ -26,7 +26,7 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate --artifact-id springboot-reactive -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-reactive -Dreactive=true,hideGenerationTimestamp=true $@"
+ags="generate --artifact-id springboot-reactive -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-reactive -Dreactive=true,delegatePattern=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-reactive/src/main"
 rm -rf samples/server/petstore/springboot-reactive/src/main

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -111,7 +111,7 @@ public interface {{classname}} {
         {{>methodBody}}
         {{/isDelegate}}
         {{#isDelegate}}
-        return getDelegate().{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#reactive}}, exchange{{/reactive}});
+        return getDelegate().{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#reactive}}{{#hasParams}}, {{/hasParams}}exchange{{/reactive}});
         {{/isDelegate}}
     }{{/jdk8}}
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiDelegate.mustache
@@ -12,6 +12,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.request.NativeWebRequest;
 {{/jdk8}}
 import org.springframework.web.multipart.MultipartFile;
+{{#reactive}}
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+{{/reactive}}
 
 import java.util.List;
 import java.util.Map;
@@ -45,9 +50,9 @@ public interface {{classname}}Delegate {
     /**
      * @see {{classname}}#{{operationId}}
      */
-    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}} {{>optionalDataType}} {{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
-        {{/hasMore}}{{^hasMore}}{{#reactive}},
-        {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
+    {{#jdk8}}default {{/jdk8}}{{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{^isBodyParam}}{{>optionalDataType}}{{/isBodyParam}}{{#isBodyParam}}{{^reactive}}{{{dataType}}}{{/reactive}}{{#reactive}}{{^isListContainer}}Mono{{/isListContainer}}{{#isListContainer}}Flux{{/isListContainer}}<{{{baseType}}}>{{/reactive}}{{/isBodyParam}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},
+        {{/hasMore}}{{/allParams}}{{#reactive}}{{#hasParams}},
+        {{/hasParams}}ServerWebExchange exchange{{/reactive}}){{^jdk8}};{{/jdk8}}{{#jdk8}} {
         {{>methodBody}}
     }{{/jdk8}}
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiDelegate.java
@@ -35,7 +35,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#fakeOuterBooleanSerialize
      */
-    default ResponseEntity<Boolean> fakeOuterBooleanSerialize( Boolean  body) {
+    default ResponseEntity<Boolean> fakeOuterBooleanSerialize(Boolean body) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -51,7 +51,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#fakeOuterCompositeSerialize
      */
-    default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize( OuterComposite  outerComposite) {
+    default ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(OuterComposite outerComposite) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -67,7 +67,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#fakeOuterNumberSerialize
      */
-    default ResponseEntity<BigDecimal> fakeOuterNumberSerialize( BigDecimal  body) {
+    default ResponseEntity<BigDecimal> fakeOuterNumberSerialize(BigDecimal body) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -83,7 +83,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#fakeOuterStringSerialize
      */
-    default ResponseEntity<String> fakeOuterStringSerialize( String  body) {
+    default ResponseEntity<String> fakeOuterStringSerialize(String body) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
@@ -99,7 +99,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testBodyWithFileSchema
      */
-    default ResponseEntity<Void> testBodyWithFileSchema( FileSchemaTestClass  fileSchemaTestClass) {
+    default ResponseEntity<Void> testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -107,8 +107,8 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testBodyWithQueryParams
      */
-    default ResponseEntity<Void> testBodyWithQueryParams( String  query,
-         User  user) {
+    default ResponseEntity<Void> testBodyWithQueryParams(String query,
+        User user) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -116,7 +116,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testClientModel
      */
-    default ResponseEntity<Client> testClientModel( Client  client) {
+    default ResponseEntity<Client> testClientModel(Client client) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -132,20 +132,20 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testEndpointParameters
      */
-    default ResponseEntity<Void> testEndpointParameters( BigDecimal  number,
-         Double  _double,
-         String  patternWithoutDelimiter,
-         byte[]  _byte,
-         Integer  integer,
-         Integer  int32,
-         Long  int64,
-         Float  _float,
-         String  string,
+    default ResponseEntity<Void> testEndpointParameters(BigDecimal number,
+        Double _double,
+        String patternWithoutDelimiter,
+        byte[] _byte,
+        Integer integer,
+        Integer int32,
+        Long int64,
+        Float _float,
+        String string,
         MultipartFile binary,
-         LocalDate  date,
-         OffsetDateTime  dateTime,
-         String  password,
-         String  paramCallback) {
+        LocalDate date,
+        OffsetDateTime dateTime,
+        String password,
+        String paramCallback) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -153,14 +153,14 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testEnumParameters
      */
-    default ResponseEntity<Void> testEnumParameters( List<String>  enumHeaderStringArray,
-         String  enumHeaderString,
-         List<String>  enumQueryStringArray,
-         String  enumQueryString,
-         Integer  enumQueryInteger,
-         Double  enumQueryDouble,
-         List<String>  enumFormStringArray,
-         String  enumFormString) {
+    default ResponseEntity<Void> testEnumParameters(List<String> enumHeaderStringArray,
+        String enumHeaderString,
+        List<String> enumQueryStringArray,
+        String enumQueryString,
+        Integer enumQueryInteger,
+        Double enumQueryDouble,
+        List<String> enumFormStringArray,
+        String enumFormString) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -168,7 +168,7 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testInlineAdditionalProperties
      */
-    default ResponseEntity<Void> testInlineAdditionalProperties( Map<String, String>  requestBody) {
+    default ResponseEntity<Void> testInlineAdditionalProperties(Map<String, String> requestBody) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -176,8 +176,8 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#testJsonFormData
      */
-    default ResponseEntity<Void> testJsonFormData( String  param,
-         String  param2) {
+    default ResponseEntity<Void> testJsonFormData(String param,
+        String param2) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -185,9 +185,9 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#uploadFileWithRequiredFile
      */
-    default ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile( Long  petId,
+    default ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(Long petId,
         MultipartFile requiredFile,
-         String  additionalMetadata) {
+        String additionalMetadata) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/PetApiDelegate.java
@@ -28,7 +28,7 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#addPet
      */
-    default ResponseEntity<Void> addPet( Pet  pet) {
+    default ResponseEntity<Void> addPet(Pet pet) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -36,8 +36,8 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#deletePet
      */
-    default ResponseEntity<Void> deletePet( Long  petId,
-         String  apiKey) {
+    default ResponseEntity<Void> deletePet(Long petId,
+        String apiKey) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -45,7 +45,7 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#findPetsByStatus
      */
-    default ResponseEntity<List<Pet>> findPetsByStatus( List<String>  status) {
+    default ResponseEntity<List<Pet>> findPetsByStatus(List<String> status) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -65,7 +65,7 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#findPetsByTags
      */
-    default ResponseEntity<List<Pet>> findPetsByTags( List<String>  tags) {
+    default ResponseEntity<List<Pet>> findPetsByTags(List<String> tags) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -85,7 +85,7 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#getPetById
      */
-    default ResponseEntity<Pet> getPetById( Long  petId) {
+    default ResponseEntity<Pet> getPetById(Long petId) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -105,7 +105,7 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#updatePet
      */
-    default ResponseEntity<Void> updatePet( Pet  pet) {
+    default ResponseEntity<Void> updatePet(Pet pet) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -113,9 +113,9 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#updatePetWithForm
      */
-    default ResponseEntity<Void> updatePetWithForm( Long  petId,
-         String  name,
-         String  status) {
+    default ResponseEntity<Void> updatePetWithForm(Long petId,
+        String name,
+        String status) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -123,8 +123,8 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#uploadFile
      */
-    default ResponseEntity<ModelApiResponse> uploadFile( Long  petId,
-         String  additionalMetadata,
+    default ResponseEntity<ModelApiResponse> uploadFile(Long petId,
+        String additionalMetadata,
         MultipartFile file) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/StoreApiDelegate.java
@@ -27,7 +27,7 @@ public interface StoreApiDelegate {
     /**
      * @see StoreApi#deleteOrder
      */
-    default ResponseEntity<Void> deleteOrder( String  orderId) {
+    default ResponseEntity<Void> deleteOrder(String orderId) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -43,7 +43,7 @@ public interface StoreApiDelegate {
     /**
      * @see StoreApi#getOrderById
      */
-    default ResponseEntity<Order> getOrderById( Long  orderId) {
+    default ResponseEntity<Order> getOrderById(Long orderId) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -63,7 +63,7 @@ public interface StoreApiDelegate {
     /**
      * @see StoreApi#placeOrder
      */
-    default ResponseEntity<Order> placeOrder( Order  order) {
+    default ResponseEntity<Order> placeOrder(Order order) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -27,7 +27,7 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#createUser
      */
-    default ResponseEntity<Void> createUser( User  user) {
+    default ResponseEntity<Void> createUser(User user) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -35,7 +35,7 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#createUsersWithArrayInput
      */
-    default ResponseEntity<Void> createUsersWithArrayInput( List<User>  user) {
+    default ResponseEntity<Void> createUsersWithArrayInput(List<User> user) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -43,7 +43,7 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#createUsersWithListInput
      */
-    default ResponseEntity<Void> createUsersWithListInput( List<User>  user) {
+    default ResponseEntity<Void> createUsersWithListInput(List<User> user) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -51,7 +51,7 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#deleteUser
      */
-    default ResponseEntity<Void> deleteUser( String  username) {
+    default ResponseEntity<Void> deleteUser(String username) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -59,7 +59,7 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#getUserByName
      */
-    default ResponseEntity<User> getUserByName( String  username) {
+    default ResponseEntity<User> getUserByName(String username) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
@@ -79,8 +79,8 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#loginUser
      */
-    default ResponseEntity<String> loginUser( String  username,
-         String  password) {
+    default ResponseEntity<String> loginUser(String username,
+        String password) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }
@@ -96,8 +96,8 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#updateUser
      */
-    default ResponseEntity<Void> updateUser( String  username,
-         User  user) {
+    default ResponseEntity<Void> updateUser(String username,
+        User user) {
         return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
 
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApiDelegate.java
@@ -18,6 +18,6 @@ public interface AnotherFakeApiDelegate {
     /**
      * @see AnotherFakeApi#call123testSpecialTags
      */
-    ResponseEntity<Client> call123testSpecialTags( Client  client);
+    ResponseEntity<Client> call123testSpecialTags(Client client);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiDelegate.java
@@ -27,85 +27,85 @@ public interface FakeApiDelegate {
     /**
      * @see FakeApi#fakeOuterBooleanSerialize
      */
-    ResponseEntity<Boolean> fakeOuterBooleanSerialize( Boolean  body);
+    ResponseEntity<Boolean> fakeOuterBooleanSerialize(Boolean body);
 
     /**
      * @see FakeApi#fakeOuterCompositeSerialize
      */
-    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize( OuterComposite  outerComposite);
+    ResponseEntity<OuterComposite> fakeOuterCompositeSerialize(OuterComposite outerComposite);
 
     /**
      * @see FakeApi#fakeOuterNumberSerialize
      */
-    ResponseEntity<BigDecimal> fakeOuterNumberSerialize( BigDecimal  body);
+    ResponseEntity<BigDecimal> fakeOuterNumberSerialize(BigDecimal body);
 
     /**
      * @see FakeApi#fakeOuterStringSerialize
      */
-    ResponseEntity<String> fakeOuterStringSerialize( String  body);
+    ResponseEntity<String> fakeOuterStringSerialize(String body);
 
     /**
      * @see FakeApi#testBodyWithFileSchema
      */
-    ResponseEntity<Void> testBodyWithFileSchema( FileSchemaTestClass  fileSchemaTestClass);
+    ResponseEntity<Void> testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass);
 
     /**
      * @see FakeApi#testBodyWithQueryParams
      */
-    ResponseEntity<Void> testBodyWithQueryParams( String  query,
-         User  user);
+    ResponseEntity<Void> testBodyWithQueryParams(String query,
+        User user);
 
     /**
      * @see FakeApi#testClientModel
      */
-    ResponseEntity<Client> testClientModel( Client  client);
+    ResponseEntity<Client> testClientModel(Client client);
 
     /**
      * @see FakeApi#testEndpointParameters
      */
-    ResponseEntity<Void> testEndpointParameters( BigDecimal  number,
-         Double  _double,
-         String  patternWithoutDelimiter,
-         byte[]  _byte,
-         Integer  integer,
-         Integer  int32,
-         Long  int64,
-         Float  _float,
-         String  string,
+    ResponseEntity<Void> testEndpointParameters(BigDecimal number,
+        Double _double,
+        String patternWithoutDelimiter,
+        byte[] _byte,
+        Integer integer,
+        Integer int32,
+        Long int64,
+        Float _float,
+        String string,
         MultipartFile binary,
-         LocalDate  date,
-         OffsetDateTime  dateTime,
-         String  password,
-         String  paramCallback);
+        LocalDate date,
+        OffsetDateTime dateTime,
+        String password,
+        String paramCallback);
 
     /**
      * @see FakeApi#testEnumParameters
      */
-    ResponseEntity<Void> testEnumParameters( List<String>  enumHeaderStringArray,
-         String  enumHeaderString,
-         List<String>  enumQueryStringArray,
-         String  enumQueryString,
-         Integer  enumQueryInteger,
-         Double  enumQueryDouble,
-         List<String>  enumFormStringArray,
-         String  enumFormString);
+    ResponseEntity<Void> testEnumParameters(List<String> enumHeaderStringArray,
+        String enumHeaderString,
+        List<String> enumQueryStringArray,
+        String enumQueryString,
+        Integer enumQueryInteger,
+        Double enumQueryDouble,
+        List<String> enumFormStringArray,
+        String enumFormString);
 
     /**
      * @see FakeApi#testInlineAdditionalProperties
      */
-    ResponseEntity<Void> testInlineAdditionalProperties( Map<String, String>  requestBody);
+    ResponseEntity<Void> testInlineAdditionalProperties(Map<String, String> requestBody);
 
     /**
      * @see FakeApi#testJsonFormData
      */
-    ResponseEntity<Void> testJsonFormData( String  param,
-         String  param2);
+    ResponseEntity<Void> testJsonFormData(String param,
+        String param2);
 
     /**
      * @see FakeApi#uploadFileWithRequiredFile
      */
-    ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile( Long  petId,
+    ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(Long petId,
         MultipartFile requiredFile,
-         String  additionalMetadata);
+        String additionalMetadata);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApiDelegate.java
@@ -18,6 +18,6 @@ public interface FakeClassnameTestApiDelegate {
     /**
      * @see FakeClassnameTestApi#testClassname
      */
-    ResponseEntity<Client> testClassname( Client  client);
+    ResponseEntity<Client> testClassname(Client client);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApiDelegate.java
@@ -20,46 +20,46 @@ public interface PetApiDelegate {
     /**
      * @see PetApi#addPet
      */
-    ResponseEntity<Void> addPet( Pet  pet);
+    ResponseEntity<Void> addPet(Pet pet);
 
     /**
      * @see PetApi#deletePet
      */
-    ResponseEntity<Void> deletePet( Long  petId,
-         String  apiKey);
+    ResponseEntity<Void> deletePet(Long petId,
+        String apiKey);
 
     /**
      * @see PetApi#findPetsByStatus
      */
-    ResponseEntity<List<Pet>> findPetsByStatus( List<String>  status);
+    ResponseEntity<List<Pet>> findPetsByStatus(List<String> status);
 
     /**
      * @see PetApi#findPetsByTags
      */
-    ResponseEntity<List<Pet>> findPetsByTags( List<String>  tags);
+    ResponseEntity<List<Pet>> findPetsByTags(List<String> tags);
 
     /**
      * @see PetApi#getPetById
      */
-    ResponseEntity<Pet> getPetById( Long  petId);
+    ResponseEntity<Pet> getPetById(Long petId);
 
     /**
      * @see PetApi#updatePet
      */
-    ResponseEntity<Void> updatePet( Pet  pet);
+    ResponseEntity<Void> updatePet(Pet pet);
 
     /**
      * @see PetApi#updatePetWithForm
      */
-    ResponseEntity<Void> updatePetWithForm( Long  petId,
-         String  name,
-         String  status);
+    ResponseEntity<Void> updatePetWithForm(Long petId,
+        String name,
+        String status);
 
     /**
      * @see PetApi#uploadFile
      */
-    ResponseEntity<ModelApiResponse> uploadFile( Long  petId,
-         String  additionalMetadata,
+    ResponseEntity<ModelApiResponse> uploadFile(Long petId,
+        String additionalMetadata,
         MultipartFile file);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApiDelegate.java
@@ -19,7 +19,7 @@ public interface StoreApiDelegate {
     /**
      * @see StoreApi#deleteOrder
      */
-    ResponseEntity<Void> deleteOrder( String  orderId);
+    ResponseEntity<Void> deleteOrder(String orderId);
 
     /**
      * @see StoreApi#getInventory
@@ -29,11 +29,11 @@ public interface StoreApiDelegate {
     /**
      * @see StoreApi#getOrderById
      */
-    ResponseEntity<Order> getOrderById( Long  orderId);
+    ResponseEntity<Order> getOrderById(Long orderId);
 
     /**
      * @see StoreApi#placeOrder
      */
-    ResponseEntity<Order> placeOrder( Order  order);
+    ResponseEntity<Order> placeOrder(Order order);
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -19,33 +19,33 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#createUser
      */
-    ResponseEntity<Void> createUser( User  user);
+    ResponseEntity<Void> createUser(User user);
 
     /**
      * @see UserApi#createUsersWithArrayInput
      */
-    ResponseEntity<Void> createUsersWithArrayInput( List<User>  user);
+    ResponseEntity<Void> createUsersWithArrayInput(List<User> user);
 
     /**
      * @see UserApi#createUsersWithListInput
      */
-    ResponseEntity<Void> createUsersWithListInput( List<User>  user);
+    ResponseEntity<Void> createUsersWithListInput(List<User> user);
 
     /**
      * @see UserApi#deleteUser
      */
-    ResponseEntity<Void> deleteUser( String  username);
+    ResponseEntity<Void> deleteUser(String username);
 
     /**
      * @see UserApi#getUserByName
      */
-    ResponseEntity<User> getUserByName( String  username);
+    ResponseEntity<User> getUserByName(String username);
 
     /**
      * @see UserApi#loginUser
      */
-    ResponseEntity<String> loginUser( String  username,
-         String  password);
+    ResponseEntity<String> loginUser(String username,
+        String password);
 
     /**
      * @see UserApi#logoutUser
@@ -55,7 +55,7 @@ public interface UserApiDelegate {
     /**
      * @see UserApi#updateUser
      */
-    ResponseEntity<Void> updateUser( String  username,
-         User  user);
+    ResponseEntity<Void> updateUser(String username,
+        User user);
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -7,8 +7,6 @@ package org.openapitools.api;
 
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,11 +25,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Validated
 @Api(value = "another-fake", description = "the another-fake API")
 public interface AnotherFakeApi {
+
+    default AnotherFakeApiDelegate getDelegate() {
+        return new AnotherFakeApiDelegate() {};
+    }
 
     @ApiOperation(value = "To test special tags", nickname = "call123testSpecialTags", notes = "To test special tags and operation ID starting with number", response = Client.class, tags={ "$another-fake?", })
     @ApiResponses(value = { 
@@ -41,16 +42,7 @@ public interface AnotherFakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default Mono<ResponseEntity<Client>> call123testSpecialTags(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"client\" : \"client\"}");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().call123testSpecialTags(client, exchange);
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApiController.java
@@ -2,11 +2,21 @@ package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
 @Controller
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class AnotherFakeApiController implements AnotherFakeApi {
+
+    private final AnotherFakeApiDelegate delegate;
+
+    public AnotherFakeApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) AnotherFakeApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new AnotherFakeApiDelegate() {});
+    }
+
+    @Override
+    public AnotherFakeApiDelegate getDelegate() {
+        return delegate;
+    }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/AnotherFakeApiDelegate.java
@@ -7,6 +7,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
@@ -26,16 +29,17 @@ public interface AnotherFakeApiDelegate {
     /**
      * @see AnotherFakeApi#call123testSpecialTags
      */
-    default ResponseEntity<Client> call123testSpecialTags(Client client) {
-        getRequest().ifPresent(request -> {
-            for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
-                if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                    ApiUtil.setExampleResponse(request, "application/json", "{  \"client\" : \"client\"}");
-                    break;
-                }
+    default Mono<ResponseEntity<Client>> call123testSpecialTags(Mono<Client> client,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"client\" : \"client\"}");
+                break;
             }
-        });
-        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+        }
+        return result.then(Mono.empty());
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
@@ -16,8 +16,6 @@ import org.openapitools.model.OuterComposite;
 import org.springframework.core.io.Resource;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,11 +34,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Validated
 @Api(value = "fake", description = "the fake API")
 public interface FakeApi {
+
+    default FakeApiDelegate getDelegate() {
+        return new FakeApiDelegate() {};
+    }
 
     @ApiOperation(value = "", nickname = "fakeOuterBooleanSerialize", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @ApiResponses(value = { 
@@ -49,16 +50,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Boolean>> fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body"  )  @Valid @RequestBody Mono<Boolean> body, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
-                result = ApiUtil.getExampleResponse(exchange, "null");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().fakeOuterBooleanSerialize(body, exchange);
     }
 
 
@@ -69,16 +61,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         method = RequestMethod.POST)
     default Mono<ResponseEntity<OuterComposite>> fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body"  )  @Valid @RequestBody Mono<OuterComposite> outerComposite, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"my_string\" : \"my_string\",  \"my_number\" : 0.80082819046101150206595775671303272247314453125,  \"my_boolean\" : true}");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().fakeOuterCompositeSerialize(outerComposite, exchange);
     }
 
 
@@ -89,16 +72,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         method = RequestMethod.POST)
     default Mono<ResponseEntity<BigDecimal>> fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body"  )  @Valid @RequestBody Mono<BigDecimal> body, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
-                result = ApiUtil.getExampleResponse(exchange, "null");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().fakeOuterNumberSerialize(body, exchange);
     }
 
 
@@ -109,16 +83,7 @@ public interface FakeApi {
         produces = { "*/*" }, 
         method = RequestMethod.POST)
     default Mono<ResponseEntity<String>> fakeOuterStringSerialize(@ApiParam(value = "Input string as post body"  )  @Valid @RequestBody Mono<String> body, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
-                result = ApiUtil.getExampleResponse(exchange, "null");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().fakeOuterStringSerialize(body, exchange);
     }
 
 
@@ -129,10 +94,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PUT)
     default Mono<ResponseEntity<Void>> testBodyWithFileSchema(@ApiParam(value = "" ,required=true )  @Valid @RequestBody Mono<FileSchemaTestClass> fileSchemaTestClass, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().testBodyWithFileSchema(fileSchemaTestClass, exchange);
     }
 
 
@@ -143,10 +105,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PUT)
     default Mono<ResponseEntity<Void>> testBodyWithQueryParams(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "query", required = true) String query,@ApiParam(value = "" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().testBodyWithQueryParams(query, user, exchange);
     }
 
 
@@ -158,16 +117,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default Mono<ResponseEntity<Client>> testClientModel(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"client\" : \"client\"}");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().testClientModel(client, exchange);
     }
 
 
@@ -181,10 +131,7 @@ public interface FakeApi {
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> testEndpointParameters(@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="number", required=true)  BigDecimal number,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="double", required=true)  Double _double,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="pattern_without_delimiter", required=true)  String patternWithoutDelimiter,@ApiParam(value = "None", required=true, defaultValue="null") @RequestParam(value="byte", required=true)  byte[] _byte,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="integer", required=false)  Integer integer,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="int32", required=false)  Integer int32,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="int64", required=false)  Long int64,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="float", required=false)  Float _float,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="string", required=false)  String string,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile binary,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="date", required=false)  LocalDate date,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="dateTime", required=false)  OffsetDateTime dateTime,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="password", required=false)  String password,@ApiParam(value = "None", defaultValue="null") @RequestParam(value="callback", required=false)  String paramCallback, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, exchange);
     }
 
 
@@ -196,10 +143,7 @@ public interface FakeApi {
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Void>> testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $") @RequestHeader(value="enum_header_string_array", required=false) List<String> enumHeaderStringArray,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestHeader(value="enum_header_string", required=false) String enumHeaderString,@ApiParam(value = "Query parameter enum test (string array)", allowableValues = ">, $") @Valid @RequestParam(value = "enum_query_string_array", required = false) List<String> enumQueryStringArray,@ApiParam(value = "Query parameter enum test (string)", allowableValues = "_abc, -efg, (xyz)", defaultValue = "-efg") @Valid @RequestParam(value = "enum_query_string", required = false, defaultValue="-efg") String enumQueryString,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1, -2") @Valid @RequestParam(value = "enum_query_integer", required = false) Integer enumQueryInteger,@ApiParam(value = "Query parameter enum test (double)", allowableValues = "1.1, -1.2") @Valid @RequestParam(value = "enum_query_double", required = false) Double enumQueryDouble,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$") @RequestParam(value="enum_form_string_array", required=false)  List<String> enumFormStringArray,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @RequestParam(value="enum_form_string", required=false)  String enumFormString, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, exchange);
     }
 
 
@@ -210,10 +154,7 @@ public interface FakeApi {
         consumes = { "application/json" },
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true )  @Valid @RequestBody Mono<String> requestBody, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().testInlineAdditionalProperties(requestBody, exchange);
     }
 
 
@@ -224,10 +165,7 @@ public interface FakeApi {
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Void>> testJsonFormData(@ApiParam(value = "field1", required=true, defaultValue="null") @RequestParam(value="param", required=true)  String param,@ApiParam(value = "field2", required=true, defaultValue="null") @RequestParam(value="param2", required=true)  String param2, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().testJsonFormData(param, param2, exchange);
     }
 
 
@@ -244,16 +182,7 @@ public interface FakeApi {
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
     default Mono<ResponseEntity<ModelApiResponse>> uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile requiredFile,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, exchange);
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiController.java
@@ -2,11 +2,21 @@ package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
 @Controller
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class FakeApiController implements FakeApi {
+
+    private final FakeApiDelegate delegate;
+
+    public FakeApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) FakeApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new FakeApiDelegate() {});
+    }
+
+    @Override
+    public FakeApiDelegate getDelegate() {
+        return delegate;
+    }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiDelegate.java
@@ -1,0 +1,230 @@
+package org.openapitools.api;
+
+import java.math.BigDecimal;
+import org.openapitools.model.Client;
+import org.openapitools.model.FileSchemaTestClass;
+import java.time.LocalDate;
+import java.util.Map;
+import org.openapitools.model.ModelApiResponse;
+import java.time.OffsetDateTime;
+import org.openapitools.model.OuterComposite;
+import org.springframework.core.io.Resource;
+import org.openapitools.model.User;
+import io.swagger.annotations.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A delegate to be called by the {@link FakeApiController}}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
+ */
+
+public interface FakeApiDelegate {
+
+    default Optional<NativeWebRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    /**
+     * @see FakeApi#fakeOuterBooleanSerialize
+     */
+    default Mono<ResponseEntity<Boolean>> fakeOuterBooleanSerialize(Mono<Boolean> body,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
+                result = ApiUtil.getExampleResponse(exchange, "null");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#fakeOuterCompositeSerialize
+     */
+    default Mono<ResponseEntity<OuterComposite>> fakeOuterCompositeSerialize(Mono<OuterComposite> outerComposite,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"my_string\" : \"my_string\",  \"my_number\" : 0.80082819046101150206595775671303272247314453125,  \"my_boolean\" : true}");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#fakeOuterNumberSerialize
+     */
+    default Mono<ResponseEntity<BigDecimal>> fakeOuterNumberSerialize(Mono<BigDecimal> body,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
+                result = ApiUtil.getExampleResponse(exchange, "null");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#fakeOuterStringSerialize
+     */
+    default Mono<ResponseEntity<String>> fakeOuterStringSerialize(Mono<String> body,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("*/*"))) {
+                result = ApiUtil.getExampleResponse(exchange, "null");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testBodyWithFileSchema
+     */
+    default Mono<ResponseEntity<Void>> testBodyWithFileSchema(Mono<FileSchemaTestClass> fileSchemaTestClass,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testBodyWithQueryParams
+     */
+    default Mono<ResponseEntity<Void>> testBodyWithQueryParams(String query,
+        Mono<User> user,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testClientModel
+     */
+    default Mono<ResponseEntity<Client>> testClientModel(Mono<Client> client,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"client\" : \"client\"}");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testEndpointParameters
+     */
+    default Mono<ResponseEntity<Void>> testEndpointParameters(BigDecimal number,
+        Double _double,
+        String patternWithoutDelimiter,
+        byte[] _byte,
+        Integer integer,
+        Integer int32,
+        Long int64,
+        Float _float,
+        String string,
+        MultipartFile binary,
+        LocalDate date,
+        OffsetDateTime dateTime,
+        String password,
+        String paramCallback,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testEnumParameters
+     */
+    default Mono<ResponseEntity<Void>> testEnumParameters(List<String> enumHeaderStringArray,
+        String enumHeaderString,
+        List<String> enumQueryStringArray,
+        String enumQueryString,
+        Integer enumQueryInteger,
+        Double enumQueryDouble,
+        List<String> enumFormStringArray,
+        String enumFormString,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testInlineAdditionalProperties
+     */
+    default Mono<ResponseEntity<Void>> testInlineAdditionalProperties(Mono<String> requestBody,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#testJsonFormData
+     */
+    default Mono<ResponseEntity<Void>> testJsonFormData(String param,
+        String param2,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see FakeApi#uploadFileWithRequiredFile
+     */
+    default Mono<ResponseEntity<ModelApiResponse>> uploadFileWithRequiredFile(Long petId,
+        MultipartFile requiredFile,
+        String additionalMetadata,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+}

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -7,8 +7,6 @@ package org.openapitools.api;
 
 import org.openapitools.model.Client;
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,11 +25,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Validated
 @Api(value = "fake_classname_test", description = "the fake_classname_test API")
 public interface FakeClassnameTestApi {
+
+    default FakeClassnameTestApiDelegate getDelegate() {
+        return new FakeClassnameTestApiDelegate() {};
+    }
 
     @ApiOperation(value = "To test class name in snake case", nickname = "testClassname", notes = "To test class name in snake case", response = Client.class, authorizations = {
         @Authorization(value = "api_key_query")
@@ -43,16 +44,7 @@ public interface FakeClassnameTestApi {
         consumes = { "application/json" },
         method = RequestMethod.PATCH)
     default Mono<ResponseEntity<Client>> testClassname(@ApiParam(value = "client model" ,required=true )  @Valid @RequestBody Mono<Client> client, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"client\" : \"client\"}");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().testClassname(client, exchange);
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApiController.java
@@ -2,11 +2,21 @@ package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
 @Controller
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class FakeClassnameTestApiController implements FakeClassnameTestApi {
+
+    private final FakeClassnameTestApiDelegate delegate;
+
+    public FakeClassnameTestApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) FakeClassnameTestApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new FakeClassnameTestApiDelegate() {});
+    }
+
+    @Override
+    public FakeClassnameTestApiDelegate getDelegate() {
+        return delegate;
+    }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeClassnameTestApiDelegate.java
@@ -7,6 +7,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
@@ -26,16 +29,17 @@ public interface FakeClassnameTestApiDelegate {
     /**
      * @see FakeClassnameTestApi#testClassname
      */
-    default ResponseEntity<Client> testClassname(Client client) {
-        getRequest().ifPresent(request -> {
-            for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
-                if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                    ApiUtil.setExampleResponse(request, "application/json", "{  \"client\" : \"client\"}");
-                    break;
-                }
+    default Mono<ResponseEntity<Client>> testClassname(Mono<Client> client,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"client\" : \"client\"}");
+                break;
             }
-        });
-        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+        }
+        return result.then(Mono.empty());
 
     }
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -9,8 +9,6 @@ import org.openapitools.model.ModelApiResponse;
 import org.openapitools.model.Pet;
 import org.springframework.core.io.Resource;
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,11 +27,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Validated
 @Api(value = "pet", description = "the pet API")
 public interface PetApi {
+
+    default PetApiDelegate getDelegate() {
+        return new PetApiDelegate() {};
+    }
 
     @ApiOperation(value = "Add a new pet to the store", nickname = "addPet", notes = "", authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
@@ -47,10 +48,7 @@ public interface PetApi {
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Mono<Pet> pet, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().addPet(pet, exchange);
     }
 
 
@@ -65,10 +63,7 @@ public interface PetApi {
     @RequestMapping(value = "/pet/{petId}",
         method = RequestMethod.DELETE)
     default Mono<ResponseEntity<Void>> deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) String apiKey, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().deletePet(petId, apiKey, exchange);
     }
 
 
@@ -85,20 +80,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Flux<Pet>>> findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) List<String> status, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}");
-                break;
-            }
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
-                result = ApiUtil.getExampleResponse(exchange, "<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().findPetsByStatus(status, exchange);
     }
 
 
@@ -115,20 +97,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Flux<Pet>>> findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) List<String> tags, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}");
-                break;
-            }
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
-                result = ApiUtil.getExampleResponse(exchange, "<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().findPetsByTags(tags, exchange);
     }
 
 
@@ -143,20 +112,7 @@ public interface PetApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Pet>> getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathVariable("petId") Long petId, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}");
-                break;
-            }
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
-                result = ApiUtil.getExampleResponse(exchange, "<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().getPetById(petId, exchange);
     }
 
 
@@ -174,10 +130,7 @@ public interface PetApi {
         consumes = { "application/json", "application/xml" },
         method = RequestMethod.PUT)
     default Mono<ResponseEntity<Void>> updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true )  @Valid @RequestBody Mono<Pet> pet, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().updatePet(pet, exchange);
     }
 
 
@@ -193,10 +146,7 @@ public interface PetApi {
         consumes = { "application/x-www-form-urlencoded" },
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false)  String name,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false)  String status, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().updatePetWithForm(petId, name, status, exchange);
     }
 
 
@@ -213,16 +163,7 @@ public interface PetApi {
         consumes = { "multipart/form-data" },
         method = RequestMethod.POST)
     default Mono<ResponseEntity<ModelApiResponse>> uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile file, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().uploadFile(petId, additionalMetadata, file, exchange);
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApiController.java
@@ -2,11 +2,21 @@ package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
 @Controller
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class PetApiController implements PetApi {
+
+    private final PetApiDelegate delegate;
+
+    public PetApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) PetApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new PetApiDelegate() {});
+    }
+
+    @Override
+    public PetApiDelegate getDelegate() {
+        return delegate;
+    }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/PetApiDelegate.java
@@ -1,0 +1,160 @@
+package org.openapitools.api;
+
+import org.openapitools.model.ModelApiResponse;
+import org.openapitools.model.Pet;
+import org.springframework.core.io.Resource;
+import io.swagger.annotations.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A delegate to be called by the {@link PetApiController}}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
+ */
+
+public interface PetApiDelegate {
+
+    default Optional<NativeWebRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    /**
+     * @see PetApi#addPet
+     */
+    default Mono<ResponseEntity<Void>> addPet(Mono<Pet> pet,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#deletePet
+     */
+    default Mono<ResponseEntity<Void>> deletePet(Long petId,
+        String apiKey,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#findPetsByStatus
+     */
+    default Mono<ResponseEntity<Flux<Pet>>> findPetsByStatus(List<String> status,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}");
+                break;
+            }
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
+                result = ApiUtil.getExampleResponse(exchange, "<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#findPetsByTags
+     */
+    default Mono<ResponseEntity<Flux<Pet>>> findPetsByTags(List<String> tags,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}");
+                break;
+            }
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
+                result = ApiUtil.getExampleResponse(exchange, "<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#getPetById
+     */
+    default Mono<ResponseEntity<Pet>> getPetById(Long petId,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"photoUrls\" : [ \"photoUrls\", \"photoUrls\" ],  \"name\" : \"doggie\",  \"id\" : 0,  \"category\" : {    \"name\" : \"name\",    \"id\" : 6  },  \"tags\" : [ {    \"name\" : \"name\",    \"id\" : 1  }, {    \"name\" : \"name\",    \"id\" : 1  } ],  \"status\" : \"available\"}");
+                break;
+            }
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
+                result = ApiUtil.getExampleResponse(exchange, "<Pet>  <id>123456789</id>  <name>doggie</name>  <photoUrls>    <photoUrls>aeiou</photoUrls>  </photoUrls>  <tags>  </tags>  <status>aeiou</status></Pet>");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#updatePet
+     */
+    default Mono<ResponseEntity<Void>> updatePet(Mono<Pet> pet,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#updatePetWithForm
+     */
+    default Mono<ResponseEntity<Void>> updatePetWithForm(Long petId,
+        String name,
+        String status,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see PetApi#uploadFile
+     */
+    default Mono<ResponseEntity<ModelApiResponse>> uploadFile(Long petId,
+        String additionalMetadata,
+        MultipartFile file,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"code\" : 0,  \"type\" : \"type\",  \"message\" : \"message\"}");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+}

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -8,8 +8,6 @@ package org.openapitools.api;
 import java.util.Map;
 import org.openapitools.model.Order;
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,11 +26,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Validated
 @Api(value = "store", description = "the store API")
 public interface StoreApi {
+
+    default StoreApiDelegate getDelegate() {
+        return new StoreApiDelegate() {};
+    }
 
     @ApiOperation(value = "Delete purchase order by ID", nickname = "deleteOrder", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", tags={ "store", })
     @ApiResponses(value = { 
@@ -41,10 +42,7 @@ public interface StoreApi {
     @RequestMapping(value = "/store/order/{order_id}",
         method = RequestMethod.DELETE)
     default Mono<ResponseEntity<Void>> deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathVariable("order_id") String orderId, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().deleteOrder(orderId, exchange);
     }
 
 
@@ -57,10 +55,7 @@ public interface StoreApi {
         produces = { "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Map<String, Integer>>> getInventory(ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().getInventory(exchange);
     }
 
 
@@ -73,20 +68,7 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Order>> getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathVariable("order_id") Long orderId, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}");
-                break;
-            }
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
-                result = ApiUtil.getExampleResponse(exchange, "<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().getOrderById(orderId, exchange);
     }
 
 
@@ -98,20 +80,7 @@ public interface StoreApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Order>> placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true )  @Valid @RequestBody Mono<Order> order, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}");
-                break;
-            }
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
-                result = ApiUtil.getExampleResponse(exchange, "<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().placeOrder(order, exchange);
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApiController.java
@@ -2,11 +2,21 @@ package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
 @Controller
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class StoreApiController implements StoreApi {
+
+    private final StoreApiDelegate delegate;
+
+    public StoreApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) StoreApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new StoreApiDelegate() {});
+    }
+
+    @Override
+    public StoreApiDelegate getDelegate() {
+        return delegate;
+    }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/StoreApiDelegate.java
@@ -1,0 +1,93 @@
+package org.openapitools.api;
+
+import java.util.Map;
+import org.openapitools.model.Order;
+import io.swagger.annotations.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A delegate to be called by the {@link StoreApiController}}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
+ */
+
+public interface StoreApiDelegate {
+
+    default Optional<NativeWebRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    /**
+     * @see StoreApi#deleteOrder
+     */
+    default Mono<ResponseEntity<Void>> deleteOrder(String orderId,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see StoreApi#getInventory
+     */
+    default Mono<ResponseEntity<Map<String, Integer>>> getInventory(ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see StoreApi#getOrderById
+     */
+    default Mono<ResponseEntity<Order>> getOrderById(Long orderId,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}");
+                break;
+            }
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
+                result = ApiUtil.getExampleResponse(exchange, "<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see StoreApi#placeOrder
+     */
+    default Mono<ResponseEntity<Order>> placeOrder(Mono<Order> order,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"petId\" : 6,  \"quantity\" : 1,  \"id\" : 0,  \"shipDate\" : \"2000-01-23T04:56:07.000+00:00\",  \"complete\" : false,  \"status\" : \"placed\"}");
+                break;
+            }
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
+                result = ApiUtil.getExampleResponse(exchange, "<Order>  <id>123456789</id>  <petId>123456789</petId>  <quantity>123</quantity>  <shipDate>2000-01-23T04:56:07.000Z</shipDate>  <status>aeiou</status>  <complete>true</complete></Order>");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+}

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -8,8 +8,6 @@ package org.openapitools.api;
 import java.util.List;
 import org.openapitools.model.User;
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,11 +26,14 @@ import javax.validation.Valid;
 import javax.validation.constraints.*;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Validated
 @Api(value = "user", description = "the user API")
 public interface UserApi {
+
+    default UserApiDelegate getDelegate() {
+        return new UserApiDelegate() {};
+    }
 
     @ApiOperation(value = "Create user", nickname = "createUser", notes = "This can only be done by the logged in user.", tags={ "user", })
     @ApiResponses(value = { 
@@ -40,10 +41,7 @@ public interface UserApi {
     @RequestMapping(value = "/user",
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> createUser(@ApiParam(value = "Created user object" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().createUser(user, exchange);
     }
 
 
@@ -53,10 +51,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithArray",
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody Flux<List> user, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().createUsersWithArrayInput(user, exchange);
     }
 
 
@@ -66,10 +61,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/createWithList",
         method = RequestMethod.POST)
     default Mono<ResponseEntity<Void>> createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true )  @Valid @RequestBody Flux<List> user, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().createUsersWithListInput(user, exchange);
     }
 
 
@@ -80,10 +72,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         method = RequestMethod.DELETE)
     default Mono<ResponseEntity<Void>> deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathVariable("username") String username, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().deleteUser(username, exchange);
     }
 
 
@@ -96,20 +85,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<User>> getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathVariable("username") String username, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                result = ApiUtil.getExampleResponse(exchange, "{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}");
-                break;
-            }
-            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
-                result = ApiUtil.getExampleResponse(exchange, "<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>");
-                break;
-            }
-        }
-        return result.then(Mono.empty());
-
+        return getDelegate().getUserByName(username, exchange);
     }
 
 
@@ -121,10 +97,7 @@ public interface UserApi {
         produces = { "application/xml", "application/json" }, 
         method = RequestMethod.GET)
     default Mono<ResponseEntity<String>> loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) String username,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) String password, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().loginUser(username, password, exchange);
     }
 
 
@@ -134,10 +107,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/logout",
         method = RequestMethod.GET)
     default Mono<ResponseEntity<Void>> logoutUser(ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().logoutUser(exchange);
     }
 
 
@@ -148,10 +118,7 @@ public interface UserApi {
     @RequestMapping(value = "/user/{username}",
         method = RequestMethod.PUT)
     default Mono<ResponseEntity<Void>> updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathVariable("username") String username,@ApiParam(value = "Updated user object" ,required=true )  @Valid @RequestBody Mono<User> user, ServerWebExchange exchange) {
-        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
-        Mono<Void> result = Mono.empty();
-        return result.then(Mono.empty());
-
+        return getDelegate().updateUser(username, user, exchange);
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiController.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiController.java
@@ -2,11 +2,21 @@ package org.openapitools.api;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.context.request.NativeWebRequest;
 import java.util.Optional;
 
 @Controller
 @RequestMapping("${openapi.openAPIPetstore.base-path:/v2}")
 public class UserApiController implements UserApi {
+
+    private final UserApiDelegate delegate;
+
+    public UserApiController(@org.springframework.beans.factory.annotation.Autowired(required = false) UserApiDelegate delegate) {
+        this.delegate = Optional.ofNullable(delegate).orElse(new UserApiDelegate() {});
+    }
+
+    @Override
+    public UserApiDelegate getDelegate() {
+        return delegate;
+    }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/UserApiDelegate.java
@@ -1,0 +1,129 @@
+package org.openapitools.api;
+
+import java.util.List;
+import org.openapitools.model.User;
+import io.swagger.annotations.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A delegate to be called by the {@link UserApiController}}.
+ * Implement this interface with a {@link org.springframework.stereotype.Service} annotated class.
+ */
+
+public interface UserApiDelegate {
+
+    default Optional<NativeWebRequest> getRequest() {
+        return Optional.empty();
+    }
+
+    /**
+     * @see UserApi#createUser
+     */
+    default Mono<ResponseEntity<Void>> createUser(Mono<User> user,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#createUsersWithArrayInput
+     */
+    default Mono<ResponseEntity<Void>> createUsersWithArrayInput(Flux<List> user,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#createUsersWithListInput
+     */
+    default Mono<ResponseEntity<Void>> createUsersWithListInput(Flux<List> user,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#deleteUser
+     */
+    default Mono<ResponseEntity<Void>> deleteUser(String username,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#getUserByName
+     */
+    default Mono<ResponseEntity<User>> getUserByName(String username,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        for (MediaType mediaType : exchange.getRequest().getHeaders().getAccept()) {
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                result = ApiUtil.getExampleResponse(exchange, "{  \"firstName\" : \"firstName\",  \"lastName\" : \"lastName\",  \"password\" : \"password\",  \"userStatus\" : 6,  \"phone\" : \"phone\",  \"id\" : 0,  \"email\" : \"email\",  \"username\" : \"username\"}");
+                break;
+            }
+            if (mediaType.isCompatibleWith(MediaType.valueOf("application/xml"))) {
+                result = ApiUtil.getExampleResponse(exchange, "<User>  <id>123456789</id>  <username>aeiou</username>  <firstName>aeiou</firstName>  <lastName>aeiou</lastName>  <email>aeiou</email>  <password>aeiou</password>  <phone>aeiou</phone>  <userStatus>123</userStatus></User>");
+                break;
+            }
+        }
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#loginUser
+     */
+    default Mono<ResponseEntity<String>> loginUser(String username,
+        String password,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#logoutUser
+     */
+    default Mono<ResponseEntity<Void>> logoutUser(ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+    /**
+     * @see UserApi#updateUser
+     */
+    default Mono<ResponseEntity<Void>> updateUser(String username,
+        Mono<User> user,
+        ServerWebExchange exchange) {
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        Mono<Void> result = Mono.empty();
+        return result.then(Mono.empty());
+
+    }
+
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

This combination currently doesn't work.

cc @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @jeff9finger (2018/01)