### PR TITLE
[all] Add leading slash in path if missing

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2254,7 +2254,11 @@ public class DefaultCodegen implements CodegenConfig {
         }
         operationId = removeNonNameElementToCamelCase(operationId);
 
-        op.path = path;
+        if(path.startsWith("/")) {
+            op.path = path;
+        } else {
+            op.path = "/" + path;
+        }
         op.operationId = toOperationId(operationId);
         op.summary = escapeText(operation.getSummary());
         op.unescapedNotes = operation.getDescription();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -21,6 +21,7 @@ import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
@@ -37,7 +38,6 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -498,6 +498,21 @@ public class DefaultCodegenTest {
                 Assert.fail(String.format(Locale.getDefault(), "invalid callback request http method '%s'", req.httpMethod));
             }
         });
+    }
+
+    @Test
+    public void testLeadingSlashIsAddedIfMissing() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Operation operation1 = new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")));
+        openAPI.path("/here", new PathItem().get(operation1));
+        Operation operation2 = new Operation().operationId("op2").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")));
+        openAPI.path("some/path", new PathItem().get(operation2));
+        final DefaultCodegen codegen = new DefaultCodegen();
+
+        CodegenOperation co1 = codegen.fromOperation("/here", "get", operation2, ModelUtils.getSchemas(openAPI), openAPI);
+        Assert.assertEquals(co1.path, "/here");
+        CodegenOperation co2 = codegen.fromOperation("some/path", "get", operation2, ModelUtils.getSchemas(openAPI), openAPI);
+        Assert.assertEquals(co2.path, "/some/path");
     }
 
     private void verifyPersonDiscriminator(CodegenDiscriminator discriminator) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -38,7 +38,14 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -224,8 +231,8 @@ public class DefaultCodegenTest {
             .responses(new ApiResponses().addApiResponse("200", new ApiResponse().description("OK")));
 
         DefaultCodegen codegen = new DefaultCodegen();
-        CodegenOperation co = codegen.fromOperation("p/", "get", operation, Collections.emptyMap());
-        Assert.assertEquals(co.path, "p/");
+        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, Collections.emptyMap());
+        Assert.assertEquals(co.path, "/some/path");
         Assert.assertEquals(co.allParams.size(), 2);
         List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
         Assert.assertTrue(allParamsNames.contains("myparam"));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -22,10 +22,10 @@ public class DefaultGeneratorTest {
     public void testProcessPaths() throws Exception {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         openAPI.setPaths(new Paths());
-        openAPI.getPaths().addPathItem("path1/", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
-        openAPI.getPaths().addPathItem("path2/", new PathItem().get(new Operation().operationId("op2").addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
-        openAPI.getPaths().addPathItem("path3/", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op3").addParametersItem(new QueryParameter().name("p2").schema(new IntegerSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
-        openAPI.getPaths().addPathItem("path4/", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op4").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        openAPI.getPaths().addPathItem("/path1", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        openAPI.getPaths().addPathItem("/path2", new PathItem().get(new Operation().operationId("op2").addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        openAPI.getPaths().addPathItem("/path3", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op3").addParametersItem(new QueryParameter().name("p2").schema(new IntegerSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        openAPI.getPaths().addPathItem("/path4", new PathItem().addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).get(new Operation().operationId("op4").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
 
         ClientOptInput opts = new ClientOptInput();
         opts.setOpenAPI(openAPI);
@@ -38,13 +38,13 @@ public class DefaultGeneratorTest {
         Assert.assertEquals(result.size(), 1);
         List<CodegenOperation> defaultList = result.get("Default");
         Assert.assertEquals(defaultList.size(), 4);
-        Assert.assertEquals(defaultList.get(0).path, "path1/");
+        Assert.assertEquals(defaultList.get(0).path, "/path1");
         Assert.assertEquals(defaultList.get(0).allParams.size(), 0);
-        Assert.assertEquals(defaultList.get(1).path, "path2/");
+        Assert.assertEquals(defaultList.get(1).path, "/path2");
         Assert.assertEquals(defaultList.get(1).allParams.size(), 1);
-        Assert.assertEquals(defaultList.get(2).path, "path3/");
+        Assert.assertEquals(defaultList.get(2).path, "/path3");
         Assert.assertEquals(defaultList.get(2).allParams.size(), 2);
-        Assert.assertEquals(defaultList.get(3).path, "path4/");
+        Assert.assertEquals(defaultList.get(3).path, "/path4");
         Assert.assertEquals(defaultList.get(3).allParams.size(), 1);
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team  @OpenAPITools/openapi-generator-collaborators (change in core)

### Description of the PR

From https://github.com/OpenAPITools/openapi-generator/pull/967#issuecomment-418602467 and #997.

This PR adds the leading `/` if it is missing in the path definition.

---

More details:

This spec is not valid:

```yaml
openapi: '3.0.1'
info:
  title: ping test
  version: '1.0'
servers:
  - url: 'http://localhost:8000/api'
paths:
  ping/me:
    get:
      operationId: pingGet
      responses:
        '201':
          description: OK
```

Because the path `ping/me` do not conform to this rule:

> The field name MUST begin with a slash.

See the [OpenAPI Specification 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#patterned-fields).

Some editors like [Swagger online editor](https://editor.swagger.io/) or the [KaiZen-Editor](https://github.com/RepreZen/KaiZen-OpenApi-Editor/) are reporting errors, but Swagger-Parser does not.

Some templates uses `{{{basePathWithoutHost}}}{{{path}}}`. 

* Before this PR it will generate `http://localhost:8000/apiping/me` (incorrect) 
* After this PR it will generate `http://localhost:8000/api/ping/me` (correct)