### PR TITLE
Added pry-byebug to make it easier to debug the Ruby client during development

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.lock.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.lock.mustache
@@ -17,6 +17,8 @@ GEM
       sys-uname
     autotest-growl (0.2.16)
     autotest-rails-pure (4.1.2)
+    byebug (10.0.2)
+    coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -25,6 +27,13 @@ GEM
     ffi (1.9.25)
     hashdiff (0.3.7)
     json (2.1.0)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.3)
     rake (12.0.0)
     rspec (3.8.0)
@@ -60,6 +69,7 @@ DEPENDENCIES
   autotest-growl (~> 0.2, >= 0.2.16)
   autotest-rails-pure (~> 4.1, >= 4.1.2)
   {{gemName}}{{^gemName}}{{{appName}}}{{/gemName}}!
+  pry-byebug
   rake (~> 12.0.0)
   rspec (~> 3.6, >= 3.6.0)
   vcr (~> 3.0, >= 3.0.1)

--- a/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.mustache
@@ -4,4 +4,5 @@ gemspec
 
 group :development, :test do
   gem 'rake', '~> 12.0.0'
+  gem 'pry-byebug'
 end

--- a/samples/client/petstore/ruby/Gemfile
+++ b/samples/client/petstore/ruby/Gemfile
@@ -4,4 +4,5 @@ gemspec
 
 group :development, :test do
   gem 'rake', '~> 12.0.0'
+  gem 'pry-byebug'
 end

--- a/samples/client/petstore/ruby/Gemfile.lock
+++ b/samples/client/petstore/ruby/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
       sys-uname
     autotest-growl (0.2.16)
     autotest-rails-pure (4.1.2)
+    byebug (10.0.2)
+    coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -25,6 +27,13 @@ GEM
     ffi (1.9.25)
     hashdiff (0.3.7)
     json (2.1.0)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.3)
     rake (12.0.0)
     rspec (3.8.0)
@@ -60,6 +69,7 @@ DEPENDENCIES
   autotest-growl (~> 0.2, >= 0.2.16)
   autotest-rails-pure (~> 4.1, >= 4.1.2)
   petstore!
+  pry-byebug
   rake (~> 12.0.0)
   rspec (~> 3.6, >= 3.6.0)
   vcr (~> 3.0, >= 3.0.1)


### PR DESCRIPTION
cc @cliffano, @zlx

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adds the `pry-byebug` gem for development, which makes it much easier to debug the Ruby client if you need to check something. Add `binding.pry` to get a breakpoint where you can inspect variables, etc.

