### PR TITLE
Better context errors

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -19,7 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
-swagger = "1.0.1"
+swagger = { git = "https://github.com/tca-ms/swagger-rs.git", branch = "improve_context_debugging"}
 
 # Not required by example server.
 #

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -19,7 +19,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
-swagger = { git = "https://github.com/tca-ms/swagger-rs.git", branch = "improve_context_debugging"}
+swagger = "2"
 
 # Not required by example server.
 #

--- a/modules/openapi-generator/src/main/resources/rust-server/example-client.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-client.mustache
@@ -64,7 +64,7 @@ fn main() {
     };
 
     let context: make_context_ty!(ContextBuilder, EmptyContext, Option<AuthData>, XSpanIdString) =
-        make_context!(ContextBuilder, EmptyContext, None, XSpanIdString(self::uuid::Uuid::new_v4().to_string()));
+        make_context!(ContextBuilder, EmptyContext, None as Option<AuthData>, XSpanIdString(self::uuid::Uuid::new_v4().to_string()));
     let client = client.with_context(context);
 
     match matches.value_of("operation") {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
-swagger = { git = "https://github.com/tca-ms/swagger-rs.git", branch = "improve_context_debugging"}
+swagger = "2"
 
 # Not required by example server.
 #

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
-swagger = "1.0.1"
+swagger = { git = "https://github.com/tca-ms/swagger-rs.git", branch = "improve_context_debugging"}
 
 # Not required by example server.
 #

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client.rs
@@ -116,7 +116,7 @@ fn main() {
     };
 
     let context: make_context_ty!(ContextBuilder, EmptyContext, Option<AuthData>, XSpanIdString) =
-        make_context!(ContextBuilder, EmptyContext, None, XSpanIdString(self::uuid::Uuid::new_v4().to_string()));
+        make_context!(ContextBuilder, EmptyContext, None as Option<AuthData>, XSpanIdString(self::uuid::Uuid::new_v4().to_string()));
     let client = client.with_context(context);
 
     match matches.value_of("operation") {

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
-swagger = { git = "https://github.com/tca-ms/swagger-rs.git", branch = "improve_context_debugging"}
+swagger = "2"
 
 # Not required by example server.
 #

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.1"
 hyper = {version = "0.11", optional = true}
 hyper-tls = {version = "0.1.2", optional = true}
-swagger = "1.0.1"
+swagger = { git = "https://github.com/tca-ms/swagger-rs.git", branch = "improve_context_debugging"}
 
 # Not required by example server.
 #

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
@@ -64,7 +64,7 @@ fn main() {
     };
 
     let context: make_context_ty!(ContextBuilder, EmptyContext, Option<AuthData>, XSpanIdString) =
-        make_context!(ContextBuilder, EmptyContext, None, XSpanIdString(self::uuid::Uuid::new_v4().to_string()));
+        make_context!(ContextBuilder, EmptyContext, None as Option<AuthData>, XSpanIdString(self::uuid::Uuid::new_v4().to_string()));
     let client = client.with_context(context);
 
     match matches.value_of("operation") {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol, @farcaller, already reviewed by @bjgill 

### Description of the PR

Update to version 2 of the `swagger` crate, which contains changes intended to make it easier to debug errors involving middleware and contexts. Crates making use of the autogenerated libraries to also update their swagger dependency to version 2. See [here](https://github.com/Metaswitch/swagger-rs/blob/2.0.0/CHANGELOG.md) for details.

