### PR TITLE
Add an option to enable file post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 :notebook_with_decorative_cover: The eBook [A Beginner's Guide to Code Generation for REST APIs](https://gumroad.com/l/swagger_codegen_beginner) is a good starting point for beginners :notebook_with_decorative_cover:
 
-:warning: If the OpenAPI spec is obtained from an untrusted source, please make sure you've reviewed the spec before using OpenAPI Generator to generate the API client, server stub or documentation as [code injection](https://en.wikipedia.org/wiki/Code_injection) may occur :warning:
+:warning: If the OpenAPI spec, templates or any input (e.g. options, envirionment variables) is obtained from an untrusted source or environment, please make sure you've reviewed these inputs before using OpenAPI Generator to generate the API client, server stub or documentation to avoid potential security issues (e.g. [code injection](https://en.wikipedia.org/wiki/Code_injection)) :warning:
 
 :bangbang: Both "OpenAPI Tools" (https://OpenAPITools.org - the parent organization of OpenAPI Generator) and "OpenAPI Generator" are not affiliated with OpenAPI Initiative (OAI) :bangbang:
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -208,6 +208,9 @@ public class Generate implements Runnable {
                     + " Useful for piping the JSON output of debug options (e.g. `-DdebugOperations`) to an external parser directly while testing a generator.")
     private Boolean logToStderr;
 
+    @Option(name = {"--enable-post-process-file"}, title = "enable post-process file", description = CodegenConstants.ENABLE_POST_PROCESS_FILE)
+    private Boolean enablePostProcessFile;
+
     @Override
     public void run() {
         if (logToStderr != null) {
@@ -327,6 +330,10 @@ public class Generate implements Runnable {
 
         if (removeOperationIdPrefix != null) {
             configurator.setRemoveOperationIdPrefix(removeOperationIdPrefix);
+        }
+
+        if (enablePostProcessFile != null) {
+            configurator.setEnablePostProcessFile(enablePostProcessFile);
         }
 
         applySystemPropertiesKvpList(systemProperties, configurator);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -257,4 +257,8 @@ public interface CodegenConfig {
 
     void postProcessFile(File file, String fileType);
 
+    boolean isEnablePostProcessFile();
+
+    public void setEnablePostProcessFile(boolean isEnablePostProcessFile);
+
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -182,6 +182,7 @@ public class CodegenConstants {
     public static final String DOTNET_FRAMEWORK_DESC = "The target .NET framework version.";
 
     public static enum MODEL_PROPERTY_NAMING_TYPE {camelCase, PascalCase, snake_case, original}
+
     public static enum ENUM_PROPERTY_NAMING_TYPE {camelCase, PascalCase, snake_case, original, UPPERCASE}
 
     public static final String ENUM_PROPERTY_NAMING = "enumPropertyNaming";
@@ -267,10 +268,14 @@ public class CodegenConstants {
 
     public static final String PARENT_GROUP_ID = "parentGroupId";
     public static final String PARENT_GROUP_ID_DESC = "parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect";
-    
+
     public static final String PARENT_ARTIFACT_ID = "parentArtifactId";
     public static final String PARENT_ARTIFACT_ID_DESC = "parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect";
-    
+
     public static final String PARENT_VERSION = "parentVersion";
     public static final String PARENT_VERSION_DESC = "parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect";
+
+    public static final String ENABLE_POST_PROCESS_FILE = "enablePostProcessFile";
+    public static final String ENABLE_POST_PROCESS_FILE_DESC = "Enable post-processing file using environment variables.";
+
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -128,7 +128,7 @@ public class DefaultCodegen implements CodegenConfig {
     // They are translated to words like "Dollar" and prefixed with '
     // Then translated back during JSON encoding and decoding
     protected Map<String, String> specialCharReplacements = new HashMap<String, String>();
-    // When a model is an alias for a simple typegetIgnoreFilePathOverride
+    // When a model is an alias for a simple type
     protected Map<String, String> typeAliases = null;
     protected Boolean prependFormOrBodyParameters = false;
     // The extension of the generated documentation files (defaults to markdown .md)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -128,13 +128,15 @@ public class DefaultCodegen implements CodegenConfig {
     // They are translated to words like "Dollar" and prefixed with '
     // Then translated back during JSON encoding and decoding
     protected Map<String, String> specialCharReplacements = new HashMap<String, String>();
-    // When a model is an alias for a simple type
+    // When a model is an alias for a simple typegetIgnoreFilePathOverride
     protected Map<String, String> typeAliases = null;
     protected Boolean prependFormOrBodyParameters = false;
     // The extension of the generated documentation files (defaults to markdown .md)
     protected String docExtension;
-
     protected String ignoreFilePathOverride;
+    // flag to indicate whether to use environment variable to post process file
+    protected boolean enablePostProcessFile = false;
+
 
     public List<CliOption> cliOptions() {
         return cliOptions;
@@ -195,6 +197,11 @@ public class DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.DOCEXTENSION)) {
             this.setDocExtension(String.valueOf(additionalProperties
                     .get(CodegenConstants.DOCEXTENSION).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.ENABLE_POST_PROCESS_FILE)) {
+            this.setEnablePostProcessFile(Boolean.valueOf(additionalProperties
+                    .get(CodegenConstants.ENABLE_POST_PROCESS_FILE).toString()));
         }
     }
 
@@ -4698,6 +4705,24 @@ public class DefaultCodegen implements CodegenConfig {
      */
     public void postProcessFile(File file, String fileType) {
         LOGGER.debug("Post processing file {} ({})", file, fileType);
-    } 
+    }
+
+    /**
+     * Boolean value indicating the state of the option for post-processing file using envirionment variables.
+     *
+     * @return true if the option is enabled
+     */
+    public boolean isEnablePostProcessFile() {
+        return enablePostProcessFile;
+    }
+
+    /**
+     * Set the boolean value indicating the state of the option for post-processing file using envirionment variables.
+     *
+     * @param enablePostProcessFile     true to enable post-processing file
+     */
+    public void setEnablePostProcessFile(boolean enablePostProcessFile) {
+        this.enablePostProcessFile = enablePostProcessFile;
+    }
 
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -273,7 +273,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             File written = processTemplateToFile(models, templateName, filename);
             if (written != null) {
                 files.add(written);
-                config.postProcessFile(written, "model-test");
+                if (config.isEnablePostProcessFile()) {
+                    config.postProcessFile(written, "model-test");
+                }
             }
         }
     }
@@ -290,7 +292,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             File written = processTemplateToFile(models, templateName, filename);
             if (written != null) {
                 files.add(written);
-                config.postProcessFile(written, "model-doc");
+                if (config.isEnablePostProcessFile()) {
+                    config.postProcessFile(written, "model-doc");
+                }
             }
         }
     }
@@ -306,7 +310,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             File written = processTemplateToFile(models, templateName, filename);
             if (written != null) {
                 files.add(written);
-                config.postProcessFile(written, "model");
+                if (config.isEnablePostProcessFile()) {
+                    config.postProcessFile(written, "model");
+                }
             }
         }
     }
@@ -552,7 +558,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     File written = processTemplateToFile(operation, templateName, filename);
                     if (written != null) {
                         files.add(written);
-                        config.postProcessFile(written, "api");
+                        if (config.isEnablePostProcessFile()) {
+                            config.postProcessFile(written, "api");
+                        }
                     }
                 }
 
@@ -569,7 +577,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         File written = processTemplateToFile(operation, templateName, filename);
                         if (written != null) {
                             files.add(written);
-                            config.postProcessFile(written, "api-test");
+                            if (config.isEnablePostProcessFile()) {
+                                config.postProcessFile(written, "api-test");
+                            }
                         }
                     }
                 }
