### PR TITLE
Add group parameters support in TypeScript Fetch

### DIFF
--- a/bin/typescript-fetch-petstore.sh
+++ b/bin/typescript-fetch-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default $@"
+ags="generate -t modules/openapi-generator/src/main/resources/typescript-fetch -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
@@ -84,6 +84,10 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
          {{#summary}}
          * @summary {{&summary}}
          {{/summary}}
+         {{#vendorExtensions.x-group-parameters}}
+         * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+         *
+         {{/vendorExtensions.x-group-parameters}}
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
          {{/allParams}}
@@ -263,14 +267,18 @@ export const {{classname}}Fp = function(configuration?: Configuration) {
          {{#summary}}
          * @summary {{&summary}}
          {{/summary}}
+         {{#vendorExtensions.x-group-parameters}}
+         * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+         *
+         {{/vendorExtensions.x-group-parameters}}
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
          {{/allParams}}
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Response{{/returnType}}> {
-            const localVarFetchArgs = {{classname}}FetchParamCreator(configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
+        {{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters: any = {}, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Response{{/returnType}}> {
+            const localVarFetchArgs = {{classname}}FetchParamCreator(configuration).{{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
@@ -385,7 +385,7 @@ export class {{classname}} extends BaseAPI {
      * @memberof {{classname}}
      */
     public {{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters: any = {}, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options?: any) {
-        return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options)(this.fetch, this.basePath);
+        return {{classname}}Fp(this.configuration).{{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options)(this.fetch, this.basePath);
     }
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
@@ -90,7 +90,12 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: any = {}): FetchArgs {
+        {{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters: any = {}, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options: any = {}): FetchArgs {
+    {{#vendorExtensions.x-group-parameters}}
+    {{#allParams}}
+            const {{paramName}}: {{{dataType}}} = methodParameters['{{paramName}}']
+    {{/allParams}}
+    {{/vendorExtensions.x-group-parameters}}
     {{#allParams}}
     {{#required}}
             // verify required parameter '{{paramName}}' is not null or undefined

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
@@ -306,14 +306,18 @@ export const {{classname}}Factory = function (configuration?: Configuration, fet
          {{#summary}}
          * @summary {{&summary}}
          {{/summary}}
+         {{#vendorExtensions.x-group-parameters}}
+         * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+         *
+         {{/vendorExtensions.x-group-parameters}}
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
          {{/allParams}}
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any) {
-            return {{classname}}Fp(configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options)(fetch, basePath);
+        {{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters: any = {}, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options?: any) {
+            return {{classname}}Fp(configuration).{{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options)(fetch, basePath);
         },
     {{/operation}}
     };
@@ -333,6 +337,10 @@ export interface {{classname}}Interface {
      {{#summary}}
      * @summary {{&summary}}
      {{/summary}}
+     {{#vendorExtensions.x-group-parameters}}
+     * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+     *
+     {{/vendorExtensions.x-group-parameters}}
      {{#allParams}}
      * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
      {{/allParams}}
@@ -340,7 +348,7 @@ export interface {{classname}}Interface {
      * @throws {RequiredError}
      * @memberof {{classname}}Interface
      */
-    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}>;
+    {{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters: any = {}, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options?: any): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}{}{{/returnType}}>;
 
 {{/operation}}
 }
@@ -365,6 +373,10 @@ export class {{classname}} extends BaseAPI {
      {{#summary}}
      * @summary {{&summary}}
      {{/summary}}
+     {{#vendorExtensions.x-group-parameters}}
+     * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+     *
+     {{/vendorExtensions.x-group-parameters}}
      {{#allParams}}
      * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}} {{description}}
      {{/allParams}}
@@ -372,7 +384,7 @@ export class {{classname}} extends BaseAPI {
      * @throws {RequiredError}
      * @memberof {{classname}}
      */
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any) {
+    public {{nickname}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams.0}}methodParameters: any = {}, {{/allParams.0}}{{/vendorExtensions.x-group-parameters}}options?: any) {
         return {{classname}}Fp(this.configuration).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options)(this.fetch, this.basePath);
     }
 

--- a/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
@@ -550,6 +550,41 @@ paths:
           description: Invalid username supplied
         '404':
           description: User not found
+    patch:
+      tags:
+        - user
+      summary: Delete user
+      description: for testing x-group-parameters, will be removed later
+      operationId: patchUser
+      x-group-parameters: true
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          type: string
+        - name: string_group
+          type: integer
+          in: query
+          description: String in group parameters
+        - name: boolean_group
+          type: boolean
+          in: header
+          description: Boolean in group parameters
+        - name: int64_group
+          type: integer
+          format: int64
+          required: true
+          in: query
+          description: Integer in group parameters
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
 securityDefinitions:
   petstore_auth:
     type: oauth2

--- a/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
@@ -536,7 +536,6 @@ paths:
       summary: Delete user
       description: This can only be done by the logged in user.
       operationId: deleteUser
-      x-group-parameters: true
       produces:
         - application/xml
         - application/json
@@ -546,19 +545,6 @@ paths:
           description: The name that needs to be deleted
           required: true
           type: string
-        - name: string_group
-          type: integer
-          in: query
-          description: String in group parameters
-        - name: boolean_group
-          type: boolean
-          in: header
-          description: Boolean in group parameters
-        - name: int64_group
-          type: integer
-          format: int64
-          in: query
-          description: Integer in group parameters
       responses:
         '400':
           description: Invalid username supplied

--- a/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
@@ -536,6 +536,7 @@ paths:
       summary: Delete user
       description: This can only be done by the logged in user.
       operationId: deleteUser
+      x-group-parameters: true
       produces:
         - application/xml
         - application/json
@@ -545,6 +546,19 @@ paths:
           description: The name that needs to be deleted
           required: true
           type: string
+        - name: string_group
+          type: integer
+          in: query
+          description: String in group parameters
+        - name: boolean_group
+          type: boolean
+          in: header
+          description: Boolean in group parameters
+        - name: int64_group
+          type: integer
+          format: int64
+          in: query
+          description: Integer in group parameters
       responses:
         '400':
           description: Invalid username supplied

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -2165,7 +2165,7 @@ export class UserApi extends BaseAPI {
      * @memberof UserApi
      */
     public patchUser(methodParameters: any = {}, options?: any) {
-        return UserApiFp(this.configuration).patchUser(username, int64Group, stringGroup, booleanGroup, options)(this.fetch, this.basePath);
+        return UserApiFp(this.configuration).patchUser(methodParameters, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -1532,10 +1532,17 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
+         * @param {number} [stringGroup] String in group parameters
+         * @param {boolean} [booleanGroup] Boolean in group parameters
+         * @param {number} [int64Group] Integer in group parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options: any = {}): FetchArgs {
+        deleteUser(methodParameters: any = {}, options: any = {}): FetchArgs {
+            const username: string = methodParameters['username']
+            const stringGroup: number = methodParameters['stringGroup']
+            const booleanGroup: boolean = methodParameters['booleanGroup']
+            const int64Group: number = methodParameters['int64Group']
             // verify required parameter 'username' is not null or undefined
             if (username === null || username === undefined) {
                 throw new RequiredError('username','Required parameter username was null or undefined when calling deleteUser.');
@@ -1550,6 +1557,18 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             const localVarRequestOptions = Object.assign({ method: 'DELETE' }, baseOptions, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            if (stringGroup !== undefined) {
+                localVarQueryParameter['string_group'] = stringGroup;
+            }
+
+            if (int64Group !== undefined) {
+                localVarQueryParameter['int64_group'] = int64Group;
+            }
+
+            if (booleanGroup !== undefined && booleanGroup !== null) {
+                localVarHeaderParameter['boolean_group'] = String(booleanGroup);
+            }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
@@ -1778,11 +1797,14 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
+         * @param {number} [stringGroup] String in group parameters
+         * @param {boolean} [booleanGroup] Boolean in group parameters
+         * @param {number} [int64Group] Integer in group parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
-            const localVarFetchArgs = UserApiFetchParamCreator(configuration).deleteUser(username, options);
+        deleteUser(username: string, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+            const localVarFetchArgs = UserApiFetchParamCreator(configuration).deleteUser(username, stringGroup, booleanGroup, int64Group, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -1913,11 +1935,14 @@ export const UserApiFactory = function (configuration?: Configuration, fetch?: F
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
+         * @param {number} [stringGroup] String in group parameters
+         * @param {boolean} [booleanGroup] Boolean in group parameters
+         * @param {number} [int64Group] Integer in group parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, options?: any) {
-            return UserApiFp(configuration).deleteUser(username, options)(fetch, basePath);
+        deleteUser(username: string, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any) {
+            return UserApiFp(configuration).deleteUser(username, stringGroup, booleanGroup, int64Group, options)(fetch, basePath);
         },
         /**
          * 
@@ -2010,12 +2035,15 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
+     * @param {number} [stringGroup] String in group parameters
+     * @param {boolean} [booleanGroup] Boolean in group parameters
+     * @param {number} [int64Group] Integer in group parameters
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, options?: any) {
-        return UserApiFp(this.configuration).deleteUser(username, options)(this.fetch, this.basePath);
+    public deleteUser(username: string, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any) {
+        return UserApiFp(this.configuration).deleteUser(username, stringGroup, booleanGroup, int64Group, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -1532,17 +1532,10 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {number} [stringGroup] String in group parameters
-         * @param {boolean} [booleanGroup] Boolean in group parameters
-         * @param {number} [int64Group] Integer in group parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(methodParameters: any = {}, options: any = {}): FetchArgs {
-            const username: string = methodParameters['username']
-            const stringGroup: number = methodParameters['stringGroup']
-            const booleanGroup: boolean = methodParameters['booleanGroup']
-            const int64Group: number = methodParameters['int64Group']
+        deleteUser(username: string, options: any = {}): FetchArgs {
             // verify required parameter 'username' is not null or undefined
             if (username === null || username === undefined) {
                 throw new RequiredError('username','Required parameter username was null or undefined when calling deleteUser.');
@@ -1557,18 +1550,6 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             const localVarRequestOptions = Object.assign({ method: 'DELETE' }, baseOptions, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
-
-            if (stringGroup !== undefined) {
-                localVarQueryParameter['string_group'] = stringGroup;
-            }
-
-            if (int64Group !== undefined) {
-                localVarQueryParameter['int64_group'] = int64Group;
-            }
-
-            if (booleanGroup !== undefined && booleanGroup !== null) {
-                localVarHeaderParameter['boolean_group'] = String(booleanGroup);
-            }
 
             localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
@@ -1797,14 +1778,11 @@ export const UserApiFp = function(configuration?: Configuration) {
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {number} [stringGroup] String in group parameters
-         * @param {boolean} [booleanGroup] Boolean in group parameters
-         * @param {number} [int64Group] Integer in group parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
-            const localVarFetchArgs = UserApiFetchParamCreator(configuration).deleteUser(username, stringGroup, booleanGroup, int64Group, options);
+        deleteUser(username: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+            const localVarFetchArgs = UserApiFetchParamCreator(configuration).deleteUser(username, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
@@ -1935,14 +1913,11 @@ export const UserApiFactory = function (configuration?: Configuration, fetch?: F
          * This can only be done by the logged in user.
          * @summary Delete user
          * @param {string} username The name that needs to be deleted
-         * @param {number} [stringGroup] String in group parameters
-         * @param {boolean} [booleanGroup] Boolean in group parameters
-         * @param {number} [int64Group] Integer in group parameters
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(username: string, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any) {
-            return UserApiFp(configuration).deleteUser(username, stringGroup, booleanGroup, int64Group, options)(fetch, basePath);
+        deleteUser(username: string, options?: any) {
+            return UserApiFp(configuration).deleteUser(username, options)(fetch, basePath);
         },
         /**
          * 
@@ -2035,15 +2010,12 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * @summary Delete user
      * @param {string} username The name that needs to be deleted
-     * @param {number} [stringGroup] String in group parameters
-     * @param {boolean} [booleanGroup] Boolean in group parameters
-     * @param {number} [int64Group] Integer in group parameters
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public deleteUser(username: string, stringGroup?: number, booleanGroup?: boolean, int64Group?: number, options?: any) {
-        return UserApiFp(this.configuration).deleteUser(username, stringGroup, booleanGroup, int64Group, options)(this.fetch, this.basePath);
+    public deleteUser(username: string, options?: any) {
+        return UserApiFp(this.configuration).deleteUser(username, options)(this.fetch, this.basePath);
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/default/api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/api.ts
@@ -1667,6 +1667,64 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             };
         },
         /**
+         * for testing x-group-parameters, will be removed later
+         * @summary Delete user
+         * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+         *
+         * @param {string} username The name that needs to be deleted
+         * @param {number} int64Group Integer in group parameters
+         * @param {number} [stringGroup] String in group parameters
+         * @param {boolean} [booleanGroup] Boolean in group parameters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        patchUser(methodParameters: any = {}, options: any = {}): FetchArgs {
+            const username: string = methodParameters['username']
+            const int64Group: number = methodParameters['int64Group']
+            const stringGroup: number = methodParameters['stringGroup']
+            const booleanGroup: boolean = methodParameters['booleanGroup']
+            // verify required parameter 'username' is not null or undefined
+            if (username === null || username === undefined) {
+                throw new RequiredError('username','Required parameter username was null or undefined when calling patchUser.');
+            }
+            // verify required parameter 'int64Group' is not null or undefined
+            if (int64Group === null || int64Group === undefined) {
+                throw new RequiredError('int64Group','Required parameter int64Group was null or undefined when calling patchUser.');
+            }
+            const localVarPath = `/user/{username}`
+                .replace(`{${"username"}}`, encodeURIComponent(String(username)));
+            const localVarUrlObj = url.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = Object.assign({ method: 'PATCH' }, baseOptions, options);
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (stringGroup !== undefined) {
+                localVarQueryParameter['string_group'] = stringGroup;
+            }
+
+            if (int64Group !== undefined) {
+                localVarQueryParameter['int64_group'] = int64Group;
+            }
+
+            if (booleanGroup !== undefined && booleanGroup !== null) {
+                localVarHeaderParameter['boolean_group'] = String(booleanGroup);
+            }
+
+            localVarUrlObj.query = Object.assign({}, localVarUrlObj.query, localVarQueryParameter, options.query);
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
+
+            return {
+                url: url.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
@@ -1851,6 +1909,30 @@ export const UserApiFp = function(configuration?: Configuration) {
             };
         },
         /**
+         * for testing x-group-parameters, will be removed later
+         * @summary Delete user
+         * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+         *
+         * @param {string} username The name that needs to be deleted
+         * @param {number} int64Group Integer in group parameters
+         * @param {number} [stringGroup] String in group parameters
+         * @param {boolean} [booleanGroup] Boolean in group parameters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        patchUser(methodParameters: any = {}, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Response> {
+            const localVarFetchArgs = UserApiFetchParamCreator(configuration).patchUser(methodParameters, options);
+            return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
+                return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
+                    if (response.status >= 200 && response.status < 300) {
+                        return response;
+                    } else {
+                        throw response;
+                    }
+                });
+            };
+        },
+        /**
          * This can only be done by the logged in user.
          * @summary Updated user
          * @param {string} username name that need to be deleted
@@ -1948,6 +2030,21 @@ export const UserApiFactory = function (configuration?: Configuration, fetch?: F
          */
         logoutUser(options?: any) {
             return UserApiFp(configuration).logoutUser(options)(fetch, basePath);
+        },
+        /**
+         * for testing x-group-parameters, will be removed later
+         * @summary Delete user
+         * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+         *
+         * @param {string} username The name that needs to be deleted
+         * @param {number} int64Group Integer in group parameters
+         * @param {number} [stringGroup] String in group parameters
+         * @param {boolean} [booleanGroup] Boolean in group parameters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        patchUser(methodParameters: any = {}, options?: any) {
+            return UserApiFp(configuration).patchUser(methodParameters, options)(fetch, basePath);
         },
         /**
          * This can only be done by the logged in user.
@@ -2052,6 +2149,23 @@ export class UserApi extends BaseAPI {
      */
     public logoutUser(options?: any) {
         return UserApiFp(this.configuration).logoutUser(options)(this.fetch, this.basePath);
+    }
+
+    /**
+     * for testing x-group-parameters, will be removed later
+     * @summary Delete user
+     * Note: the input parameter is a dictionary with the keys listed as the parameter name below
+     *
+     * @param {string} username The name that needs to be deleted
+     * @param {number} int64Group Integer in group parameters
+     * @param {number} [stringGroup] String in group parameters
+     * @param {boolean} [booleanGroup] Boolean in group parameters
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserApi
+     */
+    public patchUser(methodParameters: any = {}, options?: any) {
+        return UserApiFp(this.configuration).patchUser(username, int64Group, stringGroup, booleanGroup, options)(this.fetch, this.basePath);
     }
 
     /**


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- prototype to show group parameter support in TS fetch

TODO:
- update all method signature to support x-group-parameters
- update docstring about using group parameters
