### PR TITLE
Handle untyped schemas (in some languages)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -919,6 +919,7 @@ public class DefaultCodegen implements CodegenConfig {
         typeMapping.put("char", "String");
         typeMapping.put("double", "Double");
         typeMapping.put("object", "Object");
+        typeMapping.put(null, "Object");
         typeMapping.put("integer", "Integer");
         typeMapping.put("ByteArray", "byte[]");
         typeMapping.put("binary", "File");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -104,6 +104,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         typeMapping.put("binary", "*os.File");
         typeMapping.put("ByteArray", "string");
         typeMapping.put("object", "map[string]interface{}");
+        typeMapping.put(null, "interface{}");
 
         importMapping = new HashMap<String, String>();
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
@@ -90,6 +90,7 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
         typeMapping.put("bigdecimal", "float()");
         typeMapping.put("List", "list()");
         typeMapping.put("object", "maps:map()");
+        typeMapping.put(null, "any()");
         typeMapping.put("file", "binary()");
         typeMapping.put("binary", "binary()");
         typeMapping.put("bytearray", "binary()");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -129,6 +129,7 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
         typeMapping.put("binary", "::models::File");
         typeMapping.put("ByteArray", "String");
         typeMapping.put("object", "Value");
+        typeMapping.put(null, "Value");
 
         // no need for rust
         //importMapping = new HashMap<String, String>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttpClientCodegen.java
@@ -114,6 +114,7 @@ public class ScalaHttpClientCodegen extends AbstractScalaCodegen implements Code
         typeMapping.put("char", "Char");
         typeMapping.put("double", "Double");
         typeMapping.put("object", "Any");
+        typeMapping.put(null, "Any");
         typeMapping.put("file", "File");
         typeMapping.put("binary", "File");
         typeMapping.put("ByteArray", "Array[Byte]");


### PR DESCRIPTION
Ref https://github.com/swagger-api/swagger-codegen/pull/6898
Ref https://github.com/swagger-api/swagger-codegen/issues/6896

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Partial copy of https://github.com/swagger-api/swagger-codegen/pull/6898 (for handling untyped schemas, especially as `additionalProperties`), at the request of @wing328 . This has not yet been tested, nor have tests been updated, nor are all languages covered.