### PR TITLE
Consider callbacks in unused schemas

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -19,7 +19,11 @@ package org.openapitools.codegen.utils;
 
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -40,7 +44,7 @@ public class ModelUtilsTest {
     public void testGetAllUsedSchemas() {
         final OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/unusedSchemas.yaml", null, new ParseOptions()).getOpenAPI();
         List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
-        Assert.assertEquals(allUsedSchemas.size(), 28);
+        Assert.assertEquals(allUsedSchemas.size(), 30);
 
         Assert.assertTrue(allUsedSchemas.contains("SomeObjShared"), "contains 'SomeObjShared'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj1"), "contains 'UnusedObj1'");
@@ -70,6 +74,8 @@ public class ModelUtilsTest {
         Assert.assertTrue(allUsedSchemas.contains("Obj19ByType"), "contains 'Obj19ByType'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj20"), "contains 'SomeObj20'");
         Assert.assertTrue(allUsedSchemas.contains("OtherObj20"), "contains 'OtherObj20'");
+        Assert.assertTrue(allUsedSchemas.contains("PingDataInput21"), "contains 'PingDataInput21'");
+        Assert.assertTrue(allUsedSchemas.contains("PingDataOutput21"), "contains 'PingDataOutput21'");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
@@ -233,6 +233,36 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/SomeObj20'
+  /some/p21:
+    post:
+      operationId: op21
+      parameters:
+        - name: callbackUrl
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uri
+            example: https://some-server.com
+      responses:
+        '201':
+          description: OK
+      callbacks:
+        onPing:
+          '{$request.query.callbackUrl}/ping':
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/PingDataInput21'
+              responses:
+                '200':
+                  description: Ok
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/PingDataOutput21'
 components:
   schemas:
     UnusedObj1:
@@ -463,6 +493,20 @@ components:
     OtherObj20:
       type: string
       enum: [A, B, C]
+    PingDataInput21:
+      type: object
+      properties:
+        id:
+          type: integer
+        data:
+          type: String
+    PingDataOutput21:
+      type: object
+      properties:
+        id:
+          type: integer
+        reply:
+          type: String
     SomeObjShared:
       type: object
       properties:
@@ -516,3 +560,4 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/SomeObj11'
+  


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the technical committee: @OpenAPITools/generator-core-team (change to the core)

### Description of the PR

Callbacks can reference Schemas. The `ModelUtils` methods that compute used and unused schemas should visit the callbacks.

Callbacks effort in general is tracked as #372.