### PR TITLE
Uncomment the status.isNullable test in RubyClientCodegenTest.java since #820 is now solved in swagger-parser

### DIFF
--- a/CI/pom.xml.bash
+++ b/CI/pom.xml.bash
@@ -920,7 +920,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
+        <swagger-parser-version>2.0.4-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.circleci
+++ b/CI/pom.xml.circleci
@@ -1030,7 +1030,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
+        <swagger-parser-version>2.0.4-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.circleci.java7
+++ b/CI/pom.xml.circleci.java7
@@ -1000,7 +1000,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
+        <swagger-parser-version>2.0.4-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/CI/pom.xml.ios
+++ b/CI/pom.xml.ios
@@ -928,7 +928,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
+        <swagger-parser-version>2.0.4-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -203,11 +203,11 @@
             <artifactId>swagger-core</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
-        <dependency> 
+        <dependency>
             <groupId>org.openapitools.swagger.parser</groupId>
             <artifactId>swagger-parser</artifactId>
             <version>${swagger-parser-version}</version>
-        </dependency> 
+        </dependency>
         <dependency>
             <groupId>com.samskivert</groupId>
             <artifactId>jmustache</artifactId>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -268,7 +268,6 @@ public class RubyClientCodegenTest {
         CodegenParameter name = op.formParams.get(0);
         Assert.assertFalse(name.isNullable);
         CodegenParameter status = op.formParams.get(1);
-        // TODO comment out the following until https://github.com/swagger-api/swagger-parser/issues/820 is solved
-        //Assert.assertTrue(status.isNullable);
+        Assert.assertTrue(status.isNullable);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1147,7 +1147,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <swagger-parser-version>2.0.3-OpenAPITools.org-1</swagger-parser-version>
+        <swagger-parser-version>2.0.4-OpenAPITools.org-1</swagger-parser-version>
         <swagger-core-version>2.0.1</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.0</felix-version>


### PR DESCRIPTION
I just saw this line in `RubyClientCodegenTest.java` that said:

```
// TODO comment out the following until https://github.com/swagger-api/swagger-parser/issues/820 is solved
```

That issue is now solved, so I've updated the `swagger-parser-version` to `2.0.4` and uncommented this line.

