### PR TITLE
FIX: remove special quotation marks from filename generation.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -731,7 +731,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelFilename(String name) {
-        return this.cleanModelFilename(initialCaps(name));
+        return this.sanitizeName(initialCaps(name));
     }
 
     /**
@@ -741,7 +741,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelTestFilename(String name) {
-        return this.cleanModelFilename(initialCaps(name) + "Test");
+        return this.sanitizeName(initialCaps(name) + "Test");
     }
 
     /**
@@ -4704,15 +4704,4 @@ public class DefaultCodegen implements CodegenConfig {
         LOGGER.debug("Post processing file {} ({})", file, fileType);
     } 
 
-    /**
-     * Cleans the given filename by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
-     * for model names marked with generics.
-     * "myModel«MyGeneric»" to "myModelMyGeneric"
-     * 
-     * @param name given filename string to clean
-     * @return cleaned filename
-     */
-    protected String cleanModelFilename(String name) {
-        return name.replaceAll("[\\u00AB\\u00BB]", "");
-    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4708,7 +4708,8 @@ public class DefaultCodegen implements CodegenConfig {
      * Cleans the given filename by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
      * for model names marked with generics.
      * myModel«MyGeneric» => myModelMyGeneric
-     * @param name
+     * 
+     * @param name given filename string to clean
      * @return cleaned filename
      */
     protected String cleanModelFilename(String name) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -731,7 +731,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelFilename(String name) {
-        return this.cleanModelName(initialCaps(name));
+        return this.cleanModelFilename(initialCaps(name));
     }
 
     /**
@@ -741,7 +741,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelTestFilename(String name) {
-        return this.cleanModelName(initialCaps(name) + "Test");
+        return this.cleanModelFilename(initialCaps(name) + "Test");
     }
 
     /**
@@ -4705,13 +4705,13 @@ public class DefaultCodegen implements CodegenConfig {
     } 
 
     /**
-     * Cleans the given name by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
+     * Cleans the given filename by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
      * for model names marked with generics.
      * myModel«MyGeneric» => myModelMyGeneric
      * @param name
-     * @return cleaned name
+     * @return cleaned filename
      */
-    protected String cleanModelName(String name) {
+    protected String cleanModelFilename(String name) {
         return name.replaceAll("[\\u00AB\\u00BB]", "");
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -731,7 +731,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelFilename(String name) {
-        return initialCaps(name);
+        return this.cleanModelName(initialCaps(name));
     }
 
     /**
@@ -741,7 +741,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelTestFilename(String name) {
-        return initialCaps(name) + "Test";
+        return this.cleanModelName(initialCaps(name) + "Test");
     }
 
     /**
@@ -4702,5 +4702,16 @@ public class DefaultCodegen implements CodegenConfig {
      */
     public void postProcessFile(File file, String fileType) {
         LOGGER.debug("Post processing file {} ({})", file, fileType);
+    } 
+
+    /**
+     * Cleans the given name by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
+     * for model names marked with generics.
+     * myModel«MyGeneric» => myModelMyGeneric
+     * @param name
+     * @return cleaned name
+     */
+    protected String cleanModelName(String name) {
+        return name.replaceAll("[\\u00AB\\u00BB]", "");
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -731,7 +731,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelFilename(String name) {
-        return this.sanitizeName(initialCaps(name));
+        return initialCaps(name);
     }
 
     /**
@@ -741,7 +741,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the file name of the model
      */
     public String toModelTestFilename(String name) {
-        return this.sanitizeName(initialCaps(name) + "Test");
+        return initialCaps(name) + "Test";
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4707,7 +4707,7 @@ public class DefaultCodegen implements CodegenConfig {
     /**
      * Cleans the given filename by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
      * for model names marked with generics.
-     * myModel«MyGeneric» => myModelMyGeneric
+     * "myModel«MyGeneric»" to "myModelMyGeneric"
      * 
      * @param name given filename string to clean
      * @return cleaned filename

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -298,7 +298,8 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     private void generateModel(List<File> files, Map<String, Object> models, String modelName) throws IOException {
         for (String templateName : config.modelTemplateFiles().keySet()) {
             String suffix = config.modelTemplateFiles().get(templateName);
-            String filename = config.modelFileFolder() + File.separator + config.toModelFilename(modelName) + suffix;
+            String cleanedModelFileName = this.cleanModelFilename(config.toModelFilename(modelName));
+            String filename = config.modelFileFolder() + File.separator + cleanedModelFileName + suffix;
             if (!config.shouldOverwrite(filename)) {
                 LOGGER.info("Skipped overwriting " + filename);
                 continue;
@@ -309,6 +310,17 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 config.postProcessFile(written, "model");
             }
         }
+    }
+
+    /**
+     * Cleans the given filename by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
+     * for model names marked with generics.
+     * myModel«MyGeneric» => myModelMyGeneric
+     * @param filename
+     * @return cleaned filename
+     */
+    private String cleanModelFilename(String filename) {
+        return filename.replaceAll("[\\u00AB\\u00BB]", "");
     }
 
     private void generateModels(List<File> files, List<Object> allModels, List<String> unusedModels) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -298,8 +298,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
     private void generateModel(List<File> files, Map<String, Object> models, String modelName) throws IOException {
         for (String templateName : config.modelTemplateFiles().keySet()) {
             String suffix = config.modelTemplateFiles().get(templateName);
-            String cleanedModelFileName = this.cleanModelFilename(config.toModelFilename(modelName));
-            String filename = config.modelFileFolder() + File.separator + cleanedModelFileName + suffix;
+            String filename = config.modelFileFolder() + File.separator + config.toModelFilename(modelName) + suffix;
             if (!config.shouldOverwrite(filename)) {
                 LOGGER.info("Skipped overwriting " + filename);
                 continue;
@@ -310,17 +309,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 config.postProcessFile(written, "model");
             }
         }
-    }
-
-    /**
-     * Cleans the given filename by removing all {LEFT-POINTING | RIGH-POINTING} DOUBLE ANGLE QUOTATION MARKs
-     * for model names marked with generics.
-     * myModel«MyGeneric» => myModelMyGeneric
-     * @param filename
-     * @return cleaned filename
-     */
-    private String cleanModelFilename(String filename) {
-        return filename.replaceAll("[\\u00AB\\u00BB]", "");
     }
 
     private void generateModels(List<File> files, List<Object> allModels, List<String> unusedModels) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -472,7 +472,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toModelFilename(String name) {
-        return this.convertUsingFileNamingConvention(name) + modelFileSuffix;
+        return this.cleanModelName(this.convertUsingFileNamingConvention(name) + modelFileSuffix);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -472,7 +472,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toModelFilename(String name) {
-        return this.cleanModelName(this.convertUsingFileNamingConvention(name) + modelFileSuffix);
+        return this.cleanModelFilename(this.convertUsingFileNamingConvention(name) + modelFileSuffix);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -472,7 +472,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toModelFilename(String name) {
-        return this.cleanModelFilename(this.convertUsingFileNamingConvention(name) + modelFileSuffix);
+        return this.sanitizeName(this.convertUsingFileNamingConvention(name) + modelFileSuffix);
     }
 
     @Override


### PR DESCRIPTION
Developed with @tropan

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (3.3.x), `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09)

### Description of the PR

Generics are given double left and right pointing quotation marks in the `JSON` declaration file:

```typescript
MyModel«Set«AnotherType»»
```

Although the API in (TypeScript) imports the models correctly:

```typescript
import { MyModel } from '../models/myModelSetAnotherType'
```

The filename itself still has the special punctuation marks:

```typescript
myModel«Set«AnotherType»».ts
```

This pull request simply removes the special characters from the filename before creation by cleaning the filename string accordingly.

```typescript
myModel«Set«AnotherType»».ts => myModelSetAnotherType.ts
```

Original Issue:
https://github.com/OpenAPITools/openapi-generator/issues/1137