### PR TITLE
Fix for https://github.com/OpenAPITools/openapi-generator/issues/1164

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -74,6 +74,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         this.opts = opts;
         this.openAPI = opts.getOpenAPI();
         this.config = opts.getConfig();
+        //change for issue 1164 begins
+        adjustToBoolean("async");
+        //change for issue 1164 ends
         this.config.additionalProperties().putAll(opts.getOpts().getProperties());
 
         String ignoreFileLocation = this.config.getIgnoreFilePathOverride();
@@ -1106,4 +1109,41 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         }
         return authMethods;
     }
+    
+  //new method related to issue 1164
+    public void adjustToBoolean(String propertyName)
+    {
+    	Object object = this.config.additionalProperties().get(propertyName);
+    	Boolean val=Boolean.FALSE;
+    	if(object!=null)
+    	{
+    		if(object instanceof String)
+    		{
+    			String string=(String) object;
+    			if(string.equalsIgnoreCase("true"))
+    			{
+    				val=true;
+    			}
+    			else
+    			{
+    				val=Boolean.FALSE;
+    			}
+    		}
+    		else if(object instanceof Boolean)
+    		{
+    			val=(Boolean) object;
+    		}
+    		else
+    		{
+    			val=Boolean.TRUE;
+    		}
+    	}
+    	else
+    	{
+    		val=Boolean.FALSE;
+    	}
+    	this.config.additionalProperties().put(propertyName, val);
+    	
+    }
+
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1109,41 +1109,27 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         }
         return authMethods;
     }
-    
-  //new method related to issue 1164
-    public void adjustToBoolean(String propertyName)
-    {
-    	Object object = this.config.additionalProperties().get(propertyName);
-    	Boolean val=Boolean.FALSE;
-    	if(object!=null)
-    	{
-    		if(object instanceof String)
-    		{
-    			String string=(String) object;
-    			if(string.equalsIgnoreCase("true"))
-    			{
-    				val=true;
-    			}
-    			else
-    			{
-    				val=Boolean.FALSE;
-    			}
-    		}
-    		else if(object instanceof Boolean)
-    		{
-    			val=(Boolean) object;
-    		}
-    		else
-    		{
-    			val=Boolean.TRUE;
-    		}
-    	}
-    	else
-    	{
-    		val=Boolean.FALSE;
-    	}
-    	this.config.additionalProperties().put(propertyName, val);
-    	
-    }
+ // new method related to issue 1164
+    public void adjustToBoolean(String propertyName) {
+        Object object = this.config.additionalProperties().get(propertyName);
+        Boolean val = Boolean.FALSE;
+        if (object != null) {
+            if (object instanceof String) {
+                String string = (String) object;
+                if (string.equalsIgnoreCase("true")) {
+                    val = true;
+                } else {
+                    val = Boolean.FALSE;
+                }
+            } else if (object instanceof Boolean) {
+                val = (Boolean) object;
+            } else {
+                val = Boolean.TRUE;
+            }
+        } else {
+            val = Boolean.FALSE;
+        }
+        this.config.additionalProperties().put(propertyName, val);
 
+    }
 }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/openapi2SpringBoot.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/openapi2SpringBoot.mustache
@@ -49,16 +49,16 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
 
     }
 
-    @Bean
+   /* @Bean
     public Web{{^reactive}}Mvc{{/reactive}}{{#reactive}}Flux{{/reactive}}Configurer webConfigurer() {
         return new Web{{^reactive}}Mvc{{/reactive}}{{#reactive}}Flux{{/reactive}}Configurer{{^java8}}Adapter{{/java8}}() {
-            /*@Override
+            @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
                         .allowedOrigins("*")
                         .allowedMethods("*")
                         .allowedHeaders("Content-Type");
-            }*/
+            }
 {{^useSpringfox}}
 
             @Override
@@ -68,5 +68,5 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
 {{/useSpringfox}}
         };
     }
-
+*/
 }


### PR DESCRIPTION
Hi,
 I am using the openapi-generator-maven-plugin with these versions: 3.3.1-SNAPSHOT (thats master ).
I came across this bug.  Please see code snippet below of the pom.xml alongwith my suggestions for the fix.. 

