### PR TITLE
Fix issue with Ruby client where strings from example properties are not wrapped with quotes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -18,6 +18,8 @@
 package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.examples.Example;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.slf4j.Logger;
@@ -535,6 +537,34 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         }
 
         p.example = example;
+    }
+
+    /**
+     * Return the example value of the parameter. Overrides the
+     * setParameterExampleValue(CodegenParameter, Parameter) method in
+     * DefaultCodegen to always call setParameterExampleValue(CodegenParameter)
+     * in this class, which adds single quotes around strings from the
+     * x-example property.
+     *
+     * @param codegenParameter Codegen parameter
+     * @param parameter        Parameter
+     */
+    public void setParameterExampleValue(CodegenParameter codegenParameter, Parameter parameter) {
+        if (parameter.getExample() != null) {
+            codegenParameter.example = parameter.getExample().toString();
+        } else if (parameter.getExamples() != null && !parameter.getExamples().isEmpty()) {
+            Example example = parameter.getExamples().values().iterator().next();
+            if (example.getValue() != null) {
+                codegenParameter.example = example.getValue().toString();
+            }
+        } else {
+            Schema schema = parameter.getSchema();
+            if (schema != null && schema.getExample() != null) {
+                codegenParameter.example = schema.getExample().toString();
+            }
+        }
+
+        setParameterExampleValue(codegenParameter);
     }
 
     public void setGemName(String gemName) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -271,4 +271,33 @@ public class RubyClientCodegenTest {
         // TODO comment out the following until https://github.com/swagger-api/swagger-parser/issues/820 is solved
         //Assert.assertTrue(status.isNullable);
     }
+
+    @Test(description = "test example string imported from x-example parameterr (OAS2)")
+    public void exampleStringFromExampleParameterOAS2Test() {
+        final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/2_0/petstore-nullable.yaml", null, new ParseOptions()).getOpenAPI();
+        final RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setModuleName("OnlinePetstore");
+        final String path = "/store/order/{orderId}";
+
+        final Operation p = openAPI.getPaths().get(path).getDelete();
+        final CodegenOperation op = codegen.fromOperation(path, "delete", p, openAPI.getComponents().getSchemas());
+
+        CodegenParameter pp = op.pathParams.get(0);
+        Assert.assertEquals(pp.example, "'orderid123'");
+    }
+
+    @Test(description = "test example string imported from example in schema (OAS3)")
+    public void exampleStringFromXExampleParameterOAS3Test() {
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/petstore_oas3_test.yaml", null, new ParseOptions()).getOpenAPI();
+        final RubyClientCodegen codegen = new RubyClientCodegen();
+        codegen.setModuleName("OnlinePetstore");
+        final String path = "/store/order/{orderId}";
+
+        final Operation p = openAPI.getPaths().get(path).getDelete();
+        final CodegenOperation op = codegen.fromOperation(path, "delete", p, openAPI.getComponents().getSchemas());
+
+        CodegenParameter pp = op.pathParams.get(0);
+        Assert.assertEquals(pp.example, "'orderid123'");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/2_0/petstore-nullable.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore-nullable.yaml
@@ -361,6 +361,7 @@ paths:
           description: ID of the order that needs to be deleted
           required: true
           type: string
+          x-example: orderid123
       responses:
         '400':
           description: Invalid ID supplied

--- a/modules/openapi-generator/src/test/resources/3_0/petstore_oas3_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore_oas3_test.yaml
@@ -360,6 +360,7 @@ paths:
           required: true
           schema:
             type: string
+            example: orderid123
       responses:
         '400':
           description: Invalid ID supplied


### PR DESCRIPTION
This fixes an issue with examples for the Ruby client, where example strings are not properly quoted.

Before, it would generate code like this:

```
order_id = order_id123 # String | 
```

After this change, the example string is wrapped with single quotes:

```
order_id = 'order_id123' # String | 
```

This change might be useful for some other languages too, but not sure. Maybe I should update the code in `DefaultCodegen`.
