### PR TITLE
Kotlin spring server codegen improvements

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -173,7 +173,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         typeMapping.put("DateTime", "java.time.LocalDateTime");
 
         instantiationTypes.put("array", "kotlin.arrayOf");
-        instantiationTypes.put("list", "kotlin.arrayOf");
+        instantiationTypes.put("list", "kotlin.listOf");
         instantiationTypes.put("map", "kotlin.mapOf");
 
         importMapping = new HashMap<String, String>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -173,7 +173,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         typeMapping.put("DateTime", "java.time.LocalDateTime");
 
         instantiationTypes.put("array", "kotlin.arrayOf");
-        instantiationTypes.put("list", "kotlin.listOf");
+        instantiationTypes.put("list", "kotlin.arrayOf");
         instantiationTypes.put("map", "kotlin.mapOf");
 
         importMapping = new HashMap<String, String>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -86,6 +86,38 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         apiPackage = "org.openapitools.api";
         modelPackage = "org.openapitools.model";
 
+        // Use lists instead of arrays
+        typeMapping.put("array", "List");
+        typeMapping.put("string", "String");
+        typeMapping.put("boolean", "Boolean");
+        typeMapping.put("integer", "Int");
+        typeMapping.put("float", "Float");
+        typeMapping.put("long", "Long");
+        typeMapping.put("double", "Double");
+        typeMapping.put("ByteArray", "ByteArray");
+        typeMapping.put("list", "List");
+        typeMapping.put("map", "Map");
+        typeMapping.put("object", "Any");
+        typeMapping.put("binary", "Array<kotlin.Byte>");
+
+        languageSpecificPrimitives.addAll(Arrays.asList(
+                "Any",
+                "Byte",
+                "ByteArray",
+                "Short",
+                "Int",
+                "Long",
+                "Float",
+                "Double",
+                "Boolean",
+                "Char",
+                "String",
+                "Array",
+                "List",
+                "Map",
+                "Set"
+        ));
+
         addOption(TITLE, "server title name or client service name", title);
         addOption(BASE_PACKAGE, "base package (invokerPackage) for generated code", basePackage);
         addOption(SERVER_PORT, "configuration the port in which the sever is to run on", serverPort);
