### PR TITLE
Make Symfony generated controllers explicitly public

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
@@ -24,6 +24,7 @@ services:
 {{#operations}}
     {{bundleAlias}}.controller.{{pathPrefix}}:
         class: {{controllerPackage}}\{{baseName}}Controller
+        public: true
         calls:
          - [setSerializer, ['@{{bundleAlias}}.service.serializer']]
          - [setValidator,  ['@{{bundleAlias}}.service.validator']]

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
@@ -21,6 +21,7 @@ services:
 
     open_apiserver.controller.pet:
         class: OpenAPI\Server\Controller\PetController
+        public: true
         calls:
          - [setSerializer, ['@open_apiserver.service.serializer']]
          - [setValidator,  ['@open_apiserver.service.validator']]
@@ -28,6 +29,7 @@ services:
 
     open_apiserver.controller.store:
         class: OpenAPI\Server\Controller\StoreController
+        public: true
         calls:
          - [setSerializer, ['@open_apiserver.service.serializer']]
          - [setValidator,  ['@open_apiserver.service.validator']]
@@ -35,6 +37,7 @@ services:
 
     open_apiserver.controller.user:
         class: OpenAPI\Server\Controller\UserController
+        public: true
         calls:
          - [setSerializer, ['@open_apiserver.service.serializer']]
          - [setValidator,  ['@open_apiserver.service.validator']]


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for #1002

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko 
