### PR TITLE
Update gradle plugin's Readme.adoc with note about use of system properties

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -278,6 +278,32 @@ in others being disabled. That is, OpenAPI Generator considers any one of these 
 For more control over generation of individual files, configure an ignore file and refer to it via `ignoreFileOverride`.
 ====
 
+[NOTE]
+====
+When configuring `systemProperties` in order to perform selective generation you can disable generation of some parts by providing `"false"` value:
+[source,groovy]
+----
+openApiGenerate {
+    // other settings omitted
+    systemProperties = [
+        modelDocs: "false",
+        apis: "false"
+    ]
+}
+----
+When enabling generation of only specific parts you either have to provide CSV list of what you particularly are generating or provide an empty string `""` to generate everything. If you provide `"true"` it will be treated as a specific name of model or api you want to generate.
+[source,groovy]
+----
+openApiGenerate {
+    // other settings omitted
+    systemProperties = [
+        apis: "",
+        models: "User,Pet"
+    ]
+}
+----
+====
+
 === openApiValidate
 
 .Options


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add a note about use of `systemProperties` since some options are confusing and it's hard to guess how to use correctly. The only source I was able to find how to configure it in the way I need was a comment to issue https://github.com/OpenAPITools/openapi-generator/issues/551#issuecomment-411686091

