### PR TITLE
Add nullable support to Ruby client

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -43,6 +43,7 @@ module {{moduleName}}
         @api_client.config.logger.debug 'Calling API: {{classname}}.{{operationId}} ...'
       end
       {{#allParams}}
+      {{^isNullable}}
       {{#required}}
       # verify the required parameter '{{paramName}}' is set
       if @api_client.config.client_side_validation && {{{paramName}}}.nil?
@@ -57,6 +58,7 @@ module {{moduleName}}
       {{/isContainer}}
       {{/isEnum}}
       {{/required}}
+      {{/isNullable}}
       {{^required}}
       {{#isEnum}}
       {{#collectionFormat}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -87,12 +87,14 @@
     def list_invalid_properties
       invalid_properties = Array.new
       {{#vars}}
+      {{^isNullable}}
       {{#required}}
       if @{{{name}}}.nil?
         invalid_properties.push('invalid value for "{{{name}}}", {{{name}}} cannot be nil.')
       end
 
       {{/required}}
+      {{/isNullable}}
       {{#hasValidation}}
       {{#maxLength}}
       if {{^required}}!@{{{name}}}.nil? && {{/required}}@{{{name}}}.to_s.length > {{{maxLength}}}
@@ -145,9 +147,11 @@
     # @return true if the model is valid
     def valid?
       {{#vars}}
+      {{^isNullable}}
       {{#required}}
       return false if @{{{name}}}.nil?
       {{/required}}
+      {{/isNullable}}
       {{#isEnum}}
       {{^isContainer}}
       {{{name}}}_validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}])
@@ -201,12 +205,14 @@
     # Custom attribute writer method with validation
     # @param [Object] {{{name}}} Value to be assigned
     def {{{name}}}=({{{name}}})
+      {{^isNullable}}
       {{#required}}
       if {{{name}}}.nil?
         fail ArgumentError, '{{{name}}} cannot be nil'
       end
 
       {{/required}}
+      {{/isNullable}}
       {{#maxLength}}
       if {{^required}}!{{{name}}}.nil? && {{/required}}{{{name}}}.to_s.length > {{{maxLength}}}
         fail ArgumentError, 'invalid value for "{{{name}}}", the character length must be smaller than or equal to {{{maxLength}}}.'


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- add nullable support to the operation's parameters and model's properties
- tested manually with OAS2 and OAS3 spec

cc @cliffano (2017/07) @zlx (2017/09)




