### PR TITLE
Add mapping for "map" in C generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -133,6 +133,7 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
         languageSpecificPrimitives.add("char");
         languageSpecificPrimitives.add("FILE");
         languageSpecificPrimitives.add("Object");
+        languageSpecificPrimitives.add("list_t*");
 
         typeMapping.put("string", "char");
         typeMapping.put("char", "char");
@@ -149,6 +150,7 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("ByteArray", "char");
         typeMapping.put("UUID", "char");
         typeMapping.put("array", "list");
+        typeMapping.put("map", "list_t*");
         typeMapping.put("date-time", "char");
         
         // remove modelPackage and apiPackage added by default

--- a/samples/client/petstore/C/api/PetAPI.c
+++ b/samples/client/petstore/C/api/PetAPI.c
@@ -74,12 +74,18 @@ void *PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(petId) + 3);
-	snprintf(localVarToReplace, strlen("petId") + 3, "%s%s%s", "{", "petId", "}");
+	snprintf(localVarToReplace,
+	         strlen("petId") + 3,
+	         "%s%s%s",
+	         "{",
+	         "petId",
+	         "}");
 
 	char localVarBuff[256];
 	intToStr(localVarBuff, petId);
 
-	localVarPath = strReplace(localVarPath, localVarToReplace, localVarBuff);
+	localVarPath =
+		strReplace(localVarPath, localVarToReplace, localVarBuff);
 
 
 	// header parameters (TODO free function to implement)
@@ -89,8 +95,10 @@ void *PetAPI_deletePet(apiClient_t *apiClient, long petId, char *api_key) {
 	if(api_key) {
 		keyHeader_api_key = strdup("api_key");
 		valueHeader_api_key = strdup(api_key);
-		keyPairHeader_api_key = keyValuePair_create(keyHeader_api_key, valueHeader_api_key);
-		list_addElement(localVarHeaderParameters, keyPairHeader_api_key);
+		keyPairHeader_api_key = keyValuePair_create(keyHeader_api_key,
+		                                            valueHeader_api_key);
+		list_addElement(localVarHeaderParameters,
+		                keyPairHeader_api_key);
 	}
 
 	apiClient_invoke(apiClient,
@@ -263,12 +271,18 @@ pet_t *PetAPI_getPetById(apiClient_t *apiClient, long petId) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(petId) + 3);
-	snprintf(localVarToReplace, strlen("petId") + 3, "%s%s%s", "{", "petId", "}");
+	snprintf(localVarToReplace,
+	         strlen("petId") + 3,
+	         "%s%s%s",
+	         "{",
+	         "petId",
+	         "}");
 
 	char localVarBuff[256];
 	intToStr(localVarBuff, petId);
 
-	localVarPath = strReplace(localVarPath, localVarToReplace, localVarBuff);
+	localVarPath =
+		strReplace(localVarPath, localVarToReplace, localVarBuff);
 
 
 	list_addElement(localVarHeaderType, "application/xml"); // produces
@@ -349,7 +363,10 @@ void *PetAPI_updatePet(apiClient_t *apiClient, pet_t *pet) {
 
 // Updates a pet in the store with form data
 //
-void *PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, char *status) {
+void *PetAPI_updatePetWithForm(apiClient_t	*apiClient,
+                               long		petId,
+                               char		*name,
+                               char		*status) {
 	list_t *localVarQueryParameters = list_create();
 	list_t *localVarHeaderParameters = list_create();
 	list_t *localVarFormParameters = list_create();
@@ -363,12 +380,18 @@ void *PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, c
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(petId) + 3);
-	snprintf(localVarToReplace, strlen("petId") + 3, "%s%s%s", "{", "petId", "}");
+	snprintf(localVarToReplace,
+	         strlen("petId") + 3,
+	         "%s%s%s",
+	         "{",
+	         "petId",
+	         "}");
 
 	char localVarBuff[256];
 	intToStr(localVarBuff, petId);
 
-	localVarPath = strReplace(localVarPath, localVarToReplace, localVarBuff);
+	localVarPath =
+		strReplace(localVarPath, localVarToReplace, localVarBuff);
 
 
 	// form parameters
@@ -378,7 +401,8 @@ void *PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, c
 	if(name) {
 		keyForm_name = strdup("name");
 		valueForm_name = strdup(name);
-		keyPairForm_name = keyValuePair_create(keyForm_name, valueForm_name);
+		keyPairForm_name = keyValuePair_create(keyForm_name,
+		                                       valueForm_name);
 		list_addElement(localVarFormParameters, keyPairForm_name); // String
 	}
 
@@ -389,11 +413,13 @@ void *PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, c
 	if(status) {
 		keyForm_status = strdup("status");
 		valueForm_status = strdup(status);
-		keyPairForm_status = keyValuePair_create(keyForm_status, valueForm_status);
+		keyPairForm_status = keyValuePair_create(keyForm_status,
+		                                         valueForm_status);
 		list_addElement(localVarFormParameters, keyPairForm_status); // String
 	}
 
-	list_addElement(localVarContentType, "application/x-www-form-urlencoded"); // consumes
+	list_addElement(localVarContentType,
+	                "application/x-www-form-urlencoded");                     // consumes
 
 	apiClient_invoke(apiClient,
 	                 localVarPath,
@@ -422,7 +448,10 @@ void *PetAPI_updatePetWithForm(apiClient_t *apiClient, long petId, char *name, c
 
 // uploads an image
 //
-api_response_t *PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *additionalMetadata, FILE *file) {
+api_response_t *PetAPI_uploadFile(apiClient_t	*apiClient,
+                                  long		petId,
+                                  char		*additionalMetadata,
+                                  FILE		*file) {
 	list_t *localVarQueryParameters = list_create();
 	list_t *localVarHeaderParameters = list_create();
 	list_t *localVarFormParameters = list_create();
@@ -436,12 +465,18 @@ api_response_t *PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *addi
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(petId) + 3);
-	snprintf(localVarToReplace, strlen("petId") + 3, "%s%s%s", "{", "petId", "}");
+	snprintf(localVarToReplace,
+	         strlen("petId") + 3,
+	         "%s%s%s",
+	         "{",
+	         "petId",
+	         "}");
 
 	char localVarBuff[256];
 	intToStr(localVarBuff, petId);
 
-	localVarPath = strReplace(localVarPath, localVarToReplace, localVarBuff);
+	localVarPath =
+		strReplace(localVarPath, localVarToReplace, localVarBuff);
 
 
 	// form parameters
@@ -451,8 +486,11 @@ api_response_t *PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *addi
 	if(additionalMetadata) {
 		keyForm_additionalMetadata = strdup("additionalMetadata");
 		valueForm_additionalMetadata = strdup(additionalMetadata);
-		keyPairForm_additionalMetadata = keyValuePair_create(keyForm_additionalMetadata, valueForm_additionalMetadata);
-		list_addElement(localVarFormParameters, keyPairForm_additionalMetadata); // String
+		keyPairForm_additionalMetadata = keyValuePair_create(
+			keyForm_additionalMetadata,
+			valueForm_additionalMetadata);
+		list_addElement(localVarFormParameters,
+		                keyPairForm_additionalMetadata);                // String
 	}
 
 	// form parameters
@@ -493,7 +531,8 @@ api_response_t *PetAPI_uploadFile(apiClient_t *apiClient, long petId, char *addi
 	                 "POST");
 
 	// nonprimitive not container
-	api_response_t *elementToReturn = api_response_parseFromJSON(apiClient->dataReceived);
+	api_response_t *elementToReturn = api_response_parseFromJSON(
+		apiClient->dataReceived);
 	if(elementToReturn == NULL) {
 		return 0;
 	}

--- a/samples/client/petstore/C/api/PetAPI.h
+++ b/samples/client/petstore/C/api/PetAPI.h
@@ -44,9 +44,15 @@ void *PetAPI_updatePet(apiClient_t *apiClient, pet_t *Pet);
 
 // Updates a pet in the store with form data
 //
-void *PetAPI_updatePetWithForm(apiClient_t *apiClient, long PetId, char *Name, char *Status);
+void *PetAPI_updatePetWithForm(apiClient_t	*apiClient,
+                               long		PetId,
+                               char		*Name,
+                               char		*Status);
 
 
 // uploads an image
 //
-api_response_t *PetAPI_uploadFile(apiClient_t *apiClient, long PetId, char *AdditionalMetadata, FILE *File);
+api_response_t *PetAPI_uploadFile(apiClient_t	*apiClient,
+                                  long		PetId,
+                                  char		*AdditionalMetadata,
+                                  FILE		*File);

--- a/samples/client/petstore/C/api/StoreAPI.c
+++ b/samples/client/petstore/C/api/StoreAPI.c
@@ -4,7 +4,6 @@
 #include "apiClient.h"
 #include "cJSON.h"
 #include "keyValuePair.h"
-//#include "map.h"
 #include "order.h"
 
 #define MAX_BUFFER_LENGTH 4096
@@ -32,7 +31,12 @@ void *StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(orderId) + 2);
-	snprintf(localVarToReplace, strlen(orderId) + 3, "%s%s%s", "{", "orderId", "}");
+	snprintf(localVarToReplace,
+	         strlen(orderId) + 3,
+	         "%s%s%s",
+	         "{",
+	         "orderId",
+	         "}");
 
 	localVarPath = strReplace(localVarPath, localVarToReplace, orderId);
 
@@ -61,41 +65,41 @@ void *StoreAPI_deleteOrder(apiClient_t *apiClient, char *orderId) {
 //
 // Returns a map of status codes to quantities
 //
-//map *StoreAPI_getInventory(apiClient_t *apiClient) {
-//	list_t *localVarQueryParameters = list_create();
-//	list_t *localVarHeaderParameters = list_create();
-//	list_t *localVarFormParameters = list_create();
-//	list_t *localVarHeaderType = list_create();
-//	list_t *localVarContentType = list_create();
-//	char *localVarBodyParameters = NULL;
-//
-//	// create the path
-//	char *localVarPath = malloc(MAX_BUFFER_LENGTH);
-//	snprintf(localVarPath, MAX_BUFFER_LENGTH, "/store/inventory");
-//
-//	list_addElement(localVarHeaderType, "application/json"); // produces
-//
-//	apiClient_invoke(apiClient,
-//	                 localVarPath,
-//	                 localVarQueryParameters,
-//	                 localVarHeaderParameters,
-//	                 localVarFormParameters,
-//	                 localVarHeaderType,
-//	                 localVarContentType,
-//	                 localVarBodyParameters,
-//	                 "GET");
-//
-//	// primitive reutrn type
-//	char *elementToReturn = (char *) apiClient->dataReceived;
-//	apiClient_free(apiClient);
-//	list_free(localVarQueryParameters);
-//	list_free(localVarHeaderParameters);
-//	list_free(localVarFormParameters);
-//	list_free(localVarHeaderType);
-//	list_free(localVarContentType);
-//	free(localVarPath);
-//	return elementToReturn;
-//}
+list_t **StoreAPI_getInventory(apiClient_t *apiClient) {
+	list_t *localVarQueryParameters = list_create();
+	list_t *localVarHeaderParameters = list_create();
+	list_t *localVarFormParameters = list_create();
+	list_t *localVarHeaderType = list_create();
+	list_t *localVarContentType = list_create();
+	char *localVarBodyParameters = NULL;
+
+	// create the path
+	char *localVarPath = malloc(MAX_BUFFER_LENGTH);
+	snprintf(localVarPath, MAX_BUFFER_LENGTH, "/store/inventory");
+
+	list_addElement(localVarHeaderType, "application/json"); // produces
+
+	apiClient_invoke(apiClient,
+	                 localVarPath,
+	                 localVarQueryParameters,
+	                 localVarHeaderParameters,
+	                 localVarFormParameters,
+	                 localVarHeaderType,
+	                 localVarContentType,
+	                 localVarBodyParameters,
+	                 "GET");
+
+	// primitive reutrn type
+	char *elementToReturn = (char *) apiClient->dataReceived;
+	apiClient_free(apiClient);
+	list_free(localVarQueryParameters);
+	list_free(localVarHeaderParameters);
+	list_free(localVarFormParameters);
+	list_free(localVarHeaderType);
+	list_free(localVarContentType);
+	free(localVarPath);
+	return elementToReturn;
+}
 
 // Find purchase order by ID
 //
@@ -115,12 +119,18 @@ order_t *StoreAPI_getOrderById(apiClient_t *apiClient, long orderId) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(orderId) + 3);
-	snprintf(localVarToReplace, strlen("orderId") + 3, "%s%s%s", "{", "orderId", "}");
+	snprintf(localVarToReplace,
+	         strlen("orderId") + 3,
+	         "%s%s%s",
+	         "{",
+	         "orderId",
+	         "}");
 
 	char localVarBuff[256];
 	intToStr(localVarBuff, orderId);
 
-	localVarPath = strReplace(localVarPath, localVarToReplace, localVarBuff);
+	localVarPath =
+		strReplace(localVarPath, localVarToReplace, localVarBuff);
 
 
 	list_addElement(localVarHeaderType, "application/xml"); // produces

--- a/samples/client/petstore/C/api/StoreAPI.h
+++ b/samples/client/petstore/C/api/StoreAPI.h
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include "apiClient.h"
 #include "cJSON.h"
-//#include "map.h"
 #include "order.h"
 
 
@@ -17,7 +16,7 @@ void *StoreAPI_deleteOrder(apiClient_t *apiClient, char *OrderId);
 //
 // Returns a map of status codes to quantities
 //
-//map *StoreAPI_getInventory(apiClient_t *apiClient);
+list_t **StoreAPI_getInventory(apiClient_t *apiClient);
 
 
 // Find purchase order by ID

--- a/samples/client/petstore/C/api/UserAPI.c
+++ b/samples/client/petstore/C/api/UserAPI.c
@@ -73,7 +73,9 @@ void *UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *user) {
 	// Body Param
 	// notstring
 	cJSON *localVarItemJSON_user = cJSON_CreateObject();
-	cJSON *localVarSingleItemJSON_user = cJSON_AddArrayToObject(localVarItemJSON_user, "user");
+	cJSON *localVarSingleItemJSON_user = cJSON_AddArrayToObject(
+		localVarItemJSON_user,
+		"user");
 	if(localVarSingleItemJSON_user == NULL) {
 		return 0; // nonprimitive container
 	}
@@ -84,7 +86,8 @@ void *UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *user) {
 		if(localVar_user == NULL) {
 			return 0;
 		}
-		cJSON_AddItemToArray(localVarSingleItemJSON_user, localVar_user);
+		cJSON_AddItemToArray(localVarSingleItemJSON_user,
+		                     localVar_user);
 	}
 
 	localVarBodyParameters = cJSON_Print(localVarItemJSON_user);
@@ -130,7 +133,9 @@ void *UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *user) {
 	// Body Param
 	// notstring
 	cJSON *localVarItemJSON_user = cJSON_CreateObject();
-	cJSON *localVarSingleItemJSON_user = cJSON_AddArrayToObject(localVarItemJSON_user, "user");
+	cJSON *localVarSingleItemJSON_user = cJSON_AddArrayToObject(
+		localVarItemJSON_user,
+		"user");
 	if(localVarSingleItemJSON_user == NULL) {
 		return 0; // nonprimitive container
 	}
@@ -141,7 +146,8 @@ void *UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *user) {
 		if(localVar_user == NULL) {
 			return 0;
 		}
-		cJSON_AddItemToArray(localVarSingleItemJSON_user, localVar_user);
+		cJSON_AddItemToArray(localVarSingleItemJSON_user,
+		                     localVar_user);
 	}
 
 	localVarBodyParameters = cJSON_Print(localVarItemJSON_user);
@@ -188,7 +194,12 @@ void *UserAPI_deleteUser(apiClient_t *apiClient, char *username) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(username) + 2);
-	snprintf(localVarToReplace, strlen(username) + 3, "%s%s%s", "{", "username", "}");
+	snprintf(localVarToReplace,
+	         strlen(username) + 3,
+	         "%s%s%s",
+	         "{",
+	         "username",
+	         "}");
 
 	localVarPath = strReplace(localVarPath, localVarToReplace, username);
 
