### PR TITLE
[Spring] Fix character conversion error

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
@@ -16,8 +16,10 @@ public class ApiUtil {
 {{^reactive}}
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/ApiUtil.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
-            req.getNativeResponse(HttpServletResponse.class).addHeader("Content-Type", contentType);
-            req.getNativeResponse(HttpServletResponse.class).getOutputStream().print(example);
+            HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
+            res.setCharacterEncoding("UTF-8");
+            res.addHeader("Content-Type", contentType);
+            res.getWriter().print(example);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

In order to run a Spring stub server which returns **multibyte** example value, we need set character encoding.

This PR fixes the error below:

```
2018-10-08 20:42:09.842 ERROR 10859 --- [nio-8080-exec-1] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.RuntimeException: java.io.CharConversionException: Not an ISO 8859-1 character: [こ]] with root cause
```

