### PR TITLE
Add hierarchy traversal to the Qt5 client

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
@@ -115,7 +115,7 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
     else if(type.startsWith("{{prefix}}") && obj.isObject()) {
         // complex type
         QJsonObject jsonObj = obj.toObject();
-        {{prefix}}Object * so = ({{prefix}}Object*)::{{cppNamespace}}::create(complexType);
+        {{prefix}}Object * so = ({{prefix}}Object*)::{{cppNamespace}}::createPoly(complexType, jsonObj);
         if(so != nullptr) {
             so->fromJsonObject(jsonObj);
             {{prefix}}Object **val = static_cast<{{prefix}}Object**>(value);
@@ -134,10 +134,12 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
             QJsonArray arr = obj.toArray();
             for (const QJsonValue & jval : arr) {
                 // it's an object
-                {{prefix}}Object * val = ({{prefix}}Object*)::{{cppNamespace}}::create(complexType);
                 QJsonObject t = jval.toObject();
-                val->fromJsonObject(t);
-                (*output)->append(val);
+                {{prefix}}Object * val = ({{prefix}}Object*)::{{cppNamespace}}::createPoly(complexType, t);
+                if (val != nullptr) {
+	                val->fromJsonObject(t);
+    	            (*output)->append(val);
+    	        }
             }
         }
         else if(QStringLiteral("qint32").compare(complexType) == 0) {
@@ -241,8 +243,9 @@ setValue(void* value, QJsonValue obj, QString type, QString complexType) {
             auto varmap = obj.toObject().toVariantMap();
             if(varmap.count() > 0){
                 for(auto itemkey : varmap.keys() ){
-                    auto  val = ({{prefix}}Object*)::{{cppNamespace}}::create(complexType);
                     auto  jsonval = QJsonValue::fromVariant(varmap.value(itemkey));
+                    auto jsonObj = jsonval.toObject();
+                    auto  val = ({{prefix}}Object*)::{{cppNamespace}}::createPoly(complexType, jsonObj);
                     ::{{cppNamespace}}::setValue(&val, jsonval, complexType, complexType);
                     (*output)->insert(itemkey, val);
                 }

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-body.mustache
@@ -69,9 +69,18 @@ void
 
 void
 {{classname}}::fromJsonObject(QJsonObject pJson) {
+    {{^discriminator}}
+    parentFromJsonObject(pJson);
+    {{/discriminator}}
     {{#vars}}
-    {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");{{/isContainer}}
-    {{#isContainer}}{{^items.isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");{{/items.isContainer}}{{#items.isContainer}}{{#isListContainer}}
+    {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");
+    {{/isContainer}}
+
+    {{#isContainer}}
+    {{^items.isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");
+    {{/items.isContainer}}
+    {{#items.isContainer}}
+    {{#isListContainer}}
     if(pJson["{{baseName}}"].isArray()){
         auto arr = pJson["{{baseName}}"].toArray();
         for (const QJsonValue & jval : arr) {
@@ -81,7 +90,9 @@ void
             ::{{cppNamespace}}::setValue({{name}}_item, jsonval, "{{items.baseType}}", "{{items.items.baseType}}");
             {{name}}->push_back({{name}}_item);
         }
-    }{{/isListContainer}}{{#isMapContainer}}
+    }
+    {{/isListContainer}}
+    {{#isMapContainer}}
     if(pJson["{{baseName}}"].isObject()){
         auto varmap = pJson["{{baseName}}"].toObject().toVariantMap();
         if(varmap.count() > 0){
@@ -94,9 +105,56 @@ void
                 {{name}}->insert({{name}}->end(), val, {{name}}_item);
             }
         }
-    }{{/isMapContainer}}{{/items.isContainer}}{{/isContainer}}
+    }{{/isMapContainer}}
+
+    {{/items.isContainer}}
+    {{/isContainer}}
     {{/vars}}
 }
+
+{{#discriminator}}
+void
+{{classname}}::parentFromJsonObject(QJsonObject pJson) {
+    {{#vars}}
+    {{^isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{complexType}}");
+    {{/isContainer}}
+
+    {{#isContainer}}
+    {{^items.isContainer}}::{{cppNamespace}}::setValue(&{{name}}, pJson["{{baseName}}"], "{{baseType}}", "{{items.baseType}}");
+    {{/items.isContainer}}
+    {{#items.isContainer}}
+    {{#isListContainer}}
+    if(pJson["{{baseName}}"].isArray()){
+        auto arr = pJson["{{baseName}}"].toArray();
+        for (const QJsonValue & jval : arr) {
+            {{#items.isListContainer}}auto {{name}}_item = new QList<{{items.items.baseType}}{{^items.items.isLong}}{{^items.items.isInteger}}{{^items.items.isDouble}}{{^items.items.isFloat}}{{^items.items.isBoolean}}*{{/items.items.isBoolean}}{{/items.items.isFloat}}{{/items.items.isDouble}}{{/items.items.isInteger}}{{/items.items.isLong}}>();{{/items.isListContainer}}
+            {{#items.isMapContainer}}auto {{name}}_item = new QMap<QString, {{items.items.baseType}} {{^items.items.isLong}}{{^items.items.isInteger}}{{^items.items.isDouble}}{{^items.items.isFloat}}{{^items.items.isBoolean}}*{{/items.items.isBoolean}}{{/items.items.isFloat}}{{/items.items.isDouble}}{{/items.items.isInteger}}{{/items.items.isLong}}>();{{/items.isMapContainer}}
+            auto jsonval = jval.toObject();
+            ::{{cppNamespace}}::setValue({{name}}_item, jsonval, "{{items.baseType}}", "{{items.items.baseType}}");
+            {{name}}->push_back({{name}}_item);
+        }
+    }
+    {{/isListContainer}}
+    {{#isMapContainer}}
+    if(pJson["{{baseName}}"].isObject()){
+        auto varmap = pJson["{{baseName}}"].toObject().toVariantMap();
+        if(varmap.count() > 0){
+            for(auto val : varmap.keys()){
+                {{#items.isListContainer}}auto {{name}}_item = new QList<{{items.items.baseType}}{{^items.items.isLong}}{{^items.items.isInteger}}{{^items.items.isDouble}}{{^items.items.isFloat}}{{^items.items.isBoolean}}*{{/items.items.isBoolean}}{{/items.items.isFloat}}{{/items.items.isDouble}}{{/items.items.isInteger}}{{/items.items.isLong}}>();{{/items.isListContainer}}
+                {{#items.isMapContainer}}auto {{name}}_item = new QMap<QString, {{items.items.baseType}}{{^items.items.isLong}}{{^items.items.isInteger}}{{^items.items.isDouble}}{{^items.items.isFloat}}{{^items.items.isBoolean}}*{{/items.items.isBoolean}}{{/items.items.isFloat}}{{/items.items.isDouble}}{{/items.items.isInteger}}{{/items.items.isLong}}>();{{/items.isMapContainer}}
+    		    auto jsonval = QJsonValue::fromVariant(varmap.value(val));
+    		    ::{{cppNamespace}}::setValue((QMap<QString, void *>*)&{{name}}_item, jsonval, "{{items.baseType}}", "{{items.items.baseType}}");
+
+                {{name}}->insert({{name}}->end(), val, {{name}}_item);
+            }
+        }
+    }{{/isMapContainer}}
+
+    {{/items.isContainer}}
+    {{/isContainer}}
+    {{/vars}}
+}
+{{/discriminator}}
 
 QString
 {{classname}}::asJson ()
@@ -110,6 +168,9 @@ QString
 QJsonObject
 {{classname}}::asJsonObject() {
     QJsonObject obj;
+    {{^discriminator}}
+    parentAsJsonObject(obj);
+    {{/discriminator}}
     {{#vars}}
     {{^isContainer}}
     {{#complexType}}
@@ -201,6 +262,102 @@ QJsonObject
 
     return obj;
 }
+
+{{#discriminator}}
+void
+{{classname}}::parentAsJsonObject(QJsonObject &obj) {
+    {{#vars}}
+    {{^isContainer}}
+    {{#complexType}}
+    {{^isString}}
+    {{^isDate}}
+    {{^isDateTime}}
+    {{^isByteArray}}
+    if(({{name}} != nullptr) && ({{name}}->isSet())){
+        toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));
+    }
+    {{/isByteArray}}
+    {{/isDateTime}}
+    {{/isDate}}
+    {{/isString}}
+    {{#isString}}
+    if({{name}} != nullptr && *{{name}} != QString("")){
+        toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));
+    }
+    {{/isString}}
+    {{/complexType}}
+    {{#isPrimitiveType}}
+    {{^isDateTime}}
+    {{^isDate}}
+    {{^isByteArray}}
+    if(m_{{name}}_isSet){
+        obj.insert("{{baseName}}", QJsonValue({{name}}));
+    }
+    {{/isByteArray}}
+    {{/isDate}}
+    {{/isDateTime}}
+    {{/isPrimitiveType}}
+    {{#isDate}}
+    if({{name}} != nullptr) {
+        toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));
+    }
+    {{/isDate}}
+    {{#isByteArray}}
+    if({{name}} != nullptr) {
+        obj.insert("{{name}}", QJsonValue(*{{name}}));
+    }
+    {{/isByteArray}}
+    {{#isDateTime}}
+    if({{name}} != nullptr) {
+        toJsonValue(QString("{{baseName}}"), {{name}}, obj, QString("{{complexType}}"));
+    }
+    {{/isDateTime}}
+    {{/isContainer}}
+    {{#isContainer}}
+    {{#isListContainer}}
+    if({{name}}->size() > 0){
+        {{^items.isContainer}}
+        toJsonArray((QList<void*>*){{name}}, obj, "{{baseName}}", "{{complexType}}");
+        {{/items.isContainer}}
+        {{#items.isContainer}}
+        QJsonArray jarray;
+        for(auto items : *{{name}}){
+            QJsonObject jobj;
+            {{#items.isListContainer}}
+            toJsonArray((QList<void*>*)items, jobj, "{{baseName}}", "{{items.items.baseType}}");
+            {{/items.isListContainer}}
+            {{#items.isMapContainer}}
+            toJsonMap((QMap<QString, void*>*)items, jobj, "{{baseName}}", "{{items.items.baseType}}");
+            {{/items.isMapContainer}}
+            jarray.append(jobj.value("{{baseName}}"));
+        }
+        obj.insert("{{baseName}}", jarray);
+        {{/items.isContainer}}
+    }
+    {{/isListContainer}}
+    {{#isMapContainer}}
+    if({{name}}->size() > 0){
+        {{^items.isContainer}}toJsonMap((QMap<QString, void*>*) {{name}}, obj, "{{baseName}}", "{{complexType}}");{{/items.isContainer}}{{#items.isContainer}}
+        QJsonObject mapobj;
+        for(auto itemkey : {{name}}->keys()){
+            QJsonObject jobj;
+            {{#items.isListContainer}}
+            toJsonArray((QList<void*>*){{name}}->value(itemkey), jobj, itemkey, "{{items.items.baseType}}");
+            {{/items.isListContainer}}
+            {{#items.isMapContainer}}
+            toJsonMap((QMap<QString, void*>*){{name}}->value(itemkey), jobj, itemkey, "{{items.items.baseType}}");
+            {{/items.isMapContainer}}
+            mapobj.insert(itemkey, jobj);
+        }
+        obj.insert("{{baseName}}", mapobj);{{/items.isContainer}}
+    }
+    {{/isMapContainer}}
+    {{/isContainer}}
+    {{/vars}}
+
+    return;
+}
+{{/discriminator}}
 
 {{#vars}}
 {{{dataType}}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
@@ -22,7 +22,12 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
+{{#model.parent}}
+class {{classname}}: public {{model.parent}} {
+{{/model.parent}}
+{{^model.parent}}
 class {{classname}}: public {{prefix}}Object {
+{{/model.parent}}
 public:
     {{classname}}();
     {{classname}}(QString json);
@@ -33,6 +38,10 @@ public:
     QString asJson () override;
     QJsonObject asJsonObject() override;
     void fromJsonObject(QJsonObject json) override;
+    {{#discriminator}}
+    void parentFromJsonObject(QJsonObject json) override;
+    void parentAsJsonObject(QJsonObject &jobj) override;
+    {{/discriminator}}
     {{classname}}* fromJson(QString jsonString) override;
 
     {{#vars}}
@@ -47,7 +56,6 @@ private:
     {{#vars}}
     {{{dataType}}} {{name}};
     bool m_{{name}}_isSet;
-
     {{/vars}}
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/modelFactory.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/modelFactory.mustache
@@ -18,6 +18,31 @@ namespace {{this}} {
     return nullptr;
   }
 
+  inline void* createPoly(QString type, QJsonObject &t) {
+    {{#models}}{{#model}}{{#discriminator}}
+    if (QString("{{classname}}").compare(type) == 0) {
+      auto baseClass = new {{classname}}();
+      baseClass->fromJsonObject(t);
+      QString * discriminator = baseClass->get{{{discriminator.propertyName}}}();
+
+      void *derivedClass;
+      {{#children}}
+      if (QString("{{name}}").compare(*discriminator) == 0)
+      {
+        derivedClass = create(QString("{{prefix}}") + *discriminator);
+      }
+      {{/children}}
+      delete baseClass;
+      return derivedClass;
+    }
+    {{/discriminator}}{{^discriminator}}
+    if(QString("{{classname}}").compare(type) == 0) {
+      return create(type);
+    }
+    {{/discriminator}}
+    {{/model}}{{/models}}
+  }
+
   inline void* create(QString json, QString type) {
     if(type.startsWith("QString")) {
       return new QString();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/object.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/object.mustache
@@ -18,6 +18,11 @@ class {{prefix}}Object {
         return QJsonObject();
     }
 
+    virtual void parentAsJsonObject(QJsonObject &jobj) {
+    	Q_UNUSED(jobj);
+    	return;
+    }
+
     {{prefix}}Object() {
         jObj = nullptr;
     }
@@ -41,6 +46,12 @@ class {{prefix}}Object {
             delete jObj;
         }
         jObj = new QJsonObject(json);
+    }
+
+    virtual void parentFromJsonObject(QJsonObject json) {
+    	Q_UNUSED(json);
+
+    	return;
     }
 
     virtual QString asJson() {


### PR DESCRIPTION
### PR checklist

- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [X ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This add polymorphic support for the cpp Qt5 client.  Issue #1345