@@ -483,10 +515,10 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     private void doDataTypeAssignment(final String returnType, DataTypeAssigner dataTypeAssigner) {
         if (returnType == null) {
             dataTypeAssigner.setReturnType("Unit");
-        } else if (returnType.startsWith("kotlin.Array")) {
+        } else if (returnType.startsWith("kotlin.collections.List")) {
             int end = returnType.lastIndexOf(">");
             if (end > 0) {
-                dataTypeAssigner.setReturnType(returnType.substring("kotlin.Array<".length(), end).trim());
+                dataTypeAssigner.setReturnType(returnType.substring("kotlin.collections.List<".length(), end).trim());
                 dataTypeAssigner.setReturnContainer("List");
             }
         } else if (returnType.startsWith("kotlin.collections.Map")) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -515,16 +515,16 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     private void doDataTypeAssignment(final String returnType, DataTypeAssigner dataTypeAssigner) {
         if (returnType == null) {
             dataTypeAssigner.setReturnType("Unit");
-        } else if (returnType.startsWith("kotlin.collections.List")) {
+        } else if (returnType.startsWith("List")) {
             int end = returnType.lastIndexOf(">");
             if (end > 0) {
-                dataTypeAssigner.setReturnType(returnType.substring("kotlin.collections.List<".length(), end).trim());
+                dataTypeAssigner.setReturnType(returnType.substring("List<".length(), end).trim());
                 dataTypeAssigner.setReturnContainer("List");
             }
-        } else if (returnType.startsWith("kotlin.collections.Map")) {
+        } else if (returnType.startsWith("Map")) {
             int end = returnType.lastIndexOf(">");
             if (end > 0) {
-                dataTypeAssigner.setReturnType(returnType.substring("kotlin.collections.Map<".length(), end).split(",")[1].trim());
+                dataTypeAssigner.setReturnType(returnType.substring("Map<".length(), end).split(",")[1].trim());
                 dataTypeAssigner.setReturnContainer("Map");
             }
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
@@ -1,4 +1,4 @@
 {{#useBeanValidation}}{{#required}}
-        @get:NotNull {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
+    {{^isReadOnly}}@get:NotNull{{/isReadOnly}} {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
         @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swaggerAnnotations}}
         @JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassOptVar.mustache
@@ -1,4 +1,4 @@
 {{#useBeanValidation}}{{#required}}
-    {{^isReadOnly}}@get:NotNull{{/isReadOnly}} {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
+        {{^isReadOnly}}@get:NotNull{{/isReadOnly}} {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
         @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swaggerAnnotations}}
         @JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache
@@ -1,4 +1,4 @@
 {{#useBeanValidation}}{{#required}}
-        @get:NotNull {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
+    {{^isReadOnly}}@get:NotNull{{/isReadOnly}} {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
         @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swaggerAnnotations}}
-        @JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}
+        @JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isReadOnly}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}{{/isReadOnly}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClassReqVar.mustache
@@ -1,4 +1,4 @@
 {{#useBeanValidation}}{{#required}}
-    {{^isReadOnly}}@get:NotNull{{/isReadOnly}} {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
+        {{^isReadOnly}}@get:NotNull{{/isReadOnly}} {{/required}}{{>beanValidationModel}}{{/useBeanValidation}}{{#swaggerAnnotations}}
         @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}"){{/swaggerAnnotations}}
         @JsonProperty("{{{baseName}}}"){{#isInherited}} override{{/isInherited}} val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isReadOnly}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}{{/isReadOnly}}

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -56,7 +56,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
     @RequestMapping(
             value = ["/pet/{petId}"],
             method = [RequestMethod.DELETE])
-    fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: kotlin.Long,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: kotlin.String?): ResponseEntity<Unit> {
+    fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: String?): ResponseEntity<Unit> {
         return ResponseEntity(service.deletePet(petId, apiKey), HttpStatus.OK)
     }
 
@@ -73,7 +73,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/findByStatus"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) status: kotlin.Array<kotlin.String>): ResponseEntity<List<Pet>> {
+    fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) status: List<String>): ResponseEntity<List<Pet>> {
         return ResponseEntity(service.findPetsByStatus(status), HttpStatus.OK)
     }
 
@@ -90,7 +90,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/findByTags"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: kotlin.Array<kotlin.String>): ResponseEntity<List<Pet>> {
+    fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: List<String>): ResponseEntity<List<Pet>> {
         return ResponseEntity(service.findPetsByTags(tags), HttpStatus.OK)
     }
 
@@ -106,7 +106,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/{petId}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getPetById(@ApiParam(value = "ID of pet to return", required=true) @PathVariable("petId") petId: kotlin.Long): ResponseEntity<Pet> {
+    fun getPetById(@ApiParam(value = "ID of pet to return", required=true) @PathVariable("petId") petId: Long): ResponseEntity<Pet> {
         return ResponseEntity(service.getPetById(petId), HttpStatus.OK)
     }
 
@@ -136,7 +136,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/{petId}"],
             consumes = ["application/x-www-form-urlencoded"],
             method = [RequestMethod.POST])
-    fun updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required=true) @PathVariable("petId") petId: kotlin.Long,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false) name: kotlin.String ,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false) status: kotlin.String ): ResponseEntity<Unit> {
+    fun updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false) name: String ,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false) status: String ): ResponseEntity<Unit> {
         return ResponseEntity(service.updatePetWithForm(petId, name, status), HttpStatus.OK)
     }
 
@@ -153,7 +153,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             produces = ["application/json"], 
             consumes = ["multipart/form-data"],
             method = [RequestMethod.POST])
-    fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: kotlin.Long,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: kotlin.String ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: MultipartFile): ResponseEntity<ModelApiResponse> {
+    fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: String ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: MultipartFile): ResponseEntity<ModelApiResponse> {
         return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.OK)
     }
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
@@ -7,17 +7,17 @@ interface PetApiService {
 
     fun addPet(pet: Pet): Unit
 
-    fun deletePet(petId: kotlin.Long,apiKey: kotlin.String?): Unit
+    fun deletePet(petId: Long,apiKey: String?): Unit
 
-    fun findPetsByStatus(status: kotlin.Array<kotlin.String>): List<Pet>
+    fun findPetsByStatus(status: List<String>): List<Pet>
 
-    fun findPetsByTags(tags: kotlin.Array<kotlin.String>): List<Pet>
+    fun findPetsByTags(tags: List<String>): List<Pet>
 
-    fun getPetById(petId: kotlin.Long): Pet
+    fun getPetById(petId: Long): Pet
 
     fun updatePet(pet: Pet): Unit
 
-    fun updatePetWithForm(petId: kotlin.Long,name: kotlin.String?,status: kotlin.String?): Unit
+    fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit
 
-    fun uploadFile(petId: kotlin.Long,additionalMetadata: kotlin.String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse
+    fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
@@ -11,19 +11,19 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun deletePet(petId: kotlin.Long,apiKey: kotlin.String?): Unit {
+    override fun deletePet(petId: Long,apiKey: String?): Unit {
         TODO("Implement me")
     }
 
-    override fun findPetsByStatus(status: kotlin.Array<kotlin.String>): List<Pet> {
+    override fun findPetsByStatus(status: List<String>): List<Pet> {
         TODO("Implement me")
     }
 
-    override fun findPetsByTags(tags: kotlin.Array<kotlin.String>): List<Pet> {
+    override fun findPetsByTags(tags: List<String>): List<Pet> {
         TODO("Implement me")
     }
 
-    override fun getPetById(petId: kotlin.Long): Pet {
+    override fun getPetById(petId: Long): Pet {
         TODO("Implement me")
     }
 
@@ -31,11 +31,11 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun updatePetWithForm(petId: kotlin.Long,name: kotlin.String?,status: kotlin.String?): Unit {
+    override fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit {
         TODO("Implement me")
     }
 
-    override fun uploadFile(petId: kotlin.Long,additionalMetadata: kotlin.String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse {
+    override fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse {
         TODO("Implement me")
     }
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -39,7 +39,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
     @RequestMapping(
             value = ["/store/order/{orderId}"],
             method = [RequestMethod.DELETE])
-    fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true) @PathVariable("orderId") orderId: kotlin.String): ResponseEntity<Unit> {
+    fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true) @PathVariable("orderId") orderId: String): ResponseEntity<Unit> {
         return ResponseEntity(service.deleteOrder(orderId), HttpStatus.OK)
     }
 
@@ -47,16 +47,16 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             value = "Returns pet inventories by status",
             nickname = "getInventory",
             notes = "Returns a map of status codes to quantities",
-            response = kotlin.Int::class,
+            response = Int::class,
             responseContainer = "Map",
             authorizations = [Authorization(value = "api_key")])
     @ApiResponses(
-            value = [ApiResponse(code = 200, message = "successful operation", response = kotlin.collections.Map::class, responseContainer = "Map")])
+            value = [ApiResponse(code = 200, message = "successful operation", response = Map::class, responseContainer = "Map")])
     @RequestMapping(
             value = ["/store/inventory"],
             produces = ["application/json"], 
             method = [RequestMethod.GET])
-    fun getInventory(): ResponseEntity<Map<String, kotlin.Int>> {
+    fun getInventory(): ResponseEntity<Map<String, Int>> {
         return ResponseEntity(service.getInventory(), HttpStatus.OK)
     }
 
@@ -71,7 +71,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             value = ["/store/order/{orderId}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true) @PathVariable("orderId") orderId: kotlin.Long): ResponseEntity<Order> {
+    fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true) @PathVariable("orderId") orderId: Long): ResponseEntity<Order> {
         return ResponseEntity(service.getOrderById(orderId), HttpStatus.OK)
     }
 

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiService.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiService.kt
@@ -4,11 +4,11 @@ import org.openapitools.model.Order
 
 interface StoreApiService {
 
-    fun deleteOrder(orderId: kotlin.String): Unit
+    fun deleteOrder(orderId: String): Unit
 
-    fun getInventory(): Map<String, kotlin.Int>
+    fun getInventory(): Map<String, Int>
 
-    fun getOrderById(orderId: kotlin.Long): Order
+    fun getOrderById(orderId: Long): Order
 
     fun placeOrder(order: Order): Order
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiServiceImpl.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiServiceImpl.kt
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service
 @Service
 class StoreApiServiceImpl : StoreApiService {
 
-    override fun deleteOrder(orderId: kotlin.String): Unit {
+    override fun deleteOrder(orderId: String): Unit {
         TODO("Implement me")
     }
 
-    override fun getInventory(): Map<String, kotlin.Int> {
+    override fun getInventory(): Map<String, Int> {
         TODO("Implement me")
     }
 
-    override fun getOrderById(orderId: kotlin.Long): Order {
+    override fun getOrderById(orderId: Long): Order {
         TODO("Implement me")
     }
 

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -54,7 +54,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/createWithArray"],
             consumes = ["application/json"],
             method = [RequestMethod.POST])
-    fun createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: kotlin.Array<User>): ResponseEntity<Unit> {
+    fun createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: List<User>): ResponseEntity<Unit> {
         return ResponseEntity(service.createUsersWithArrayInput(user), HttpStatus.OK)
     }
 
@@ -68,7 +68,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/createWithList"],
             consumes = ["application/json"],
             method = [RequestMethod.POST])
-    fun createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: kotlin.Array<User>): ResponseEntity<Unit> {
+    fun createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: List<User>): ResponseEntity<Unit> {
         return ResponseEntity(service.createUsersWithListInput(user), HttpStatus.OK)
     }
 
@@ -81,7 +81,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/{username}"],
             method = [RequestMethod.DELETE])
-    fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true) @PathVariable("username") username: kotlin.String): ResponseEntity<Unit> {
+    fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true) @PathVariable("username") username: String): ResponseEntity<Unit> {
         return ResponseEntity(service.deleteUser(username), HttpStatus.OK)
     }
 
@@ -96,7 +96,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/{username}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true) @PathVariable("username") username: kotlin.String): ResponseEntity<User> {
+    fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true) @PathVariable("username") username: String): ResponseEntity<User> {
         return ResponseEntity(service.getUserByName(username), HttpStatus.OK)
     }
 
