### PR TITLE
Add logic to handle uuid in Elm generator (0.19)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -527,7 +527,7 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     private String paramToString(final CodegenParameter param) {
         final String paramName = param.paramName;
-        if (param.isString) {
+        if (param.isString || param.isUuid) {
             return paramName;
         }
         if (ElmVersion.ELM_018.equals(elmVersion)) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To fix the following issue reported in the chat room by @mxinden
```
Exception in thread "main" java.lang.RuntimeException: Could not generate api file for 'Silence'
        at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:596)
        at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:828)
        at org.openapitools.codegen.cmd.Generate.run(Generate.java:342)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
Caused by: java.lang.RuntimeException: Parameter 'silenceID' cannot be converted to a string
        at org.openapitools.codegen.languages.ElmClientCodegen.paramToString(ElmClientCodegen.java:542)
        at org.openapitools.codegen.languages.ElmClientCodegen.postProcessOperationsWithModels(ElmClientCodegen.java:446)
        at org.openapitools.codegen.DefaultGenerator.processOperations(DefaultGenerator.java:1037)
        at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:507)
        ... 3 more
```

Spec: https://github.com/prometheus/alertmanager/blob/master/api/v2/openapi.yaml

cc @trenneman 