### PR TITLE
Set isModel property

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class CodegenParameter {
     public boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
             isCookieParam, isBodyParam, hasMore, isContainer,
-            secondaryParam, isCollectionFormatMulti, isPrimitiveType;
+            secondaryParam, isCollectionFormatMulti, isPrimitiveType, isModel;
     public String baseName, paramName, dataType, datatypeWithEnum, dataFormat,
           collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName;
 
@@ -110,6 +110,7 @@ public class CodegenParameter {
         output.collectionFormat = this.collectionFormat;
         output.isCollectionFormatMulti = this.isCollectionFormatMulti;
         output.isPrimitiveType = this.isPrimitiveType;
+        output.isModel = this.isModel;
         output.description = this.description;
         output.unescapedDescription = this.unescapedDescription;
         output.baseType = this.baseType;
@@ -200,6 +201,8 @@ public class CodegenParameter {
         if (isCollectionFormatMulti != that.isCollectionFormatMulti)
             return false;
         if (isPrimitiveType != that.isPrimitiveType)
+            return false;
+        if (isModel != that.isModel)
             return false;
         if (baseName != null ? !baseName.equals(that.baseName) : that.baseName != null)
             return false;
@@ -312,6 +315,7 @@ public class CodegenParameter {
         result = 31 * result + (secondaryParam ? 13:31);
         result = 31 * result + (isCollectionFormatMulti ? 13:31);
         result = 31 * result + (isPrimitiveType ? 13:31);
+        result = 31 * result + (isModel ? 13:31);
         result = 31 * result + (baseName != null ? baseName.hashCode() : 0);
         result = 31 * result + (paramName != null ? paramName.hashCode() : 0);
         result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
@@ -378,6 +382,7 @@ public class CodegenParameter {
                 ", secondaryParam=" + secondaryParam +
                 ", isCollectionFormatMulti=" + isCollectionFormatMulti +
                 ", isPrimitiveType=" + isPrimitiveType +
+                ", isModel=" + isModel +
                 ", baseName='" + baseName + '\'' +
                 ", paramName='" + paramName + '\'' +
                 ", dataType='" + dataType + '\'' +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -55,7 +55,7 @@ public class CodegenProperty implements Cloneable {
     public boolean exclusiveMaximum;
     public boolean hasMore, required, secondaryParam;
     public boolean hasMoreNonReadOnly; // for model constructor, true if next property is not readonly
-    public boolean isPrimitiveType, isContainer, isNotContainer;
+    public boolean isPrimitiveType, isModel, isContainer, isNotContainer;
     public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile, isBoolean, isDate, isDateTime, isUuid;
     public boolean isListContainer, isMapContainer;
     public boolean isEnum;
@@ -438,6 +438,7 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + (isEnum ? 1231 : 1237);
         result = prime * result + ((isNotContainer ? 13:31));
         result = prime * result + ((isPrimitiveType  ? 13:31));
+        result = prime * result + ((isModel  ? 13:31));
         result = prime * result + ((isReadOnly  ? 13:31));
         result = prime * result + ((isWriteOnly  ? 13:31));
         result = prime * result + ((isNullable  ? 13:31));
@@ -577,6 +578,9 @@ public class CodegenProperty implements Cloneable {
             return false;
         }
         if (this.isPrimitiveType != other.isPrimitiveType) {
+            return false;
+        }
+        if (this.isModel != other.isModel) {
             return false;
         }
         if (this.isContainer != other.isContainer) {
@@ -759,6 +763,7 @@ public class CodegenProperty implements Cloneable {
                 ", secondaryParam=" + secondaryParam +
                 ", hasMoreNonReadOnly=" + hasMoreNonReadOnly +
                 ", isPrimitiveType=" + isPrimitiveType +
+                ", isModel=" + isModel +
                 ", isContainer=" + isContainer +
                 ", isNotContainer=" + isNotContainer +
                 ", isString=" + isString +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2008,7 +2008,7 @@ public class DefaultCodegen implements CodegenConfig {
             //    property.baseType = getSimpleRef(p.get$ref());
             //}
             // --END of revision
-			setNonArrayMapProperty(property, type);
+            setNonArrayMapProperty(property, type);
         }
 
         LOGGER.debug("debugging from property return: " + property);
@@ -2170,7 +2170,7 @@ public class DefaultCodegen implements CodegenConfig {
             property.isPrimitiveType = true;
         } else {
             property.complexType = property.baseType;
-	        property.isModel = true;
+            property.isModel = true;
         }
     }
 
@@ -4512,9 +4512,9 @@ public class DefaultCodegen implements CodegenConfig {
                 schema.setName(name);
                 codegenModel = fromModel(name, schema, schemas);
             }
-			if (codegenModel != null) {
-				codegenParameter.isModel = true;
-			}
+            if (codegenModel != null) {
+                codegenParameter.isModel = true;
+            }
 
             if (codegenModel != null && !codegenModel.emptyVars) {
                 if (StringUtils.isEmpty(bodyParameterName)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2008,7 +2008,7 @@ public class DefaultCodegen implements CodegenConfig {
             //    property.baseType = getSimpleRef(p.get$ref());
             //}
             // --END of revision
-            setNonArrayMapProperty(property, type);
+			setNonArrayMapProperty(property, type);
         }
 
         LOGGER.debug("debugging from property return: " + property);
@@ -2170,6 +2170,7 @@ public class DefaultCodegen implements CodegenConfig {
             property.isPrimitiveType = true;
         } else {
             property.complexType = property.baseType;
+	        property.isModel = true;
         }
     }
 
@@ -4511,6 +4512,9 @@ public class DefaultCodegen implements CodegenConfig {
                 schema.setName(name);
                 codegenModel = fromModel(name, schema, schemas);
             }
+			if (codegenModel != null) {
+				codegenParameter.isModel = true;
+			}
 
             if (codegenModel != null && !codegenModel.emptyVars) {
                 if (StringUtils.isEmpty(bodyParameterName)) {


### PR DESCRIPTION
### PR checklist

- [ X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [NA ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X ] Filed the PR against the [master]
- [ NA] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Added an attribute **isModel** available to the mustache-based code generators. This should be set for all parameters and fields that are objects or referenced schemas.
