### PR TITLE
[Python] Commenting supportsInheritance is enabling the model properties inhe…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -68,7 +68,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // at the moment
         importMapping.clear();
 
-        supportsInheritance = true;
+        // Commenting supportsInheritance is enabling the model properties inheritence properly from parent model
+        //supportsInheritance = true;
         modelPackage = "models";
         apiPackage = "api";
         outputFolder = "generated-code" + File.separatorChar + "python";


### PR DESCRIPTION
@wing328 

CC'ing [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee): @taxpon @frol @mbohlool @cbornet @kenjones-cisco to review the pull request if your PR is targeting python programming language.

### Description of the PR

It is kind of counter intuitive, but setting `supportsInheritance = true` is failing to get the properties from the parent when a child model inherits. Didn't dive deep in to the actual base class for the code generation, but commenting out the line from `PythonClientCodegen.java` fixed the issue.

This solves the reported issues
- https://github.com/OpenAPITools/openapi-generator/issues/453 (@poli-granot)
- https://github.com/OpenAPITools/openapi-generator/issues/623 (@emreakca)

There could be multiple reasons since I didn't go to the root cause
- First that there is no `AbstractPyCodegen.java`, which might/might not tackle the issue
- Second, we **don't know** if other code gen for other languages are working since, they also are using `supportsInheritence = true` in their generation code. Just to quote a few
    -  `AbstractJavaCodegen` (@bbdouglas @JFCote @sreeshas @jfiala  @lukoyanov  @cbornet  @jeff9finger )
    - ` JavascriptClientCodegen` (@CodeNinjai @frol @cliffano)
    - `CSharpClientCodegen` / `AbstractCSharpCodegen.java` (@mandrean @jimschubert)
    - `AbstractKotlinCodegen` (@jimschubert @dr4ke616)
