### PR TITLE
Fix openapi_types generation error

### DIFF
--- a/modules/openapi-generator/src/main/resources/flaskConnexion/model.mustache
+++ b/modules/openapi-generator/src/main/resources/flaskConnexion/model.mustache
@@ -35,7 +35,7 @@ class {{classname}}(Model):
         """
         self.openapi_types = {
 {{#vars}}
-            '{{name}}': '{{{dataType}}}'{{#hasMore}},{{/hasMore}}
+            '{{name}}': {{{dataType}}}{{#hasMore}},{{/hasMore}}
 {{/vars}}
         }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The generate model attribute `openapi_types` should be a dict map to data type(`str`, `int`) or `typing` `List[str]`, not the string of them (`'str'`, `'int'` or `'List[str]'`)

Currently, generated codes are like those:
```python
        self.openapi_types = {
            'answer': 'str',
            'status': 'str'
        }
```

@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11)
--