@@ -104,14 +104,14 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = "Logs user into the system",
             nickname = "loginUser",
             notes = "",
-            response = kotlin.String::class)
+            response = String::class)
     @ApiResponses(
-            value = [ApiResponse(code = 200, message = "successful operation", response = kotlin.String::class),ApiResponse(code = 400, message = "Invalid username/password supplied")])
+            value = [ApiResponse(code = 200, message = "successful operation", response = String::class),ApiResponse(code = 400, message = "Invalid username/password supplied")])
     @RequestMapping(
             value = ["/user/login"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: kotlin.String,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: kotlin.String): ResponseEntity<kotlin.String> {
+    fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: String,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: String): ResponseEntity<String> {
         return ResponseEntity(service.loginUser(username, password), HttpStatus.OK)
     }
 
@@ -138,7 +138,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/{username}"],
             consumes = ["application/json"],
             method = [RequestMethod.PUT])
-    fun updateUser(@ApiParam(value = "name that need to be deleted", required=true) @PathVariable("username") username: kotlin.String,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody user: User): ResponseEntity<Unit> {
+    fun updateUser(@ApiParam(value = "name that need to be deleted", required=true) @PathVariable("username") username: String,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody user: User): ResponseEntity<Unit> {
         return ResponseEntity(service.updateUser(username, user), HttpStatus.OK)
     }
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiService.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiService.kt
@@ -6,17 +6,17 @@ interface UserApiService {
 
     fun createUser(user: User): Unit
 
-    fun createUsersWithArrayInput(user: kotlin.Array<User>): Unit
+    fun createUsersWithArrayInput(user: List<User>): Unit
 
-    fun createUsersWithListInput(user: kotlin.Array<User>): Unit
+    fun createUsersWithListInput(user: List<User>): Unit
 
-    fun deleteUser(username: kotlin.String): Unit
+    fun deleteUser(username: String): Unit
 
-    fun getUserByName(username: kotlin.String): User
+    fun getUserByName(username: String): User
 
-    fun loginUser(username: kotlin.String,password: kotlin.String): kotlin.String
+    fun loginUser(username: String,password: String): String
 
     fun logoutUser(): Unit
 
-    fun updateUser(username: kotlin.String,user: User): Unit
+    fun updateUser(username: String,user: User): Unit
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiServiceImpl.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiServiceImpl.kt
@@ -10,23 +10,23 @@ class UserApiServiceImpl : UserApiService {
         TODO("Implement me")
     }
 
-    override fun createUsersWithArrayInput(user: kotlin.Array<User>): Unit {
+    override fun createUsersWithArrayInput(user: List<User>): Unit {
         TODO("Implement me")
     }
 
-    override fun createUsersWithListInput(user: kotlin.Array<User>): Unit {
+    override fun createUsersWithListInput(user: List<User>): Unit {
         TODO("Implement me")
     }
 
-    override fun deleteUser(username: kotlin.String): Unit {
+    override fun deleteUser(username: String): Unit {
         TODO("Implement me")
     }
 
-    override fun getUserByName(username: kotlin.String): User {
+    override fun getUserByName(username: String): User {
         TODO("Implement me")
     }
 
-    override fun loginUser(username: kotlin.String,password: kotlin.String): kotlin.String {
+    override fun loginUser(username: String,password: String): String {
         TODO("Implement me")
     }
 
@@ -34,7 +34,7 @@ class UserApiServiceImpl : UserApiService {
         TODO("Implement me")
     }
 
-    override fun updateUser(username: kotlin.String,user: User): Unit {
+    override fun updateUser(username: String,user: User): Unit {
         TODO("Implement me")
     }
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Body.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Body.kt
@@ -14,10 +14,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Body (
 
         @ApiModelProperty(value = "Updated name of the pet")
-        @JsonProperty("name") val name: kotlin.String? = null,
+        @JsonProperty("name") val name: String? = null,
 
         @ApiModelProperty(value = "Updated status of the pet")
-        @JsonProperty("status") val status: kotlin.String? = null
+        @JsonProperty("status") val status: String? = null
 ) {
 
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Body1.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Body1.kt
@@ -14,7 +14,7 @@ import io.swagger.annotations.ApiModelProperty
 data class Body1 (
 
         @ApiModelProperty(value = "Additional data to pass to server")
-        @JsonProperty("additionalMetadata") val additionalMetadata: kotlin.String? = null,
+        @JsonProperty("additionalMetadata") val additionalMetadata: String? = null,
 
         @ApiModelProperty(value = "file to upload")
         @JsonProperty("file") val file: java.io.File? = null

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -14,10 +14,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Category (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("name") val name: kotlin.String? = null
+        @JsonProperty("name") val name: String? = null
 ) {
 
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -15,13 +15,13 @@ import io.swagger.annotations.ApiModelProperty
 data class ModelApiResponse (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("code") val code: kotlin.Int? = null,
+        @JsonProperty("code") val code: Int? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("type") val type: kotlin.String? = null,
+        @JsonProperty("type") val type: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("message") val message: kotlin.String? = null
+        @JsonProperty("message") val message: String? = null
 ) {
 
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -19,13 +19,13 @@ import io.swagger.annotations.ApiModelProperty
 data class Order (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("petId") val petId: kotlin.Long? = null,
+        @JsonProperty("petId") val petId: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("quantity") val quantity: kotlin.Int? = null,
+        @JsonProperty("quantity") val quantity: Int? = null,
 
         @ApiModelProperty(value = "")
         @JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
@@ -34,14 +34,14 @@ data class Order (
         @JsonProperty("status") val status: Order.Status? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("complete") val complete: kotlin.Boolean? = null
+        @JsonProperty("complete") val complete: Boolean? = null
 ) {
 
     /**
     * Order Status
     * Values: placed,approved,delivered
     */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(val value: String) {
     
         @JsonProperty("placed") placed("placed"),
     

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -20,22 +20,22 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Pet (
 
-        @get:NotNull 
+    @get:NotNull 
         @ApiModelProperty(example = "doggie", required = true, value = "")
-        @JsonProperty("name") val name: kotlin.String,
+        @JsonProperty("name") val name: String,
 
-        @get:NotNull 
+    @get:NotNull 
         @ApiModelProperty(required = true, value = "")
-        @JsonProperty("photoUrls") val photoUrls: kotlin.Array<kotlin.String>,
+        @JsonProperty("photoUrls") val photoUrls: List<String>,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
         @JsonProperty("category") val category: Category? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("tags") val tags: kotlin.Array<Tag>? = null,
+        @JsonProperty("tags") val tags: List<Tag>? = null,
 
         @ApiModelProperty(value = "pet status in the store")
         @JsonProperty("status") val status: Pet.Status? = null
@@ -45,7 +45,7 @@ data class Pet (
     * pet status in the store
     * Values: available,pending,sold
     */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(val value: String) {
     
         @JsonProperty("available") available("available"),
     

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -20,11 +20,11 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Pet (
 
-    @get:NotNull 
+        @get:NotNull 
         @ApiModelProperty(example = "doggie", required = true, value = "")
         @JsonProperty("name") val name: String,
 
-    @get:NotNull 
+        @get:NotNull 
         @ApiModelProperty(required = true, value = "")
         @JsonProperty("photoUrls") val photoUrls: List<String>,
 

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -14,10 +14,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Tag (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("name") val name: kotlin.String? = null
+        @JsonProperty("name") val name: String? = null
 ) {
 
 }

--- a/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/openapi3/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
@@ -20,28 +20,28 @@ import io.swagger.annotations.ApiModelProperty
 data class User (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("username") val username: kotlin.String? = null,
+        @JsonProperty("username") val username: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("firstName") val firstName: kotlin.String? = null,
+        @JsonProperty("firstName") val firstName: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("lastName") val lastName: kotlin.String? = null,
+        @JsonProperty("lastName") val lastName: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("email") val email: kotlin.String? = null,
+        @JsonProperty("email") val email: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("password") val password: kotlin.String? = null,
+        @JsonProperty("password") val password: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("phone") val phone: kotlin.String? = null,
+        @JsonProperty("phone") val phone: String? = null,
 
         @ApiModelProperty(value = "User Status")
-        @JsonProperty("userStatus") val userStatus: kotlin.Int? = null
+        @JsonProperty("userStatus") val userStatus: Int? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -56,7 +56,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
     @RequestMapping(
             value = ["/pet/{petId}"],
             method = [RequestMethod.DELETE])
-    fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: kotlin.Long,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: kotlin.String?): ResponseEntity<Unit> {
+    fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: String?): ResponseEntity<Unit> {
         return ResponseEntity(service.deletePet(petId, apiKey), HttpStatus.OK)
     }
 
@@ -73,7 +73,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/findByStatus"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) status: kotlin.Array<kotlin.String>): ResponseEntity<List<Pet>> {
+    fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) status: List<String>): ResponseEntity<List<Pet>> {
         return ResponseEntity(service.findPetsByStatus(status), HttpStatus.OK)
     }
 
@@ -90,7 +90,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/findByTags"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: kotlin.Array<kotlin.String>): ResponseEntity<List<Pet>> {
+    fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: List<String>): ResponseEntity<List<Pet>> {
         return ResponseEntity(service.findPetsByTags(tags), HttpStatus.OK)
     }
 
@@ -106,7 +106,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/{petId}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getPetById(@ApiParam(value = "ID of pet to return", required=true) @PathVariable("petId") petId: kotlin.Long): ResponseEntity<Pet> {
+    fun getPetById(@ApiParam(value = "ID of pet to return", required=true) @PathVariable("petId") petId: Long): ResponseEntity<Pet> {
         return ResponseEntity(service.getPetById(petId), HttpStatus.OK)
     }
 
@@ -136,7 +136,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/{petId}"],
             consumes = ["application/x-www-form-urlencoded"],
             method = [RequestMethod.POST])
-    fun updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required=true) @PathVariable("petId") petId: kotlin.Long,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false) name: kotlin.String ,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false) status: kotlin.String ): ResponseEntity<Unit> {
+    fun updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false) name: String ,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false) status: String ): ResponseEntity<Unit> {
         return ResponseEntity(service.updatePetWithForm(petId, name, status), HttpStatus.OK)
     }
 
@@ -153,7 +153,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             produces = ["application/json"], 
             consumes = ["multipart/form-data"],
             method = [RequestMethod.POST])
-    fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: kotlin.Long,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: kotlin.String ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: MultipartFile): ResponseEntity<ModelApiResponse> {
+    fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: String ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: MultipartFile): ResponseEntity<ModelApiResponse> {
         return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.OK)
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
@@ -7,17 +7,17 @@ interface PetApiService {
 
     fun addPet(pet: Pet): Unit
 
-    fun deletePet(petId: kotlin.Long,apiKey: kotlin.String?): Unit
+    fun deletePet(petId: Long,apiKey: String?): Unit
 
-    fun findPetsByStatus(status: kotlin.Array<kotlin.String>): List<Pet>
+    fun findPetsByStatus(status: List<String>): List<Pet>
 
-    fun findPetsByTags(tags: kotlin.Array<kotlin.String>): List<Pet>
+    fun findPetsByTags(tags: List<String>): List<Pet>
 
-    fun getPetById(petId: kotlin.Long): Pet
+    fun getPetById(petId: Long): Pet
 
     fun updatePet(pet: Pet): Unit
 
-    fun updatePetWithForm(petId: kotlin.Long,name: kotlin.String?,status: kotlin.String?): Unit
+    fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit
 
-    fun uploadFile(petId: kotlin.Long,additionalMetadata: kotlin.String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse
+    fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
@@ -11,19 +11,19 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun deletePet(petId: kotlin.Long,apiKey: kotlin.String?): Unit {
+    override fun deletePet(petId: Long,apiKey: String?): Unit {
         TODO("Implement me")
     }
 
-    override fun findPetsByStatus(status: kotlin.Array<kotlin.String>): List<Pet> {
+    override fun findPetsByStatus(status: List<String>): List<Pet> {
         TODO("Implement me")
     }
 
-    override fun findPetsByTags(tags: kotlin.Array<kotlin.String>): List<Pet> {
+    override fun findPetsByTags(tags: List<String>): List<Pet> {
         TODO("Implement me")
     }
 
-    override fun getPetById(petId: kotlin.Long): Pet {
+    override fun getPetById(petId: Long): Pet {
         TODO("Implement me")
     }
 
@@ -31,11 +31,11 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun updatePetWithForm(petId: kotlin.Long,name: kotlin.String?,status: kotlin.String?): Unit {
+    override fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit {
         TODO("Implement me")
     }
 
-    override fun uploadFile(petId: kotlin.Long,additionalMetadata: kotlin.String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse {
+    override fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -39,7 +39,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
     @RequestMapping(
             value = ["/store/order/{orderId}"],
             method = [RequestMethod.DELETE])
-    fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true) @PathVariable("orderId") orderId: kotlin.String): ResponseEntity<Unit> {
+    fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true) @PathVariable("orderId") orderId: String): ResponseEntity<Unit> {
         return ResponseEntity(service.deleteOrder(orderId), HttpStatus.OK)
     }
 
@@ -47,16 +47,16 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             value = "Returns pet inventories by status",
             nickname = "getInventory",
             notes = "Returns a map of status codes to quantities",
-            response = kotlin.Int::class,
+            response = Int::class,
             responseContainer = "Map",
             authorizations = [Authorization(value = "api_key")])
     @ApiResponses(
-            value = [ApiResponse(code = 200, message = "successful operation", response = kotlin.collections.Map::class, responseContainer = "Map")])
+            value = [ApiResponse(code = 200, message = "successful operation", response = Map::class, responseContainer = "Map")])
     @RequestMapping(
             value = ["/store/inventory"],
             produces = ["application/json"], 
             method = [RequestMethod.GET])
-    fun getInventory(): ResponseEntity<Map<String, kotlin.Int>> {
+    fun getInventory(): ResponseEntity<Map<String, Int>> {
         return ResponseEntity(service.getInventory(), HttpStatus.OK)
     }
 
@@ -71,7 +71,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             value = ["/store/order/{orderId}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true) @PathVariable("orderId") orderId: kotlin.Long): ResponseEntity<Order> {
+    fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true) @PathVariable("orderId") orderId: Long): ResponseEntity<Order> {
         return ResponseEntity(service.getOrderById(orderId), HttpStatus.OK)
     }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiService.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiService.kt
@@ -4,11 +4,11 @@ import org.openapitools.model.Order
 
 interface StoreApiService {
 
-    fun deleteOrder(orderId: kotlin.String): Unit
+    fun deleteOrder(orderId: String): Unit
 
-    fun getInventory(): Map<String, kotlin.Int>
+    fun getInventory(): Map<String, Int>
 
-    fun getOrderById(orderId: kotlin.Long): Order
+    fun getOrderById(orderId: Long): Order
 
     fun placeOrder(order: Order): Order
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiServiceImpl.kt
@@ -6,15 +6,15 @@ import org.springframework.stereotype.Service
 @Service
 class StoreApiServiceImpl : StoreApiService {
 
-    override fun deleteOrder(orderId: kotlin.String): Unit {
+    override fun deleteOrder(orderId: String): Unit {
         TODO("Implement me")
     }
 
-    override fun getInventory(): Map<String, kotlin.Int> {
+    override fun getInventory(): Map<String, Int> {
         TODO("Implement me")
     }
 
-    override fun getOrderById(orderId: kotlin.Long): Order {
+    override fun getOrderById(orderId: Long): Order {
         TODO("Implement me")
     }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -52,7 +52,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/createWithArray"],
             method = [RequestMethod.POST])
-    fun createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: kotlin.Array<User>): ResponseEntity<Unit> {
+    fun createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: List<User>): ResponseEntity<Unit> {
         return ResponseEntity(service.createUsersWithArrayInput(user), HttpStatus.OK)
     }
 
@@ -65,7 +65,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/createWithList"],
             method = [RequestMethod.POST])
-    fun createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: kotlin.Array<User>): ResponseEntity<Unit> {
+    fun createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody user: List<User>): ResponseEntity<Unit> {
         return ResponseEntity(service.createUsersWithListInput(user), HttpStatus.OK)
     }
 
@@ -78,7 +78,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/{username}"],
             method = [RequestMethod.DELETE])
-    fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true) @PathVariable("username") username: kotlin.String): ResponseEntity<Unit> {
+    fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true) @PathVariable("username") username: String): ResponseEntity<Unit> {
         return ResponseEntity(service.deleteUser(username), HttpStatus.OK)
     }
 
@@ -93,7 +93,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/{username}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true) @PathVariable("username") username: kotlin.String): ResponseEntity<User> {
+    fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true) @PathVariable("username") username: String): ResponseEntity<User> {
         return ResponseEntity(service.getUserByName(username), HttpStatus.OK)
     }
 
@@ -101,14 +101,14 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = "Logs user into the system",
             nickname = "loginUser",
             notes = "",
-            response = kotlin.String::class)
+            response = String::class)
     @ApiResponses(
-            value = [ApiResponse(code = 200, message = "successful operation", response = kotlin.String::class),ApiResponse(code = 400, message = "Invalid username/password supplied")])
+            value = [ApiResponse(code = 200, message = "successful operation", response = String::class),ApiResponse(code = 400, message = "Invalid username/password supplied")])
     @RequestMapping(
             value = ["/user/login"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: kotlin.String,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: kotlin.String): ResponseEntity<kotlin.String> {
+    fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: String,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: String): ResponseEntity<String> {
         return ResponseEntity(service.loginUser(username, password), HttpStatus.OK)
     }
 
@@ -134,7 +134,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/{username}"],
             method = [RequestMethod.PUT])
-    fun updateUser(@ApiParam(value = "name that need to be deleted", required=true) @PathVariable("username") username: kotlin.String,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody user: User): ResponseEntity<Unit> {
+    fun updateUser(@ApiParam(value = "name that need to be deleted", required=true) @PathVariable("username") username: String,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody user: User): ResponseEntity<Unit> {
         return ResponseEntity(service.updateUser(username, user), HttpStatus.OK)
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiService.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiService.kt
@@ -6,17 +6,17 @@ interface UserApiService {
 
     fun createUser(user: User): Unit
 
-    fun createUsersWithArrayInput(user: kotlin.Array<User>): Unit
+    fun createUsersWithArrayInput(user: List<User>): Unit
 
-    fun createUsersWithListInput(user: kotlin.Array<User>): Unit
+    fun createUsersWithListInput(user: List<User>): Unit
 
-    fun deleteUser(username: kotlin.String): Unit
+    fun deleteUser(username: String): Unit
 
-    fun getUserByName(username: kotlin.String): User
+    fun getUserByName(username: String): User
 
-    fun loginUser(username: kotlin.String,password: kotlin.String): kotlin.String
+    fun loginUser(username: String,password: String): String
 
     fun logoutUser(): Unit
 
-    fun updateUser(username: kotlin.String,user: User): Unit
+    fun updateUser(username: String,user: User): Unit
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiServiceImpl.kt
@@ -10,23 +10,23 @@ class UserApiServiceImpl : UserApiService {
         TODO("Implement me")
     }
 
-    override fun createUsersWithArrayInput(user: kotlin.Array<User>): Unit {
+    override fun createUsersWithArrayInput(user: List<User>): Unit {
         TODO("Implement me")
     }
 
-    override fun createUsersWithListInput(user: kotlin.Array<User>): Unit {
+    override fun createUsersWithListInput(user: List<User>): Unit {
         TODO("Implement me")
     }
 
-    override fun deleteUser(username: kotlin.String): Unit {
+    override fun deleteUser(username: String): Unit {
         TODO("Implement me")
     }
 
-    override fun getUserByName(username: kotlin.String): User {
+    override fun getUserByName(username: String): User {
         TODO("Implement me")
     }
 
-    override fun loginUser(username: kotlin.String,password: kotlin.String): kotlin.String {
+    override fun loginUser(username: String,password: String): String {
         TODO("Implement me")
     }
 
@@ -34,7 +34,7 @@ class UserApiServiceImpl : UserApiService {
         TODO("Implement me")
     }
 
-    override fun updateUser(username: kotlin.String,user: User): Unit {
+    override fun updateUser(username: String,user: User): Unit {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -14,10 +14,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Category (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("name") val name: kotlin.String? = null
+        @JsonProperty("name") val name: String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -15,13 +15,13 @@ import io.swagger.annotations.ApiModelProperty
 data class ModelApiResponse (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("code") val code: kotlin.Int? = null,
+        @JsonProperty("code") val code: Int? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("type") val type: kotlin.String? = null,
+        @JsonProperty("type") val type: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("message") val message: kotlin.String? = null
+        @JsonProperty("message") val message: String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -19,13 +19,13 @@ import io.swagger.annotations.ApiModelProperty
 data class Order (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("petId") val petId: kotlin.Long? = null,
+        @JsonProperty("petId") val petId: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("quantity") val quantity: kotlin.Int? = null,
+        @JsonProperty("quantity") val quantity: Int? = null,
 
         @ApiModelProperty(value = "")
         @JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
@@ -34,14 +34,14 @@ data class Order (
         @JsonProperty("status") val status: Order.Status? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("complete") val complete: kotlin.Boolean? = null
+        @JsonProperty("complete") val complete: Boolean? = null
 ) {
 
     /**
     * Order Status
     * Values: placed,approved,delivered
     */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(val value: String) {
     
         @JsonProperty("placed") placed("placed"),
     

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -20,22 +20,22 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Pet (
 
-        @get:NotNull 
+    @get:NotNull 
         @ApiModelProperty(example = "doggie", required = true, value = "")
-        @JsonProperty("name") val name: kotlin.String,
+        @JsonProperty("name") val name: String,
 
-        @get:NotNull 
+    @get:NotNull 
         @ApiModelProperty(required = true, value = "")
-        @JsonProperty("photoUrls") val photoUrls: kotlin.Array<kotlin.String>,
+        @JsonProperty("photoUrls") val photoUrls: List<String>,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
         @JsonProperty("category") val category: Category? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("tags") val tags: kotlin.Array<Tag>? = null,
+        @JsonProperty("tags") val tags: List<Tag>? = null,
 
         @ApiModelProperty(value = "pet status in the store")
         @JsonProperty("status") val status: Pet.Status? = null
@@ -45,7 +45,7 @@ data class Pet (
     * pet status in the store
     * Values: available,pending,sold
     */
-    enum class Status(val value: kotlin.String) {
+    enum class Status(val value: String) {
     
         @JsonProperty("available") available("available"),
     

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -20,11 +20,11 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Pet (
 
-    @get:NotNull 
+        @get:NotNull 
         @ApiModelProperty(example = "doggie", required = true, value = "")
         @JsonProperty("name") val name: String,
 
-    @get:NotNull 
+        @get:NotNull 
         @ApiModelProperty(required = true, value = "")
         @JsonProperty("photoUrls") val photoUrls: List<String>,
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -14,10 +14,10 @@ import io.swagger.annotations.ApiModelProperty
 data class Tag (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("name") val name: kotlin.String? = null
+        @JsonProperty("name") val name: String? = null
 ) {
 
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
@@ -20,28 +20,28 @@ import io.swagger.annotations.ApiModelProperty
 data class User (
 
         @ApiModelProperty(value = "")
-        @JsonProperty("id") val id: kotlin.Long? = null,
+        @JsonProperty("id") val id: Long? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("username") val username: kotlin.String? = null,
+        @JsonProperty("username") val username: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("firstName") val firstName: kotlin.String? = null,
+        @JsonProperty("firstName") val firstName: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("lastName") val lastName: kotlin.String? = null,
+        @JsonProperty("lastName") val lastName: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("email") val email: kotlin.String? = null,
+        @JsonProperty("email") val email: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("password") val password: kotlin.String? = null,
+        @JsonProperty("password") val password: String? = null,
 
         @ApiModelProperty(value = "")
-        @JsonProperty("phone") val phone: kotlin.String? = null,
+        @JsonProperty("phone") val phone: String? = null,
 
         @ApiModelProperty(value = "User Status")
-        @JsonProperty("userStatus") val userStatus: kotlin.Int? = null
+        @JsonProperty("userStatus") val userStatus: Int? = null
 ) {
 
 }


### PR DESCRIPTION


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@dr4ke616
### Description of the PR

- Fixes a bug where lists were instantiated with the arrayOf function.
- If required and readonly, a field should be optional. This is to allow people to do a GET and easily PUT it back with small changes.
- Use List type for the OpenApi array. This is because kotlin data classes should not use kotlin.Array since arrays are compared by reference rather than structure. Different arrays with the same content should return true but return false.
- Uses String instead of kotlin.String, Int instead of kotlin.Int, etc for built-in kotlin types.