### PR TITLE
Rename Scala post processing env variable to SCALA_POST_PROCESS_FILE

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractScalaCodegen.java
@@ -114,8 +114,8 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (StringUtils.isEmpty(System.getenv("SCALAFMT_PATH"))) {
-            LOGGER.info("Environment variable SCALAFMT_PATH not defined so the Scala code may not be properly formatted. To define it, try 'export SCALAFMT_PATH=/usr/local/bin/scalafmt' (Linux/Mac)");
+        if (StringUtils.isEmpty(System.getenv("SCALA_POST_PROCESS_FILE"))) {
+            LOGGER.info("Environment variable SCALA_POST_PROCESS_FILE not defined so the Scala code may not be properly formatted. To define it, try 'export SCALA_POST_PROCESS_FILE=/usr/local/bin/scalafmt' (Linux/Mac)");
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
@@ -309,21 +309,22 @@ public abstract class AbstractScalaCodegen extends DefaultCodegen {
             return;
         }
 
-        String scalafmtPath = System.getenv("SCALAFMT_PATH");
-        if (StringUtils.isEmpty(scalafmtPath)) {
-            return; // skip if SCALAFMT_PATH env variable is not defined
+        String scalaPostProcessFile = System.getenv("SCALA_POST_PROCESS_FILE");
+        if (StringUtils.isEmpty(scalaPostProcessFile)) {
+            return; // skip if SCALA_POST_PROCESS_FILE env variable is not defined
         }
 
         // only process files with scala extension
         if ("scala".equals(FilenameUtils.getExtension(file.toString()))) {
-            String command = scalafmtPath + " " + file.toString();
+            String command = scalaPostProcessFile + " " + file.toString();
             try {
                 Process p = Runtime.getRuntime().exec(command);
-                p.waitFor();
-                if (p.exitValue() != 0) {
-                    LOGGER.error("Error running the command ({}). Exit value: {}", command, p.exitValue());
+                int exitValue = p.waitFor();
+                if (exitValue != 0) {
+                    LOGGER.error("Error running the command ({}). Exit value: {}", command, exitValue);
+                } else {
+                    LOGGER.info("Successfully executed: " + command);
                 }
-                LOGGER.info("Successfully executed: " + command);
             } catch (Exception e) {
                 LOGGER.error("Error running the command ({}). Exception: {}", command, e.getMessage());
             }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (3.3.x), `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Rename Scala post processing env variable to SCALA_POST_PROCESS_FILE, e.g. `export SCALA_POST_PROCESS_FILE=/usr/local/bin/scalafmt`

FYI. @clasnake  @jimschubert @shijinkui @ramzimaalej



