### PR TITLE
Add a CLI option to control logging level

### DIFF
--- a/modules/openapi-generator-cli/src/main/resources/logback.xml
+++ b/modules/openapi-generator-cli/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="STDERR"/>
     </logger>
-    <logger name="org.openapitools" level="${log-level:-info}">
+    <logger name="org.openapitools" level="${log.level:-info}">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="STDERR"/>
     </logger>

--- a/modules/openapi-generator-cli/src/main/resources/logback.xml
+++ b/modules/openapi-generator-cli/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="STDERR"/>
     </logger>
-    <logger name="org.openapitools" level="info">
+    <logger name="org.openapitools" level="${log-level:-info}">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="STDERR"/>
     </logger>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

closes https://github.com/OpenAPITools/openapi-generator/issues/989

This PR makes logging level controllable with the property as below.

```
$ java -Dlog.level=error ....
```

