### PR TITLE
[rust-server] Always derive Debug

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -39,9 +39,7 @@ pub const BASE_PATH: &'static str = "{{{basePathWithoutHost}}}";
 pub const API_VERSION: &'static str = "{{{appVersion}}}";
 
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
-{{^isResponseFile}}
 #[derive(Debug, PartialEq)]
-{{/isResponseFile}}
 pub enum {{{operationId}}}Response {
 {{#responses}}
 {{#message}}    /// {{{message}}}{{/message}}

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -34,6 +34,14 @@ paths:
           description: Success
           schema:
             type: string
+  /file_response:
+    get:
+      summary: Get a file
+      responses:
+        200:
+          description: Success
+          schema:
+            type: file
 parameters:
   nested_response:
     name: nested_response

--- a/samples/server/petstore/rust-server/output/rust-server-test/README.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/README.md
@@ -57,6 +57,7 @@ To run a client, follow one of the following simple steps:
 ```
 cargo run --example client DummyGet
 cargo run --example client DummyPut
+cargo run --example client FileResponseGet
 cargo run --example client HtmlPost
 ```
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
@@ -48,6 +48,17 @@ paths:
                 type: string
           description: Success
       summary: Test HTML handling
+  /file_response:
+    get:
+      responses:
+        200:
+          content:
+            '*/*':
+              schema:
+                format: binary
+                type: string
+          description: Success
+      summary: Get a file
 components:
   requestBodies:
     nested_response:

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/client.rs
@@ -21,6 +21,7 @@ use rust_server_test::{ApiNoContext, ContextWrapperExt,
                       ApiError,
                       DummyGetResponse,
                       DummyPutResponse,
+                      FileResponseGetResponse,
                       HtmlPostResponse
                      };
 use clap::{App, Arg};
@@ -32,6 +33,7 @@ fn main() {
             .possible_values(&[
     "DummyGet",
     "DummyPut",
+    "FileResponseGet",
     "HtmlPost",
 ])
             .required(true)
@@ -80,6 +82,11 @@ fn main() {
 
         Some("DummyPut") => {
             let result = core.run(client.dummy_put(None));
+            println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
+         },
+
+        Some("FileResponseGet") => {
+            let result = core.run(client.file_response_get());
             println!("{:?} (X-Span-ID: {:?})", result, (client.context() as &Has<XSpanIdString>).get().clone());
          },
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server_lib/server.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server_lib/server.rs
@@ -13,6 +13,7 @@ use swagger::{Has, XSpanIdString};
 use rust_server_test::{Api, ApiError,
                       DummyGetResponse,
                       DummyPutResponse,
+                      FileResponseGetResponse,
                       HtmlPostResponse
 };
 use rust_server_test::models;
@@ -41,6 +42,13 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString>{
     fn dummy_put(&self, inline_object: Option<models::InlineObject>, context: &C) -> Box<Future<Item=DummyPutResponse, Error=ApiError>> {
         let context = context.clone();
         println!("dummy_put({:?}) - X-Span-ID: {:?}", inline_object, context.get().0.clone());
+        Box::new(futures::failed("Generic failure".into()))
+    }
+
+    /// Get a file
+    fn file_response_get(&self, context: &C) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>> {
+        let context = context.clone();
+        println!("file_response_get() - X-Span-ID: {:?}", context.get().0.clone());
         Box::new(futures::failed("Generic failure".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -51,6 +51,7 @@ pub enum DummyPutResponse {
     Success ,
 }
 
+#[derive(Debug, PartialEq)]
 pub enum FileResponseGetResponse {
     /// Success
     Success ( swagger::ByteArray ) ,

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -51,6 +51,11 @@ pub enum DummyPutResponse {
     Success ,
 }
 
+pub enum FileResponseGetResponse {
+    /// Success
+    Success ( swagger::ByteArray ) ,
+}
+
 #[derive(Debug, PartialEq)]
 pub enum HtmlPostResponse {
     /// Success
@@ -67,6 +72,9 @@ pub trait Api<C> {
 
     fn dummy_put(&self, inline_object: Option<models::InlineObject>, context: &C) -> Box<Future<Item=DummyPutResponse, Error=ApiError>>;
 
+    /// Get a file
+    fn file_response_get(&self, context: &C) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>>;
+
     /// Test HTML handling
     fn html_post(&self, body: String, context: &C) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>>;
 
@@ -80,6 +88,9 @@ pub trait ApiNoContext {
 
 
     fn dummy_put(&self, inline_object: Option<models::InlineObject>) -> Box<Future<Item=DummyPutResponse, Error=ApiError>>;
+
+    /// Get a file
+    fn file_response_get(&self) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>>;
 
     /// Test HTML handling
     fn html_post(&self, body: String) -> Box<Future<Item=HtmlPostResponse, Error=ApiError>>;
@@ -108,6 +119,11 @@ impl<'a, T: Api<C>, C> ApiNoContext for ContextWrapper<'a, T, C> {
 
     fn dummy_put(&self, inline_object: Option<models::InlineObject>) -> Box<Future<Item=DummyPutResponse, Error=ApiError>> {
         self.api().dummy_put(inline_object, &self.context())
+    }
+
+    /// Get a file
+    fn file_response_get(&self) -> Box<Future<Item=FileResponseGetResponse, Error=ApiError>> {
+        self.api().file_response_get(&self.context())
     }
 
     /// Test HTML handling

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/mimetypes.rs
@@ -4,6 +4,10 @@ pub mod responses {
     use hyper::mime::*;
 
     // The macro is called per-operation to beat the recursion limit
+    /// Create Mime objects for the response content types for FileResponseGet
+    lazy_static! {
+        pub static ref FILE_RESPONSE_GET_SUCCESS: Mime = "*/*".parse().unwrap();
+    }
     /// Create Mime objects for the response content types for HtmlPost
     lazy_static! {
         pub static ref HTML_POST_SUCCESS: Mime = "text/html".parse().unwrap();

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -39,6 +39,7 @@ use swagger::auth::Scopes;
 use {Api,
      DummyGetResponse,
      DummyPutResponse,
+     FileResponseGetResponse,
      HtmlPostResponse
      };
 #[allow(unused_imports)]
@@ -54,11 +55,13 @@ mod paths {
     lazy_static! {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(&[
             r"^/dummy$",
+            r"^/file_response$",
             r"^/html$"
         ]).unwrap();
     }
     pub static ID_DUMMY: usize = 0;
-    pub static ID_HTML: usize = 1;
+    pub static ID_FILE_RESPONSE: usize = 1;
+    pub static ID_HTML: usize = 2;
 }
 
 pub struct NewService<T, C> {
@@ -242,6 +245,60 @@ where
                         }
                     })
                 ) as Box<Future<Item=Response, Error=Error>>
+
+            },
+
+
+            // FileResponseGet - GET /file_response
+            &hyper::Method::Get if path.matched(paths::ID_FILE_RESPONSE) => {
+
+
+
+
+
+
+
+                Box::new({
+                        {{
+
+                                Box::new(api_impl.file_response_get(&context)
+                                    .then(move |result| {
+                                        let mut response = Response::new();
+                                        response.headers_mut().set(XSpanId((&context as &Has<XSpanIdString>).get().0.to_string()));
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                FileResponseGetResponse::Success
+
+                                                    (body)
+
+
+                                                => {
+                                                    response.set_status(StatusCode::try_from(200).unwrap());
+
+                                                    response.headers_mut().set(ContentType(mimetypes::responses::FILE_RESPONSE_GET_SUCCESS.clone()));
+
+
+                                                    let body = serde_json::to_string(&body).expect("impossible to fail to serialize");
+
+                                                    response.set_body(body);
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                response.set_status(StatusCode::InternalServerError);
+                                                response.set_body("An internal error occurred");
+                                            },
+                                        }
+
+                                        future::ok(response)
+                                    }
+                                ))
+
+                        }}
+                }) as Box<Future<Item=Response, Error=Error>>
+
 
             },
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

Now that we're using a byte array, we can guarantee that deriving Debug will always work.