### PR TITLE
Rust server html

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -477,6 +477,10 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
         return mimetype.toLowerCase(Locale.ROOT).startsWith("text/plain");
     }
 
+    boolean isMimetypeHtmlText(String mimetype) {
+        return mimetype.toLowerCase(Locale.ROOT).startsWith("text/html");
+    }
+
     boolean isMimetypeWwwFormUrlEncoded(String mimetype) {
         return mimetype.toLowerCase(Locale.ROOT).startsWith("application/x-www-form-urlencoded");
     }
@@ -547,6 +551,8 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
                     consumesXml = true;
                 } else if (isMimetypePlainText(mimeType)) {
                     consumesPlainText = true;
+                } else if (isMimetypeHtmlText(mimeType)) {
+                    consumesPlainText = true;
                 } else if (isMimetypeWwwFormUrlEncoded(mimeType)) {
                     additionalProperties.put("usesUrlEncodedForm", true);
                 }
@@ -572,6 +578,8 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
                     additionalProperties.put("usesXml", true);
                     producesXml = true;
                 } else if (isMimetypePlainText(mimeType)) {
+                    producesPlainText = true;
+                } else if (isMimetypeHtmlText(mimeType)) {
                     producesPlainText = true;
                 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -673,7 +673,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
                         if (isMimetypeXml(mediaType)) {
                             additionalProperties.put("usesXml", true);
                             consumesXml = true;
-                        } else if (isMimetypePlainText(mediaType)) {
+                        } else if (isMimetypePlainText(mediaType) || isMimetypeHtmlText(mediaType)) {
                             consumesPlainText = true;
                         } else if (isMimetypeWwwFormUrlEncoded(mediaType)) {
                             additionalProperties.put("usesUrlEncodedForm", true);

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -12,6 +12,22 @@ paths:
       responses:
         '200':
           description: Success
+  /html:
+    post:
+      summary: Test HTML handling
+      consumes: [text/html]
+      produces: [text/html]
+      parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Success
+          schema:
+            type: string
 definitions:
   additionalPropertiesObject:
     description: An additionalPropertiesObject

--- a/samples/server/petstore/rust-server/output/rust-server-test/README.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/README.md
@@ -56,6 +56,7 @@ To run a client, follow one of the following simple steps:
 
 ```
 cargo run --example client DummyGet
+cargo run --example client HtmlPost
 ```
 
 ### HTTPS

--- a/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
@@ -13,6 +13,22 @@ paths:
           content: {}
           description: Success
       summary: A dummy endpoint to make the spec valid.
+  /html:
+    post:
+      requestBody:
+        content:
+          text/html:
+            schema:
+              type: string
+        required: true
+      responses:
+        200:
+          content:
+            text/html:
+              schema:
+                type: string
+          description: Success
+      summary: Test HTML handling
 components:
   schemas:
     additionalPropertiesObject:

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
@@ -19,7 +19,8 @@ use tokio_core::reactor;
 #[allow(unused_imports)]
 use rust_server_test::{ApiNoContext, ContextWrapperExt,
                       ApiError,
-                      DummyGetResponse
+                      DummyGetResponse,
+                      HtmlPostResponse
                      };
 use clap::{App, Arg};
 
@@ -29,6 +30,7 @@ fn main() {
             .help("Sets the operation to run")
             .possible_values(&[
     "DummyGet",
+    "HtmlPost",
 ])
             .required(true)
             .index(1))
@@ -71,6 +73,11 @@ fn main() {
 
         Some("DummyGet") => {
             let result = core.run(client.dummy_get());
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+         },
+
+        Some("HtmlPost") => {
+            let result = core.run(client.html_post("body_example".to_string()));
             println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
          },
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server_lib/server.rs
@@ -11,7 +11,8 @@ use swagger;
 use swagger::{Has, XSpanIdString};
 
 use rust_server_test::{Api, ApiError,
-                      DummyGetResponse
+                      DummyGetResponse,
+                      HtmlPostResponse
 };
 use rust_server_test::models;
 
@@ -32,6 +33,13 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn dummy_get(&self, context: &C) -> Box<Future<Item=DummyGetResponse, Error=ApiError>> {
         let context = context.clone();
         println!("dummy_get() - X-Span-ID: {:?}", context.get().0.clone());
+        Box::new(futures::failed("Generic failure".into()))
+    }
+
+    /// Test HTML handling
+    fn html_post(&self, body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>> {
+        let context = context.clone();
+        println!("html_post(\"{}\") - X-Span-ID: {:?}", body, context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -39,7 +39,8 @@ use swagger;
 use swagger::{ApiError, XSpanId, XSpanIdString, Has, AuthData};
 
 use {Api,
-     DummyGetResponse
+     DummyGetResponse,
+     HtmlPostResponse
      };
 use models;
 
@@ -275,6 +276,78 @@ impl<F, C> Api<C> for Client<F> where
 
                         future::ok(
                             DummyGetResponse::Success
+                        )
+                    ) as Box<Future<Item=_, Error=_>>
+                },
+                code => {
+                    let headers = response.headers().clone();
+                    Box::new(response.body()
+                            .take(100)
+                            .concat2()
+                            .then(move |body|
+                                future::err(ApiError(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                    code,
+                                    headers,
+                                    match body {
+                                        Ok(ref body) => match str::from_utf8(body) {
+                                            Ok(body) => Cow::from(body),
+                                            Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                        },
+                                        Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                    })))
+                            )
+                    ) as Box<Future<Item=_, Error=_>>
+                }
+            }
+        }))
+
+    }
+
+    fn html_post(&self, param_body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>> {
+
+
+        let uri = format!(
+            "{}/html",
+            self.base_path
+        );
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Box::new(futures::done(Err(ApiError(format!("Unable to build URI: {}", err))))),
+        };
+
+        let mut request = hyper::Request::new(hyper::Method::Post, uri);
+
+
+        let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
+
+
+        request.set_body(body.into_bytes());
+
+
+        request.headers_mut().set(ContentType(mimetypes::requests::HTML_POST.clone()));
+        request.headers_mut().set(XSpanId((context as &Has<XSpanIdString>).get().0.clone()));
+
+
+        Box::new(self.client_service.call(request)
+                             .map_err(|e| ApiError(format!("No response received: {}", e)))
+                             .and_then(|mut response| {
+            match response.status().as_u16() {
+                200 => {
+                    let body = response.body();
+                    Box::new(
+                        body
+                        .concat2()
+                        .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                        .and_then(|body| str::from_utf8(&body)
+                                             .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))
+                                             .and_then(|body|
+
+                                                 Ok(body.to_string())
+
+                                             ))
+                        .map(move |body|
+                            HtmlPostResponse::Success(body)
                         )
                     ) as Box<Future<Item=_, Error=_>>
                 },

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/client/mod.rs
@@ -318,8 +318,7 @@ impl<F, C> Api<C> for Client<F> where
 
         let mut request = hyper::Request::new(hyper::Method::Post, uri);
 
-
-        let body = serde_json::to_string(&param_body).expect("impossible to fail to serialize");
+        let body = param_body;
 
 
         request.set_body(body.into_bytes());

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -45,12 +45,21 @@ pub enum DummyGetResponse {
     Success ,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum HtmlPostResponse {
+    /// Success
+    Success ( String ) ,
+}
+
 
 /// API
 pub trait Api<C> {
 
     /// A dummy endpoint to make the spec valid.
     fn dummy_get(&self, context: &C) -> Box<Future<Item=DummyGetResponse, Error=ApiError>>;
+
+    /// Test HTML handling
+    fn html_post(&self, body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>>;
 
 }
 
@@ -59,6 +68,9 @@ pub trait ApiNoContext {
 
     /// A dummy endpoint to make the spec valid.
     fn dummy_get(&self) -> Box<Future<Item=DummyGetResponse, Error=ApiError>>;
+
+    /// Test HTML handling
+    fn html_post(&self, body: String) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>>;
 
 }
 
@@ -79,6 +91,11 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
     /// A dummy endpoint to make the spec valid.
     fn dummy_get(&self) -> Box<Future<Item=DummyGetResponse, Error=ApiError>> {
         self.api().dummy_get(&self.context())
+    }
+
+    /// Test HTML handling
+    fn html_post(&self, body: String) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>> {
+        self.api().html_post(body, &self.context())
     }
 
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/mimetypes.rs
@@ -4,10 +4,18 @@ pub mod responses {
     use hyper::mime::*;
 
     // The macro is called per-operation to beat the recursion limit
+    /// Create Mime objects for the response content types for HtmlPost
+    lazy_static! {
+        pub static ref HTML_POST_SUCCESS: Mime = "text/html".parse().unwrap();
+    }
 
 }
 
 pub mod requests {
     use hyper::mime::*;
+   /// Create Mime objects for the request content types for HtmlPost
+    lazy_static! {
+        pub static ref HTML_POST: Mime = "text/html".parse().unwrap();
+    }
 
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -37,7 +37,8 @@ use swagger::{ApiError, XSpanId, XSpanIdString, Has, RequestParser};
 use swagger::auth::Scopes;
 
 use {Api,
-     DummyGetResponse
+     DummyGetResponse,
+     HtmlPostResponse
      };
 #[allow(unused_imports)]
 use models;
@@ -51,10 +52,12 @@ mod paths {
 
     lazy_static! {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(&[
-            r"^/dummy$"
+            r"^/dummy$",
+            r"^/html$"
         ]).unwrap();
     }
     pub static ID_DUMMY: usize = 0;
+    pub static ID_HTML: usize = 1;
 }
 
 pub struct NewService<T, C> {
@@ -162,6 +165,91 @@ where
                         }}
                 }) as Box<Future<Item=Response, Error=Error>>
 
+
+            },
+
+
+            // HtmlPost - POST /html
+            &hyper::Method::Post if path.matched(paths::ID_HTML) => {
+
+
+
+
+
+
+                // Body parameters (note that non-required body parameters will ignore garbage
+                // values, rather than causing a 400 response). Produce warning header and logs for
+                // any unused fields.
+                Box::new(body.concat2()
+                    .then(move |result| -> Box<Future<Item=Response, Error=Error>> {
+                        match result {
+                            Ok(body) => {
+
+                                let mut unused_elements = Vec::new();
+                                let param_body: Option<String> = if !body.is_empty() {
+
+                                    let deserializer = &mut serde_json::Deserializer::from_slice(&*body);
+
+                                    match serde_ignored::deserialize(deserializer, |path| {
+                                            warn!("Ignoring unknown field in body: {}", path);
+                                            unused_elements.push(path.to_string());
+                                    }) {
+                                        Ok(param_body) => param_body,
+                                        Err(e) => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't parse body parameter body - doesn't match schema: {}", e)))),
+                                    }
+
+                                } else {
+                                    None
+                                };
+                                let param_body = match param_body {
+                                    Some(param_body) => param_body,
+                                    None => return Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body("Missing required body parameter body"))),
+                                };
+
+
+                                Box::new(api_impl.html_post(param_body, &context)
+                                    .then(move |result| {
+                                        let mut response = Response::new();
+                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+
+                                        if !unused_elements.is_empty() {
+                                            response.headers_mut().set(Warning(format!("Ignoring unknown fields in body: {:?}", unused_elements)));
+                                        }
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                HtmlPostResponse::Success
+
+                                                    (body)
+
+
+                                                => {
+                                                    response.set_status(StatusCode::try_from(200).unwrap());
+
+                                                    response.headers_mut().set(ContentType(mimetypes::responses::HTML_POST_SUCCESS.clone()));
+
+
+                                                    response.set_body(body);
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                response.set_status(StatusCode::InternalServerError);
+                                                response.set_body("An internal error occurred");
+                                            },
+                                        }
+
+                                        future::ok(response)
+                                    }
+                                ))
+
+
+                            },
+                            Err(e) => Box::new(future::ok(Response::new().with_status(StatusCode::BadRequest).with_body(format!("Couldn't read body parameter body: {}", e)))),
+                        }
+                    })
+                ) as Box<Future<Item=Response, Error=Error>>
 
             },
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

Builds on https://github.com/OpenAPITools/openapi-generator/pull/1180 by @colelawrence. This addition to the rust-server generator enables the use of text/html responses as plaintext.

I've added an html endpoint to the sample to demonstrate that this works (and fixed the problem that that uncovered).