### PR TITLE
[C] changed base url from static to dynamic

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -10,7 +10,7 @@ size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp);
 apiClient_t *apiClient_create() {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
-    apiClient->basePath = "http://petstore.swagger.io:80/v2";
+    apiClient->basePath = "{{{basePath}}}";
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     #ifdef BASIC_AUTH

--- a/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/list.c.mustache
@@ -4,7 +4,6 @@
 
 #include "cJSON.h"
 #include "list.h"
-#include "tag.h"
 
 static listEntry_t *listEntry_create(void *data) {
     listEntry_t *createdListEntry = malloc(sizeof(listEntry_t));

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -10,7 +10,7 @@ size_t writeDataCallback(void *buffer, size_t size, size_t nmemb, void *userp);
 apiClient_t *apiClient_create() {
 	curl_global_init(CURL_GLOBAL_ALL);
 	apiClient_t *apiClient = malloc(sizeof(apiClient_t));
-	apiClient->basePath = "http://petstore.swagger.io:80/v2";
+	apiClient->basePath = "http://petstore.swagger.io/v2";
 	apiClient->dataReceived = NULL;
 	apiClient->response_code = 0;
     #ifdef BASIC_AUTH

--- a/samples/client/petstore/c/src/list.c
+++ b/samples/client/petstore/c/src/list.c
@@ -4,7 +4,6 @@
 
 #include "cJSON.h"
 #include "list.h"
-#include "tag.h"
 
 static listEntry_t *listEntry_create(void *data) {
 	listEntry_t *createdListEntry = malloc(sizeof(listEntry_t));


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- change base url from static petstore to dynamic according to specs
- removed unnecessary header from list.c