@@ -587,7 +597,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         File written = processTemplateToFile(operation, templateName, filename);
                         if (written != null) {
                             files.add(written);
-                            config.postProcessFile(written, "api-doc");
+                            if (config.isEnablePostProcessFile()) {
+                                config.postProcessFile(written, "api-doc");
+                            }
                         }
                     }
                 }
@@ -660,7 +672,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         writeToFile(outputFilename, tmpl.execute(bundle));
                         File written = new File(outputFilename);
                         files.add(written);
-                        config.postProcessFile(written, "supporting-mustache");
+                        if (config.isEnablePostProcessFile()) {
+                            config.postProcessFile(written, "supporting-mustache");
+                        }
                     } else {
                         InputStream in = null;
 
@@ -674,7 +688,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         }
                         File outputFile = writeInputStreamToFile(outputFilename, in, templateFile);
                         files.add(outputFile);
-                        config.postProcessFile(outputFile, "supporting-common");
+                        if (config.isEnablePostProcessFile()) {
+                            config.postProcessFile(outputFile, "supporting-common");
+                        }
                     }
                 } else {
                     LOGGER.info("Skipped generation of " + outputFilename + " due to rule in .openapi-generator-ignore");
@@ -698,7 +714,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 throw new RuntimeException("Could not generate supporting file '" + openapiGeneratorIgnore + "'", e);
             }
             files.add(ignoreFile);
-            config.postProcessFile(ignoreFile, "openapi-generator-ignore");
+            if (config.isEnablePostProcessFile()) {
+                config.postProcessFile(ignoreFile, "openapi-generator-ignore");
+            }
         }
 
         if (generateMetadata) {
@@ -707,7 +725,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             try {
                 writeToFile(versionMetadata, ImplementationVersion.read());
                 files.add(versionMetadataFile);
-                config.postProcessFile(ignoreFile, "openapi-generator-version");
+                if (config.isEnablePostProcessFile()) {
+                    config.postProcessFile(ignoreFile, "openapi-generator-version");
+                }
             } catch (IOException e) {
                 throw new RuntimeException("Could not generate supporting file '" + versionMetadata + "'", e);
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -96,6 +96,7 @@ public class CodegenConfigurator implements Serializable {
     private boolean skipOverwrite;
     private boolean removeOperationIdPrefix;
     private boolean validateSpec;
+    private boolean enablePostProcessFile;
     private String templateDir;
     private String auth;
     private String apiPackage;
@@ -207,6 +208,15 @@ public class CodegenConfigurator implements Serializable {
 
     public CodegenConfigurator setRemoveOperationIdPrefix(boolean removeOperationIdPrefix) {
         this.removeOperationIdPrefix = removeOperationIdPrefix;
+        return this;
+    }
+
+    public boolean getEnablePostProcessFile() {
+        return enablePostProcessFile;
+    }
+
+    public CodegenConfigurator setEnablePostProcessFile(boolean enablePostProcessFile) {
+        this.enablePostProcessFile = enablePostProcessFile;
         return this;
     }
 
@@ -503,6 +513,7 @@ public class CodegenConfigurator implements Serializable {
         config.setSkipOverwrite(skipOverwrite);
         config.setIgnoreFilePathOverride(ignoreFileOverride);
         config.setRemoveOperationIdPrefix(removeOperationIdPrefix);
+        config.setEnablePostProcessFile(enablePostProcessFile);
 
         config.instantiationTypes().putAll(instantiationTypes);
         config.typeMapping().putAll(typeMappings);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add an option `enablePostProcessFile` (--enable-post-process-file) (default o false) to allow users enabling file post-processing in environment variables.

Also update wiki about potential security risks

cc @OpenAPITools/generator-core-team 
