### PR TITLE
Allow specifying/overriding the parent in the pom file for Java and S…

### DIFF
--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -104,6 +104,15 @@ CONFIG OPTIONS for java
 	booleanGetterPrefix
 	    Set booleanGetterPrefix (default value 'get')
 
+	parentGroupId
+	    parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+
+	parentArtifactId
+	    parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+
+	parentVersion
+	    parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+
 	useRxJava
 	    Whether to use the RxJava adapter with the retrofit2 library. (Default: false)
 

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -104,6 +104,15 @@ CONFIG OPTIONS for spring
 	booleanGetterPrefix
 	    Set booleanGetterPrefix (default value 'get')
 
+	parentGroupId
+	    parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+
+	parentArtifactId
+	    parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+
+	parentVersion
+	    parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect
+
 	title
 	    server title name or client service name
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -265,4 +265,12 @@ public class CodegenConstants {
     public static final String DATABASE_ADAPTER = "databaseAdapter";
     public static final String DATABASE_ADAPTER_DESC = "The adapter for database (e.g. mysql, sqlite). Default: sqlite";
 
+    public static final String PARENT_GROUP_ID = "parentGroupId";
+    public static final String PARENT_GROUP_ID_DESC = "parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect";
+    
+    public static final String PARENT_ARTIFACT_ID = "parentArtifactId";
+    public static final String PARENT_ARTIFACT_ID_DESC = "parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect";
+    
+    public static final String PARENT_VERSION = "parentVersion";
+    public static final String PARENT_VERSION_DESC = "parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -105,6 +105,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected boolean disableHtmlEscaping = false;
     protected String booleanGetterPrefix = BOOLEAN_GETTER_PREFIX_DEFAULT;
     protected boolean useNullForUnknownEnumValue = false;
+    protected String parentGroupId = "";
+    protected String parentArtifactId = "";
+    protected String parentVersion = "";
+    protected boolean parentOverridden = false;
 
     public AbstractJavaCodegen() {
         super();
@@ -198,6 +202,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         cliOptions.add(CliOption.newBoolean(DISABLE_HTML_ESCAPING, "Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)"));
         cliOptions.add(CliOption.newString(BOOLEAN_GETTER_PREFIX, "Set booleanGetterPrefix (default value '" + BOOLEAN_GETTER_PREFIX_DEFAULT + "')"));
+        
+        cliOptions.add(CliOption.newString(CodegenConstants.PARENT_GROUP_ID, CodegenConstants.PARENT_GROUP_ID_DESC));
+        cliOptions.add(CliOption.newString(CodegenConstants.PARENT_ARTIFACT_ID, CodegenConstants.PARENT_ARTIFACT_ID_DESC));
+        cliOptions.add(CliOption.newString(CodegenConstants.PARENT_VERSION, CodegenConstants.PARENT_VERSION_DESC));
     }
 
     @Override
@@ -375,6 +383,22 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             this.setWithXml(Boolean.valueOf(additionalProperties.get(WITH_XML).toString()));
         }
         additionalProperties.put(WITH_XML, withXml);
+        
+        if (additionalProperties.containsKey(CodegenConstants.PARENT_GROUP_ID)) {
+            this.setParentGroupId((String) additionalProperties.get(CodegenConstants.PARENT_GROUP_ID));
+        }
+        
+        if (additionalProperties.containsKey(CodegenConstants.PARENT_ARTIFACT_ID)) {
+            this.setParentArtifactId((String) additionalProperties.get(CodegenConstants.PARENT_ARTIFACT_ID));
+        }
+        
+        if (additionalProperties.containsKey(CodegenConstants.PARENT_VERSION)) {
+            this.setParentVersion((String) additionalProperties.get(CodegenConstants.PARENT_VERSION));
+        }
+        
+        if (!StringUtils.isEmpty(parentGroupId) && !StringUtils.isEmpty(parentArtifactId) && !StringUtils.isEmpty(parentVersion)) {
+            additionalProperties.put("parentOverridden", true);
+        }
 
         // make api and model doc path available in mustache template
         additionalProperties.put("apiDocPath", apiDocPath);
