### PR TITLE
Fixes an issue where code generator for Java produces not compileable code

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/JSON.mustache
@@ -25,7 +25,9 @@ import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 {{/threetenbp}}
 
+{{#parent.length}}
 import {{modelPackage}}.*;
+{{/parent.length}}
 import okio.ByteString;
 
 import java.io.IOException;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/JSON.mustache
@@ -25,7 +25,9 @@ import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 {{/threetenbp}}
 
+{{#parent.length}}
 import {{modelPackage}}.*;
+{{/parent.length}}
 
 import java.io.IOException;
 import java.io.StringReader;


### PR DESCRIPTION
Fixes: #436

... if the yml-definition does not have any type definitions. This
is normal if the api only uses simple datatypes (Int, String) for
input/output.

I have not updated the pet-store-clients for this PR. The reason is that the change does not affect the pet store api in any way, since this is fix is for apis with no model definitions.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

