### PR TITLE
[cpp-restsdk]Add ref support inside fromProperty

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-header.mustache
@@ -13,6 +13,7 @@
 
 {{#imports}}{{{import}}}
 {{/imports}}
+{{^hasModelImport}}#include "../ModelBase.h"{{/hasModelImport}}
 
 #include <boost/optional.hpp>
 

--- a/samples/client/petstore/cpp-restsdk/api/PetApi.h
+++ b/samples/client/petstore/cpp-restsdk/api/PetApi.h
@@ -26,6 +26,7 @@
 #include "Pet.h"
 #include <cpprest/details/basic_types.h>
 
+
 #include <boost/optional.hpp>
 
 namespace org {

--- a/samples/client/petstore/cpp-restsdk/api/StoreApi.h
+++ b/samples/client/petstore/cpp-restsdk/api/StoreApi.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <cpprest/details/basic_types.h>
 
+
 #include <boost/optional.hpp>
 
 namespace org {

--- a/samples/client/petstore/cpp-restsdk/api/UserApi.h
+++ b/samples/client/petstore/cpp-restsdk/api/UserApi.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cpprest/details/basic_types.h>
 
+
 #include <boost/optional.hpp>
 
 namespace org {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Add ref support inside `fromProperty` to enable vendor extension flags for ref property in responses
- Add include of `ModelBase.h` when no models are generated.
Fixes #1163 
Fixes #1174 
@stkrwork @MartinDelille @ravinikam @fvarose 