### PR TITLE
[cli] config-help writes doc-compat output

### DIFF
--- a/bin/utils/export_docs_generators.sh
+++ b/bin/utils/export_docs_generators.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 SCRIPT="$0"
-echo "# START SCRIPT: $SCRIPT"
+echo "# START SCRIPT: ${SCRIPT}"
 
 executable="./modules/openapi-generator-cli/target/openapi-generator-cli.jar"
 
-for GENERATOR in $(java -jar $executable list --short | sed -e 's/,/\'$'\n''/g')
+for GENERATOR in $(java -jar ${executable} list --short | sed -e 's/,/\'$'\n''/g')
 do
-    ./bin/utils/export_generator.sh $GENERATOR
+    ./bin/utils/export_generator.sh ${GENERATOR}
 done

--- a/bin/utils/export_generator.sh
+++ b/bin/utils/export_generator.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
 SCRIPT="$0"
-echo "# START SCRIPT: $SCRIPT"
 
 if [[ "$1" != "" ]]; then
     NAME="$1"
+    echo "# START SCRIPT: ${SCRIPT} ${NAME}"
 else
-    echo "Missing argument. Usage e.g.: ./bin/utils/export-generator.sh jaxrs-jersey"
+    echo "Missing argument to ${SCRIPT}."
+    echo "    Usage: ${SCRIPT} generator-name"
+    echo "    Example: ${SCRIPT} groovy"
     exit 1;
 fi
 
 executable="./modules/openapi-generator-cli/target/openapi-generator-cli.jar"
 
-java -jar $executable config-help -g $NAME | sed -e 's/CONFIG OPTIONS/CONFIG OPTIONS for '$NAME'\'$'\n''/g' > docs/generators/$NAME.md
+java -jar ${executable} config-help -g ${NAME} --named-header -o docs/generators/${NAME}.md
 
-echo "Back to the [generators list](README.md)" >> docs/generators/$NAME.md
+echo "Back to the [generators list](README.md)" >> docs/generators/${NAME}.md


### PR DESCRIPTION
This updates config-help to have more control over how the output is
written for the user. We dump config-help output for per-generator
documentation, and this cleans up some cross-platform compatibility
issues that might arise from tweaking the output for clarity in the
target file.

Previously, we'd pipe config-help output to sed, then insert the
generator name, which we then redirected to an output file. The sed
syntax had to include a trailing newline so our tabbed configs would
automatically become code tags in markdown. Inserting newlines into sed
replacement strings doesn't work the same across platforms, mostly
because of Apple's customizations to GNU programs.

This commit moves the generator name and newline insertion into the
command itself. It also includes a new --output option, allowing the
user to specify the output location of the config-help.

Currently, we only dump in plain-text, and it is only coincidental that
our plaintext output results in a desirable Markdown output. If
tabbed lines did not automatically convert to a code style block, some
generators like C# would end up with broken text (`List<T>` would become
just `List`, for example).

I had previously discussed extending config-help to output to other
formats like asciidoc. This commit does not introduce any steps toward
that end.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