@@ -229,7 +240,12 @@ user_t *UserAPI_getUserByName(apiClient_t *apiClient, char *username) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(username) + 2);
-	snprintf(localVarToReplace, strlen(username) + 3, "%s%s%s", "{", "username", "}");
+	snprintf(localVarToReplace,
+	         strlen(username) + 3,
+	         "%s%s%s",
+	         "{",
+	         "username",
+	         "}");
 
 	localVarPath = strReplace(localVarPath, localVarToReplace, username);
 
@@ -267,7 +283,8 @@ user_t *UserAPI_getUserByName(apiClient_t *apiClient, char *username) {
 
 // Logs user into the system
 //
-char *UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password) {
+char *UserAPI_loginUser(apiClient_t *apiClient, char *username,
+                        char *password) {
 	list_t *localVarQueryParameters = list_create();
 	list_t *localVarHeaderParameters = list_create();
 	list_t *localVarFormParameters = list_create();
@@ -287,7 +304,8 @@ char *UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password) 
 		// string
 		keyQuery_username = strdup("username");
 		valueQuery_username = strdup(username);
-		keyPairQuery_username = keyValuePair_create(keyQuery_username, valueQuery_username);
+		keyPairQuery_username = keyValuePair_create(keyQuery_username,
+		                                            valueQuery_username);
 		list_addElement(localVarQueryParameters, keyPairQuery_username);
 	}
 
@@ -299,7 +317,8 @@ char *UserAPI_loginUser(apiClient_t *apiClient, char *username, char *password) 
 		// string
 		keyQuery_password = strdup("password");
 		valueQuery_password = strdup(password);
-		keyPairQuery_password = keyValuePair_create(keyQuery_password, valueQuery_password);
+		keyPairQuery_password = keyValuePair_create(keyQuery_password,
+		                                            valueQuery_password);
 		list_addElement(localVarQueryParameters, keyPairQuery_password);
 	}
 
@@ -385,7 +404,12 @@ void *UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *user) {
 
 	// Path Params
 	char *localVarToReplace = malloc(sizeof(username) + 2);
-	snprintf(localVarToReplace, strlen(username) + 3, "%s%s%s", "{", "username", "}");
+	snprintf(localVarToReplace,
+	         strlen(username) + 3,
+	         "%s%s%s",
+	         "{",
+	         "username",
+	         "}");
 
 	localVarPath = strReplace(localVarPath, localVarToReplace, username);
 

--- a/samples/client/petstore/C/external/include/cJSON.h
+++ b/samples/client/petstore/C/external/include/cJSON.h
@@ -147,17 +147,24 @@ CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks * hooks);
 CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
 /* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
 /* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
-CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value,
+                                          const char **return_parse_end,
+                                          cJSON_bool require_null_terminated);
 
 /* Render a cJSON entity to text for transfer/storage. */
 CJSON_PUBLIC(char *) cJSON_Print(const cJSON * item);
 /* Render a cJSON entity to text for transfer/storage without any formatting. */
 CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON * item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
-CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON * item, int prebuffer, cJSON_bool fmt);
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON * item,
+                                         int prebuffer,
+                                         cJSON_bool fmt);
 /* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
 /* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
-CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON * item, char *buffer, const int length, const cJSON_bool format);
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON * item,
+                                                 char *buffer,
+                                                 const int length,
+                                                 const cJSON_bool format);
 /* Delete a cJSON entity and all subentities. */
 CJSON_PUBLIC(void) cJSON_Delete(cJSON * c);
 
@@ -166,9 +173,13 @@ CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON * array);
 /* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
 CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON * array, int index);
 /* Get item "string" from object. Case insensitive. */
-CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char *const string);
-CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char *const string);
-CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON * object, const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object,
+                                          const char *const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(
+	const cJSON * const object,
+	const char *const string);
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON * object,
+                                             const char *string);
 /* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
 
@@ -215,30 +226,51 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char **strings, int count);
 
 /* Append item to the specified array/object. */
 CJSON_PUBLIC(void) cJSON_AddItemToArray(cJSON * array, cJSON * item);
-CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON * object, const char *string, cJSON * item);
+CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON * object,
+                                         const char *string,
+                                         cJSON * item);
 /* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
  * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
  * writing to `item->string` */
-CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON * object, const char *string, cJSON * item);
+CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON * object,
+                                           const char *string,
+                                           cJSON * item);
 /* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON * array, cJSON * item);
-CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON * object, const char *string, cJSON * item);
+CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON * object,
+                                                  const char *string,
+                                                  cJSON * item);
 
 /* Remove/Detatch items from Arrays/Objects. */
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON * parent, cJSON * const item);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON * parent,
+                                                 cJSON * const item);
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON * array, int which);
 CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON * array, int which);
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON * object, const char *string);
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON * object, const char *string);
-CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON * object, const char *string);
-CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON * object, const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON * object,
+                                                 const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON * object,
+                                                              const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON * object,
+                                              const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON * object,
+                                                           const char *string);
 
 /* Update array items. */
-CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON * array, int which, cJSON * newitem); /* Shifts pre-existing items to the right. */
-CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
-CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON * array, int which, cJSON * newitem);
-CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON * object, const char *string, cJSON * newitem);
-CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON * object, const char *string, cJSON * newitem);
+CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON * array,
+                                           int which,
+                                           cJSON * newitem);                         /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent,
+                                                     cJSON * const item,
+                                                     cJSON * replacement);
+CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON * array,
+                                            int which,
+                                            cJSON * newitem);
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON * object,
+                                             const char *string,
+                                             cJSON * newitem);
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON * object,
+                                                          const char *string,
+                                                          cJSON * newitem);
 
 /* Duplicate a cJSON item */
 CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON * item, cJSON_bool recurse);
@@ -247,31 +279,60 @@ CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON * item, cJSON_bool recurse);
    The item->next and ->prev pointers are always zero on return from Duplicate. */
 /* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
  * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
-CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a,
+                                       const cJSON * const b,
+                                       const cJSON_bool case_sensitive);
 
 
 CJSON_PUBLIC(void) cJSON_Minify(char *json);
 
 /* Helper functions for creating and adding items to an object at the same time.
  * They return the added item or NULL on failure. */
