### PR TITLE
Fix wrong matching between yaml enum value starting with a digit and its Java code (JavaJaxrs/resteasy)

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumClass.mustache
@@ -1,18 +1,28 @@
   /**
    * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
    */
-  public enum {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
-    {{#allowableValues}}
-    {{#enumVars}}
+  public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+    {{#gson}}
+        {{#allowableValues}}
+            {{#enumVars}}
+    @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
     {{{name}}}({{{value}}}){{^-last}},
+    {{/-last}}{{#-last}};{{/-last}}
+            {{/enumVars}}
+        {{/allowableValues}}
+    {{/gson}}
+    {{^gson}}
+        {{#allowableValues}}
+            {{#enumVars}}
+    {{{name}}}({{{value}}}){{^-last}},
+    {{/-last}}{{#-last}};{{/-last}}
+            {{/enumVars}}
+        {{/allowableValues}}
+    {{/gson}}
 
-    {{/-last}}{{#-last}};
-    {{/-last}}
-    {{/enumVars}}
-    {{/allowableValues}}
-    private {{dataType}} value;
+    private {{{dataType}}} value;
 
-    {{#datatypeWithEnum}}{{.}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{dataType}} value) {
+    {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{{dataType}}} value) {
       this.value = value;
     }
 
@@ -20,5 +30,15 @@
     @JsonValue
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
+      for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
     }
   }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/enumOuterClass.mustache
@@ -1,3 +1,42 @@
-public enum {{classname}} {
-    {{#allowableValues}}{{#enumVars}}{{{name}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+{{/jackson}}
+
+/**
+ * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
+ */
+public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#gson}}
+  {{#allowableValues}}{{#enumVars}}
+  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+  {{/gson}}
+  {{^gson}}
+  {{#allowableValues}}{{#enumVars}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+  {{/gson}}
+
+  private {{{dataType}}} value;
+
+  {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(String text) {
+    for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
+    }
+    {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
+  }
 }

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Order.java
@@ -24,10 +24,11 @@ public class Order   {
    */
   public enum StatusEnum {
     PLACED("placed"),
+    
+    APPROVED("approved"),
+    
+    DELIVERED("delivered");
 
-        APPROVED("approved"),
-
-        DELIVERED("delivered");
     private String value;
 
     StatusEnum(String value) {
@@ -38,6 +39,16 @@ public class Order   {
     @JsonValue
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Pet.java
@@ -27,10 +27,11 @@ public class Pet   {
    */
   public enum StatusEnum {
     AVAILABLE("available"),
+    
+    PENDING("pending"),
+    
+    SOLD("sold");
 
-        PENDING("pending"),
-
-        SOLD("sold");
     private String value;
 
     StatusEnum(String value) {
@@ -41,6 +42,16 @@ public class Pet   {
     @JsonValue
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Order.java
@@ -24,10 +24,11 @@ public class Order   {
    */
   public enum StatusEnum {
     PLACED("placed"),
+    
+    APPROVED("approved"),
+    
+    DELIVERED("delivered");
 
-        APPROVED("approved"),
-
-        DELIVERED("delivered");
     private String value;
 
     StatusEnum(String value) {
@@ -38,6 +39,16 @@ public class Order   {
     @JsonValue
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Pet.java
@@ -27,10 +27,11 @@ public class Pet   {
    */
   public enum StatusEnum {
     AVAILABLE("available"),
+    
+    PENDING("pending"),
+    
+    SOLD("sold");
 
-        PENDING("pending"),
-
-        SOLD("sold");
     private String value;
 
     StatusEnum(String value) {
@@ -41,6 +42,16 @@ public class Pet   {
     @JsonValue
     public String toString() {
       return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static StatusEnum fromValue(String text) {
+      for (StatusEnum b : StatusEnum.values()) {
+        if (String.valueOf(b.value).equals(text)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Cherry-picking https://github.com/OpenAPITools/openapi-generator/pull/1065

Credits go to @tnmtechnologies 

To fix #1051

cc @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)
