### PR TITLE
Rename JS environment variable for post-processing files

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -232,8 +232,8 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         }
         super.processOpts();
 
-        if (StringUtils.isEmpty(System.getenv("JS_BEAUTIFY_PATH"))) {
-            LOGGER.info("Environment variable JS_BEAUTIFY_PATH not defined so the JS code may not be properly formatted. To define it, try 'export JS_BEAUTIFY_PATH=/usr/local/bin/js-beautify' (Linux/Mac)");
+        if (StringUtils.isEmpty(System.getenv("JS_POST_PROCESS_FILE"))) {
+            LOGGER.info("Environment variable JS_POST_PROCESS_FILE not defined so the JS code may not be properly formatted. To define it, try 'export JS_POST_PROCESS_FILE=\"/usr/local/bin/js-beautify -r -f\"' (Linux/Mac)");
         }
 
         if (additionalProperties.containsKey(PROJECT_NAME)) {
@@ -1167,19 +1167,20 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
             return;
         }
 
-        String jsBeautifyPath = System.getenv("JS_BEAUTIFY_PATH");
-        if (StringUtils.isEmpty(jsBeautifyPath)) {
-            return; // skip if JS_BEAUTIFY_PATH env variable is not defined
+        String jsPostProcessFile = System.getenv("JS_POST_PROCESS_FILE");
+        if (StringUtils.isEmpty(jsPostProcessFile)) {
+            return; // skip if JS_POST_PROCESS_FILE env variable is not defined
         }
 
         // only process files with js extension
         if ("js".equals(FilenameUtils.getExtension(file.toString()))) {
-            String command = jsBeautifyPath + " -r -f " + file.toString();
+            String command = jsPostProcessFile + " " + file.toString();
             try {
                 Process p = Runtime.getRuntime().exec(command);
                 p.waitFor();
-                if (p.exitValue() != 0) {
-                    LOGGER.error("Error running the command ({}). Exit code: {}", command, p.exitValue());
+                int exitValue = p.exitValue();
+                if (exitValue != 0) {
+                    LOGGER.error("Error running the command ({}). Exit code: {}", command, exitValue);
                 }
                 LOGGER.info("Successfully executed: " + command);
             } catch (Exception e) {
@@ -1187,5 +1188,4 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
             }
         }
     }
-
 }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Rename JS environment variables to JS_POST_PROCESS_FILE

e.g. `export JS_POST_PROCESS_FILE="/usr/local/bin/js-beautify -r -f"`
