### PR TITLE
Fix run-in-docker by disabling useSystemClassLoader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,8 +122,8 @@ script:
   # fail if generators contain tab '\t'
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
-  - mvn --quiet clean install
-  - mvn --quiet verify -Psamples
+  - ./bin/run-in-docker.sh mvn --quiet --batch clean install
+  - mvn --quiet --batch verify -Psamples
 after_success:
   # push to maven repo
   - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,8 +122,8 @@ script:
   # fail if generators contain tab '\t'
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
-  - ./run-in-docker.sh mvn --quiet --batch clean install
-  - mvn --quiet --batch verify -Psamples
+  - ./run-in-docker.sh mvn --quiet --batch-mode clean install
+  - mvn --quiet --batch-mode verify -Psamples
 after_success:
   # push to maven repo
   - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ script:
   # fail if generators contain tab '\t'
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
-  - ./bin/run-in-docker.sh mvn --quiet --batch clean install
+  - ./run-in-docker.sh mvn --quiet --batch clean install
   - mvn --quiet --batch verify -Psamples
 after_success:
   # push to maven repo

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-version}</version>
                 <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                     <testNGArtifactName>none:none</testNGArtifactName>
                     <argLine>-XX:+StartAttachListener</argLine>
                     <argLine>-javaagent:${settings.localRepository}/org/jmockit/jmockit/${jmockit-version}/jmockit-${jmockit-version}.jar</argLine>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To fix https://github.com/OpenAPITools/openapi-generator/issues/1412

Thanks @meganemura  for suggesting the fix