### PR TITLE
Fix defaultValue for String schama in Dart

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -313,6 +313,9 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
 
         if (schema.getDefault() != null) {
+            if (ModelUtils.isStringSchema(schema)) {
+                return "\"" + schema.getDefault().toString().replaceAll("\"", "\\\"") + "\"";
+            }
             return schema.getDefault().toString();
         } else {
             return "null";


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Output `defaultValue` value for String is unquoted and it will cause syntax errors in Dart.

Markdown outputs is like:

```markdown
# openapi.model.CharacterDetail

## Properties
Name | Type | Description | Notes
------------ | ------------- | ------------- | -------------
**name** | **String** |  | [default to null]
**description** | **String** |  | [optional] [default to ]
```

and, `**description** | **String** |  | [optional] [default to ""]` may be better.

Also, generated Dart code is as below:

```dart
class CharacterDetail {

  String name = null;

  String description = ;
```
, and this should be `String description = "";`.

I hope it will be fixed.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09)