### PR TITLE
[PHP-Symfony] fix #1272 Fix wrong PHP Symfony typehint

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -424,6 +424,10 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
                     var.vendorExtensions.put("x-parameterType", typeHint);
                 }
 
+                if (var.isContainer) {
+                    var.vendorExtensions.put("x-parameterType", getTypeHint(var.dataType + "[]"));
+                }
+
                 // Create a variable to display the correct data type in comments for models
                 var.vendorExtensions.put("x-commentType", var.dataType);
                 if (var.isContainer) {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -203,7 +203,7 @@ class Pet
      *
      * @return $this
      */
-    public function setPhotoUrls($photoUrls)
+    public function setPhotoUrls(array $photoUrls)
     {
         $this->photoUrls = $photoUrls;
 
@@ -227,7 +227,7 @@ class Pet
      *
      * @return $this
      */
-    public function setTags(Tag $tags = null)
+    public function setTags(array $tags = null)
     {
         $this->tags = $tags;
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fix #1272 

A model with an array property used to have the wrong PHP typehint in the setter: the array item object type instead of "array"

This is visible in the samples, in the Pet.php model: `setPhotoUrls` and `setTags`

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @ybelenko
