### PR TITLE
PR: Fix error when giving an array as parameter to an endpoint body r…

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -51,19 +51,25 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            $formats = $data::openAPIFormats();
-            foreach ($data::openAPITypes() as $property => $openAPIType) {
-                $getter = $data::getters()[$property];
-                $value = $data->$getter();
-                if ($value !== null
-                    && !in_array($openAPIType, [{{&primitives}}], true)
-                    && method_exists($openAPIType, 'getAllowableEnumValues')
-                    && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
-                    $imploded = implode("', '", $openAPIType::getAllowableEnumValues());
-                    throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+            if($data instanceof ModelInterface) {
+                $formats = $data::openAPIFormats();
+                foreach ($data::openAPITypes() as $property => $openAPIType) {
+                    $getter = $data::getters()[$property];
+                    $value = $data->$getter();
+                    if ($value !== null
+                        && !in_array($openAPIType, [{{&primitives}}], true)
+                        && method_exists($openAPIType, 'getAllowableEnumValues')
+                        && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
+                        $imploded = implode("', '", $openAPIType::getAllowableEnumValues());
+                        throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+                    }
+                    if ($value !== null) {
+                        $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
+                    }
                 }
-                if ($value !== null) {
-                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
+            } else {
+                foreach($data as $property => $value) {
+                    $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
             return (object)$values;

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -19,6 +19,8 @@
 
 namespace {{invokerPackage}};
 
+use {{modelPackage}}\ModelInterface;
+
 /**
  * ObjectSerializer Class Doc Comment
  *

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -53,7 +53,7 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            if($data instanceof ModelInterface) {
+            if ($data instanceof ModelInterface) {
                 $formats = $data::openAPIFormats();
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -77,6 +77,33 @@ use {{invokerPackage}}\ObjectSerializer;
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
 {{#operation}}
     /**
      * Operation {{{operationId}}}
@@ -444,10 +471,10 @@ use {{invokerPackage}}\ObjectSerializer;
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -444,10 +444,10 @@ use {{invokerPackage}}\ObjectSerializer;
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -77,33 +77,6 @@ use {{invokerPackage}}\ObjectSerializer;
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
 {{#operation}}
     /**
      * Operation {{{operationId}}}
@@ -474,7 +447,7 @@ use {{invokerPackage}}\ObjectSerializer;
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -307,10 +307,10 @@ class AnotherFakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -87,33 +87,6 @@ class AnotherFakeApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation call123TestSpecialTags
      *
@@ -337,7 +310,7 @@ class AnotherFakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -87,6 +87,33 @@ class AnotherFakeApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation call123TestSpecialTags
      *
@@ -307,10 +334,10 @@ class AnotherFakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -87,33 +87,6 @@ class FakeApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation fakeOuterBooleanSerialize
      *
@@ -327,7 +300,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -584,7 +557,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -841,7 +814,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1098,7 +1071,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1313,7 +1286,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1543,7 +1516,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1810,7 +1783,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2213,7 +2186,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2500,7 +2473,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2719,7 +2692,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2954,7 +2927,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -297,10 +297,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -554,10 +554,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -811,10 +811,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1068,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1283,10 +1283,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1513,10 +1513,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1780,10 +1780,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2183,10 +2183,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2470,10 +2470,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2689,10 +2689,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2924,10 +2924,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -87,6 +87,33 @@ class FakeApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation fakeOuterBooleanSerialize
      *
@@ -297,10 +324,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -554,10 +581,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -811,10 +838,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1095,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1283,10 +1310,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1513,10 +1540,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1780,10 +1807,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2183,10 +2210,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2470,10 +2497,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2689,10 +2716,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2924,10 +2951,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -87,6 +87,33 @@ class FakeClassnameTags123Api
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation testClassname
      *
@@ -307,10 +334,10 @@ class FakeClassnameTags123Api
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -307,10 +307,10 @@ class FakeClassnameTags123Api
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -87,33 +87,6 @@ class FakeClassnameTags123Api
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation testClassname
      *
@@ -337,7 +310,7 @@ class FakeClassnameTags123Api
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -87,33 +87,6 @@ class PetApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation addPet
      *
@@ -289,7 +262,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -526,7 +499,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -801,7 +774,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1076,7 +1049,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1352,7 +1325,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1576,7 +1549,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1822,7 +1795,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2117,7 +2090,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2418,7 +2391,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -87,6 +87,33 @@ class PetApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation addPet
      *
@@ -259,10 +286,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -496,10 +523,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -771,10 +798,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1046,10 +1073,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1322,10 +1349,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1546,10 +1573,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1792,10 +1819,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2087,10 +2114,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2388,10 +2415,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -259,10 +259,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -496,10 +496,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -771,10 +771,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1046,10 +1046,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1322,10 +1322,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1546,10 +1546,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1792,10 +1792,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2087,10 +2087,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2388,10 +2388,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -87,33 +87,6 @@ class StoreApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation deleteOrder
      *
@@ -294,7 +267,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -547,7 +520,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -831,7 +804,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1098,7 +1071,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -87,6 +87,33 @@ class StoreApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation deleteOrder
      *
@@ -264,10 +291,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -517,10 +544,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -801,10 +828,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1095,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -264,10 +264,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -517,10 +517,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -801,10 +801,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1068,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -259,10 +259,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -478,10 +478,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -697,10 +697,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -921,10 +921,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1193,10 +1193,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1476,10 +1476,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1681,10 +1681,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1919,10 +1919,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -87,6 +87,33 @@ class UserApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation createUser
      *
@@ -259,10 +286,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -478,10 +505,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -697,10 +724,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -921,10 +948,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1193,10 +1220,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1476,10 +1503,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1681,10 +1708,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1919,10 +1946,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -87,33 +87,6 @@ class UserApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation createUser
      *
@@ -289,7 +262,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -508,7 +481,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -727,7 +700,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -951,7 +924,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1223,7 +1196,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1506,7 +1479,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1711,7 +1684,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1949,7 +1922,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -63,7 +63,7 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            if($data instanceof ModelInterface) {
+            if ($data instanceof ModelInterface) {
                 $formats = $data::openAPIFormats();
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -61,19 +61,25 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            $formats = $data::openAPIFormats();
-            foreach ($data::openAPITypes() as $property => $openAPIType) {
-                $getter = $data::getters()[$property];
-                $value = $data->$getter();
-                if ($value !== null
-                    && !in_array($openAPIType, ['DateTime', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)
-                    && method_exists($openAPIType, 'getAllowableEnumValues')
-                    && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
-                    $imploded = implode("', '", $openAPIType::getAllowableEnumValues());
-                    throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+            if($data instanceof ModelInterface) {
+                $formats = $data::openAPIFormats();
+                foreach ($data::openAPITypes() as $property => $openAPIType) {
+                    $getter = $data::getters()[$property];
+                    $value = $data->$getter();
+                    if ($value !== null
+                        && !in_array($openAPIType, ['DateTime', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)
+                        && method_exists($openAPIType, 'getAllowableEnumValues')
+                        && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
+                        $imploded = implode("', '", $openAPIType::getAllowableEnumValues());
+                        throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+                    }
+                    if ($value !== null) {
+                        $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
+                    }
                 }
-                if ($value !== null) {
-                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
+            } else {
+                foreach($data as $property => $value) {
+                    $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
             return (object)$values;

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -29,6 +29,8 @@
 
 namespace OpenAPI\Client;
 
+use OpenAPI\Client\Model\ModelInterface;
+
 /**
  * ObjectSerializer Class Doc Comment
  *

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -307,10 +307,10 @@ class AnotherFakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -87,33 +87,6 @@ class AnotherFakeApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation call123TestSpecialTags
      *
@@ -337,7 +310,7 @@ class AnotherFakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -87,6 +87,33 @@ class AnotherFakeApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation call123TestSpecialTags
      *
@@ -307,10 +334,10 @@ class AnotherFakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -87,33 +87,6 @@ class FakeApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation fakeOuterBooleanSerialize
      *
@@ -327,7 +300,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -584,7 +557,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -841,7 +814,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1098,7 +1071,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1313,7 +1286,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1543,7 +1516,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1810,7 +1783,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2213,7 +2186,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2500,7 +2473,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2719,7 +2692,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2954,7 +2927,7 @@ class FakeApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -297,10 +297,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -554,10 +554,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -811,10 +811,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1068,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1283,10 +1283,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1513,10 +1513,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1780,10 +1780,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2183,10 +2183,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2470,10 +2470,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2689,10 +2689,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2924,10 +2924,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -87,6 +87,33 @@ class FakeApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation fakeOuterBooleanSerialize
      *
@@ -297,10 +324,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -554,10 +581,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -811,10 +838,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1095,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1283,10 +1310,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1513,10 +1540,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1780,10 +1807,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2183,10 +2210,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2470,10 +2497,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2689,10 +2716,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2924,10 +2951,10 @@ class FakeApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -87,6 +87,33 @@ class FakeClassnameTags123Api
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation testClassname
      *
@@ -307,10 +334,10 @@ class FakeClassnameTags123Api
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -307,10 +307,10 @@ class FakeClassnameTags123Api
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -87,33 +87,6 @@ class FakeClassnameTags123Api
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation testClassname
      *
@@ -337,7 +310,7 @@ class FakeClassnameTags123Api
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -87,33 +87,6 @@ class PetApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation addPet
      *
@@ -289,7 +262,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -526,7 +499,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -801,7 +774,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1076,7 +1049,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1352,7 +1325,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1576,7 +1549,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1822,7 +1795,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2117,7 +2090,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2418,7 +2391,7 @@ class PetApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -87,6 +87,33 @@ class PetApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation addPet
      *
@@ -259,10 +286,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -496,10 +523,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -771,10 +798,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1046,10 +1073,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1322,10 +1349,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1546,10 +1573,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1792,10 +1819,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2087,10 +2114,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2388,10 +2415,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -259,10 +259,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -496,10 +496,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -771,10 +771,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1046,10 +1046,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1322,10 +1322,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1546,10 +1546,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1792,10 +1792,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2087,10 +2087,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -2388,10 +2388,10 @@ class PetApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -87,33 +87,6 @@ class StoreApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation deleteOrder
      *
@@ -294,7 +267,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -547,7 +520,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -831,7 +804,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1098,7 +1071,7 @@ class StoreApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -87,6 +87,33 @@ class StoreApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation deleteOrder
      *
@@ -264,10 +291,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -517,10 +544,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -801,10 +828,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1095,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -264,10 +264,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -517,10 +517,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -801,10 +801,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1068,10 +1068,10 @@ class StoreApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -259,10 +259,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -478,10 +478,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -697,10 +697,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -921,10 +921,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1193,10 +1193,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1476,10 +1476,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1681,10 +1681,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1919,10 +1919,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            if($headers['Content-Type'] !== 'application/json') {
-                $httpBody = $_tempBody;
-            } else {
+            if ($headers['Content-Type'] === 'application/json') {
                 $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -87,6 +87,33 @@ class UserApi
         return $this->config;
     }
 
+
+    /**
+     * @param mixed $body Element to become the body of the Request
+     *
+     * @return mixed|string
+     */
+    private function formatBody($body)
+    {
+        // \stdClass and arrays have no __toString(), so we should encode them manually
+        if($body instanceof \stdClass) {
+            return \GuzzleHttp\json_encode($body);
+        }
+
+        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
+        if(is_array($body)) {
+            $return = "[";
+
+            foreach($body as $item) {
+                $return .="\n".$this->formatBody($item).",";
+            }
+
+            return trim($return, ',')."\n]";
+        }
+
+        return $body;
+    }
+
     /**
      * Operation createUser
      *
@@ -259,10 +286,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -478,10 +505,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -697,10 +724,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -921,10 +948,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1193,10 +1220,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1476,10 +1503,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1681,10 +1708,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1919,10 +1946,10 @@ class UserApi
         // for model (json/xml)
         if (isset($_tempBody)) {
             // $_tempBody is the method argument, if present
-            $httpBody = $_tempBody;
-            // \stdClass has no __toString(), so we should encode it manually
-            if ($httpBody instanceof \stdClass && $headers['Content-Type'] === 'application/json') {
-                $httpBody = \GuzzleHttp\json_encode($httpBody);
+            if($headers['Content-Type'] !== 'application/json') {
+                $httpBody = $_tempBody;
+            } else {
+                $httpBody = $this->formatBody($_tempBody);
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -87,33 +87,6 @@ class UserApi
         return $this->config;
     }
 
-
-    /**
-     * @param mixed $body Element to become the body of the Request
-     *
-     * @return mixed|string
-     */
-    private function formatBody($body)
-    {
-        // \stdClass and arrays have no __toString(), so we should encode them manually
-        if($body instanceof \stdClass) {
-            return \GuzzleHttp\json_encode($body);
-        }
-
-        // arrays must be encoded manually as well, otherwise the objects inside it don't get encoded
-        if(is_array($body)) {
-            $return = "[";
-
-            foreach($body as $item) {
-                $return .="\n".$this->formatBody($item).",";
-            }
-
-            return trim($return, ',')."\n]";
-        }
-
-        return $body;
-    }
-
     /**
      * Operation createUser
      *
@@ -289,7 +262,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -508,7 +481,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -727,7 +700,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -951,7 +924,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1223,7 +1196,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1506,7 +1479,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1711,7 +1684,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {
@@ -1949,7 +1922,7 @@ class UserApi
             if($headers['Content-Type'] !== 'application/json') {
                 $httpBody = $_tempBody;
             } else {
-                $httpBody = $this->formatBody($_tempBody);
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -63,7 +63,7 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            if($data instanceof ModelInterface) {
+            if ($data instanceof ModelInterface) {
                 $formats = $data::openAPIFormats();
                 foreach ($data::openAPITypes() as $property => $openAPIType) {
                     $getter = $data::getters()[$property];

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -61,19 +61,25 @@ class ObjectSerializer
             return $data;
         } elseif (is_object($data)) {
             $values = [];
-            $formats = $data::openAPIFormats();
-            foreach ($data::openAPITypes() as $property => $openAPIType) {
-                $getter = $data::getters()[$property];
-                $value = $data->$getter();
-                if ($value !== null
-                    && !in_array($openAPIType, ['DateTime', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)
-                    && method_exists($openAPIType, 'getAllowableEnumValues')
-                    && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
-                    $imploded = implode("', '", $openAPIType::getAllowableEnumValues());
-                    throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+            if($data instanceof ModelInterface) {
+                $formats = $data::openAPIFormats();
+                foreach ($data::openAPITypes() as $property => $openAPIType) {
+                    $getter = $data::getters()[$property];
+                    $value = $data->$getter();
+                    if ($value !== null
+                        && !in_array($openAPIType, ['DateTime', 'bool', 'boolean', 'byte', 'double', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)
+                        && method_exists($openAPIType, 'getAllowableEnumValues')
+                        && !in_array($value, $openAPIType::getAllowableEnumValues(), true)) {
+                        $imploded = implode("', '", $openAPIType::getAllowableEnumValues());
+                        throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+                    }
+                    if ($value !== null) {
+                        $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
+                    }
                 }
-                if ($value !== null) {
-                    $values[$data::attributeMap()[$property]] = self::sanitizeForSerialization($value, $openAPIType, $formats[$property]);
+            } else {
+                foreach($data as $property => $value) {
+                    $values[$property] = self::sanitizeForSerialization($value);
                 }
             }
             return (object)$values;

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -29,6 +29,8 @@
 
 namespace OpenAPI\Client;
 
+use OpenAPI\Client\Model\ModelInterface;
+
 /**
  * ObjectSerializer Class Doc Comment
  *


### PR DESCRIPTION
…equest

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
- @jebentier 
- @dkarlovi 
- @mandrean 
- @jfastnacht 
- @ackintosh 
- @ybelenko 

### Description of the PR
This PR targets Issue #1036 : as of today, it is not possible to provide an array of model objects as parameter for an operation, since it will not be properly json-encoded. This PR fixes this, by adding a recursive method that is able to properly json-encode arrays of model objects.