### PR TITLE
Use the string representation for serializing enum values with Jackson

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/enumOuterClass.mustache
@@ -26,16 +26,15 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
   }
 
   @Override
-{{#jackson}}
+  {{#jackson}}
   @JsonValue
-{{/jackson}}  
+  {{/jackson}}
   public String toString() {
     return String.valueOf(value);
   }
 
-{{#jackson}}
+  {{#jackson}}
   @JsonCreator
-{{/jackson}}
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
     for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
       if (String.valueOf(b.value).equals(text)) {
@@ -44,5 +43,5 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     }
     {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
-  
+  {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/enumClass.mustache
@@ -27,11 +27,14 @@
     }
 
     @Override
+    {{#jackson}}
     @JsonValue
+    {{/jackson}}
     public String toString() {
       return String.valueOf(value);
     }
 
+    {{#jackson}}
     @JsonCreator
     public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
       for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
@@ -41,4 +44,5 @@
       }
       {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
+    {{/jackson}}
   }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/enumOuterClass.mustache
@@ -1,5 +1,6 @@
 {{#jackson}}
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 {{/jackson}}
 
 /**
@@ -25,11 +26,14 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
   }
 
   @Override
+  {{#jackson}}
   @JsonValue
+  {{/jackson}}
   public String toString() {
     return String.valueOf(value);
   }
 
+  {{#jackson}}
   @JsonCreator
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
     for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
@@ -39,4 +43,5 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     }
     {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
+  {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/modelEnum.mustache
@@ -1,4 +1,5 @@
 {{#jackson}}
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 {{/jackson}}
 
@@ -24,11 +25,14 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     this.value = value;
   }
 
+  {{#jackson}}
+  @JsonValue
+  {{/jackson}}
   @Override
   public String toString() {
     return String.valueOf(value);
   }
-{{#jackson}}
+  {{#jackson}}
 
   @JsonCreator
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
@@ -39,5 +43,5 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     }
     {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
-{{/jackson}}
+  {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap/enumClass.mustache
@@ -17,7 +17,9 @@
     }
 
     @Override
+    {{#jackson}}
     @JsonValue
+    {{/jackson}}
     public String toString() {
       return String.valueOf(value);
     }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumClass.mustache
@@ -17,7 +17,9 @@
     }
 
     @Override
+    {{#jackson}}
     @JsonValue
+    {{/jackson}}
     public String toString() {
       return String.valueOf(value);
     }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
@@ -16,11 +16,14 @@ public enum {{datatypeWithEnum}} {
     }
 
     @Override
+    {{#jackson}}
     @JsonValue
+    {{/jackson}}
     public String toString() {
         return String.valueOf(value);
     }
 
+    {{#jackson}}
     @JsonCreator
     public static {{datatypeWithEnum}} fromValue(String v) {
         for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
@@ -30,4 +33,5 @@ public enum {{datatypeWithEnum}} {
         }
         {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + v + "'");{{/useNullForUnknownEnumValue}}
     }
+    {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
@@ -26,11 +26,14 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
   }
 
   @Override
+  {{#jackson}}
   @JsonValue
+  {{/jackson}}
   public String toString() {
     return String.valueOf(value);
   }
 
+  {{#jackson}}
   @JsonCreator
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
     for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
@@ -40,4 +43,5 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
     }
     {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
+  {{/jackson}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -2,9 +2,11 @@
 import io.swagger.annotations.*;
 {{/useSwaggerAnnotations}}
 import java.util.Objects;
+{{#jackson}}
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
 
 {{#description}}
 /**
@@ -38,7 +40,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}{{#useSwaggerAnnotations}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}
+  {{#jackson}}
   @JsonProperty("{{baseName}}")
+  {{/jackson}}
 {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/EnumClass.java
@@ -38,6 +38,5 @@ public enum EnumClass {
     }
     throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
-  
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -38,6 +38,5 @@ public enum OuterEnum {
     }
     throw new IllegalArgumentException("Unexpected value '" + text + "'");
   }
-  
 }
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumClass.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -38,6 +39,7 @@ public enum EnumClass {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -38,6 +39,7 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs-spec/pom.xml
+++ b/samples/server/petstore/jaxrs-spec/pom.xml
@@ -107,7 +107,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <jackson-version>2.8.9</jackson-version>
+    <jackson-version>2.9.0</jackson-version>
     <junit-version>4.8.1</junit-version>
   </properties>
 </project>

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumClass.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum EnumClass {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumClass.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum EnumClass {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumClass.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum EnumClass {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumClass.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum EnumClass {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
@@ -37,6 +38,7 @@ public enum OuterEnum {
     this.value = value;
   }
 
+  @JsonValue
   @Override
   public String toString() {
     return String.valueOf(value);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The current serialization of enums when using Jackson is always generating uppercase values. This violates what's in the spec for the cases when the different enum values contain lower case letters.

The only significant change is in the `modelEnum.mustache` file, all other changes are the result of running the `bin/java-jaxrs-petstore-server-all.sh` script (except for the bump in version for Jackson from `2.8.9` to `2.9.0`).

