### PR TITLE
Improve "allOf" support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4215,12 +4215,12 @@ public class DefaultCodegen implements CodegenConfig {
 
     protected String getParentName(ComposedSchema composedSchema, Map<String, Schema> allSchemas) {
         if (composedSchema.getAllOf() != null && !composedSchema.getAllOf().isEmpty()) {
-            Schema schema = composedSchema.getAllOf().get(0);
-            String ref = schema.get$ref();
-            if (StringUtils.isBlank(ref)) {
-                return null;
+            for (Schema schema : composedSchema.getAllOf()) {
+                String ref = schema.get$ref();
+                if (!StringUtils.isBlank(ref)) {
+                    return ModelUtils.getSimpleRef(ref);
+                }
             }
-            return ModelUtils.getSimpleRef(ref);
         }
         return null;
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -454,6 +454,16 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testParentName() {
+        final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/allOf.yaml", null, new ParseOptions()).getOpenAPI();
+        DefaultCodegen codegen = new DefaultCodegen();
+
+        Schema child = openAPI.getComponents().getSchemas().get("Child");
+        CodegenModel childModel = codegen.fromModel("Child", child, openAPI.getComponents().getSchemas());
+        Assert.assertEquals(childModel.parentSchema, "Person");
+    }
+
+    @Test
     public void testCallbacks() {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/callbacks.yaml", null, new ParseOptions()).getOpenAPI();
         final CodegenConfig codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/allOf.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf.yaml
@@ -53,9 +53,9 @@ components:
     Child:
       description: A representation of a child
       allOf:
-      - $ref: '#/components/schemas/Person'
       - type: object
         properties:
           age:
             type: integer
             format: int32
+      - $ref: '#/components/schemas/Person'


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR closes https://github.com/OpenAPITools/openapi-generator/issues/340

https://github.com/OpenAPITools/openapi-generator/issues/340#issuecomment-400013067
The parent is ignored if it is not at first position. This PR improves the issue by taking the first `$ref` we find in the allOf-List.