### PR TITLE
[validation] add error if path do not start with a slash

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
@@ -46,6 +46,7 @@ public class Validate implements Runnable {
         SwaggerParseResult result = new OpenAPIParser().readLocation(spec, null, null);
         List<String> messageList = result.getMessages();
         Set<String> errors = new HashSet<String>(messageList);
+        errors.addAll(ModelUtils.getErrorMessages(result.getOpenAPI()));
         Set<String> warnings = new HashSet<String>();
 
         StringBuilder sb = new StringBuilder();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -543,6 +543,7 @@ public class CodegenConfigurator implements Serializable {
 
         Set<String> validationMessages = new HashSet<>(result.getMessages());
         OpenAPI specification = result.getOpenAPI();
+        validationMessages.addAll(ModelUtils.getErrorMessages(specification));
 
         // NOTE: We will only expose errors+warnings if there are already errors in the spec.
         if (validationMessages.size() > 0) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -692,4 +692,21 @@ public class ModelUtils {
         }
         return null;
     }
+
+    /**
+     * Compute additional error messages that are not detected by the parser
+     * @param openAPI specification being checked
+     * @return a list of errors (items that are not conform)
+     */
+    public static List<String> getErrorMessages(OpenAPI openAPI) {
+        List<String> errors = new ArrayList<>();
+        if (openAPI.getPaths() != null) {
+            List<String> pathErrors = openAPI.getPaths().keySet().stream()
+                .filter(path -> !path.startsWith("/"))
+                .map(path -> String.format("'%s' must begin with a slash, change it to '/%s'", path, path))
+                .collect(Collectors.toList());
+            errors.addAll(pathErrors);
+        }
+        return errors;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -703,7 +704,7 @@ public class ModelUtils {
         if (openAPI.getPaths() != null) {
             List<String> pathErrors = openAPI.getPaths().keySet().stream()
                 .filter(path -> !path.startsWith("/"))
-                .map(path -> String.format("'%s' must begin with a slash, change it to '/%s'", path, path))
+                .map(path -> String.format(Locale.ROOT, "'%s' must begin with a slash, change it to '/%s'", path, path))
                 .collect(Collectors.toList());
             errors.addAll(pathErrors);
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -19,10 +19,13 @@ package org.openapitools.codegen.utils;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.parser.core.models.ParseOptions;
 
 import org.openapitools.codegen.TestUtils;
@@ -192,5 +195,26 @@ public class ModelUtilsTest {
         allSchemas.put("SomeComposedSchema", composedSchema);
 
         Assert.assertEquals(refToComposedSchema, ModelUtils.unaliasSchema(allSchemas, refToComposedSchema));
+    }
+
+    @Test
+    public void testGetErrorMessages() {
+        //empty case:
+        OpenAPI openAPI1 = TestUtils.createOpenAPI();
+        List<String> errors1 = ModelUtils.getErrorMessages(openAPI1);
+        Assert.assertEquals(errors1.size(), 0);
+
+        //wrong path:
+        OpenAPI openAPI2 = TestUtils.createOpenAPI();
+        openAPI2.path("some/path", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        List<String> errors2 = ModelUtils.getErrorMessages(openAPI2);
+        Assert.assertEquals(errors2.size(), 1);
+        Assert.assertEquals(errors2.get(0), "'some/path' must begin with a slash, change it to '/some/path'");
+
+        //correct path:
+        OpenAPI openAPI3 = TestUtils.createOpenAPI();
+        openAPI3.path("/path2", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        List<String> errors3 = ModelUtils.getErrorMessages(openAPI3);
+        Assert.assertEquals(errors3.size(), 0);
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team  @OpenAPITools/openapi-generator-collaborators (change in core)

### Description of the PR

From https://github.com/OpenAPITools/openapi-generator/pull/967#issuecomment-418602467

This spec is not valid:

```yaml
openapi: '3.0.1'
info:
  title: ping test
  version: '1.0'
servers:
  - url: 'http://localhost:8000/api/'
paths:
  ping/me:
    get:
      operationId: pingGet
      responses:
        '201':
          description: OK
```

Because the path `ping/me` do not conform to this rule:

> The field name MUST begin with a slash.

See the [OpenAPI Specification 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#patterned-fields).

Some editors like [Swagger online editor](https://editor.swagger.io/) or the [KaiZen-Editor](https://github.com/RepreZen/KaiZen-OpenApi-Editor/) are reporting errors, but Swagger-Parser do not.

This PR add additional errors to the Swagger-Parser error message. If the user decide to by-pass the validation he might get invalid generated code.

