### PR TITLE
[CLI] Fix help command

### DIFF
--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>airline</artifactId>
-            <version>0.7</version>
+            <version>0.8</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.lambdaj</groupId>

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/CompletionCommand.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/CompletionCommand.java
@@ -84,7 +84,8 @@ public class CompletionCommand
                         null,
                         null,
                         suggesterMetadata.getMetadataInjections(),
-                        bindings.build());
+                        bindings.build(),
+                        new DefaultCommandFactory<Suggester>());
 
                 return suggester.suggest();
             }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR fixes https://github.com/OpenAPITools/openapi-generator/issues/1278 .

---


Since guava 21, `firstNonNull` is removed but airline 0.7 still using that. so the following error is caused by run `java -jar openapi-generator-cli.jar help`.

```bash
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.base.Objects.firstNonNull(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
	at io.airlift.airline.GlobalUsageSummary$2.apply(GlobalUsageSummary.java:100)
	at io.airlift.airline.GlobalUsageSummary$2.apply(GlobalUsageSummary.java:97)
	at com.google.common.collect.Iterators$6.transform(Iterators.java:785)
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
	at io.airlift.airline.UsagePrinter.appendTable(UsagePrinter.java:57)
	at io.airlift.airline.GlobalUsageSummary.usage(GlobalUsageSummary.java:96)
	at io.airlift.airline.GlobalUsageSummary.usage(GlobalUsageSummary.java:52)
	at io.airlift.airline.Help.help(Help.java:57)
	at io.airlift.airline.Help.help(Help.java:50)
	at io.airlift.airline.Help.run(Help.java:25)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
```