### PR TITLE
fix name sanitation when using kebab case filenaming

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -472,9 +472,9 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
     @Override
     public String toModelFilename(String name) {
-        return this.sanitizeName(this.convertUsingFileNamingConvention(name) + modelFileSuffix);
+        return this.convertUsingFileNamingConvention(this.sanitizeName(name) + modelFileSuffix);
     }
-
+    
     @Override
     public String toModelImport(String name) {
         return modelPackage() + "/" + toModelFilename(name);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -474,7 +474,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     public String toModelFilename(String name) {
         return this.convertUsingFileNamingConvention(this.sanitizeName(name) + modelFileSuffix);
     }
-    
+
     @Override
     public String toModelImport(String name) {
         return modelPackage() + "/" + toModelFilename(name);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes: https://github.com/OpenAPITools/openapi-generator/issues/1253


cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09)