@@ -1347,4 +1371,19 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         return tag;
     }
 
+    public void setParentGroupId(final String parentGroupId) {
+        this.parentGroupId = parentGroupId;
+    }
+
+    public void setParentArtifactId(final String parentArtifactId) {
+        this.parentArtifactId = parentArtifactId;
+    }
+
+    public void setParentVersion(final String parentVersion) {
+        this.parentVersion = parentVersion;
+    }
+
+    public void setParentOverridden(final boolean parentOverridden) {
+        this.parentOverridden = parentOverridden;
+    }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -20,7 +20,7 @@
         <version>{{{parentVersion}}}</version>
     </parent>
 {{/parentOverridden}}
-    
+
     <licenses>
         <license>
             <name>{{licenseName}}</name>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
     
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -13,7 +13,14 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
+    
     <licenses>
         <license>
             <name>{{licenseName}}</name>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -11,13 +11,13 @@
         <developerConnection>scm:git:git@github.com:openapitools/openapi-generator.git</developerConnection>
         <url>https://openapi-generator.tech</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <build>
         <plugins>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -11,6 +11,13 @@
         <developerConnection>scm:git:git@github.com:openapitools/openapi-generator.git</developerConnection>
         <url>https://openapi-generator.tech</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <build>
         <plugins>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -13,13 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -13,6 +13,13 @@
         <developerConnection>{{scmDeveloperConnection}}</developerConnection>
         <url>{{scmUrl}}</url>
     </scm>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
 
     <licenses>
         <license>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -13,20 +13,20 @@
         <springfox-version>2.8.0</springfox-version>
         {{/useSpringfox}}
     </properties>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
-    {{^parentOverridden}}
+{{/parentOverridden}}
+{{^parentOverridden}}
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>{{#java8}}2.0.1.RELEASE{{/java8}}{{^java8}}1.5.12.RELEASE{{/java8}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         {{^interfaceOnly}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -13,11 +13,20 @@
         <springfox-version>2.8.0</springfox-version>
         {{/useSpringfox}}
     </properties>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
+    {{^parentOverridden}}
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>{{#java8}}2.0.1.RELEASE{{/java8}}{{^java8}}1.5.12.RELEASE{{/java8}}</version>
     </parent>
+    {{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         {{^interfaceOnly}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -11,20 +11,20 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.18</swagger-core-version>
     </properties>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
-    {{^parentOverridden}}
+{{/parentOverridden}}
+{{^parentOverridden}}
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>1.5.4.RELEASE</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
     </build>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -11,11 +11,20 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <swagger-core-version>1.5.18</swagger-core-version>
     </properties>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
+    {{^parentOverridden}}
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>1.5.4.RELEASE</version>
     </parent>
+    {{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
     </build>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -5,6 +5,13 @@
     <packaging>jar</packaging>
     <name>{{artifactId}}</name>
     <version>{{artifactVersion}}</version>
+    {{#parentOverridden}}
+    <parent>
+        <groupId>{{{parentGroupId}}}</groupId>
+        <artifactId>{{{parentArtifactId}}}</artifactId>
+        <version>{{{parentVersion}}}</version>
+    </parent>
+    {{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -5,13 +5,13 @@
     <packaging>jar</packaging>
     <name>{{artifactId}}</name>
     <version>{{artifactVersion}}</version>
-    {{#parentOverridden}}
+{{#parentOverridden}}
     <parent>
         <groupId>{{{parentGroupId}}}</groupId>
         <artifactId>{{{parentArtifactId}}}</artifactId>
         <version>{{{parentVersion}}}</version>
     </parent>
-    {{/parentOverridden}}
+{{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.3.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Add support for overriding/specifying the parent in the generated pom file.
issue #1131 

The run-all-petstore.cmd command did't work as some of the scripts it calls are looking for jars in swagger-codegen-cli directory - hence why I haven't checked "ran the schell script" above.

I have checked using the Spring generator while specifying none of the parent properties, all of them and one of them.

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)