### PR TITLE
Enable error handling in Java WebClient library, fixes #1243

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -453,6 +453,23 @@ public class ApiClient {
     }
 
     /**
+     * Handles an unsuccessful server response.
+     * This method is called when the server returns a HTTP status code != 2xx.
+     *
+     * The default behaviour is to wrap the unsuccessful response in an {@code ApiException}
+     * and terminate the reactive stream with the exception.
+     *
+     * Can be overwritten to implement custom error handling.
+     *
+     * @param response the unsuccessful HTTP response
+     * @param <T>
+     * @return reactive stream in error state
+     */
+    protected <T> Mono<T> handleUnsuccessfulResponse(ClientResponse response) {
+        return Mono.error(new ApiException(response.statusCode().toString(), null, response.statusCode().value(), response.headers().asHttpHeaders()));
+    }
+
+    /**
      * Invoke API by sending HTTP request with the given options.
      *
      * @param <T> the return type to use
@@ -483,7 +500,7 @@ public class ApiClient {
                         return response.bodyToMono(returnType);
                     }
                 } else {
-                    return Mono.error(new RestClientException("API returned " + statusCode + " and it wasn't handled by the RestTemplate error handler"));
+                    return handleUnsuccessfulResponse(response);
                 }
         });
     }
@@ -520,7 +537,7 @@ public class ApiClient {
                         return response.bodyToFlux(returnType);
                     }
                 } else {
-                    return Flux.error(new RestClientException("API returned " + statusCode + " and it wasn't handled by the RestTemplate error handler"));
+                    return handleUnsuccessfulResponse(response);
                 }
             });
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -453,23 +453,6 @@ public class ApiClient {
     }
 
     /**
-     * Handles an unsuccessful server response.
-     * This method is called when the server returns a HTTP status code != 2xx.
-     *
-     * The default behaviour is to wrap the unsuccessful response in an {@code ApiException}
-     * and terminate the reactive stream with the exception.
-     *
-     * Can be overwritten to implement custom error handling.
-     *
-     * @param response the unsuccessful HTTP response
-     * @param <T>
-     * @return reactive stream in error state
-     */
-    protected <T> Mono<T> handleUnsuccessfulResponse(ClientResponse response) {
-        return Mono.error(new ApiException(response.statusCode().toString(), null, response.statusCode().value(), response.headers().asHttpHeaders()));
-    }
-
-    /**
      * Invoke API by sending HTTP request with the given options.
      *
      * @param <T> the return type to use
@@ -487,22 +470,7 @@ public class ApiClient {
      */
     public <T> Mono<T> invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
         final WebClient.RequestBodySpec requestBuilder = prepareRequest(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames);
-
-        return requestBuilder.exchange()
-            .flatMap(response -> {
-                HttpStatus statusCode = response.statusCode();
-                if (response.statusCode() == HttpStatus.NO_CONTENT) {
-                    return Mono.empty();
-                } else if (statusCode.is2xxSuccessful()) {
-                    if (returnType == null) {
-                        return Mono.empty();
-                    } else {
-                        return response.bodyToMono(returnType);
-                    }
-                } else {
-                    return handleUnsuccessfulResponse(response);
-                }
-        });
+        return requestBuilder.retrieve().bodyToMono(returnType);
     }
 
     /**
@@ -523,23 +491,7 @@ public class ApiClient {
      */
     public <T> Flux<T> invokeFluxAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
         final WebClient.RequestBodySpec requestBuilder = prepareRequest(path, method, queryParams, body, headerParams, formParams, accept, contentType, authNames);
-
-        return requestBuilder.exchange()
-            .flatMapMany(response -> {
-                HttpStatus statusCode = response.statusCode();
-                ClientResponse.Headers headers = response.headers();
-                if (response.statusCode() == HttpStatus.NO_CONTENT) {
-                    return Flux.empty();
-                } else if (statusCode.is2xxSuccessful()) {
-                    if (returnType == null) {
-                        return Flux.empty();
-                    } else {
-                        return response.bodyToFlux(returnType);
-                    }
-                } else {
-                    return handleUnsuccessfulResponse(response);
-                }
-            });
+        return requestBuilder.retrieve().bodyToFlux(returnType);
     }
 
     private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Enable error handling in Java WebClient library, fixes #1243.
Also now the generated Exception class `ApiException` is used.

Custom error handling behaviour can be defined in an overwriting class e.g.:

```java
public class MyApiClient extends ApiClient {
  @Override
  protected <T> Mono<T> handleUnsuccessfulResponse(ClientResponse response) {
    return super.<T>handleUnsuccessfulResponse(response)
      .onErrorMap(errorcode(404), x -> new MyNotFoundException("Not found"));
  }

  private static Predicate<Throwable> errorcode(int errorCode) {
    return x -> x instanceof ApiException && ((ApiException) x).getCode() == errorCode;
  }
}
```

@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger