### PR TITLE
Implement aspdotnet core Produces, Consumes, partial controller

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/BinaryBodyFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/BinaryBodyFormatter.mustache
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An input formatter that "transforms" the incoming request body
+    /// to an I/O stream. Supports content types of application/octet-stream
+    /// and text/plain.
+    /// </summary>
+    public class BinaryBodyFormatter: InputFormatter
+    {
+        /// <summary>
+        /// Create a new BinaryBodyFormatter instance.
+        /// </summary>
+        public BinaryBodyFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from System.IO.Stream.</returns>
+        /// </summary>
+        protected override bool CanReadType(Type type)
+        {
+            return type.IsAssignableFrom(typeof(System.IO.Stream)) && base.CanReadType(type);
+        }
+
+        /// <summary>
+        /// "Read" the body to a stream. This actually just returns the body,
+        /// as is; there is no asynchronous operation here.
+        /// <param name="context">The filter context.</param>
+        /// <returns>The request body stream, as is.</returns>
+        /// </summary>
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            return Task.FromResult(InputFormatterResult.Success(context.HttpContext.Request.Body));
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/BinaryResultFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/BinaryResultFormatter.mustache
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An output formatter that writes an I/O stream to the result content.
+    /// Supports content types of application/octet-stream
+    /// and text/plain.
+    ///
+    /// The Content-Length header is set if possible (i.e. if the stream
+    /// can seek).
+    ///
+    /// No support for sub-ranges is provided.
+    /// </summary>
+    public class BinaryResultFormatter: OutputFormatter
+    {
+        /// <summary>
+        /// Create a new BinaryResultFormatter instance.
+        /// </summary>
+        public BinaryResultFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from System.IO.Stream.</returns>
+        /// </summary>
+        protected override bool CanWriteType(Type type)
+        {
+            return typeof(System.IO.Stream).IsAssignableFrom(type) && base.CanWriteType(type);
+        }
+
+        /// <summary>
+        /// If possible, set the Content-Length in the response header set.
+        /// <param name="context">The filter context.</param>
+        /// </summary>
+        public override void WriteResponseHeaders(OutputFormatterWriteContext context)
+        {
+            base.WriteResponseHeaders(context);
+
+            var stream = context.Object as System.IO.Stream;
+            if (stream == null) {
+                throw new ArgumentException("Object provided to BinaryResultFormatter cannot be cast to System.IO.Stream");
+            }
+            if (stream.CanSeek) {
+                context.HttpContext.Response.Headers.Add("Content-Length", stream.Length.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Write the result from a stream.
+        /// <param name="context">The filter context.</param>
+        /// <returns>A task copying the source stream to the output stream.</returns>
+        /// </summary>
+        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        {
+            var stream = context.Object as System.IO.Stream;
+            if (stream == null) {
+                throw new ArgumentException("Object provided to BinaryResultFormatter cannot be cast to System.IO.Stream");
+            }
+            var response = context.HttpContext.Response;
+            return stream.CopyToAsync(response.Body);
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/ByteBodyFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/ByteBodyFormatter.mustache
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An input formatter that transforms the incoming request body
+    /// to an array of bytes. Supports content types of application/octet-stream
+    /// and text/plain.
+    /// </summary>
+    public class ByteBodyFormatter: InputFormatter
+    {
+        /// <summary>
+        /// Create a new ByteBodyFormatter instance.
+        /// </summary>
+        public ByteBodyFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from byte [].</returns>
+        /// </summary>
+        protected override bool CanReadType(Type type)
+        {
+            return type.IsAssignableFrom(typeof(byte[])) && base.CanReadType(type);
+        }
+
+        /// <summary>
+        /// Read the body to a byte array. Uses memory stream with a fixed
+        /// 2048 buffer.
+        /// <param name="context">The filter context.</param>
+        /// <returns>A task wrapping reading of the stream to a byte array.</returns>
+        /// </summary>
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            using (var ms = new MemoryStream(2048))
+            {
+                await context.HttpContext.Request.Body.CopyToAsync(ms);
+                var content = ms.ToArray();
+                return await InputFormatterResult.SuccessAsync(content);
+            }
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/ByteResultFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Formatters/ByteResultFormatter.mustache
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An output formatter that writes a byte array to the result content.
+    /// Supports content types of application/octet-stream
+    /// and text/plain.
+    ///
+    /// The Content-Length header is set based on the array length.
+    ///
+    /// No support for sub-ranges is provided.
+    /// </summary>
+    public class ByteResultFormatter: OutputFormatter
+    {
+        /// <summary>
+        /// Create a new ByteResultFormatter instance.
+        /// </summary>
+        public ByteResultFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from byte [].</returns>
+        /// </summary>
+        protected override bool CanWriteType(Type type)
+        {
+            return typeof(byte []).IsAssignableFrom(type) && base.CanWriteType(type);
+        }
+
+        /// <summary>
+        /// Set the Content-Length in the response header set.
+        /// <param name="context">The filter context.</param>
+        /// </summary>
+        public override void WriteResponseHeaders (OutputFormatterWriteContext context)
+        {
+            base.WriteResponseHeaders(context);
+
+            var data = context.Object as byte [];
+            if (data == null) {
+                throw new ArgumentException("Object provided to ByteResultFormatter cannot be cast to byte");
+            }
+            context.HttpContext.Response.Headers.Add("Content-Length", data.Length.ToString());
+        }
+
+        /// <summary>
+        /// Write the result from a byte array.
+        /// <param name="context">The filter context.</param>
+        /// <returns>A task which will write the data.</returns>
+        /// </summary>
+        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        {
+            var data = context.Object as byte [];
+            if (data == null) {
+                throw new ArgumentException("Object provided to ByteResultFormatter cannot be cast to byte");
+            }
+            var response = context.HttpContext.Response;
+            return response.Body.WriteAsync(data, 0, data.Length);
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Startup.mustache
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Serialization;{{#useSwashbuckle}}
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using {{packageName}}.Filters;{{/useSwashbuckle}}
+using {{packageName}}.Formatters;
 
 namespace {{packageName}}
 {
@@ -40,7 +41,13 @@ namespace {{packageName}}
         {
             // Add framework services.
             services
-                .AddMvc()
+                .AddMvc(options => {
+                    options.InputFormatters.Add(new BinaryBodyFormatter());
+                    options.InputFormatters.Add(new ByteBodyFormatter());
+                    // Insert to give this highest priority (some implementations already have a stream I/O formatter).
+                    options.OutputFormatters.Insert(0, new BinaryResultFormatter());
+                    options.OutputFormatters.Add(new ByteResultFormatter());
+                })
                 .AddJsonOptions(opts =>
                 {
                     opts.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
@@ -83,7 +90,7 @@ namespace {{packageName}}
         /// <summary>
         /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         /// </summary>
-        /// <param name="app"></param>
+        /// <param name="app">Application builder.</param>
         public void Configure(IApplicationBuilder app)
         {
             app

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/controller.mustache
@@ -14,7 +14,7 @@ namespace {{packageName}}.Controllers
     /// {{description}}
     /// </summary>{{#description}}
     [Description("{{description}}")]{{/description}}
-    public class {{classname}}Controller : Controller
+    public partial class {{classname}}Controller : Controller
     { {{#operation}}
         /// <summary>
         /// {{#summary}}{{summary}}{{/summary}}
@@ -23,12 +23,15 @@ namespace {{packageName}}.Controllers
         /// <param name="{{paramName}}">{{description}}</param>{{/allParams}}{{#responses}}
         /// <response code="{{code}}">{{message}}</response>{{/responses}}
         [{{httpMethod}}]
-        [Route("{{{basePathWithoutHost}}}{{{path}}}")]
-        [ValidateModelState]{{#useSwashbuckle}}
+        [Route("{{{basePathWithoutHost}}}{{{path}}}")]{{#hasConsumes}}{{^consumes.0.x-mediaIsWildcard}}
+        [Consumes({{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}})]{{/consumes.0.x-mediaIsWildcard}}{{/hasConsumes}}{{#hasProduces}}{{^produces.0.x-mediaIsWildcard}}
+        [Produces({{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}})]
+        {{/produces.0.x-mediaIsWildcard}}{{/hasProduces}}[ValidateModelState]{{#useSwashbuckle}}
         [SwaggerOperation("{{operationId}}")]{{#responses}}{{#dataType}}
         [SwaggerResponse(statusCode: {{code}}, type: typeof({{&dataType}}), description: "{{message}}")]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}{{/useSwashbuckle}}
         public virtual IActionResult {{operationId}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
-        { {{#responses}}
+        {
+{{^usePartialControllerClass}}{{#responses}}{{#dataType}}
 {{#dataType}}
             //TODO: Uncomment the next line to return response {{code}} or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode({{code}}, default({{&dataType}}));
@@ -47,7 +50,16 @@ namespace {{packageName}}.Controllers
             //TODO: Change the data returned
             return new ObjectResult(example);{{/returnType}}{{^returnType}}
             throw new NotImplementedException();{{/returnType}}
+{{/usePartialControllerClass}}
+{{#usePartialControllerClass}}
+            IActionResult result = null;
+            {{operationId}}_impl({{#allParams}}{{paramName}}, {{/allParams}}ref result);
+            return result;
+{{/usePartialControllerClass}}
         }
+{{#usePartialControllerClass}}
+        partial void {{operationId}}_impl({{#allParams}}{{&dataType}} {{paramName}}, {{/allParams}}ref IActionResult result_);
+{{/usePartialControllerClass}}
         {{/operation}}
     }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/controller_impl.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/controller_impl.mustache
@@ -1,0 +1,50 @@
+{{#usePartialControllerClass}}
+{{>partial_header}}
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;{{#useSwashbuckle}}
+using Swashbuckle.AspNetCore.SwaggerGen;{{/useSwashbuckle}}
+using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
+using {{packageName}}.Attributes;
+using {{packageName}}.Models;
+
+namespace {{packageName}}.Controllers
+{ {{#operations}}
+    /// <summary>
+    /// {{description}}
+    /// </summary>{{#description}}
+    [Description("{{description}}")]{{/description}}
+    public partial class {{classname}}Controller : Controller
+    { {{#operation}}
+        /// <summary>
+        /// {{#summary}}{{summary}}{{/summary}}
+        /// </summary>{{#notes}}
+        /// <remarks>{{notes}}</remarks>{{/notes}}{{#allParams}}
+        /// <param name="{{paramName}}">{{description}}</param>{{/allParams}}
+        /// <param name="result_">Operation result</parm>
+        partial void {{operationId}}_impl({{#allParams}}{{&dataType}} {{paramName}}, {{/allParams}}ref IActionResult result_)
+        {
+{{#responses}}{{#dataType}}
+            //TODO: Uncomment the next line to return response {{code}} or use other options such as result_ = this.NotFound(), result_ = this.BadRequest(..), ...
+            // result_ = StatusCode({{code}}, default({{&dataType}})); return;
+{{/dataType}}{{^dataType}}
+            //TODO: Uncomment the next line to return response {{code}} or use other options such as result_ = this.NotFound(), result_ = this.BadRequest(..), ...
+            // result_ = StatusCode({{code}}); return;
+{{/dataType}}{{/responses}}
+{{#returnType}}
+            string exampleJson = null;
+            {{#examples}}
+            exampleJson = "{{{example}}}";
+            {{/examples}}
+            {{#isListCollection}}{{>listReturn}}{{/isListCollection}}{{^isListCollection}}{{#isMapContainer}}{{>mapReturn}}{{/isMapContainer}}{{^isMapContainer}}{{>objectReturn}}{{/isMapContainer}}{{/isListCollection}}
+            {{!TODO: defaultResponse, examples, auth, consumes, produces, nickname, externalDocs, imports, security}}
+            //TODO: Change the data returned
+            result_ = new ObjectResult(example);{{/returnType}}{{^returnType}}
+            throw new NotImplementedException();{{/returnType}}
+        }
+        {{/operation}}
+    }
+{{/operations}}
+}
+{{/usePartialControllerClass}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/BinaryBodyFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/BinaryBodyFormatter.mustache
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An input formatter that "transforms" the incoming request body
+    /// to an I/O stream. Supports content types of application/octet-stream
+    /// and text/plain.
+    /// </summary>
+    public class BinaryBodyFormatter: InputFormatter
+    {
+        /// <summary>
+        /// Create a new BinaryBodyFormatter instance.
+        /// </summary>
+        public BinaryBodyFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from System.IO.Stream.</returns>
+        /// </summary>
+        protected override bool CanReadType(Type type)
+        {
+            return type.IsAssignableFrom(typeof(System.IO.Stream)) && base.CanReadType(type);
+        }
+        
+        /// <summary>
+        /// "Read" the body to a stream. This actually just returns the body,
+        /// as is; there is no asynchronous operation here.
+        /// <param name="context">The filter context.</param>
+        /// <returns>The request body stream, as is.</returns>
+        /// </summary>
+        public override Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+        	return Task.FromResult(InputFormatterResult.Success(context.HttpContext.Request.Body));
+        }
+    }  
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/BinaryResultFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/BinaryResultFormatter.mustache
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An output formatter that writes an I/O stream to the result content.
+    /// Supports content types of application/octet-stream
+    /// and text/plain.
+    ///
+    /// The Content-Length header is set if possible (i.e. if the stream
+    /// can seek).
+    ///
+    /// No support for sub-ranges is provided.
+    /// </summary>
+    public class BinaryResultFormatter: OutputFormatter
+    {
+        /// <summary>
+        /// Create a new BinaryResultFormatter instance.
+        /// </summary>
+        public BinaryResultFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from System.IO.Stream.</returns>
+        /// </summary>
+        protected override bool CanWriteType(Type type)
+        {
+            return typeof(System.IO.Stream).IsAssignableFrom(type) && base.CanWriteType(type);
+        }
+
+        /// <summary>
+        /// If possible, set the Content-Length in the response header set.
+        /// <param name="context">The filter context.</param>
+        /// </summary>
+        public override void WriteResponseHeaders(OutputFormatterWriteContext context)
+        {
+            base.WriteResponseHeaders(context);
+
+            var stream = context.Object as System.IO.Stream;
+            if (stream == null) {
+                throw new ArgumentException("Object provided to BinaryResultFormatter cannot be cast to System.IO.Stream");
+            }
+            if (stream.CanSeek) {
+                context.HttpContext.Response.Headers.Add("Content-Length", stream.Length.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Write the result from a stream.
+        /// <param name="context">The filter context.</param>
+        /// <returns>A task copying the source stream to the output stream.</returns>
+        /// </summary>
+        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        {
+            var stream = context.Object as System.IO.Stream;
+            if (stream == null) {
+                throw new ArgumentException("Object provided to BinaryResultFormatter cannot be cast to System.IO.Stream");
+            }
+            var response = context.HttpContext.Response;
+            return stream.CopyToAsync(response.Body);
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/ByteBodyFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/ByteBodyFormatter.mustache
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An input formatter that transforms the incoming request body
+    /// to an array of bytes. Supports content types of application/octet-stream
+    /// and text/plain.
+    /// </summary>
+    public class ByteBodyFormatter: InputFormatter
+    {
+        /// <summary>
+        /// Create a new ByteBodyFormatter instance.
+        /// </summary>
+        public ByteBodyFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from byte [].</returns>
+        /// </summary>
+        protected override bool CanReadType(Type type)
+        {
+            return type.IsAssignableFrom(typeof(byte[])) && base.CanReadType(type);
+        }
+
+        /// <summary>
+        /// Read the body to a byte array. Uses memory stream with a fixed
+        /// 2048 buffer.
+        /// <param name="context">The filter context.</param>
+        /// <returns>A task wrapping reading of the stream to a byte array.</returns>
+        /// </summary>
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        {
+            using (var ms = new MemoryStream(2048))
+            {
+                await context.HttpContext.Request.Body.CopyToAsync(ms);
+                var content = ms.ToArray();
+                return await InputFormatterResult.SuccessAsync(content);
+            }
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/ByteResultFormatter.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Formatters/ByteResultFormatter.mustache
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Mvc.Formatters;
+using System;
+using System.Threading.Tasks;
+
+namespace {{packageName}}.Formatters
+{
+    /// <summary>
+    /// An output formatter that writes a byte array to the result content.
+    /// Supports content types of application/octet-stream
+    /// and text/plain.
+    ///
+    /// The Content-Length header is set based on the array length.
+    ///
+    /// No support for sub-ranges is provided.
+    /// </summary>
+    public class ByteResultFormatter: OutputFormatter
+    {
+        /// <summary>
+        /// Create a new ByteResultFormatter instance.
+        /// </summary>
+        public ByteResultFormatter()
+        {
+            SupportedMediaTypes.Add("application/octet-stream");
+            SupportedMediaTypes.Add("text/plain");
+        }
+
+        /// <summary>
+        /// Determine if the formatter supports reading to the given type.
+        /// <param name="type">Type to test.</param>
+        /// <returns>True if the type is assignable from byte [].</returns>
+        /// </summary>
+        protected override bool CanWriteType(Type type)
+        {
+            return typeof(byte []).IsAssignableFrom(type) && base.CanWriteType(type);
+        }
+
+        /// <summary>
+        /// Set the Content-Length in the response header set.
+        /// <param name="context">The filter context.</param>
+        /// </summary>
+        public override void WriteResponseHeaders (OutputFormatterWriteContext context)
+        {
+            base.WriteResponseHeaders(context);
+
+            var data = context.Object as byte [];
+            if (data == null) {
+                throw new ArgumentException("Object provided to ByteResultFormatter cannot be cast to byte");
+            }
+            context.HttpContext.Response.Headers.Add("Content-Length", data.Length.ToString());
+        }
+
+        /// <summary>
+        /// Write the result from a byte array.
+        /// <param name="context">The filter context.</param>
+        /// <returns>A task which will write the data.</returns>
+        /// </summary>
+        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        {
+            var data = context.Object as byte [];
+            if (data == null) {
+                throw new ArgumentException("Object provided to ByteResultFormatter cannot be cast to byte");
+            }
+            var response = context.HttpContext.Response;
+            return response.Body.WriteAsync(data, 0, data.Length);
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
@@ -12,6 +12,7 @@ using Newtonsoft.Json.Serialization;{{#useSwashbuckle}}
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using {{packageName}}.Filters;{{/useSwashbuckle}}
+using {{packageName}}.Formatters;
 
 namespace {{packageName}}
 {
@@ -42,7 +43,13 @@ namespace {{packageName}}
         {
             // Add framework services.
             services
-                .AddMvc()
+                .AddMvc(options => {
+                    options.InputFormatters.Add(new BinaryBodyFormatter());
+                    options.InputFormatters.Add(new ByteBodyFormatter());
+                    // Insert to give this highest priority (some implementations already have a stream I/O formatter).
+                    options.OutputFormatters.Insert(0, new BinaryResultFormatter());
+                    options.OutputFormatters.Add(new ByteResultFormatter());
+                })
                 .SetCompatibilityVersion                (CompatibilityVersion.Version_2_1)
                 .AddJsonOptions(opts =>
                 {
@@ -86,7 +93,8 @@ namespace {{packageName}}
         /// <summary>
         /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         /// </summary>
-        /// <param name="app"></param>
+        /// <param name="app">Application builder.</param>
+        /// <param name="env">Hosting environment.</param>
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseHttpsRedirection();

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/controller.mustache
@@ -15,7 +15,7 @@ namespace {{packageName}}.Controllers
     /// {{description}}
     /// </summary>{{#description}}
     [Description("{{description}}")]{{/description}}
-    public class {{classname}}Controller : ControllerBase
+    public partial class {{classname}}Controller : ControllerBase
     { {{#operation}}
         /// <summary>
         /// {{#summary}}{{summary}}{{/summary}}
@@ -24,13 +24,15 @@ namespace {{packageName}}.Controllers
         /// <param name="{{paramName}}">{{description}}</param>{{/allParams}}{{#responses}}
         /// <response code="{{code}}">{{message}}</response>{{/responses}}
         [{{httpMethod}}]
-        [Route("{{{basePathWithoutHost}}}{{{path}}}")]
-        [ValidateModelState]{{#useSwashbuckle}}
+        [Route("{{{basePathWithoutHost}}}{{{path}}}")]{{#hasConsumes}}{{^consumes.0.x-mediaIsWildcard}}
+        [Consumes({{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}})]{{/consumes.0.x-mediaIsWildcard}}{{/hasConsumes}}{{#hasProduces}}{{^produces.0.x-mediaIsWildcard}}
+        [Produces({{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}})]
+        {{/produces.0.x-mediaIsWildcard}}{{/hasProduces}}[ValidateModelState]{{#useSwashbuckle}}
         [SwaggerOperation("{{operationId}}")]{{#responses}}{{#dataType}}
         [SwaggerResponse(statusCode: {{code}}, type: typeof({{&dataType}}), description: "{{message}}")]{{/dataType}}{{^dataType}}{{/dataType}}{{/responses}}{{/useSwashbuckle}}
         public virtual IActionResult {{operationId}}({{#allParams}}{{>pathParam}}{{>queryParam}}{{>bodyParam}}{{>formParam}}{{>headerParam}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
-        { {{#responses}}
-{{#dataType}}
+        {
+{{^usePartialControllerClass}}{{#responses}}{{#dataType}}
             //TODO: Uncomment the next line to return response {{code}} or use other options such as return this.NotFound(), return this.BadRequest(..), ...
             // return StatusCode({{code}}, default({{&dataType}}));
 {{/dataType}}
@@ -48,7 +50,16 @@ namespace {{packageName}}.Controllers
             //TODO: Change the data returned
             return new ObjectResult(example);{{/returnType}}{{^returnType}}
             throw new NotImplementedException();{{/returnType}}
+{{/usePartialControllerClass}}
+{{#usePartialControllerClass}}
+            IActionResult result = null;
+            {{operationId}}_impl({{#allParams}}{{paramName}}, {{/allParams}}ref result);
+            return result;
+{{/usePartialControllerClass}}
         }
+{{#usePartialControllerClass}}
+        partial void {{operationId}}_impl({{#allParams}}{{&dataType}} {{paramName}}, {{/allParams}}ref IActionResult result_);
+{{/usePartialControllerClass}}
         {{/operation}}
     }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/controller_impl.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/controller_impl.mustache
@@ -1,0 +1,50 @@
+{{#usePartialControllerClass}}
+{{>partial_header}}
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;{{#useSwashbuckle}}
+using Swashbuckle.AspNetCore.SwaggerGen;{{/useSwashbuckle}}
+using Newtonsoft.Json;
+using System.ComponentModel.DataAnnotations;
+using {{packageName}}.Attributes;
+using {{packageName}}.Models;
+
+namespace {{packageName}}.Controllers
+{ {{#operations}}
+    /// <summary>
+    /// {{description}}
+    /// </summary>{{#description}}
+    [Description("{{description}}")]{{/description}}
+    public partial class {{classname}}Controller : ControllerBase
+    { {{#operation}}
+        /// <summary>
+        /// {{#summary}}{{summary}}{{/summary}}
+        /// </summary>{{#notes}}
+        /// <remarks>{{notes}}</remarks>{{/notes}}{{#allParams}}
+        /// <param name="{{paramName}}">{{description}}</param>{{/allParams}}
+        /// <param name="result_">Operation result.</param>
+        partial void {{operationId}}_impl({{#allParams}}{{&dataType}} {{paramName}}, {{/allParams}}ref IActionResult result_)
+        {
+{{#responses}}{{#dataType}}
+            //TODO: Uncomment the next line to return response {{code}} or use other options such as result_ = this.NotFound(), result_ = this.BadRequest(..), ...
+            // result_ = StatusCode({{code}}, default({{&dataType}})); return;
+{{/dataType}}{{^dataType}}
+            //TODO: Uncomment the next line to return response {{code}} or use other options such as result_ = this.NotFound(), result_ = this.BadRequest(..), ...
+            // result_ = StatusCode({{code}}); return;
+{{/dataType}}{{/responses}}
+{{#returnType}}
+            string exampleJson = null;
+            {{#examples}}
+            exampleJson = "{{{example}}}";
+            {{/examples}}
+            {{#isListCollection}}{{>listReturn}}{{/isListCollection}}{{^isListCollection}}{{#isMapContainer}}{{>mapReturn}}{{/isMapContainer}}{{^isMapContainer}}{{>objectReturn}}{{/isMapContainer}}{{/isListCollection}}
+            {{!TODO: defaultResponse, examples, auth, consumes, produces, nickname, externalDocs, imports, security}}
+            //TODO: Change the data returned
+            result_ = new ObjectResult(example);{{/returnType}}{{^returnType}}
+            throw new NotImplementedException();{{/returnType}}
+        }
+        {{/operation}}
+    }
+{{/operations}}
+}
+{{/usePartialControllerClass}}


### PR DESCRIPTION
Produces: Add [Produces("a/b", "c/d")] to actions where applicable
Consumes: Likewise, add [Consumes("a/b", "c/d")]. Requires detecting
"*/* as ASP doesn't like that.

Input formatters and output formatters to translate to/from
System.IO.Stream and byte [] added for "application/octet-stream" and
"text/plain".

Partial controller: is controlled by usePartialControllerClass. Defaults
to 'true'. NOT tested with it off.

Related issues:
 #1327 [C#] aspdotnetcore (C# server) generation does not support byte/binary body
 #426 [Server] support interface and implementation classes for API controllers

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

