### PR TITLE
[General][CI] fix gradle build error on java9+

### DIFF
--- a/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        <gradleVersion>4.10.2</gradleVersion>
     </properties>
 
     <dependencies>
@@ -54,7 +55,7 @@
                 <artifactId>gradle-maven-plugin</artifactId>
                 <version>1.0.8</version>
                 <configuration>
-                    <gradleVersion>4.10.2</gradleVersion>
+                    <gradleVersion>${gradleVersion}</gradleVersion>
                     <args>
                         <arg>-P openApiGeneratorVersion=${project.version}</arg>
                     </args>
@@ -76,6 +77,13 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.gradle</groupId>
+                        <artifactId>gradle-tooling-api</artifactId>
+                        <version>${gradleVersion}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This patch fixes shippable CI failures due to `[ERROR] Failed to execute goal org.fortasoft:gradle-maven-plugin:1.0.8:invoke (default) on project openapi-generator-gradle-plugin-mvn-wrapper: Execution default of goal org.fortasoft:gradle-maven-plugin:1.0.8:invoke failed: Could not determine java version from '9.0.4'. -> [Help 1]`

The problem is that `org.fortasoft:gradle-maven-plugin` settings didn't suport java9+.

Thanks to https://github.com/LendingClub/gradle-maven-plugin/issues/39, I added settings to pom and it works on my environment (windows10, java10, and git bash).