### PR TITLE
Fix swift4 699

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift4/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/Configuration.mustache
@@ -10,6 +10,14 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = Configuration.getDateFormat(withFractionalSeconds: true)
     
+
+    /// Get one of the two OpenAPI compatible "date-time" formats. Either with or without fractional seconds, which are optional by the OpenAPI specification.
+    ///
+    /// - Parameter withFractionalSeconds: use true to get format with fractional seconds and use false to get format without them.
+    /// - Returns: OpenAPI compatible "date-time" format
+    public static func getDateFormat(withFractionalSeconds fractional: Bool) -> String {
+        return "yyyy-MM-dd'T'HH:mm:ss\(fractional ? ".SSS" : "")ZZZZZ"
+    }
 }

--- a/modules/openapi-generator/src/main/resources/swift4/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/Extensions.mustache
@@ -70,11 +70,7 @@ private let dateFormatter: DateFormatter = {
     if let formatter = CodableHelper.dateformatter {
         return formatter
     } else {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = Configuration.dateFormat
+        let formatter = CodableHelper.OpenApiIso8601DateFormatter()
         return formatter
     }
 }()

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -10,6 +10,14 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = Configuration.getDateFormat(withFractionalSeconds: true)
     
+
+    /// Get one of the two OpenAPI compatible "date-time" formats. Either with or without fractional seconds, which are optional by the OpenAPI specification.
+    ///
+    /// - Parameter withFractionalSeconds: use true to get format with fractional seconds and use false to get format without them.
+    /// - Returns: OpenAPI compatible "date-time" format
+    public static func getDateFormat(withFractionalSeconds fractional: Bool) -> String {
+        return "yyyy-MM-dd'T'HH:mm:ss\(fractional ? ".SSS" : "")ZZZZZ"
+    }
 }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -69,11 +69,7 @@ private let dateFormatter: DateFormatter = {
     if let formatter = CodableHelper.dateformatter {
         return formatter
     } else {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = Configuration.dateFormat
+        let formatter = CodableHelper.OpenApiIso8601DateFormatter()
         return formatter
     }
 }()

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -10,6 +10,14 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = Configuration.getDateFormat(withFractionalSeconds: true)
     
+
+    /// Get one of the two OpenAPI compatible "date-time" formats. Either with or without fractional seconds, which are optional by the OpenAPI specification.
+    ///
+    /// - Parameter withFractionalSeconds: use true to get format with fractional seconds and use false to get format without them.
+    /// - Returns: OpenAPI compatible "date-time" format
+    public static func getDateFormat(withFractionalSeconds fractional: Bool) -> String {
+        return "yyyy-MM-dd'T'HH:mm:ss\(fractional ? ".SSS" : "")ZZZZZ"
+    }
 }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -69,11 +69,7 @@ private let dateFormatter: DateFormatter = {
     if let formatter = CodableHelper.dateformatter {
         return formatter
     } else {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = Configuration.dateFormat
+        let formatter = CodableHelper.OpenApiIso8601DateFormatter()
         return formatter
     }
 }()

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -10,6 +10,14 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = Configuration.getDateFormat(withFractionalSeconds: true)
     
+
+    /// Get one of the two OpenAPI compatible "date-time" formats. Either with or without fractional seconds, which are optional by the OpenAPI specification.
+    ///
+    /// - Parameter withFractionalSeconds: use true to get format with fractional seconds and use false to get format without them.
+    /// - Returns: OpenAPI compatible "date-time" format
+    public static func getDateFormat(withFractionalSeconds fractional: Bool) -> String {
+        return "yyyy-MM-dd'T'HH:mm:ss\(fractional ? ".SSS" : "")ZZZZZ"
+    }
 }

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -70,11 +70,7 @@ private let dateFormatter: DateFormatter = {
     if let formatter = CodableHelper.dateformatter {
         return formatter
     } else {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = Configuration.dateFormat
+        let formatter = CodableHelper.OpenApiIso8601DateFormatter()
         return formatter
     }
 }()

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -10,6 +10,14 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = Configuration.getDateFormat(withFractionalSeconds: true)
     
+
+    /// Get one of the two OpenAPI compatible "date-time" formats. Either with or without fractional seconds, which are optional by the OpenAPI specification.
+    ///
+    /// - Parameter withFractionalSeconds: use true to get format with fractional seconds and use false to get format without them.
+    /// - Returns: OpenAPI compatible "date-time" format
+    public static func getDateFormat(withFractionalSeconds fractional: Bool) -> String {
+        return "yyyy-MM-dd'T'HH:mm:ss\(fractional ? ".SSS" : "")ZZZZZ"
+    }
 }

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -69,11 +69,7 @@ private let dateFormatter: DateFormatter = {
     if let formatter = CodableHelper.dateformatter {
         return formatter
     } else {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = Configuration.dateFormat
+        let formatter = CodableHelper.OpenApiIso8601DateFormatter()
         return formatter
     }
 }()

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/Configuration.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/Configuration.swift
@@ -10,6 +10,14 @@ open class Configuration {
 	
 	// This value is used to configure the date formatter that is used to serialize dates into JSON format. 
 	// You must set it prior to encoding any dates, and it will only be read once. 
-    public static var dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    public static var dateFormat = Configuration.getDateFormat(withFractionalSeconds: true)
     
+
+    /// Get one of the two OpenAPI compatible "date-time" formats. Either with or without fractional seconds, which are optional by the OpenAPI specification.
+    ///
+    /// - Parameter withFractionalSeconds: use true to get format with fractional seconds and use false to get format without them.
+    /// - Returns: OpenAPI compatible "date-time" format
+    public static func getDateFormat(withFractionalSeconds fractional: Bool) -> String {
+        return "yyyy-MM-dd'T'HH:mm:ss\(fractional ? ".SSS" : "")ZZZZZ"
+    }
 }

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/Extensions.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/Extensions.swift
@@ -69,11 +69,7 @@ private let dateFormatter: DateFormatter = {
     if let formatter = CodableHelper.dateformatter {
         return formatter
     } else {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = Configuration.dateFormat
+        let formatter = CodableHelper.OpenApiIso8601DateFormatter()
         return formatter
     }
 }()


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fix for #699 

Updates Swift4 templates to support both OpenAPI "date-time" variants for deserialize dates from JSON.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @d-date (2018/03)