### PR TITLE
Re-enabling typescript node test - Take 2

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
@@ -20,7 +20,8 @@
         "rewire": "^3.0.2"
     },
     "devDependencies": {
-        "typescript": "^2.4.2"
+        "typescript": "^2.4.2",
+        "@types/node": "8.10.34"
     }{{#npmRepository}},
     "publishConfig": {
         "registry": "{{npmRepository}}"

--- a/pom.xml
+++ b/pom.xml
@@ -1041,8 +1041,7 @@
                 <module>samples/client/petstore/typescript-fetch/builds/with-npm-version</module>
                 <module>samples/client/petstore/typescript-fetch/tests/default</module>
                 <module>samples/client/petstore/typescript-axios/tests/default</module>
-                <!-- comment out due to newer version of TS installed
-                <module>samples/client/petstore/typescript-node/npm</module>-->
+                <module>samples/client/petstore/typescript-node/npm</module>
                 <!-- comment out due to github rate limit error
                 <module>samples/client/petstore/typescript-angularjs</module>-->
                 <!-- comment out due to error `npm run build`

--- a/samples/client/petstore/typescript-node/npm/package.json
+++ b/samples/client/petstore/typescript-node/npm/package.json
@@ -20,7 +20,8 @@
         "rewire": "^3.0.2"
     },
     "devDependencies": {
-        "typescript": "^2.4.2"
+        "typescript": "^2.4.2",
+        "@types/node": "8.10.34"
     },
     "publishConfig": {
         "registry": "https://skimdb.npmjs.com/registry"


### PR DESCRIPTION
Explicitly adding node.js 8 type definitions before ClientResponse interface was removed due to deprecation.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As requested in: #1138 trying to fix issue with typescript compiler for typescript-node test.
This seems to be a result of a change in the https://github.com/DefinitelyTyped/DefinitelyTyped repo.
They have deprecated the ClientResponse interface in node 10.
To resolve (at least until the generator uses the new IncomingMessage interface), I've specifically used the type definitions for node 8 in the relevant package.mustache file.
I've ran the sample, installed node_modules and then confirmed that I can run tsc and see the compiled JavaScript.

Regards,
Omer.