I have also noted another smaller issue unrelated to this.
Thanks.
R
Please note value of asynch: <async>false</async>.


     
                <plugin>
                              <groupId>org.openapitools</groupId>
				<artifactId>openapi-generator-maven-plugin</artifactId>
				<version>${openapi.codegen.version}</version>
				<executions>
					<execution>
						<id>common</id>
						<goals>
							<goal>generate</goal>
						</goals>
						<configuration>
                                                  <inputSpec>${project.basedir}/src/main/resources/api.yaml</inputSpec>
							<modelPackage>com.example.api.models</modelPackage>
							<apiPackage>com.example.api</apiPackage>
							<output>${project.basedir}</output>					
							<language>spring</language>
							<invokerPackage>com.example.api</invokerPackage>
							<basePackage>com.example.api</basePackage>
							<withXml>true</withXml>
							<configOptions>
							
								<artifactId>foo</artifactId>
								<artifactDescription>Test API</artifactDescription>
								<title>Test API</title>
								<artifactUrl>https://api.example.com</artifactUrl>
								<groupId>com.example.api</groupId>
								<artifactVersion>1</artifactVersion>								
								<sourceFolder>src/gen/java/main</sourceFolder>
								<serializableModel>true</serializableModel>
								<dateLibrary>java8</dateLibrary>
								<java8>true</java8>
								<async>false</async>
								<library>spring-boot</library>		
								<delegatePattern>true</delegatePattern>
								<useBeanValidation>true</useBeanValidation>
								<useOptional>true</useOptional>	
								<hideGenerationTimestamp>true</hideGenerationTimestamp>								
							</configOptions>							
						</configuration>
					</execution>
				</executions>
			</plugin>
`


For the above configuration in openapi-generator\modules\openapi-generator\src\main\resources\JavaSpring\methodBody.mustache  an expression of 
{{#async}}CompletableFuture.completedFuture({{/async}} should resolve to empty. Unfortunately : In openapi-generator\modules\openapi-generator\src\main\java\org\openapitools\codegen\DefaultGenerator.java the value of async in this.config.additionalProperties() is a string and not a boolean. 

This causes wrong code generation.

I can think of a few solutions of which to my mind the most effective one is this:
In openapi-generator\modules\openapi-generator\src\main\java\org\openapitools\codegen\DefaultGenerator.java in method  public Generator opts(ClientOptInput opts) right after this line 
 "this.config = opts.getConfig();"
invoke 
'adjustToBoolean("async");'

 
//new method

`
public void adjustToBoolean(String propertyName)
    {
    	Object object = this.config.additionalProperties().get(propertyName);
    	Boolean val=Boolean.FALSE;
    	if(object!=null)
    	{
    		if(object instanceof String)
    		{
    			String string=(String) object;
    			if(string.equalsIgnoreCase("true"))
    			{
    				val=true;
    			}
    			else
    			{
    				val=Boolean.FALSE;
    			}
    		}
    		else if(object instanceof Boolean)
    		{
    			val=(Boolean) object;
    		}
    		else
    		{
    			val=Boolean.TRUE;
    		}
    	}
    	else
    	{
    		val=Boolean.FALSE;
    	}
    	this.config.additionalProperties().put(propertyName, val);
    	
    } 
`
**Note:** In addition to the above problem and unrelated to this there is a generated code in the generated OpenAPI2SpringBoot.java



  @Bean
    public WebMvcConfigurer webConfigurer() {
        return new WebMvcConfigurer() {
            /* @Override
            public void addCorsMappings(CorsRegistry registry) {
                registry.addMapping("/**")
                        .allowedOrigins("*")
                        .allowedMethods("*")
                        .allowedHeaders("Content-Type");
            } */
        };
    }


This code is not fully implemented and seems mostly commented.
Maven based compilation causes compilation error here.
This can be fixed by changing in openapi-generator\modules\openapi-generator\src\main\resources\JavaSpring\libraries\spring-boot\openapi2SpringBoot.mustache
the following lines:


   @Bean
    public Web{{^reactive}}Mvc{{/reactive}}{{#reactive}}Flux{{/reactive}}Configurer webConfigurer() {
        return new Web{{^reactive}}Mvc{{/reactive}} 
                 {{#reactive}}Flux{{/reactive}}Configurer{{^java8}}Adapter{{/java8}}() {
            /*  @Override
            public void addCorsMappings(CorsRegistry registry) {
                registry.addMapping("/**")
                        .allowedOrigins("*")
                        .allowedMethods("*")
                        .allowedHeaders("Content-Type");
            }  */
         {{^useSpringfox}}

            @Override
            public void addResourceHandlers(ResourceHandlerRegistry registry) {
                registry.addResourceHandler("/swagger-ui/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.14.2/");
            }
          {{/useSpringfox}}
        };
    }

TO

   /* @Bean
    public Web{{^reactive}}Mvc{{/reactive}}{{#reactive}}Flux{{/reactive}}Configurer webConfigurer() {
        return new Web{{^reactive}}Mvc{{/reactive}}{{#reactive}}Flux{{/reactive}}Configurer{{^java8}}Adapter{{/java8}}() {
            @Override
            public void addCorsMappings(CorsRegistry registry) {
                registry.addMapping("/**")
                        .allowedOrigins("*")
                        .allowedMethods("*")
                        .allowedHeaders("Content-Type");
            }
{{^useSpringfox}}

            @Override
            public void addResourceHandlers(ResourceHandlerRegistry registry) {
                registry.addResourceHandler("/swagger-ui/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.14.2/");
            }
{{/useSpringfox}}
        };
    }
*/




