### PR TITLE
Rename Dart env variable for post processing file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -150,8 +150,8 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
     public void processOpts() {
         super.processOpts();
 
-        if (StringUtils.isEmpty(System.getenv("DART_FMT_PATH"))) {
-            LOGGER.info("Environment variable DART_FMT_PATH not defined so the Dart code may not be properly formatted. To define it, try 'export DART_FMT_PATH=/usr/local/bin/dartfmt' (Linux/Mac)");
+        if (StringUtils.isEmpty(System.getenv("DART_POST_PROCESS_FILE"))) {
+            LOGGER.info("Environment variable DART_POST_PROCESS_FILE not defined so the Dart code may not be properly formatted. To define it, try `export DART_POST_PROCESS_FILE=\"/usr/local/bin/dartfmt -w\"` (Linux/Mac)");
         }
 
         if (additionalProperties.containsKey(BROWSER_CLIENT)) {
@@ -512,9 +512,9 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
             return;
         }
 
-        String dartFmtPath = System.getenv("DART_FMT_PATH");
-        if (StringUtils.isEmpty(dartFmtPath)) {
-            return; // skip if DART_FMT_PATH env variable is not defined
+        String dartPostProcessFile = System.getenv("DART_POST_PROCESS_FILE");
+        if (StringUtils.isEmpty(dartPostProcessFile)) {
+            return; // skip if DART_POST_PROCESS_FILE env variable is not defined
         }
 
         // only procees the following type (or we can simply rely on the file extension to check if it's a Dart file)
@@ -532,14 +532,15 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         // only process files with dart extension
         if ("dart".equals(FilenameUtils.getExtension(file.toString()))) {
             // currently only support "dartfmt -w yourcode.dart"
-            String command = dartFmtPath + " -w " + file.toString();
+            String command = dartPostProcessFile + " " + file.toString();
             try {
                 Process p = Runtime.getRuntime().exec(command);
-                p.waitFor();
-                if (p.exitValue() != 0) {
-                    LOGGER.error("Error running the command ({}). Exit code: {}", command, p.exitValue());
+                int exitValue = p.waitFor();
+                if (exitValue != 0) {
+                    LOGGER.error("Error running the command ({}). Exit code: {}", command, exitValue);
+                } else {
+                    LOGGER.info("Successfully executed: " + command);
                 }
-                LOGGER.info("Successfully executed: " + command);
             } catch (Exception e) {
                 LOGGER.error("Error running the command ({}). Exception: {}", command, e.getMessage());
             }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Renamed to `DART_POST_PROCESS_FILE`

e.g. `export DART_POST_PROCESS_FILE="/usr/local/bin/dartfmt -w"`
