### PR TITLE
Fix NPE when the paramName is null

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2985,6 +2985,12 @@ public class DefaultCodegen implements CodegenConfig {
             LOGGER.warn("Unknown parameter type: " + parameter.getName());
         }
 
+        // default to UNKNOWN_PARAMETER_NAME if paramName is null
+        if (codegenParameter.paramName == null) {
+            LOGGER.warn("Parameter name not defined properly. Default to UNKNOWN_PARAMETER_NAME");
+            codegenParameter.paramName = "UNKNOWN_PARAMETER_NAME";
+        }
+
         // set the parameter excample value
         // should be overridden by lang codegen
         setParameterExampleValue(codegenParameter, parameter);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To fix the following NPE:
```
  Exception: null
	at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:996)
	at org.openapitools.codegen.DefaultGenerator.processPaths(DefaultGenerator.java:887)
	at org.openapitools.codegen.DefaultGenerator.generateApis(DefaultGenerator.java:489)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:848)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:349)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
Caused by: java.lang.NullPointerException
	at org.openapitools.codegen.DefaultCodegen.isParameterNameUnique(DefaultCodegen.java:2592)
	at org.openapitools.codegen.DefaultCodegen.fromOperation(DefaultCodegen.java:2492)
	at org.openapitools.codegen.languages.AbstractJavaCodegen.fromOperation(AbstractJavaCodegen.java:1134)
	at org.openapitools.codegen.DefaultGenerator.processOperation(DefaultGenerator.java:964)
```