-CJSON_PUBLIC(cJSON *) cJSON_AddNullToObject(cJSON * const object, const char *const name);
-CJSON_PUBLIC(cJSON *) cJSON_AddTrueToObject(cJSON * const object, const char *const name);
-CJSON_PUBLIC(cJSON *) cJSON_AddFalseToObject(cJSON * const object, const char *const name);
-CJSON_PUBLIC(cJSON *) cJSON_AddBoolToObject(cJSON * const object, const char *const name, const cJSON_bool boolean);
-CJSON_PUBLIC(cJSON *) cJSON_AddNumberToObject(cJSON * const object, const char *const name, const double number);
-CJSON_PUBLIC(cJSON *) cJSON_AddStringToObject(cJSON * const object, const char *const name, const char *const string);
-CJSON_PUBLIC(cJSON *) cJSON_AddRawToObject(cJSON * const object, const char *const name, const char *const raw);
-CJSON_PUBLIC(cJSON *) cJSON_AddObjectToObject(cJSON * const object, const char *const name);
-CJSON_PUBLIC(cJSON *) cJSON_AddArrayToObject(cJSON * const object, const char *const name);
+CJSON_PUBLIC(cJSON *) cJSON_AddNullToObject(cJSON * const object,
+                                            const char *const name);
+CJSON_PUBLIC(cJSON *) cJSON_AddTrueToObject(cJSON * const object,
+                                            const char *const name);
+CJSON_PUBLIC(cJSON *) cJSON_AddFalseToObject(cJSON * const object,
+                                             const char *const name);
+CJSON_PUBLIC(cJSON *) cJSON_AddBoolToObject(cJSON * const object,
+                                            const char *const name,
+                                            const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON *) cJSON_AddNumberToObject(cJSON * const object,
+                                              const char *const name,
+                                              const double number);
+CJSON_PUBLIC(cJSON *) cJSON_AddStringToObject(cJSON * const object,
+                                              const char *const name,
+                                              const char *const string);
+CJSON_PUBLIC(cJSON *) cJSON_AddRawToObject(cJSON * const object,
+                                           const char *const name,
+                                           const char *const raw);
+CJSON_PUBLIC(cJSON *) cJSON_AddObjectToObject(cJSON * const object,
+                                              const char *const name);
+CJSON_PUBLIC(cJSON *) cJSON_AddArrayToObject(cJSON * const object,
+                                             const char *const name);
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
-#define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+#define cJSON_SetIntValue(object, \
+	                  number) ((object) ? (object)->valueint = \
+					   (object)->valuedouble = \
+						   (number) : (number))
 /* helper for the cJSON_SetNumberValue macro */
 CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON * object, double number);
-#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double) number) : (number))
+#define cJSON_SetNumberValue(object, \
+	                     number) ((object != \
+	                               NULL) ? cJSON_SetNumberHelper(object, \
+								     ( \
+									     double) \
+	                                                             number) : ( \
+					      number))
 
 /* Macro for iterating over an array or object */
-#define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+#define cJSON_ArrayForEach(element, array) for(element = \
+						       (array != \
+						        NULL) ? (array)->child : \
+						       NULL; \
+	                                       element != NULL; \
+	                                       element = element->next)
 
 /* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
 CJSON_PUBLIC(void *) cJSON_malloc(size_t size);

--- a/samples/client/petstore/C/external/src/cJSON.c
+++ b/samples/client/petstore/C/external/src/cJSON.c
@@ -85,19 +85,25 @@ CJSON_PUBLIC(char *) cJSON_GetStringValue(cJSON * item) {
 #if (CJSON_VERSION_MAJOR != 1) || \
         (CJSON_VERSION_MINOR != 7) || \
         (CJSON_VERSION_PATCH != 7)
-    #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
+    #error \
+        cJSON.h and cJSON.c have different versions. Make sure that both have the same.
 #endif
 
 CJSON_PUBLIC(const char *) cJSON_Version(void)
 {
 	static char version[15];
-	sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+	sprintf(version,
+	        "%i.%i.%i",
+	        CJSON_VERSION_MAJOR,
+	        CJSON_VERSION_MINOR,
+	        CJSON_VERSION_PATCH);
 
 	return version;
 }
 
 /* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
-static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2) {
+static int case_insensitive_strcmp(const unsigned char	*string1,
+                                   const unsigned char	*string2) {
 	if((string1 == NULL) ||
 	   (string2 == NULL))
 	{
@@ -108,7 +114,10 @@ static int case_insensitive_strcmp(const unsigned char *string1, const unsigned 
 		return 0;
 	}
 
-	for( ; tolower(*string1) == tolower(*string2); (void) string1++, string2++) {
+	for( ;
+	     tolower(*string1) == tolower(*string2);
+	     (void) string1++, string2++)
+	{
 		if(*string1 == '\0') {
 			return 0;
 		}
@@ -140,9 +149,11 @@ static void *internal_realloc(void *pointer, size_t size) {
 #define internal_realloc realloc
 #endif
 
-static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
+static internal_hooks global_hooks =
+{ internal_malloc, internal_free, internal_realloc };
 
-static unsigned char *cJSON_strdup(const unsigned char *string, const internal_hooks *const hooks) {
+static unsigned char *cJSON_strdup(const unsigned char		*string,
+                                   const internal_hooks *const	hooks) {
 	size_t length = 0;
 	unsigned char *copy = NULL;
 
@@ -248,13 +259,16 @@ typedef struct {
 	                        (((buffer)->offset + size) <= (buffer)->length))
 /* check if the buffer can be accessed at the given index (starting with 0) */
 #define can_access_at_index(buffer, index) ((buffer != NULL) && \
-	                                    (((buffer)->offset + index) < (buffer)->length))
-#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+	                                    (((buffer)->offset + index) < \
+	                                     (buffer)->length))
+#define cannot_access_at_index(buffer, \
+	                       index) (!can_access_at_index(buffer, index))
 /* get a pointer to the buffer at the position */
 #define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
 
 /* Parse the input text to generate a number, and populate the result into item. */
