### PR TITLE
Ignore modules/openapi-generator-gradle-plugin/bin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 *.gpg
 classpath.txt
 version.properties
+modules/openapi-generator-gradle-plugin/bin/
 !modules/openapi-generator-cli/src/main/resources/version.properties
 .project
 .classpath


### PR DESCRIPTION
I'm always seeing this in `git status` after compiling the project:

```
untracked: modules/openapi-generator-gradle-plugin/bin/
```

I imagine that these are build artifacts that shouldn't be checked in, so I've added it to `.gitignore`.