### PR TITLE
[gradle plugin] Support Gradle 4.10

### DIFF
--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.41'
+    ext.kotlin_version = '1.2.60'
     repositories {
         mavenCentral()
         maven {
@@ -14,7 +14,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins:0.17.5"
+        classpath "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins:1.0-rc-3"
     }
 }
 

--- a/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -54,7 +54,7 @@
                 <artifactId>gradle-maven-plugin</artifactId>
                 <version>1.0.8</version>
                 <configuration>
-                    <gradleVersion>4.7</gradleVersion>
+                    <gradleVersion>4.10-rc-1</gradleVersion>
                     <args>
                         <arg>-P openApiGeneratorVersion=${project.version}</arg>
                     </args>

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/README.md
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/README.md
@@ -17,5 +17,5 @@ gradle generateGoWithInvalidSpec
 The samples can be tested against other versions of the plugin using the `openApiGeneratorVersion` property. For example:
 
 ```bash
-gradle -PopenApiGeneratorVersion=3.2.3 openApiValidate
+gradle -PopenApiGeneratorVersion=3.3.0 openApiValidate
 ```

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         maven {
             url "https://oss.sonatype.org/content/repositories/releases/"
         }
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
+//        maven {
+//            url "https://oss.sonatype.org/content/repositories/snapshots/"
+//        }
     }
     dependencies {
         // Updated version can be passed via command line arg as -PopenApiGeneratorVersion=VERSION

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         maven {
             url "https://oss.sonatype.org/content/repositories/releases/"
         }
-//        maven {
-//            url "https://oss.sonatype.org/content/repositories/snapshots/"
-//        }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
     dependencies {
         // Updated version can be passed via command line arg as -PopenApiGeneratorVersion=VERSION

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -18,7 +18,6 @@ package org.openapitools.generator.gradle.plugin
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.invoke
 import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension
 import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorMetaExtension
 import org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorValidateExtension
@@ -56,12 +55,13 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
 
             generate.outputDir.set("$buildDir/generate-resources/main")
 
-            tasks {
-                "openApiGenerators"(GeneratorsTask::class) {
+            tasks.apply {
+                create("openApiGenerators", GeneratorsTask::class.java) {
                     group = pluginGroup
                     description = "Lists generators available via Open API Generators."
                 }
-                "openApiMeta"(MetaTask::class) {
+
+                create("openApiMeta", MetaTask::class.java) {
                     group = pluginGroup
                     description = "Generates a new generator to be consumed via Open API Generator."
 
@@ -69,13 +69,15 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     packageName.set(meta.packageName)
                     outputFolder.set(meta.outputFolder)
                 }
-                "openApiValidate"(ValidateTask::class) {
+
+                create("openApiValidate", ValidateTask::class.java) {
                     group = pluginGroup
                     description = "Validates an Open API 2.0 or 3.x specification document."
 
                     inputSpec.set(validate.inputSpec)
                 }
-                "openApiGenerate"(GenerateTask::class) {
+
+                create("openApiGenerate", GenerateTask::class.java) {
                     group = pluginGroup
                     description = "Generate code via Open API Tools Generator for Open API 2.0 or 3.x specification documents."
 


### PR DESCRIPTION
Gradle 4.10 is bundled with Kotlin 1.60 and Kotlin DSL 1.0-rc1. The new
Kotlin DSL isn't binary compatible with the `tasks` registration used in
this plugin.

Updating to Kotlin DSL 1.0-rc1 with no other changes would require users
to update to Gradle 4.10.

As a workaround, I've modified the tasks registration being done in
OpenApiGeneratorPlugin.kt, so rather than using the Kotlin DSL's invoke,
it creates tasks manually against the TasksContainer. This works locally
with Gradle 4.7+ for all scenarios in the sample (samples/local-spec).
There may be edge cases that I'm unaware of, and we may want to consider
defining the minimum supported Gradle version of 4.10 in the next major
version of openapi-generator-gradle-plugin if we experience those cases.

See #962

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