-static cJSON_bool parse_number(cJSON *const item, parse_buffer *const input_buffer) {
+static cJSON_bool parse_number(cJSON *const		item,
+                               parse_buffer *const	input_buffer) {
 	double number = 0;
 	unsigned char *after_end = NULL;
 	unsigned char number_c_string[64];
@@ -394,7 +408,8 @@ static unsigned char *ensure(printbuffer *const p, size_t needed) {
 
 	if(p->hooks.reallocate != NULL) {
 		/* reallocate with realloc if available */
-		newbuffer = (unsigned char *) p->hooks.reallocate(p->buffer, newsize);
+		newbuffer = (unsigned char *) p->hooks.reallocate(p->buffer,
+		                                                  newsize);
 		if(newbuffer == NULL) {
 			p->hooks.deallocate(p->buffer);
 			p->length = 0;
@@ -437,7 +452,8 @@ static void update_offset(printbuffer *const buffer) {
 }
 
 /* Render the number nicely from the given item into a string. */
-static cJSON_bool print_number(const cJSON *const item, printbuffer *const output_buffer) {
+static cJSON_bool print_number(const cJSON *const	item,
+                               printbuffer *const	output_buffer) {
 	unsigned char *output_pointer = NULL;
 	double d = item->valuedouble;
 	int length = 0;
@@ -530,8 +546,10 @@ static unsigned parse_hex4(const unsigned char *const input) {
 
 /* converts a UTF-16 literal to UTF-8
  * A literal can be one or two sequences of the form \uXXXX */
-static unsigned char utf16_literal_to_utf8(const unsigned char *const input_pointer, const unsigned char *const input_end,
-                                           unsigned char **output_pointer) {
+static unsigned char utf16_literal_to_utf8(
+	const unsigned char *const	input_pointer,
+	const unsigned char *const	input_end,
+	unsigned char			**output_pointer) {
 	long unsigned int codepoint = 0;
 	unsigned int first_code = 0;
 	const unsigned char *first_sequence = input_pointer;
@@ -587,7 +605,9 @@ static unsigned char utf16_literal_to_utf8(const unsigned char *const input_poin
 
 
 		/* calculate the unicode codepoint from the surrogate pair */
-		codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+		codepoint = 0x10000 +
+		            (((first_code & 0x3FF) << 10) |
+		             (second_code & 0x3FF));
 	} else {
 		sequence_length = 6; /* \uXXXX */
 		codepoint = first_code;
@@ -617,14 +637,18 @@ static unsigned char utf16_literal_to_utf8(const unsigned char *const input_poin
 	}
 
 	/* encode as utf8 */
-	for(utf8_position = (unsigned char) (utf8_length - 1); utf8_position > 0; utf8_position--) {
+	for(utf8_position = (unsigned char) (utf8_length - 1);
+	    utf8_position > 0;
+	    utf8_position--) {
 		/* 10xxxxxx */
-		(*output_pointer)[utf8_position] = (unsigned char) ((codepoint | 0x80) & 0xBF);
+		(*output_pointer)[utf8_position] =
+			(unsigned char) ((codepoint | 0x80) & 0xBF);
 		codepoint >>= 6;
 	}
 	/* encode first byte */
 	if(utf8_length > 1) {
-		(*output_pointer)[0] = (unsigned char) ((codepoint | first_byte_mark) & 0xFF);
+		(*output_pointer)[0] =
+			(unsigned char) ((codepoint | first_byte_mark) & 0xFF);
 	} else {
 		(*output_pointer)[0] = (unsigned char) (codepoint & 0x7F);
 	}
@@ -638,7 +662,8 @@ fail:
 }
 
 /* Parse the input text into an unescaped cinput, and populate item. */
-static cJSON_bool parse_string(cJSON *const item, parse_buffer *const input_buffer) {
+static cJSON_bool parse_string(cJSON *const		item,
+                               parse_buffer *const	input_buffer) {
 	const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
 	const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
 	unsigned char *output_pointer = NULL;
@@ -653,12 +678,15 @@ static cJSON_bool parse_string(cJSON *const item, parse_buffer *const input_buff
 		/* calculate approximate size of the output (overestimate) */
 		size_t allocation_length = 0;
 		size_t skipped_bytes = 0;
-		while(((size_t) (input_end - input_buffer->content) < input_buffer->length) &&
+		while(((size_t) (input_end - input_buffer->content) <
+		       input_buffer->length) &&
 		      (*input_end != '\"'))
 		{
 			/* is escape sequence */
 			if(input_end[0] == '\\') {
-				if((size_t) (input_end + 1 - input_buffer->content) >= input_buffer->length) {
+				if((size_t) (input_end + 1 -
+				             input_buffer->content) >=
+				   input_buffer->length) {
 					/* prevent buffer overflow when last input character is a backslash */
 					goto fail;
 				}
@@ -667,15 +695,19 @@ static cJSON_bool parse_string(cJSON *const item, parse_buffer *const input_buff
 			}
 			input_end++;
 		}
-		if(((size_t) (input_end - input_buffer->content) >= input_buffer->length) ||
+		if(((size_t) (input_end - input_buffer->content) >=
+		    input_buffer->length) ||
 		   (*input_end != '\"'))
 		{
 			goto fail; /* string ended unexpectedly */
 		}
 
 		/* This is at most how much we need for the output */
-		allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
-		output = (unsigned char *) input_buffer->hooks.allocate(allocation_length + sizeof(""));
+		allocation_length =
+			(size_t) (input_end - buffer_at_offset(input_buffer)) -
+			skipped_bytes;
+		output = (unsigned char *) input_buffer->hooks.allocate(
+			allocation_length + sizeof(""));
 		if(output == NULL) {
 			goto fail; /* allocation failure */
 		}
@@ -723,7 +755,10 @@ static cJSON_bool parse_string(cJSON *const item, parse_buffer *const input_buff
 
 			/* UTF-16 literal */
 			case 'u':
-				sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
+				sequence_length = utf16_literal_to_utf8(
+					input_pointer,
+					input_end,
+					&output_pointer);
 				if(sequence_length == 0) {
 					/* failed to convert UTF16-literal to UTF-8 */
 					goto fail;
@@ -754,14 +789,16 @@ fail:
 	}
 
 	if(input_pointer != NULL) {
-		input_buffer->offset = (size_t) (input_pointer - input_buffer->content);
+		input_buffer->offset =
+			(size_t) (input_pointer - input_buffer->content);
 	}
 
 	return false;
 }
 
 /* Render the cstring provided to an escaped version that can be printed. */
-static cJSON_bool print_string_ptr(const unsigned char *const input, printbuffer *const output_buffer) {
+static cJSON_bool print_string_ptr(const unsigned char *const	input,
+                                   printbuffer *const		output_buffer) {
 	const unsigned char *input_pointer = NULL;
 	unsigned char *output = NULL;
 	unsigned char *output_pointer = NULL;
@@ -826,7 +863,9 @@ static cJSON_bool print_string_ptr(const unsigned char *const input, printbuffer
 	output[0] = '\"';
 	output_pointer = output + 1;
 	/* copy the string */
-	for(input_pointer = input; *input_pointer != '\0'; (void) input_pointer++, output_pointer++) {
+	for(input_pointer = input;
+	    *input_pointer != '\0';
+	    (void) input_pointer++, output_pointer++) {
 		if((*input_pointer > 31) &&
 		   (*input_pointer != '\"') &&
 		   (*input_pointer != '\\'))
@@ -867,7 +906,9 @@ static cJSON_bool print_string_ptr(const unsigned char *const input, printbuffer
 
 			default:
 				/* escape and print as unicode codepoint */
-				sprintf((char *) output_pointer, "u%04x", *input_pointer);
+				sprintf((char *) output_pointer,
+				        "u%04x",
+				        *input_pointer);
 				output_pointer += 4;
 				break;
 			}
@@ -885,12 +926,18 @@ static cJSON_bool print_string(const cJSON *const item, printbuffer *const p) {
 }
 
 /* Predeclare these prototypes. */
-static cJSON_bool parse_value(cJSON *const item, parse_buffer *const input_buffer);
-static cJSON_bool print_value(const cJSON *const item, printbuffer *const output_buffer);
-static cJSON_bool parse_array(cJSON *const item, parse_buffer *const input_buffer);
-static cJSON_bool print_array(const cJSON *const item, printbuffer *const output_buffer);
-static cJSON_bool parse_object(cJSON *const item, parse_buffer *const input_buffer);
-static cJSON_bool print_object(const cJSON *const item, printbuffer *const output_buffer);
+static cJSON_bool parse_value(cJSON *const		item,
+                              parse_buffer *const	input_buffer);
+static cJSON_bool print_value(const cJSON *const	item,
+                              printbuffer *const	output_buffer);
+static cJSON_bool parse_array(cJSON *const		item,
+                              parse_buffer *const	input_buffer);
+static cJSON_bool print_array(const cJSON *const	item,
+                              printbuffer *const	output_buffer);
+static cJSON_bool parse_object(cJSON *const		item,
+                               parse_buffer *const	input_buffer);
+static cJSON_bool print_object(const cJSON *const	item,
+                               printbuffer *const	output_buffer);
 
 /* Utility to jump whitespace and cr/lf */
 static parse_buffer *buffer_skip_whitespace(parse_buffer *const buffer) {
@@ -923,7 +970,8 @@ static parse_buffer *skip_utf8_bom(parse_buffer *const buffer) {
 	}
 
 	if(can_access_at_index(buffer, 4) &&
-	   (strncmp((const char *) buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+	   (strncmp((const char *) buffer_at_offset(buffer), "\xEF\xBB\xBF",
+	            3) == 0))
 	{
 		buffer->offset += 3;
 	}
@@ -932,7 +980,9 @@ static parse_buffer *skip_utf8_bom(parse_buffer *const buffer) {
 }
 
 /* Parse an object - create a new root, and populate. */
-CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value,
+                                          const char **return_parse_end,
+                                          cJSON_bool require_null_terminated)
 {
 	parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
 	cJSON *item = NULL;
@@ -992,7 +1042,8 @@ fail:
 		}
 
 		if(return_parse_end != NULL) {
-			*return_parse_end = (const char *) local_error.json + local_error.position;
+			*return_parse_end = (const char *) local_error.json +
+			                    local_error.position;
 		}
 
 		global_error = local_error;
@@ -1009,7 +1060,9 @@ CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
 
 #define cjson_min(a, b) ((a < b) ? a : b)
 
-static unsigned char *print(const cJSON *const item, cJSON_bool format, const internal_hooks *const hooks) {
+static unsigned char *print(const cJSON *const		item,
+                            cJSON_bool			format,
+                            const internal_hooks *const hooks) {
 	static const size_t default_buffer_size = 256;
 	printbuffer buffer[1];
 	unsigned char *printed = NULL;
@@ -1033,7 +1086,9 @@ static unsigned char *print(const cJSON *const item, cJSON_bool format, const in
 
 	/* check if reallocate is available */
 	if(hooks->reallocate != NULL) {
-		printed = (unsigned char *) hooks->reallocate(buffer->buffer, buffer->offset + 1);
+		printed = (unsigned char *) hooks->reallocate(buffer->buffer,
+		                                              buffer->offset +
+		                                              1);
 		if(printed == NULL) {
 			goto fail;
 		}
@@ -1043,7 +1098,8 @@ static unsigned char *print(const cJSON *const item, cJSON_bool format, const in
 		if(printed == NULL) {
 			goto fail;
 		}
-		memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+		memcpy(printed, buffer->buffer,
+		       cjson_min(buffer->length, buffer->offset + 1));
 		printed[buffer->offset] = '\0'; /* just to be sure */
 
 		/* free the buffer */
@@ -1075,7 +1131,9 @@ CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON * item)
 	return (char *) print(item, false, &global_hooks);
 }
 
-CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON * item, int prebuffer, cJSON_bool fmt)
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON * item,
+                                         int prebuffer,
+                                         cJSON_bool fmt)
 {
 	printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
 
@@ -1102,7 +1160,10 @@ CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON * item, int prebuffer, cJSO
 	return (char *) p.buffer;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON * item, char *buf, const int len, const cJSON_bool fmt)
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON * item,
+                                                 char *buf,
+                                                 const int len,
+                                                 const cJSON_bool fmt)
 {
 	printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
 
@@ -1123,7 +1184,8 @@ CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON * item, char *buf, const 
 }
 
 /* Parser core - when encountering text, process appropriately. */
-static cJSON_bool parse_value(cJSON *const item, parse_buffer *const input_buffer) {
+static cJSON_bool parse_value(cJSON *const		item,
+                              parse_buffer *const	input_buffer) {
 	if((input_buffer == NULL) ||
 	   (input_buffer->content == NULL))
 	{
@@ -1133,7 +1195,8 @@ static cJSON_bool parse_value(cJSON *const item, parse_buffer *const input_buffe
 	/* parse the different types of values */
 	/* null */
 	if(can_read(input_buffer, 4) &&
-	   (strncmp((const char *) buffer_at_offset(input_buffer), "null", 4) == 0))
+	   (strncmp((const char *) buffer_at_offset(input_buffer), "null",
+	            4) == 0))
 	{
 		item->type = cJSON_NULL;
 		input_buffer->offset += 4;
@@ -1141,7 +1204,8 @@ static cJSON_bool parse_value(cJSON *const item, parse_buffer *const input_buffe
 	}
 	/* false */
 	if(can_read(input_buffer, 5) &&
-	   (strncmp((const char *) buffer_at_offset(input_buffer), "false", 5) == 0))
+	   (strncmp((const char *) buffer_at_offset(input_buffer), "false",
+	            5) == 0))
 	{
 		item->type = cJSON_False;
 		input_buffer->offset += 5;
@@ -1149,7 +1213,8 @@ static cJSON_bool parse_value(cJSON *const item, parse_buffer *const input_buffe
 	}
 	/* true */
 	if(can_read(input_buffer, 4) &&
-	   (strncmp((const char *) buffer_at_offset(input_buffer), "true", 4) == 0))
+	   (strncmp((const char *) buffer_at_offset(input_buffer), "true",
+	            4) == 0))
 	{
 		item->type = cJSON_True;
 		item->valueint = 1;
@@ -1187,7 +1252,8 @@ static cJSON_bool parse_value(cJSON *const item, parse_buffer *const input_buffe
 }
 
 /* Render a value to text. */
-static cJSON_bool print_value(const cJSON *const item, printbuffer *const output_buffer) {
+static cJSON_bool print_value(const cJSON *const	item,
+                              printbuffer *const	output_buffer) {
 	unsigned char *output = NULL;
 
 	if((item == NULL) ||
@@ -1255,7 +1321,8 @@ static cJSON_bool print_value(const cJSON *const item, printbuffer *const output
 }
 
 /* Build an array from input text. */
-static cJSON_bool parse_array(cJSON *const item, parse_buffer *const input_buffer) {
+static cJSON_bool parse_array(cJSON *const		item,
+                              parse_buffer *const	input_buffer) {
 	cJSON *head = NULL; /* head of the linked list */
 	cJSON *current_item = NULL;
 
@@ -1340,7 +1407,8 @@ fail:
 }
 
 /* Render an array to text */
-static cJSON_bool print_array(const cJSON *const item, printbuffer *const output_buffer) {
+static cJSON_bool print_array(const cJSON *const	item,
+                              printbuffer *const	output_buffer) {
 	unsigned char *output_pointer = NULL;
 	size_t length = 0;
 	cJSON *current_element = item->child;
@@ -1393,7 +1461,8 @@ static cJSON_bool print_array(const cJSON *const item, printbuffer *const output
 }
 
 /* Build an object from the text. */
-static cJSON_bool parse_object(cJSON *const item, parse_buffer *const input_buffer) {
+static cJSON_bool parse_object(cJSON *const		item,
+                               parse_buffer *const	input_buffer) {
 	cJSON *head = NULL; /* linked list head */
 	cJSON *current_item = NULL;
 
@@ -1495,7 +1564,8 @@ fail:
 }
 
 /* Render an object to text. */
-static cJSON_bool print_object(const cJSON *const item, printbuffer *const output_buffer) {
+static cJSON_bool print_object(const cJSON *const	item,
+                               printbuffer *const	output_buffer) {
 	unsigned char *output_pointer = NULL;
 	size_t length = 0;
 	cJSON *current_item = item->child;
@@ -1521,7 +1591,8 @@ static cJSON_bool print_object(const cJSON *const item, printbuffer *const outpu
 	while(current_item) {
 		if(output_buffer->format) {
 			size_t i;
-			output_pointer = ensure(output_buffer, output_buffer->depth);
+			output_pointer = ensure(output_buffer,
+			                        output_buffer->depth);
 			if(output_pointer == NULL) {
 				return false;
 			}
@@ -1532,7 +1603,8 @@ static cJSON_bool print_object(const cJSON *const item, printbuffer *const outpu
 		}
 
 		/* print key */
-		if(!print_string_ptr((unsigned char *) current_item->string, output_buffer)) {
+		if(!print_string_ptr((unsigned char *) current_item->string,
+		                     output_buffer)) {
 			return false;
 		}
 		update_offset(output_buffer);
@@ -1555,7 +1627,9 @@ static cJSON_bool print_object(const cJSON *const item, printbuffer *const outpu
 		update_offset(output_buffer);
 
 		/* print comma if not last */
-		length = (size_t) ((output_buffer->format ? 1 : 0) + (current_item->next ? 1 : 0));
+		length =
+			(size_t) ((output_buffer->format ? 1 : 0) +
+			          (current_item->next ? 1 : 0));
 		output_pointer = ensure(output_buffer, length + 1);
 		if(output_pointer == NULL) {
 			return false;
@@ -1573,7 +1647,9 @@ static cJSON_bool print_object(const cJSON *const item, printbuffer *const outpu
 		current_item = current_item->next;
 	}
 
-	output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+	output_pointer =
+		ensure(output_buffer,
+		       output_buffer->format ? (output_buffer->depth + 1) : 2);
 	if(output_pointer == NULL) {
 		return false;
 	}
@@ -1639,7 +1715,9 @@ CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON * array, int index)
 	return get_array_item(array, (size_t) index);
 }
 
-static cJSON *get_object_item(const cJSON *const object, const char *const name, const cJSON_bool case_sensitive) {
+static cJSON *get_object_item(const cJSON *const	object,
+                              const char *const		name,
+                              const cJSON_bool		case_sensitive) {
 	cJSON *current_element = NULL;
 
 	if((object == NULL) ||
@@ -1657,7 +1735,10 @@ static cJSON *get_object_item(const cJSON *const object, const char *const name,
 		}
 	} else {
 		while((current_element != NULL) &&
-		      (case_insensitive_strcmp((const unsigned char *) name, (const unsigned char *) (current_element->string)) != 0))
+		      (case_insensitive_strcmp((const unsigned char *) name,
+		                               (const unsigned char *) (
+						       current_element->string))
+		       != 0))
 		{
 			current_element = current_element->next;
 		}
@@ -1666,17 +1747,21 @@ static cJSON *get_object_item(const cJSON *const object, const char *const name,
 	return current_element;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char *const string)
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object,
+                                          const char *const string)
 {
 	return get_object_item(object, string, false);
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char *const string)
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(
+	const cJSON * const object,
+	const char *const string)
 {
 	return get_object_item(object, string, true);
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON * object, const char *string)
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON * object,
+                                             const char *string)
 {
 	return cJSON_GetObjectItem(object, string) ? 1 : 0;
 }
@@ -1688,7 +1773,8 @@ static void suffix_object(cJSON *prev, cJSON *item) {
 }
 
 /* Utility for handling references. */
-static cJSON *create_reference(const cJSON *item, const internal_hooks *const hooks) {
+static cJSON *create_reference(const cJSON			*item,
+                               const internal_hooks *const	hooks) {
 	cJSON *reference = NULL;
 	if(item == NULL) {
 		return NULL;
@@ -1760,8 +1846,12 @@ static void *cast_away_const(const void *string) {
 #endif
 
 
-static cJSON_bool add_item_to_object(cJSON *const object, const char *const string, cJSON *const item, const internal_hooks *const hooks,
-                                     const cJSON_bool constant_key) {
+static cJSON_bool add_item_to_object(cJSON *const			object,
+                                     const char *const			string,
+                                     cJSON *const			item,
+                                     const internal_hooks *const	hooks,
+                                     const cJSON_bool			constant_key)
+{
 	char *new_key = NULL;
 	int new_type = cJSON_Invalid;
 
@@ -1776,7 +1866,8 @@ static cJSON_bool add_item_to_object(cJSON *const object, const char *const stri
 		new_key = (char *) cast_away_const(string);
 		new_type = item->type | cJSON_StringIsConst;
 	} else {
-		new_key = (char *) cJSON_strdup((const unsigned char *) string, hooks);
+		new_key = (char *) cJSON_strdup((const unsigned char *) string,
+		                                hooks);
 		if(new_key == NULL) {
 			return false;
 		}
@@ -1796,13 +1887,17 @@ static cJSON_bool add_item_to_object(cJSON *const object, const char *const stri
 	return add_item_to_array(object, item);
 }
 
-CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON * object, const char *string, cJSON * item)
+CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON * object,
+                                         const char *string,
+                                         cJSON * item)
 {
 	add_item_to_object(object, string, item, &global_hooks, false);
 }
 
 /* Add an item to an object with constant string as key */
-CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON * object, const char *string, cJSON * item)
+CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON * object,
+                                           const char *string,
+                                           cJSON * item)
 {
 	add_item_to_object(object, string, item, &global_hooks, true);
 }
@@ -1816,7 +1911,9 @@ CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON * array, cJSON * item)
 	add_item_to_array(array, create_reference(item, &global_hooks));
 }
 
-CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON * object, const char *string, cJSON * item)
+CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON * object,
+                                                  const char *string,
+                                                  cJSON * item)
 {
 	if((object == NULL) ||
 	   (string == NULL))
@@ -1824,10 +1921,15 @@ CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON * object, const char *st
 		return;
 	}
 
-	add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
+	add_item_to_object(object,
+	                   string,
+	                   create_reference(item, &global_hooks),
+	                   &global_hooks,
+	                   false);
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddNullToObject(cJSON * const object, const char *const name)
+CJSON_PUBLIC(cJSON *) cJSON_AddNullToObject(cJSON * const object,
+                                            const char *const name)
 {
 	cJSON *null = cJSON_CreateNull();
 	if(add_item_to_object(object, name, null, &global_hooks, false)) {
@@ -1838,7 +1940,8 @@ CJSON_PUBLIC(cJSON *) cJSON_AddNullToObject(cJSON * const object, const char *co
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddTrueToObject(cJSON * const object, const char *const name)
+CJSON_PUBLIC(cJSON *) cJSON_AddTrueToObject(cJSON * const object,
+                                            const char *const name)
 {
 	cJSON *true_item = cJSON_CreateTrue();
 	if(add_item_to_object(object, name, true_item, &global_hooks, false)) {
@@ -1849,7 +1952,8 @@ CJSON_PUBLIC(cJSON *) cJSON_AddTrueToObject(cJSON * const object, const char *co
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddFalseToObject(cJSON * const object, const char *const name)
+CJSON_PUBLIC(cJSON *) cJSON_AddFalseToObject(cJSON * const object,
+                                             const char *const name)
 {
 	cJSON *false_item = cJSON_CreateFalse();
 	if(add_item_to_object(object, name, false_item, &global_hooks, false)) {
@@ -1860,7 +1964,9 @@ CJSON_PUBLIC(cJSON *) cJSON_AddFalseToObject(cJSON * const object, const char *c
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddBoolToObject(cJSON * const object, const char *const name, const cJSON_bool boolean)
+CJSON_PUBLIC(cJSON *) cJSON_AddBoolToObject(cJSON * const object,
+                                            const char *const name,
+                                            const cJSON_bool boolean)
 {
 	cJSON *bool_item = cJSON_CreateBool(boolean);
 	if(add_item_to_object(object, name, bool_item, &global_hooks, false)) {
@@ -1871,10 +1977,13 @@ CJSON_PUBLIC(cJSON *) cJSON_AddBoolToObject(cJSON * const object, const char *co
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddNumberToObject(cJSON * const object, const char *const name, const double number)
+CJSON_PUBLIC(cJSON *) cJSON_AddNumberToObject(cJSON * const object,
+                                              const char *const name,
+                                              const double number)
 {
 	cJSON *number_item = cJSON_CreateNumber(number);
-	if(add_item_to_object(object, name, number_item, &global_hooks, false)) {
+	if(add_item_to_object(object, name, number_item, &global_hooks,
+	                      false)) {
 		return number_item;
 	}
 
@@ -1882,10 +1991,13 @@ CJSON_PUBLIC(cJSON *) cJSON_AddNumberToObject(cJSON * const object, const char *
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddStringToObject(cJSON * const object, const char *const name, const char *const string)
+CJSON_PUBLIC(cJSON *) cJSON_AddStringToObject(cJSON * const object,
+                                              const char *const name,
+                                              const char *const string)
 {
 	cJSON *string_item = cJSON_CreateString(string);
-	if(add_item_to_object(object, name, string_item, &global_hooks, false)) {
+	if(add_item_to_object(object, name, string_item, &global_hooks,
+	                      false)) {
 		return string_item;
 	}
 
@@ -1893,7 +2005,9 @@ CJSON_PUBLIC(cJSON *) cJSON_AddStringToObject(cJSON * const object, const char *
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddRawToObject(cJSON * const object, const char *const name, const char *const raw)
+CJSON_PUBLIC(cJSON *) cJSON_AddRawToObject(cJSON * const object,
+                                           const char *const name,
+                                           const char *const raw)
 {
 	cJSON *raw_item = cJSON_CreateRaw(raw);
 	if(add_item_to_object(object, name, raw_item, &global_hooks, false)) {
@@ -1904,10 +2018,12 @@ CJSON_PUBLIC(cJSON *) cJSON_AddRawToObject(cJSON * const object, const char *con
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddObjectToObject(cJSON * const object, const char *const name)
+CJSON_PUBLIC(cJSON *) cJSON_AddObjectToObject(cJSON * const object,
+                                              const char *const name)
 {
 	cJSON *object_item = cJSON_CreateObject();
-	if(add_item_to_object(object, name, object_item, &global_hooks, false)) {
+	if(add_item_to_object(object, name, object_item, &global_hooks,
+	                      false)) {
 		return object_item;
 	}
 
@@ -1915,7 +2031,8 @@ CJSON_PUBLIC(cJSON *) cJSON_AddObjectToObject(cJSON * const object, const char *
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_AddArrayToObject(cJSON * const object, const char *const name)
+CJSON_PUBLIC(cJSON *) cJSON_AddArrayToObject(cJSON * const object,
+                                             const char *const name)
 {
 	cJSON *array = cJSON_CreateArray();
 	if(add_item_to_object(object, name, array, &global_hooks, false)) {
@@ -1926,7 +2043,8 @@ CJSON_PUBLIC(cJSON *) cJSON_AddArrayToObject(cJSON * const object, const char *c
 	return NULL;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON * parent, cJSON * const item)
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON * parent,
+                                                 cJSON * const item)
 {
 	if((parent == NULL) ||
 	   (item == NULL))
@@ -1960,7 +2078,9 @@ CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON * array, int which)
 		return NULL;
 	}
 
-	return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t) which));
+	return cJSON_DetachItemViaPointer(array,
+	                                  get_array_item(array,
+	                                                 (size_t) which));
 }
 
 CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON * array, int which)
@@ -1968,32 +2088,38 @@ CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON * array, int which)
 	cJSON_Delete(cJSON_DetachItemFromArray(array, which));
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON * object, const char *string)
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON * object,
+                                                 const char *string)
 {
 	cJSON *to_detach = cJSON_GetObjectItem(object, string);
 
 	return cJSON_DetachItemViaPointer(object, to_detach);
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON * object, const char *string)
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON * object,
+                                                              const char *string)
 {
 	cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
 
 	return cJSON_DetachItemViaPointer(object, to_detach);
 }
 
-CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON * object, const char *string)
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON * object,
+                                              const char *string)
 {
 	cJSON_Delete(cJSON_DetachItemFromObject(object, string));
 }
 
-CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON * object, const char *string)
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON * object,
+                                                           const char *string)
 {
 	cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
 }
 
 /* Replace array/object items with new ones. */
-CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON * array, int which, cJSON * newitem)
+CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON * array,
+                                           int which,
+                                           cJSON * newitem)
 {
 	cJSON *after_inserted = NULL;
 
@@ -2017,7 +2143,9 @@ CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON * array, int which, cJSON * new
 	}
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent,
+                                                     cJSON * const item,
+                                                     cJSON * replacement)
 {
 	if((parent == NULL) ||
 	   (replacement == NULL) ||
@@ -2050,16 +2178,23 @@ CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON
 	return true;
 }
 
-CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON * array, int which, cJSON * newitem)
+CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON * array,
+                                            int which,
+                                            cJSON * newitem)
 {
 	if(which < 0) {
 		return;
 	}
 
-	cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t) which), newitem);
+	cJSON_ReplaceItemViaPointer(array,
+	                            get_array_item(array, (size_t) which),
+	                            newitem);
 }
 
-static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive) {
+static cJSON_bool replace_item_in_object(cJSON		*object,
+                                         const char	*string,
+                                         cJSON		*replacement,
+                                         cJSON_bool	case_sensitive) {
 	if((replacement == NULL) ||
 	   (string == NULL))
 	{
@@ -2072,20 +2207,29 @@ static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSO
 	{
 		cJSON_free(replacement->string);
 	}
-	replacement->string = (char *) cJSON_strdup((const unsigned char *) string, &global_hooks);
+	replacement->string = (char *) cJSON_strdup(
+		(const unsigned char *) string,
+		&global_hooks);
 	replacement->type &= ~cJSON_StringIsConst;
 
-	cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+	cJSON_ReplaceItemViaPointer(object,
+	                            get_object_item(object, string,
+	                                            case_sensitive),
+	                            replacement);
 
 	return true;
 }
 
-CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON * object, const char *string, cJSON * newitem)
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON * object,
+                                             const char *string,
+                                             cJSON * newitem)
 {
 	replace_item_in_object(object, string, newitem, false);
 }
 
-CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON * object, const char *string, cJSON * newitem)
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON * object,
+                                                          const char *string,
+                                                          cJSON * newitem)
 {
 	replace_item_in_object(object, string, newitem, true);
 }
@@ -2156,7 +2300,9 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string)
 	cJSON *item = cJSON_New_Item(&global_hooks);
 	if(item) {
 		item->type = cJSON_String;
-		item->valuestring = (char *) cJSON_strdup((const unsigned char *) string, &global_hooks);
+		item->valuestring = (char *) cJSON_strdup(
+			(const unsigned char *) string,
+			&global_hooks);
 		if(!item->valuestring) {
 			cJSON_Delete(item);
 			return NULL;
@@ -2203,7 +2349,9 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw)
 	cJSON *item = cJSON_New_Item(&global_hooks);
 	if(item) {
 		item->type = cJSON_Raw;
-		item->valuestring = (char *) cJSON_strdup((const unsigned char *) raw, &global_hooks);
+		item->valuestring = (char *) cJSON_strdup(
+			(const unsigned char *) raw,
+			&global_hooks);
 		if(!item->valuestring) {
 			cJSON_Delete(item);
 			return NULL;
@@ -2391,14 +2539,21 @@ CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON * item, cJSON_bool recurse)
 	newitem->valueint = item->valueint;
 	newitem->valuedouble = item->valuedouble;
 	if(item->valuestring) {
-		newitem->valuestring = (char *) cJSON_strdup((unsigned char *) item->valuestring, &global_hooks);
+		newitem->valuestring = (char *) cJSON_strdup(
+			(unsigned char *) item->valuestring,
+			&global_hooks);
 		if(!newitem->valuestring) {
 			goto fail;
 		}
 	}
 	if(item->string) {
-		newitem->string = (item->type & cJSON_StringIsConst) ? item->string : (char *) cJSON_strdup((unsigned char *) item->string,
-		                                                                                            &global_hooks);
+		newitem->string =
+			(item->type &
+			 cJSON_StringIsConst) ? item->string : (char *)
+			cJSON_strdup((
+					     unsigned
+					     char *) item->string,
+			             &global_hooks);
 		if(!newitem->string) {
 			goto fail;
 		}
@@ -2587,7 +2742,9 @@ CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item)
 	return (item->type & 0xFF) == cJSON_Raw;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive)
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a,
+                                       const cJSON * const b,
+                                       const cJSON_bool case_sensitive)
 {
 	if((a == NULL) ||
 	   (b == NULL) ||
@@ -2652,7 +2809,8 @@ CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * cons
 		for( ; (a_element != NULL) &&
 		     (b_element != NULL); )
 		{
-			if(!cJSON_Compare(a_element, b_element, case_sensitive)) {
+			if(!cJSON_Compare(a_element, b_element,
+			                  case_sensitive)) {
 				return false;
 			}
 
@@ -2675,12 +2833,15 @@ CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * cons
 		cJSON_ArrayForEach(a_element, a)
 		{
 			/* TODO This has O(n^2) runtime, which is horrible! */
-			b_element = get_object_item(b, a_element->string, case_sensitive);
+			b_element = get_object_item(b,
+			                            a_element->string,
+			                            case_sensitive);
 			if(b_element == NULL) {
 				return false;
 			}
 
-			if(!cJSON_Compare(a_element, b_element, case_sensitive)) {
+			if(!cJSON_Compare(a_element, b_element,
+			                  case_sensitive)) {
 				return false;
 			}
 		}
@@ -2689,12 +2850,15 @@ CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * cons
 		 * TODO: Do this the proper way, this is just a fix for now */
 		cJSON_ArrayForEach(b_element, b)
 		{
-			a_element = get_object_item(a, b_element->string, case_sensitive);
+			a_element = get_object_item(a,
+			                            b_element->string,
+			                            case_sensitive);
 			if(a_element == NULL) {
 				return false;
 			}
 
-			if(!cJSON_Compare(b_element, a_element, case_sensitive)) {
+			if(!cJSON_Compare(b_element, a_element,
+			                  case_sensitive)) {
 				return false;
 			}
 		}

--- a/samples/client/petstore/C/include/apiClient.h
+++ b/samples/client/petstore/C/include/apiClient.h
@@ -14,7 +14,7 @@ typedef struct apiClient_t {
     #ifdef BASIC_AUTH
 	char *username;
 	char *password;
-    #endif //BASIC_AUTH
+    #endif // BASIC_AUTH
 	// this would only be generated for OAUTH2 authentication
     #ifdef OAUTH2
 	char *accessToken;
@@ -34,8 +34,15 @@ apiClient_t *apiClient_create();
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient, char *operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,
-                      list_t *headerType, list_t *contentType, char *bodyParameters, char *requestType);
+void apiClient_invoke(apiClient_t	*apiClient,
+                      char		*operationParameter,
+                      list_t		*queryParameters,
+                      list_t		*headerParameters,
+                      list_t		*formParameters,
+                      list_t		*headerType,
+                      list_t		*contentType,
+                      char		*bodyParameters,
+                      char		*requestType);
 
 char *strReplace(char *orig, char *rep, char *with);
 

--- a/samples/client/petstore/C/include/list.h
+++ b/samples/client/petstore/C/include/list.h
@@ -20,7 +20,12 @@ typedef struct list_t {
 	long count;
 } list_t;
 
-#define list_ForEach(element, list) for(element = (list != NULL) ? (list)->firstEntry : NULL; element != NULL; element = element->nextListEntry)
+#define list_ForEach(element, list) for(element = \
+						(list != \
+						 NULL) ? (list)->firstEntry : \
+						NULL; \
+	                                element != NULL; \
+	                                element = element->nextListEntry)
 
 list_t *list_create();
 void list_free(list_t *listToFree);
@@ -30,8 +35,16 @@ listEntry_t *list_getElementAt(list_t *list, long indexOfElement);
 listEntry_t *list_getWithIndex(list_t *list, int index);
 void list_removeElement(list_t *list, listEntry_t *elementToRemove);
 
-void list_iterateThroughListForward(list_t *list, void (*operationToPerform)(listEntry_t *, void *), void *additionalDataNeededForCallbackFunction);
-void list_iterateThroughListBackward(list_t *list, void (*operationToPerform)(listEntry_t *, void *), void *additionalDataNeededForCallbackFunction);
+void list_iterateThroughListForward(list_t	*list,
+                                    void (	*operationToPerform)(
+					    listEntry_t *,
+					    void *),
+                                    void *additionalDataNeededForCallbackFunction);
+void list_iterateThroughListBackward(list_t	*list,
+                                     void (	*operationToPerform)(
+					     listEntry_t *,
+					     void *),
+                                     void *additionalDataNeededForCallbackFunction);
 
 void listEntry_printAsInt(listEntry_t *listEntry, void *additionalData);
 void listEntry_free(listEntry_t *listEntry, void *additionalData);

--- a/samples/client/petstore/C/model/api_response.c
+++ b/samples/client/petstore/C/model/api_response.c
@@ -36,7 +36,9 @@ cJSON *api_response_convertToJSON(api_response_t *api_response) {
 	}
 
 	// api_response->message
-	if(cJSON_AddStringToObject(item, "message", api_response->message) == NULL) {
+	if(cJSON_AddStringToObject(item, "message",
+	                           api_response->message) == NULL)
+	{
 		goto fail; // String
 	}
 
@@ -58,13 +60,15 @@ api_response_t *api_response_parseFromJSON(char *jsonString) {
 	}
 
 	// api_response->code
-	cJSON *code = cJSON_GetObjectItemCaseSensitive(api_responseJSON, "code");
+	cJSON *code =
+		cJSON_GetObjectItemCaseSensitive(api_responseJSON, "code");
 	if(!cJSON_IsNumber(code)) {
 		goto end; // Numeric
 	}
 
 	// api_response->type
-	cJSON *type = cJSON_GetObjectItemCaseSensitive(api_responseJSON, "type");
+	cJSON *type =
+		cJSON_GetObjectItemCaseSensitive(api_responseJSON, "type");
 	if(!cJSON_IsString(type) ||
 	   (type->valuestring == NULL))
 	{
@@ -72,7 +76,8 @@ api_response_t *api_response_parseFromJSON(char *jsonString) {
 	}
 
 	// api_response->message
-	cJSON *message = cJSON_GetObjectItemCaseSensitive(api_responseJSON, "message");
+	cJSON *message = cJSON_GetObjectItemCaseSensitive(api_responseJSON,
+	                                                  "message");
 	if(!cJSON_IsString(message) ||
 	   (message->valuestring == NULL))
 	{

--- a/samples/client/petstore/C/model/order.c
+++ b/samples/client/petstore/C/model/order.c
@@ -5,7 +5,12 @@
 #include "order.h"
 
 
-order_t *order_create(long id, long petId, int quantity, char *shipDate, char *status, bool complete) {
+order_t *order_create(long	id,
+                      long	petId,
+                      int	quantity,
+                      char	*shipDate,
+                      char	*status,
+                      bool	complete) {
 	order_t *order = malloc(sizeof(order_t));
 	order->id = id;
 	order->petId = petId;
@@ -91,13 +96,15 @@ order_t *order_parseFromJSON(char *jsonString) {
 	}
 
 	// order->quantity
-	cJSON *quantity = cJSON_GetObjectItemCaseSensitive(orderJSON, "quantity");
+	cJSON *quantity =
+		cJSON_GetObjectItemCaseSensitive(orderJSON, "quantity");
 	if(!cJSON_IsNumber(quantity)) {
 		goto end; // Numeric
 	}
 
 	// order->shipDate
-	cJSON *shipDate = cJSON_GetObjectItemCaseSensitive(orderJSON, "shipDate");
+	cJSON *shipDate =
+		cJSON_GetObjectItemCaseSensitive(orderJSON, "shipDate");
 	if(!cJSON_IsString(shipDate) ||
 	   (shipDate->valuestring == NULL))
 	{
@@ -113,7 +120,8 @@ order_t *order_parseFromJSON(char *jsonString) {
 	}
 
 	// order->complete
-	cJSON *complete = cJSON_GetObjectItemCaseSensitive(orderJSON, "complete");
+	cJSON *complete =
+		cJSON_GetObjectItemCaseSensitive(orderJSON, "complete");
 	if(!cJSON_IsBool(complete)) {
 		goto end; // Numeric
 	}

--- a/samples/client/petstore/C/model/order.h
+++ b/samples/client/petstore/C/model/order.h
@@ -23,7 +23,12 @@ typedef struct order_t {
 	bool complete; // boolean
 } order_t;
 
-order_t *order_create(long id, long petId, int quantity, char *shipDate, char *status, bool complete);
+order_t *order_create(long	id,
+                      long	petId,
+                      int	quantity,
+                      char	*shipDate,
+                      char	*status,
+                      bool	complete);
 
 void order_free(order_t *order);
 

--- a/samples/client/petstore/C/model/pet.c
+++ b/samples/client/petstore/C/model/pet.c
@@ -8,7 +8,12 @@
 #include "tag.h"
 
 
-pet_t *pet_create(long id, category_t *category, char *name, list_t *photoUrls, list_t *tags, char *status) {
+pet_t *pet_create(long		id,
+                  category_t	*category,
+                  char		*name,
+                  list_t	*photoUrls,
+                  list_t	*tags,
+                  char		*status) {
 	pet_t *pet = malloc(sizeof(pet_t));
 	pet->id = id;
 	pet->category = category;
@@ -62,7 +67,9 @@ cJSON *pet_convertToJSON(pet_t *pet) {
 
 	listEntry_t *photoUrlsListEntry;
 	list_ForEach(photoUrlsListEntry, pet->photoUrls) {
-		if(cJSON_AddStringToObject(photoUrls, "", photoUrlsListEntry->data) == NULL) {
+		if(cJSON_AddStringToObject(photoUrls, "",
+		                           photoUrlsListEntry->data) == NULL)
+		{
 			goto fail;
 		}
 	}
@@ -112,7 +119,8 @@ pet_t *pet_parseFromJSON(char *jsonString) {
 
 	// pet->category
 	category_t *category;
-	cJSON *categoryJSON = cJSON_GetObjectItemCaseSensitive(petJSON, "category");
+	cJSON *categoryJSON = cJSON_GetObjectItemCaseSensitive(petJSON,
+	                                                       "category");
 	if(petJSON == NULL) {
 		const char *error_ptr = cJSON_GetErrorPtr();
 		if(error_ptr != NULL) {
@@ -133,7 +141,8 @@ pet_t *pet_parseFromJSON(char *jsonString) {
 
 	// pet->photoUrls
 	cJSON *photoUrls;
-	cJSON *photoUrlsJSON = cJSON_GetObjectItemCaseSensitive(petJSON, "photoUrls");
+	cJSON *photoUrlsJSON = cJSON_GetObjectItemCaseSensitive(petJSON,
+	                                                        "photoUrls");
 	if(!cJSON_IsArray(photoUrlsJSON)) {
 		goto end; // primitive container
 	}

--- a/samples/client/petstore/C/model/pet.h
+++ b/samples/client/petstore/C/model/pet.h
@@ -23,7 +23,12 @@ typedef struct pet_t {
 	char *status; // enum string
 } pet_t;
 
-pet_t *pet_create(long id, category_t *category, char *name, list_t *photoUrls, list_t *tags, char *status);
+pet_t *pet_create(long		id,
+                  category_t	*category,
+                  char		*name,
+                  list_t	*photoUrls,
+                  list_t	*tags,
+                  char		*status);
 
 void pet_free(pet_t *pet);
 

--- a/samples/client/petstore/C/model/user.c
+++ b/samples/client/petstore/C/model/user.c
@@ -5,7 +5,14 @@
 #include "user.h"
 
 
-user_t *user_create(long id, char *username, char *firstName, char *lastName, char *email, char *password, char *phone, int userStatus) {
+user_t *user_create(long	id,
+                    char	*username,
+                    char	*firstName,
+                    char	*lastName,
+                    char	*email,
+                    char	*password,
+                    char	*phone,
+                    int		userStatus) {
 	user_t *user = malloc(sizeof(user_t));
 	user->id = id;
 	user->username = username;
@@ -46,7 +53,9 @@ cJSON *user_convertToJSON(user_t *user) {
 	}
 
 	// user->firstName
-	if(cJSON_AddStringToObject(item, "firstName", user->firstName) == NULL) {
+	if(cJSON_AddStringToObject(item, "firstName",
+	                           user->firstName) == NULL)
+	{
 		goto fail; // String
 	}
 
@@ -71,7 +80,9 @@ cJSON *user_convertToJSON(user_t *user) {
 	}
 
 	// user->userStatus
-	if(cJSON_AddNumberToObject(item, "userStatus", user->userStatus) == NULL) {
+	if(cJSON_AddNumberToObject(item, "userStatus",
+	                           user->userStatus) == NULL)
+	{
 		goto fail; // Numeric
 	}
 
@@ -99,7 +110,8 @@ user_t *user_parseFromJSON(char *jsonString) {
 	}
 
 	// user->username
-	cJSON *username = cJSON_GetObjectItemCaseSensitive(userJSON, "username");
+	cJSON *username =
+		cJSON_GetObjectItemCaseSensitive(userJSON, "username");
 	if(!cJSON_IsString(username) ||
 	   (username->valuestring == NULL))
 	{
@@ -107,7 +119,8 @@ user_t *user_parseFromJSON(char *jsonString) {
 	}
 
 	// user->firstName
-	cJSON *firstName = cJSON_GetObjectItemCaseSensitive(userJSON, "firstName");
+	cJSON *firstName = cJSON_GetObjectItemCaseSensitive(userJSON,
+	                                                    "firstName");
 	if(!cJSON_IsString(firstName) ||
 	   (firstName->valuestring == NULL))
 	{
@@ -115,7 +128,8 @@ user_t *user_parseFromJSON(char *jsonString) {
 	}
 
 	// user->lastName
-	cJSON *lastName = cJSON_GetObjectItemCaseSensitive(userJSON, "lastName");
+	cJSON *lastName =
+		cJSON_GetObjectItemCaseSensitive(userJSON, "lastName");
 	if(!cJSON_IsString(lastName) ||
 	   (lastName->valuestring == NULL))
 	{
@@ -131,7 +145,8 @@ user_t *user_parseFromJSON(char *jsonString) {
 	}
 
 	// user->password
-	cJSON *password = cJSON_GetObjectItemCaseSensitive(userJSON, "password");
+	cJSON *password =
+		cJSON_GetObjectItemCaseSensitive(userJSON, "password");
 	if(!cJSON_IsString(password) ||
 	   (password->valuestring == NULL))
 	{
@@ -147,7 +162,8 @@ user_t *user_parseFromJSON(char *jsonString) {
 	}
 
 	// user->userStatus
-	cJSON *userStatus = cJSON_GetObjectItemCaseSensitive(userJSON, "userStatus");
+	cJSON *userStatus = cJSON_GetObjectItemCaseSensitive(userJSON,
+	                                                     "userStatus");
 	if(!cJSON_IsNumber(userStatus)) {
 		goto end; // Numeric
 	}

--- a/samples/client/petstore/C/model/user.h
+++ b/samples/client/petstore/C/model/user.h
@@ -22,7 +22,14 @@ typedef struct user_t {
 	int userStatus; // numeric
 } user_t;
 
-user_t *user_create(long id, char *username, char *firstName, char *lastName, char *email, char *password, char *phone, int userStatus);
+user_t *user_create(long	id,
+                    char	*username,
+                    char	*firstName,
+                    char	*lastName,
+                    char	*email,
+                    char	*password,
+                    char	*phone,
+                    int		userStatus);
 
 void user_free(user_t *user);
 

--- a/samples/client/petstore/C/src/apiClient.c
+++ b/samples/client/petstore/C/src/apiClient.c
@@ -34,7 +34,9 @@ void replaceSpaceWithPlus(char *stringToProcess) {
 	}
 }
 
-char *assembleTargetUrl(char *basePath, char *operationParameter, list_t *queryParameters) {
+char *assembleTargetUrl(char	*basePath,
+                        char	*operationParameter,
+                        list_t	*queryParameters) {
 	int neededBufferSizeForQueryParameters = 0;
 	listEntry_t *listEntry;
 
@@ -62,7 +64,9 @@ char *assembleTargetUrl(char *basePath, char *operationParameter, list_t *queryP
 	}
 
 	char *targetUrl =
-		malloc(neededBufferSizeForQueryParameters + basePathLength + operationParameterLength + 1);
+		malloc(
+			neededBufferSizeForQueryParameters + basePathLength + operationParameterLength +
+			1);
 
 	strcpy(targetUrl, basePath);
 
@@ -106,8 +110,15 @@ void postData(CURL *handle, char *bodyParameters) {
 }
 
 
-void apiClient_invoke(apiClient_t *apiClient, char *operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,
-                      list_t *headerType, list_t *contentType, char *bodyParameters, char *requestType) {
+void apiClient_invoke(apiClient_t	*apiClient,
+                      char		*operationParameter,
+                      list_t		*queryParameters,
+                      list_t		*headerParameters,
+                      list_t		*formParameters,
+                      list_t		*headerType,
+                      list_t		*contentType,
+                      char		*bodyParameters,
+                      char		*requestType) {
 	CURL *handle = curl_easy_init();
 	CURLcode res;
 
@@ -119,27 +130,42 @@ void apiClient_invoke(apiClient_t *apiClient, char *operationParameter, list_t *
 
 		if(headerType->count != 0) {
 			list_ForEach(listEntry, headerType) {
-				if(strstr((char *) listEntry->data, "xml") == NULL) {
+				if(strstr((char *) listEntry->data,
+				          "xml") == NULL)
+				{
 					char buffHeader[256];
-					sprintf(buffHeader, "%s%s", "Accept: ", (char *) listEntry->data);
-					headers = curl_slist_append(headers, buffHeader);
+					sprintf(buffHeader,
+					        "%s%s",
+					        "Accept: ",
+					        (char *) listEntry->data);
+					headers = curl_slist_append(headers,
+					                            buffHeader);
 				}
 			}
 		}
 		if(contentType->count != 0) {
 			list_ForEach(listEntry, contentType) {
-				if(strstr((char *) listEntry->data, "xml") == NULL) {
+				if(strstr((char *) listEntry->data,
+				          "xml") == NULL)
+				{
 					char buffContent[256];
-					sprintf(buffContent, "%s%s", "Content-Type: ", (char *) listEntry->data);
-					headers = curl_slist_append(headers, buffContent);
+					sprintf(buffContent,
+					        "%s%s",
+					        "Content-Type: ",
+					        (char *) listEntry->data);
+					headers = curl_slist_append(headers,
+					                            buffContent);
 				}
 			}
 		} else {
-			headers = curl_slist_append(headers, "Content-Type: application/json");
+			headers = curl_slist_append(headers,
+			                            "Content-Type: application/json");
 		}
 
 		if(requestType != NULL) {
-			curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, requestType);
+			curl_easy_setopt(handle,
+			                 CURLOPT_CUSTOMREQUEST,
+			                 requestType);
 		}
 
 		if(formParameters->count != 0) {
@@ -151,17 +177,28 @@ void apiClient_invoke(apiClient_t *apiClient, char *operationParameter, list_t *
 				if((keyValuePair->key != NULL) &&
 				   (keyValuePair->value != NULL) )
 				{
-					curl_mimepart *part = curl_mime_addpart(mime);
+					curl_mimepart *part = curl_mime_addpart(
+						mime);
 
 					curl_mime_name(part, keyValuePair->key);
 
-					if(strcmp(keyValuePair->key, "file") == 0) {
-						FileStruct *fileVar = malloc(sizeof(FileStruct));
-						memcpy(&fileVar, keyValuePair->value, sizeof(fileVar));
-						curl_mime_data(part, fileVar->fileData, fileVar->fileSize);
-						curl_mime_filename(part, "image.png");
+					if(strcmp(keyValuePair->key,
+					          "file") == 0)
+					{
+						FileStruct *fileVar = malloc(
+							sizeof(FileStruct));
+						memcpy(&fileVar,
+						       keyValuePair->value,
+						       sizeof(fileVar));
+						curl_mime_data(part,
+						               fileVar->fileData,
+						               fileVar->fileSize);
+						curl_mime_filename(part,
+						                   "image.png");
 					} else {
-						curl_mime_data(part, keyValuePair->value, CURL_ZERO_TERMINATED);
+						curl_mime_data(part,
+						               keyValuePair->value,
+						               CURL_ZERO_TERMINATED);
 					}
 				}
 			}

--- a/samples/client/petstore/C/src/list.c
+++ b/samples/client/petstore/C/src/list.c
@@ -38,9 +38,12 @@ list_t *list_create() {
 	return createdList;
 }
 
-void list_iterateThroughListForward(list_t *list, void (*operationToPerform)(
+void list_iterateThroughListForward(list_t		*list,
+                                    void (		*operationToPerform)(
 					    listEntry_t *,
-					    void *callbackFunctionUsedData), void *additionalDataNeededForCallbackFunction) {
+					    void	*callbackFunctionUsedData),
+                                    void		*additionalDataNeededForCallbackFunction)
+{
 	listEntry_t *currentListEntry = list->firstEntry;
 	listEntry_t *nextListEntry;
 
@@ -62,9 +65,12 @@ void list_iterateThroughListForward(list_t *list, void (*operationToPerform)(
 	}
 }
 
-void list_iterateThroughListBackward(list_t *list, void (*operationToPerform)(
+void list_iterateThroughListBackward(list_t		*list,
+                                     void (		*operationToPerform)(
 					     listEntry_t *,
-					     void *callbackFunctionUsedData), void *additionalDataNeededForCallbackFunction) {
+					     void	*callbackFunctionUsedData),
+                                     void		*additionalDataNeededForCallbackFunction)
+{
 	listEntry_t *currentListEntry = list->lastEntry;
 	listEntry_t *nextListEntry = currentListEntry->prevListEntry;
 

--- a/samples/client/petstore/C/unit-test/test-PetAPI.c
+++ b/samples/client/petstore/C/unit-test/test-PetAPI.c
@@ -96,7 +96,8 @@ int main() {
 	strcpy(petName2, "sold");
 
 	apiClient_t *apiClient1 = apiClient_create();
-	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1, petName2);
+	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1,
+	                         petName2);
 
 
 

--- a/samples/client/petstore/C/unit-test/test-StoreAPI.c
+++ b/samples/client/petstore/C/unit-test/test-StoreAPI.c
@@ -96,7 +96,8 @@ int main() {
 	strcpy(petName2, "sold");
 
 	apiClient_t *apiClient1 = apiClient_create();
-	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1, petName2);
+	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1,
+	                         petName2);
 
 
 

--- a/samples/client/petstore/C/unit-test/test-UserAPI.c
+++ b/samples/client/petstore/C/unit-test/test-UserAPI.c
@@ -96,7 +96,8 @@ int main() {
 	strcpy(petName2, "sold");
 
 	apiClient_t *apiClient1 = apiClient_create();
-	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1, petName2);
+	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1,
+	                         petName2);
 
 
 

--- a/samples/client/petstore/C/unit-tests/PetAPI.c
+++ b/samples/client/petstore/C/unit-tests/PetAPI.c
@@ -96,7 +96,8 @@ int main() {
 	strcpy(petName2, "sold");
 
 	apiClient_t *apiClient1 = apiClient_create();
-	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1, petName2);
+	PetAPI_updatePetWithForm(apiClient1, EXAMPLE_PET_ID, petName1,
+	                         petName2);
 
 
 

--- a/samples/client/petstore/C/unit-tests/StoreAPI.c
+++ b/samples/client/petstore/C/unit-tests/StoreAPI.c
@@ -24,7 +24,11 @@ int main() {
 	printf("Hello world1\n");
 	apiClient_t *apiClient = apiClient_create();
 
-	order_t *neworder = order_create(ORDER_ID, PET_ID, QUANTITY, SHIP_DATE, STATUS,
+	order_t *neworder = order_create(ORDER_ID,
+	                                 PET_ID,
+	                                 QUANTITY,
+	                                 SHIP_DATE,
+	                                 STATUS,
 	                                 COMPLETE);
 
 	order_t *returnorder = StoreAPI_placeOrder(apiClient, neworder);
@@ -34,7 +38,7 @@ int main() {
 	char *dataToPrint = cJSON_Print(JSONNODE);
 
 	printf("Place order 1: \n%s\n", dataToPrint);
-	//apiClient_free(apiClient);
+	apiClient_free(apiClient);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
@@ -48,7 +52,7 @@ int main() {
 	char *dataToPrint1 = cJSON_Print(JSONNODE);
 
 	printf("Place order 2: \n%s\n", dataToPrint1);
-	//apiClient_free(apiClient2);
+	apiClient_free(apiClient2);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
@@ -58,7 +62,7 @@ int main() {
 	StoreAPI_deleteOrder(apiClient3, "1234");
 
 	printf("Order Deleted \n");
-	//apiClient_free(apiClient3);
+	apiClient_free(apiClient3);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
@@ -70,5 +74,5 @@ int main() {
 	if(neworder == NULL) {
 		printf("Order Not present \n");
 	}
-	//apiClient_free(apiClient4);
+	apiClient_free(apiClient4);
 }

--- a/samples/client/petstore/C/unit-tests/UserAPI.c
+++ b/samples/client/petstore/C/unit-tests/UserAPI.c
@@ -24,11 +24,17 @@ int main() {
 	printf("Hello world1\n");
 	apiClient_t *apiClient = apiClient_create();
 
-	user_t *newuser = user_create(USER_ID, USER_NAME, FIRST_NAME, LAST_NAME, EMAIL,
-	                              PASSWORD, PHONE, USER_STATUS);
+	user_t *newuser = user_create(USER_ID,
+	                              USER_NAME,
+	                              FIRST_NAME,
+	                              LAST_NAME,
+	                              EMAIL,
+	                              PASSWORD,
+	                              PHONE,
+	                              USER_STATUS);
 
 	UserAPI_createUser(apiClient, newuser);
-
+	apiClient_free(apiClient);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
@@ -41,26 +47,36 @@ int main() {
 	char *dataToPrint = cJSON_Print(JSONNODE);
 
 	printf("User is: \n%s\n", dataToPrint);
-
+	apiClient_free(apiClient1);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
 
 	apiClient_t *apiClient2 = apiClient_create();
 
-	user_t *newuser1 = user_create(USER_ID, USER_NAME, FIRST_NAME, LAST_NAME1, EMAIL,
-	                               PASSWORD, PHONE, USER_STATUS);
+	user_t *newuser1 = user_create(USER_ID,
+	                               USER_NAME,
+	                               FIRST_NAME,
+	                               LAST_NAME1,
+	                               EMAIL,
+	                               PASSWORD,
+	                               PHONE,
+	                               USER_STATUS);
 
 	UserAPI_updateUser(apiClient2, "example123", newuser1);
+	apiClient_free(apiClient2);
+
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
 
 	apiClient_t *apiClient3 = apiClient_create();
 
-	char *loginuserreturn = UserAPI_loginUser(apiClient3, "example123", "thisisexample!123");
+	char *loginuserreturn = UserAPI_loginUser(apiClient3,
+	                                          "example123",
+	                                          "thisisexample!123");
 
 	printf("Login User: %s\n", loginuserreturn);
-
+	apiClient_free(apiClient3);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
@@ -68,6 +84,7 @@ int main() {
 	apiClient_t *apiClient4 = apiClient_create();
 
 	UserAPI_logoutUser(apiClient4);
+	apiClient_free(apiClient4);
 
 	printf(
 		"------------------------------ Part Ends ----------------------------------\n");
@@ -75,5 +92,5 @@ int main() {
 	apiClient_t *apiClient5 = apiClient_create();
 
 	UserAPI_deleteUser(apiClient5, "example123");
-
+	apiClient_free(apiClient5);
 }

--- a/samples/client/petstore/C/unit-tests/order.c
+++ b/samples/client/petstore/C/unit-tests/order.c
@@ -13,7 +13,11 @@
 #define COMPLETE 1
 
 int main() {
-	order_t *neworder = order_create(ORDER_ID, PET_ID, QUANTITY, SHIP_DATE, STATUS,
+	order_t *neworder = order_create(ORDER_ID,
+	                                 PET_ID,
+	                                 QUANTITY,
+	                                 SHIP_DATE,
+	                                 STATUS,
 	                                 COMPLETE);
 
 	cJSON *JSONNODE = order_convertToJSON(neworder);

--- a/samples/client/petstore/C/unit-tests/user.c
+++ b/samples/client/petstore/C/unit-tests/user.c
@@ -15,8 +15,14 @@
 #define USER_STATUS 4
 
 int main() {
-	user_t *newuser = user_create(USER_ID, USER_NAME, FIRST_NAME, LAST_NAME, EMAIL,
-	                              PASSWORD, PHONE, USER_STATUS);
+	user_t *newuser = user_create(USER_ID,
+	                              USER_NAME,
+	                              FIRST_NAME,
+	                              LAST_NAME,
+	                              EMAIL,
+	                              PASSWORD,
+	                              PHONE,
+	                              USER_STATUS);
 
 	cJSON *JSONNODE = user_convertToJSON(newuser);
 

--- a/samples/client/petstore/c/src/apiKey.c
+++ b/samples/client/petstore/c/src/apiKey.c
@@ -3,7 +3,7 @@
 #include "keyValuePair.h"
 
 keyValuePair_t *keyValuePair_create(char *key, char *value) {
-	keyValuePair_t *keyValuePair =  malloc(sizeof(keyValuePair_t));
+	keyValuePair_t *keyValuePair = malloc(sizeof(keyValuePair_t));
 	keyValuePair->key = key;
 	keyValuePair->value = value;
 	return keyValuePair;


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To remove map.h import: https://github.com/OpenAPITools/openapi-generator/compare/c_generator...support_map?expand=1#diff-c4bb6b7928fd51aeca5448d651d4e020L7
