### PR TITLE
[cpp -qt5] Fixes double prefixing during model import

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5ClientCodegen.java
@@ -253,7 +253,7 @@ public class CppQt5ClientCodegen extends AbstractCppCodegen implements CodegenCo
         if (!folder.isEmpty())
             folder += File.separator;
 
-        return "#include \"" + folder + toModelName(name) + ".h\"";
+        return "#include \"" + folder + sanitizeName(name) + ".h\"";
     }
 
     /**


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Remove double prefixing in the model import.
i.e
```c++
#include "OAIUser.h"
```
instead of 
```c++
#include "OAIOAIUser.h"
```
see here
https://github.com/OpenAPITools/openapi-generator/pull/1366/files/bbebc58d8ea90b9b4285ce64cdd9fbf5afea7bd2#diff-a9518081670d402414102e315ccdcd7eR18

@stkrwork @MartinDelille @ravinikam @fvarose 