### PR TITLE
[swift4] Add ability to pass in a dedicated queue for processing network response (Fix for 230)

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift4/APIs.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/APIs.mustache
@@ -40,7 +40,7 @@ open class RequestBuilder<T> {
         }
     }
 
-    open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
+    open func execute(queue: DispatchQueue? = nil, _ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/modules/openapi-generator/src/main/resources/swift4/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/api.mustache
@@ -38,10 +38,11 @@ open class {{classname}} {
      {{{summary}}}
      {{/summary}}{{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}completion: @escaping ((_ data: {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}?,_ error: Error?) -> Void)) {
-        {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute { (response, error) -> Void in
+    open class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}queue: DispatchQueue? = nil, completion: @escaping ((_ data: {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}?,_ error: Error?) -> Void)) {
+        {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).execute(queue: queue) { (response, error) -> Void in
         {{#returnType}}
             completion(response?.body, error)
         {{/returnType}}
@@ -61,11 +62,12 @@ open class {{classname}} {
      {{{summary}}}
      {{/summary}}{{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    open class func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    open class func {{operationId}}({{#allParams}} {{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}queue: DispatchQueue? = nil) -> Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         let deferred = Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>.pending()
-        {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) { data, error in
+        {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -81,11 +83,12 @@ open class {{classname}} {
      {{{summary}}}
      {{/summary}}{{#allParams}}
      - parameter {{paramName}}: ({{#isFormParam}}form{{/isFormParam}}{{#isQueryParam}}query{{/isQueryParam}}{{#isPathParam}}path{{/isPathParam}}{{#isHeaderParam}}header{{/isHeaderParam}}{{#isBodyParam}}body{{/isBodyParam}}) {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}>
      */
-    open class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
+    open class func {{operationId}}({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}queue: DispatchQueue? = nil) -> Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         return Observable.create { observer -> Disposable in
-            {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) { data, error in
+            {{operationId}}({{#allParams}}{{paramName}}: {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{#hasParams}}, {{/hasParams}}queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs.swift
@@ -40,7 +40,7 @@ open class RequestBuilder<T> {
         }
     }
 
-    open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
+    open func execute(queue: DispatchQueue? = nil, _ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -15,10 +15,11 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func call123testSpecialTags(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        call123testSpecialTagsWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func call123testSpecialTags(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        call123testSpecialTagsWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -14,10 +14,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
-        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
+        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -44,10 +45,11 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
-        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute { (response, error) -> Void in
+    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
+        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -74,10 +76,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
-        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterNumberSerialize(body: Double? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
+        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -104,10 +107,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        fakeOuterStringSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterStringSerialize(body: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        fakeOuterStringSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -134,10 +138,11 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute { (response, error) -> Void in
+    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -169,10 +174,11 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithQueryParams(query: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute { (response, error) -> Void in
+    open class func testBodyWithQueryParams(query: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -207,10 +213,11 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClientModelWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClientModel(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClientModelWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -252,10 +259,11 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -396,10 +404,11 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { (response, error) -> Void in
+    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -461,10 +470,11 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { (response, error) -> Void in
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -513,10 +523,11 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testInlineAdditionalProperties(requestBody: [String:String], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute { (response, error) -> Void in
+    open class func testInlineAdditionalProperties(requestBody: [String:String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -549,10 +560,11 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { (response, error) -> Void in
+    open class func testJsonFormData(param: String, param2: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -15,10 +15,11 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClassnameWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClassname(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClassnameWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -15,10 +15,11 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func addPet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        addPetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func addPet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        addPetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -54,10 +55,11 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { (response, error) -> Void in
+    open class func deletePet(petId: Int64, apiKey: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -109,10 +111,11 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+    open class func findPetsByStatus(status: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByStatusWithRequestBuilder(status: status).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -147,10 +150,11 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+    open class func findPetsByTags(tags: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByTagsWithRequestBuilder(tags: tags).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -185,10 +189,11 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
-        getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+    open class func getPetById(petId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
+        getPetByIdWithRequestBuilder(petId: petId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -223,10 +228,11 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func updatePet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -263,10 +269,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -314,10 +321,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -361,10 +369,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { (response, error) -> Void in
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -15,10 +15,11 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteOrder(orderId: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func deleteOrder(orderId: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteOrderWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -53,10 +54,11 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
-        getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+    open class func getInventory(queue: DispatchQueue? = nil, completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
+        getInventoryWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -87,10 +89,11 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func getOrderById(orderId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        getOrderByIdWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -122,10 +125,11 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(order: Order, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        placeOrderWithRequestBuilder(order: order).execute { (response, error) -> Void in
+    open class func placeOrder(order: Order, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        placeOrderWithRequestBuilder(order: order).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -15,10 +15,11 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUser(user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUserWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUser(user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUserWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -51,10 +52,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithArrayInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithArrayInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithArrayInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithArrayInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -86,10 +88,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithListInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithListInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithListInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithListInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -121,10 +124,11 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteUser(username: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func deleteUser(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteUserWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -160,10 +164,11 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
-        getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func getUserByName(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
+        getUserByNameWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -195,10 +200,11 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+    open class func loginUser(username: String, password: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        loginUserWithRequestBuilder(username: username, password: password).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -231,10 +237,11 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func logoutUser(completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+    open class func logoutUser(queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        logoutUserWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -266,10 +273,11 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updateUser(username: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updateUserWithRequestBuilder(username: username, user: user).execute { (response, error) -> Void in
+    open class func updateUser(username: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updateUserWithRequestBuilder(username: username, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs.swift
@@ -40,7 +40,7 @@ open class RequestBuilder<T> {
         }
     }
 
-    open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
+    open func execute(queue: DispatchQueue? = nil, _ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -15,10 +15,11 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func call123testSpecialTags(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        call123testSpecialTagsWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func call123testSpecialTags(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        call123testSpecialTagsWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -14,10 +14,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
-        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
+        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -44,10 +45,11 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
-        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute { (response, error) -> Void in
+    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
+        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -74,10 +76,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
-        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterNumberSerialize(body: Double? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
+        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -104,10 +107,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        fakeOuterStringSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterStringSerialize(body: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        fakeOuterStringSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -134,10 +138,11 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute { (response, error) -> Void in
+    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -169,10 +174,11 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithQueryParams(query: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute { (response, error) -> Void in
+    open class func testBodyWithQueryParams(query: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -207,10 +213,11 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClientModelWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClientModel(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClientModelWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -252,10 +259,11 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -396,10 +404,11 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { (response, error) -> Void in
+    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -461,10 +470,11 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { (response, error) -> Void in
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -513,10 +523,11 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testInlineAdditionalProperties(requestBody: [String:String], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute { (response, error) -> Void in
+    open class func testInlineAdditionalProperties(requestBody: [String:String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -549,10 +560,11 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { (response, error) -> Void in
+    open class func testJsonFormData(param: String, param2: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -15,10 +15,11 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClassnameWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClassname(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClassnameWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -15,10 +15,11 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func addPet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        addPetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func addPet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        addPetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -54,10 +55,11 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { (response, error) -> Void in
+    open class func deletePet(petId: Int64, apiKey: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -109,10 +111,11 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+    open class func findPetsByStatus(status: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByStatusWithRequestBuilder(status: status).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -147,10 +150,11 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+    open class func findPetsByTags(tags: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByTagsWithRequestBuilder(tags: tags).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -185,10 +189,11 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
-        getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+    open class func getPetById(petId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
+        getPetByIdWithRequestBuilder(petId: petId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -223,10 +228,11 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func updatePet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -263,10 +269,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -314,10 +321,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -361,10 +369,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { (response, error) -> Void in
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -15,10 +15,11 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteOrder(orderId: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func deleteOrder(orderId: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteOrderWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -53,10 +54,11 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
-        getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+    open class func getInventory(queue: DispatchQueue? = nil, completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
+        getInventoryWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -87,10 +89,11 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func getOrderById(orderId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        getOrderByIdWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -122,10 +125,11 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(order: Order, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        placeOrderWithRequestBuilder(order: order).execute { (response, error) -> Void in
+    open class func placeOrder(order: Order, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        placeOrderWithRequestBuilder(order: order).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -15,10 +15,11 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUser(user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUserWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUser(user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUserWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -51,10 +52,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithArrayInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithArrayInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithArrayInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithArrayInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -86,10 +88,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithListInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithListInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithListInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithListInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -121,10 +124,11 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteUser(username: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func deleteUser(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteUserWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -160,10 +164,11 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
-        getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func getUserByName(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
+        getUserByNameWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -195,10 +200,11 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+    open class func loginUser(username: String, password: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        loginUserWithRequestBuilder(username: username, password: password).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -231,10 +237,11 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func logoutUser(completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+    open class func logoutUser(queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        logoutUserWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -266,10 +273,11 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updateUser(username: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updateUserWithRequestBuilder(username: username, user: user).execute { (response, error) -> Void in
+    open class func updateUser(username: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updateUserWithRequestBuilder(username: username, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs.swift
@@ -40,7 +40,7 @@ open class RequestBuilder<T> {
         }
     }
 
-    open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
+    open func execute(queue: DispatchQueue? = nil, _ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -16,10 +16,11 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func call123testSpecialTags(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        call123testSpecialTagsWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func call123testSpecialTags(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        call123testSpecialTagsWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -28,11 +29,12 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Client>
      */
-    open class func call123testSpecialTags( client: Client) -> Promise<Client> {
+    open class func call123testSpecialTags( client: Client, queue: DispatchQueue? = nil) -> Promise<Client> {
         let deferred = Promise<Client>.pending()
-        call123testSpecialTags(client: client) { data, error in
+        call123testSpecialTags(client: client, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -15,10 +15,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
-        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
+        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -26,11 +27,12 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Bool>
      */
-    open class func fakeOuterBooleanSerialize( body: Bool? = nil) -> Promise<Bool> {
+    open class func fakeOuterBooleanSerialize( body: Bool? = nil, queue: DispatchQueue? = nil) -> Promise<Bool> {
         let deferred = Promise<Bool>.pending()
-        fakeOuterBooleanSerialize(body: body) { data, error in
+        fakeOuterBooleanSerialize(body: body, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -61,10 +63,11 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
-        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute { (response, error) -> Void in
+    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
+        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -72,11 +75,12 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<OuterComposite>
      */
-    open class func fakeOuterCompositeSerialize( outerComposite: OuterComposite? = nil) -> Promise<OuterComposite> {
+    open class func fakeOuterCompositeSerialize( outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil) -> Promise<OuterComposite> {
         let deferred = Promise<OuterComposite>.pending()
-        fakeOuterCompositeSerialize(outerComposite: outerComposite) { data, error in
+        fakeOuterCompositeSerialize(outerComposite: outerComposite, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -107,10 +111,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
-        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterNumberSerialize(body: Double? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
+        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -118,11 +123,12 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Double>
      */
-    open class func fakeOuterNumberSerialize( body: Double? = nil) -> Promise<Double> {
+    open class func fakeOuterNumberSerialize( body: Double? = nil, queue: DispatchQueue? = nil) -> Promise<Double> {
         let deferred = Promise<Double>.pending()
-        fakeOuterNumberSerialize(body: body) { data, error in
+        fakeOuterNumberSerialize(body: body, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -153,10 +159,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        fakeOuterStringSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterStringSerialize(body: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        fakeOuterStringSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -164,11 +171,12 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<String>
      */
-    open class func fakeOuterStringSerialize( body: String? = nil) -> Promise<String> {
+    open class func fakeOuterStringSerialize( body: String? = nil, queue: DispatchQueue? = nil) -> Promise<String> {
         let deferred = Promise<String>.pending()
-        fakeOuterStringSerialize(body: body) { data, error in
+        fakeOuterStringSerialize(body: body, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -199,10 +207,11 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute { (response, error) -> Void in
+    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -214,11 +223,12 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testBodyWithFileSchema( fileSchemaTestClass: FileSchemaTestClass) -> Promise<Void> {
+    open class func testBodyWithFileSchema( fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testBodyWithFileSchema(fileSchemaTestClass: fileSchemaTestClass) { data, error in
+        testBodyWithFileSchema(fileSchemaTestClass: fileSchemaTestClass, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -250,10 +260,11 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithQueryParams(query: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute { (response, error) -> Void in
+    open class func testBodyWithQueryParams(query: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -266,11 +277,12 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testBodyWithQueryParams( query: String,  user: User) -> Promise<Void> {
+    open class func testBodyWithQueryParams( query: String,  user: User, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testBodyWithQueryParams(query: query, user: user) { data, error in
+        testBodyWithQueryParams(query: query, user: user, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -305,10 +317,11 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClientModelWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClientModel(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClientModelWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -317,11 +330,12 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Client>
      */
-    open class func testClientModel( client: Client) -> Promise<Client> {
+    open class func testClientModel( client: Client, queue: DispatchQueue? = nil) -> Promise<Client> {
         let deferred = Promise<Client>.pending()
-        testClientModel(client: client) { data, error in
+        testClientModel(client: client, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -367,10 +381,11 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -396,11 +411,12 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testEndpointParameters( number: Double,  double: Double,  patternWithoutDelimiter: String,  byte: Data,  integer: Int? = nil,  int32: Int? = nil,  int64: Int64? = nil,  float: Float? = nil,  string: String? = nil,  binary: URL? = nil,  date: Date? = nil,  dateTime: Date? = nil,  password: String? = nil,  callback: String? = nil) -> Promise<Void> {
+    open class func testEndpointParameters( number: Double,  double: Double,  patternWithoutDelimiter: String,  byte: Data,  integer: Int? = nil,  int32: Int? = nil,  int64: Int64? = nil,  float: Float? = nil,  string: String? = nil,  binary: URL? = nil,  date: Date? = nil,  dateTime: Date? = nil,  password: String? = nil,  callback: String? = nil, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback) { data, error in
+        testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -541,10 +557,11 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { (response, error) -> Void in
+    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -564,11 +581,12 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testEnumParameters( enumHeaderStringArray: [String]? = nil,  enumHeaderString: EnumHeaderString_testEnumParameters? = nil,  enumQueryStringArray: [String]? = nil,  enumQueryString: EnumQueryString_testEnumParameters? = nil,  enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil,  enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil,  enumFormStringArray: [String]? = nil,  enumFormString: EnumFormString_testEnumParameters? = nil) -> Promise<Void> {
+    open class func testEnumParameters( enumHeaderStringArray: [String]? = nil,  enumHeaderString: EnumHeaderString_testEnumParameters? = nil,  enumQueryStringArray: [String]? = nil,  enumQueryString: EnumQueryString_testEnumParameters? = nil,  enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil,  enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil,  enumFormStringArray: [String]? = nil,  enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString) { data, error in
+        testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -630,10 +648,11 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { (response, error) -> Void in
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -651,11 +670,12 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testGroupParameters( requiredStringGroup: Int,  requiredBooleanGroup: Bool,  requiredInt64Group: Int64,  stringGroup: Int? = nil,  booleanGroup: Bool? = nil,  int64Group: Int64? = nil) -> Promise<Void> {
+    open class func testGroupParameters( requiredStringGroup: Int,  requiredBooleanGroup: Bool,  requiredInt64Group: Int64,  stringGroup: Int? = nil,  booleanGroup: Bool? = nil,  int64Group: Int64? = nil, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group) { data, error in
+        testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -704,10 +724,11 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testInlineAdditionalProperties(requestBody: [String:String], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute { (response, error) -> Void in
+    open class func testInlineAdditionalProperties(requestBody: [String:String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -720,11 +741,12 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testInlineAdditionalProperties( requestBody: [String:String]) -> Promise<Void> {
+    open class func testInlineAdditionalProperties( requestBody: [String:String], queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testInlineAdditionalProperties(requestBody: requestBody) { data, error in
+        testInlineAdditionalProperties(requestBody: requestBody, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -757,10 +779,11 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { (response, error) -> Void in
+    open class func testJsonFormData(param: String, param2: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -774,11 +797,12 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func testJsonFormData( param: String,  param2: String) -> Promise<Void> {
+    open class func testJsonFormData( param: String,  param2: String, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        testJsonFormData(param: param, param2: param2) { data, error in
+        testJsonFormData(param: param, param2: param2, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -16,10 +16,11 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClassnameWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClassname(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClassnameWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -28,11 +29,12 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Client>
      */
-    open class func testClassname( client: Client) -> Promise<Client> {
+    open class func testClassname( client: Client, queue: DispatchQueue? = nil) -> Promise<Client> {
         let deferred = Promise<Client>.pending()
-        testClassname(client: client) { data, error in
+        testClassname(client: client, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -16,10 +16,11 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func addPet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        addPetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func addPet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        addPetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -32,11 +33,12 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func addPet( pet: Pet) -> Promise<Void> {
+    open class func addPet( pet: Pet, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        addPet(pet: pet) { data, error in
+        addPet(pet: pet, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -72,10 +74,11 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { (response, error) -> Void in
+    open class func deletePet(petId: Int64, apiKey: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -89,11 +92,12 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func deletePet( petId: Int64,  apiKey: String? = nil) -> Promise<Void> {
+    open class func deletePet( petId: Int64,  apiKey: String? = nil, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        deletePet(petId: petId, apiKey: apiKey) { data, error in
+        deletePet(petId: petId, apiKey: apiKey, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -145,10 +149,11 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+    open class func findPetsByStatus(status: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByStatusWithRequestBuilder(status: status).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -157,11 +162,12 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<[Pet]>
      */
-    open class func findPetsByStatus( status: [String]) -> Promise<[Pet]> {
+    open class func findPetsByStatus( status: [String], queue: DispatchQueue? = nil) -> Promise<[Pet]> {
         let deferred = Promise<[Pet]>.pending()
-        findPetsByStatus(status: status) { data, error in
+        findPetsByStatus(status: status, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -200,10 +206,11 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+    open class func findPetsByTags(tags: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByTagsWithRequestBuilder(tags: tags).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -212,11 +219,12 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<[Pet]>
      */
-    open class func findPetsByTags( tags: [String]) -> Promise<[Pet]> {
+    open class func findPetsByTags( tags: [String], queue: DispatchQueue? = nil) -> Promise<[Pet]> {
         let deferred = Promise<[Pet]>.pending()
-        findPetsByTags(tags: tags) { data, error in
+        findPetsByTags(tags: tags, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -255,10 +263,11 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
-        getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+    open class func getPetById(petId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
+        getPetByIdWithRequestBuilder(petId: petId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -267,11 +276,12 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Pet>
      */
-    open class func getPetById( petId: Int64) -> Promise<Pet> {
+    open class func getPetById( petId: Int64, queue: DispatchQueue? = nil) -> Promise<Pet> {
         let deferred = Promise<Pet>.pending()
-        getPetById(petId: petId) { data, error in
+        getPetById(petId: petId, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -310,10 +320,11 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func updatePet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -326,11 +337,12 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func updatePet( pet: Pet) -> Promise<Void> {
+    open class func updatePet( pet: Pet, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        updatePet(pet: pet) { data, error in
+        updatePet(pet: pet, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -367,10 +379,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -385,11 +398,12 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func updatePetWithForm( petId: Int64,  name: String? = nil,  status: String? = nil) -> Promise<Void> {
+    open class func updatePetWithForm( petId: Int64,  name: String? = nil,  status: String? = nil, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        updatePetWithForm(petId: petId, name: name, status: status) { data, error in
+        updatePetWithForm(petId: petId, name: name, status: status, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -437,10 +451,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -451,11 +466,12 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<ApiResponse>
      */
-    open class func uploadFile( petId: Int64,  additionalMetadata: String? = nil,  file: URL? = nil) -> Promise<ApiResponse> {
+    open class func uploadFile( petId: Int64,  additionalMetadata: String? = nil,  file: URL? = nil, queue: DispatchQueue? = nil) -> Promise<ApiResponse> {
         let deferred = Promise<ApiResponse>.pending()
-        uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { data, error in
+        uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -503,10 +519,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { (response, error) -> Void in
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -517,11 +534,12 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<ApiResponse>
      */
-    open class func uploadFileWithRequiredFile( petId: Int64,  requiredFile: URL,  additionalMetadata: String? = nil) -> Promise<ApiResponse> {
+    open class func uploadFileWithRequiredFile( petId: Int64,  requiredFile: URL,  additionalMetadata: String? = nil, queue: DispatchQueue? = nil) -> Promise<ApiResponse> {
         let deferred = Promise<ApiResponse>.pending()
-        uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata) { data, error in
+        uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -16,10 +16,11 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteOrder(orderId: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func deleteOrder(orderId: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteOrderWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -32,11 +33,12 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func deleteOrder( orderId: String) -> Promise<Void> {
+    open class func deleteOrder( orderId: String, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        deleteOrder(orderId: orderId) { data, error in
+        deleteOrder(orderId: orderId, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -71,10 +73,11 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
-        getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+    open class func getInventory(queue: DispatchQueue? = nil, completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
+        getInventoryWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -82,11 +85,12 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<[String:Int]>
      */
-    open class func getInventory() -> Promise<[String:Int]> {
+    open class func getInventory(queue: DispatchQueue? = nil) -> Promise<[String:Int]> {
         let deferred = Promise<[String:Int]>.pending()
-        getInventory() { data, error in
+        getInventory(queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -121,10 +125,11 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func getOrderById(orderId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        getOrderByIdWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -133,11 +138,12 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Order>
      */
-    open class func getOrderById( orderId: Int64) -> Promise<Order> {
+    open class func getOrderById( orderId: Int64, queue: DispatchQueue? = nil) -> Promise<Order> {
         let deferred = Promise<Order>.pending()
-        getOrderById(orderId: orderId) { data, error in
+        getOrderById(orderId: orderId, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -173,10 +179,11 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(order: Order, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        placeOrderWithRequestBuilder(order: order).execute { (response, error) -> Void in
+    open class func placeOrder(order: Order, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        placeOrderWithRequestBuilder(order: order).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -185,11 +192,12 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Order>
      */
-    open class func placeOrder( order: Order) -> Promise<Order> {
+    open class func placeOrder( order: Order, queue: DispatchQueue? = nil) -> Promise<Order> {
         let deferred = Promise<Order>.pending()
-        placeOrder(order: order) { data, error in
+        placeOrder(order: order, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -16,10 +16,11 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUser(user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUserWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUser(user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUserWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -32,11 +33,12 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func createUser( user: User) -> Promise<Void> {
+    open class func createUser( user: User, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        createUser(user: user) { data, error in
+        createUser(user: user, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -69,10 +71,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithArrayInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithArrayInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithArrayInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithArrayInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -85,11 +88,12 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func createUsersWithArrayInput( user: [User]) -> Promise<Void> {
+    open class func createUsersWithArrayInput( user: [User], queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        createUsersWithArrayInput(user: user) { data, error in
+        createUsersWithArrayInput(user: user, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -121,10 +125,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithListInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithListInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithListInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithListInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -137,11 +142,12 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func createUsersWithListInput( user: [User]) -> Promise<Void> {
+    open class func createUsersWithListInput( user: [User], queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        createUsersWithListInput(user: user) { data, error in
+        createUsersWithListInput(user: user, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -173,10 +179,11 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteUser(username: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func deleteUser(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteUserWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -189,11 +196,12 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func deleteUser( username: String) -> Promise<Void> {
+    open class func deleteUser( username: String, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        deleteUser(username: username) { data, error in
+        deleteUser(username: username, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -229,10 +237,11 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
-        getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func getUserByName(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
+        getUserByNameWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -241,11 +250,12 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<User>
      */
-    open class func getUserByName( username: String) -> Promise<User> {
+    open class func getUserByName( username: String, queue: DispatchQueue? = nil) -> Promise<User> {
         let deferred = Promise<User>.pending()
-        getUserByName(username: username) { data, error in
+        getUserByName(username: username, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -281,10 +291,11 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+    open class func loginUser(username: String, password: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        loginUserWithRequestBuilder(username: username, password: password).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -294,11 +305,12 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<String>
      */
-    open class func loginUser( username: String,  password: String) -> Promise<String> {
+    open class func loginUser( username: String,  password: String, queue: DispatchQueue? = nil) -> Promise<String> {
         let deferred = Promise<String>.pending()
-        loginUser(username: username, password: password) { data, error in
+        loginUser(username: username, password: password, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -335,10 +347,11 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func logoutUser(completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+    open class func logoutUser(queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        logoutUserWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -350,11 +363,12 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func logoutUser() -> Promise<Void> {
+    open class func logoutUser(queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        logoutUser() { data, error in
+        logoutUser(queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {
@@ -386,10 +400,11 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updateUser(username: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updateUserWithRequestBuilder(username: username, user: user).execute { (response, error) -> Void in
+    open class func updateUser(username: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updateUserWithRequestBuilder(username: username, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -403,11 +418,12 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Promise<Void>
      */
-    open class func updateUser( username: String,  user: User) -> Promise<Void> {
+    open class func updateUser( username: String,  user: User, queue: DispatchQueue? = nil) -> Promise<Void> {
         let deferred = Promise<Void>.pending()
-        updateUser(username: username, user: user) { data, error in
+        updateUser(username: username, user: user, queue: queue) { data, error in
             if let error = error {
                 deferred.reject(error)
             } else {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs.swift
@@ -40,7 +40,7 @@ open class RequestBuilder<T> {
         }
     }
 
-    open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
+    open func execute(queue: DispatchQueue? = nil, _ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -16,10 +16,11 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func call123testSpecialTags(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        call123testSpecialTagsWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func call123testSpecialTags(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        call123testSpecialTagsWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -28,11 +29,12 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Client>
      */
-    open class func call123testSpecialTags(client: Client) -> Observable<Client> {
+    open class func call123testSpecialTags(client: Client, queue: DispatchQueue? = nil) -> Observable<Client> {
         return Observable.create { observer -> Disposable in
-            call123testSpecialTags(client: client) { data, error in
+            call123testSpecialTags(client: client, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -15,10 +15,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
-        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
+        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -26,11 +27,12 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Bool>
      */
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil) -> Observable<Bool> {
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, queue: DispatchQueue? = nil) -> Observable<Bool> {
         return Observable.create { observer -> Disposable in
-            fakeOuterBooleanSerialize(body: body) { data, error in
+            fakeOuterBooleanSerialize(body: body, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -63,10 +65,11 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
-        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute { (response, error) -> Void in
+    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
+        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -74,11 +77,12 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<OuterComposite>
      */
-    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil) -> Observable<OuterComposite> {
+    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil) -> Observable<OuterComposite> {
         return Observable.create { observer -> Disposable in
-            fakeOuterCompositeSerialize(outerComposite: outerComposite) { data, error in
+            fakeOuterCompositeSerialize(outerComposite: outerComposite, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -111,10 +115,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
-        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterNumberSerialize(body: Double? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
+        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -122,11 +127,12 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Double>
      */
-    open class func fakeOuterNumberSerialize(body: Double? = nil) -> Observable<Double> {
+    open class func fakeOuterNumberSerialize(body: Double? = nil, queue: DispatchQueue? = nil) -> Observable<Double> {
         return Observable.create { observer -> Disposable in
-            fakeOuterNumberSerialize(body: body) { data, error in
+            fakeOuterNumberSerialize(body: body, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -159,10 +165,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        fakeOuterStringSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterStringSerialize(body: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        fakeOuterStringSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -170,11 +177,12 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<String>
      */
-    open class func fakeOuterStringSerialize(body: String? = nil) -> Observable<String> {
+    open class func fakeOuterStringSerialize(body: String? = nil, queue: DispatchQueue? = nil) -> Observable<String> {
         return Observable.create { observer -> Disposable in
-            fakeOuterStringSerialize(body: body) { data, error in
+            fakeOuterStringSerialize(body: body, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -207,10 +215,11 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute { (response, error) -> Void in
+    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -222,11 +231,12 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass) -> Observable<Void> {
+    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testBodyWithFileSchema(fileSchemaTestClass: fileSchemaTestClass) { data, error in
+            testBodyWithFileSchema(fileSchemaTestClass: fileSchemaTestClass, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -260,10 +270,11 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithQueryParams(query: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute { (response, error) -> Void in
+    open class func testBodyWithQueryParams(query: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -276,11 +287,12 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testBodyWithQueryParams(query: String, user: User) -> Observable<Void> {
+    open class func testBodyWithQueryParams(query: String, user: User, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testBodyWithQueryParams(query: query, user: user) { data, error in
+            testBodyWithQueryParams(query: query, user: user, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -317,10 +329,11 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClientModelWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClientModel(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClientModelWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -329,11 +342,12 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Client>
      */
-    open class func testClientModel(client: Client) -> Observable<Client> {
+    open class func testClientModel(client: Client, queue: DispatchQueue? = nil) -> Observable<Client> {
         return Observable.create { observer -> Disposable in
-            testClientModel(client: client) { data, error in
+            testClientModel(client: client, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -381,10 +395,11 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -410,11 +425,12 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) -> Observable<Void> {
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback) { data, error in
+            testEndpointParameters(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -557,10 +573,11 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { (response, error) -> Void in
+    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -580,11 +597,12 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) -> Observable<Void> {
+    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString) { data, error in
+            testEnumParameters(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -648,10 +666,11 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { (response, error) -> Void in
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -669,11 +688,12 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) -> Observable<Void> {
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group) { data, error in
+            testGroupParameters(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -724,10 +744,11 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testInlineAdditionalProperties(requestBody: [String:String], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute { (response, error) -> Void in
+    open class func testInlineAdditionalProperties(requestBody: [String:String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -740,11 +761,12 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testInlineAdditionalProperties(requestBody: [String:String]) -> Observable<Void> {
+    open class func testInlineAdditionalProperties(requestBody: [String:String], queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testInlineAdditionalProperties(requestBody: requestBody) { data, error in
+            testInlineAdditionalProperties(requestBody: requestBody, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -779,10 +801,11 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { (response, error) -> Void in
+    open class func testJsonFormData(param: String, param2: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -796,11 +819,12 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func testJsonFormData(param: String, param2: String) -> Observable<Void> {
+    open class func testJsonFormData(param: String, param2: String, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            testJsonFormData(param: param, param2: param2) { data, error in
+            testJsonFormData(param: param, param2: param2, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -16,10 +16,11 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClassnameWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClassname(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClassnameWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -28,11 +29,12 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Client>
      */
-    open class func testClassname(client: Client) -> Observable<Client> {
+    open class func testClassname(client: Client, queue: DispatchQueue? = nil) -> Observable<Client> {
         return Observable.create { observer -> Disposable in
-            testClassname(client: client) { data, error in
+            testClassname(client: client, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -16,10 +16,11 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func addPet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        addPetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func addPet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        addPetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -32,11 +33,12 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func addPet(pet: Pet) -> Observable<Void> {
+    open class func addPet(pet: Pet, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            addPet(pet: pet) { data, error in
+            addPet(pet: pet, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -74,10 +76,11 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { (response, error) -> Void in
+    open class func deletePet(petId: Int64, apiKey: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -91,11 +94,12 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func deletePet(petId: Int64, apiKey: String? = nil) -> Observable<Void> {
+    open class func deletePet(petId: Int64, apiKey: String? = nil, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            deletePet(petId: petId, apiKey: apiKey) { data, error in
+            deletePet(petId: petId, apiKey: apiKey, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -149,10 +153,11 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+    open class func findPetsByStatus(status: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByStatusWithRequestBuilder(status: status).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -161,11 +166,12 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<[Pet]>
      */
-    open class func findPetsByStatus(status: [String]) -> Observable<[Pet]> {
+    open class func findPetsByStatus(status: [String], queue: DispatchQueue? = nil) -> Observable<[Pet]> {
         return Observable.create { observer -> Disposable in
-            findPetsByStatus(status: status) { data, error in
+            findPetsByStatus(status: status, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -206,10 +212,11 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+    open class func findPetsByTags(tags: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByTagsWithRequestBuilder(tags: tags).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -218,11 +225,12 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<[Pet]>
      */
-    open class func findPetsByTags(tags: [String]) -> Observable<[Pet]> {
+    open class func findPetsByTags(tags: [String], queue: DispatchQueue? = nil) -> Observable<[Pet]> {
         return Observable.create { observer -> Disposable in
-            findPetsByTags(tags: tags) { data, error in
+            findPetsByTags(tags: tags, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -263,10 +271,11 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
-        getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+    open class func getPetById(petId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
+        getPetByIdWithRequestBuilder(petId: petId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -275,11 +284,12 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Pet>
      */
-    open class func getPetById(petId: Int64) -> Observable<Pet> {
+    open class func getPetById(petId: Int64, queue: DispatchQueue? = nil) -> Observable<Pet> {
         return Observable.create { observer -> Disposable in
-            getPetById(petId: petId) { data, error in
+            getPetById(petId: petId, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -320,10 +330,11 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func updatePet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -336,11 +347,12 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func updatePet(pet: Pet) -> Observable<Void> {
+    open class func updatePet(pet: Pet, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            updatePet(pet: pet) { data, error in
+            updatePet(pet: pet, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -379,10 +391,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -397,11 +410,12 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) -> Observable<Void> {
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            updatePetWithForm(petId: petId, name: name, status: status) { data, error in
+            updatePetWithForm(petId: petId, name: name, status: status, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -451,10 +465,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -465,11 +480,12 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<ApiResponse>
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil) -> Observable<ApiResponse> {
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, queue: DispatchQueue? = nil) -> Observable<ApiResponse> {
         return Observable.create { observer -> Disposable in
-            uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file) { data, error in
+            uploadFile(petId: petId, additionalMetadata: additionalMetadata, file: file, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -519,10 +535,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { (response, error) -> Void in
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -533,11 +550,12 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<ApiResponse>
      */
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil) -> Observable<ApiResponse> {
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, queue: DispatchQueue? = nil) -> Observable<ApiResponse> {
         return Observable.create { observer -> Disposable in
-            uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata) { data, error in
+            uploadFileWithRequiredFile(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -16,10 +16,11 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteOrder(orderId: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func deleteOrder(orderId: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteOrderWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -32,11 +33,12 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func deleteOrder(orderId: String) -> Observable<Void> {
+    open class func deleteOrder(orderId: String, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            deleteOrder(orderId: orderId) { data, error in
+            deleteOrder(orderId: orderId, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -73,10 +75,11 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
-        getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+    open class func getInventory(queue: DispatchQueue? = nil, completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
+        getInventoryWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -84,11 +87,12 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<[String:Int]>
      */
-    open class func getInventory() -> Observable<[String:Int]> {
+    open class func getInventory(queue: DispatchQueue? = nil) -> Observable<[String:Int]> {
         return Observable.create { observer -> Disposable in
-            getInventory() { data, error in
+            getInventory(queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -125,10 +129,11 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func getOrderById(orderId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        getOrderByIdWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -137,11 +142,12 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Order>
      */
-    open class func getOrderById(orderId: Int64) -> Observable<Order> {
+    open class func getOrderById(orderId: Int64, queue: DispatchQueue? = nil) -> Observable<Order> {
         return Observable.create { observer -> Disposable in
-            getOrderById(orderId: orderId) { data, error in
+            getOrderById(orderId: orderId, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -179,10 +185,11 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(order: Order, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        placeOrderWithRequestBuilder(order: order).execute { (response, error) -> Void in
+    open class func placeOrder(order: Order, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        placeOrderWithRequestBuilder(order: order).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -191,11 +198,12 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Order>
      */
-    open class func placeOrder(order: Order) -> Observable<Order> {
+    open class func placeOrder(order: Order, queue: DispatchQueue? = nil) -> Observable<Order> {
         return Observable.create { observer -> Disposable in
-            placeOrder(order: order) { data, error in
+            placeOrder(order: order, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -16,10 +16,11 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUser(user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUserWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUser(user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUserWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -32,11 +33,12 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func createUser(user: User) -> Observable<Void> {
+    open class func createUser(user: User, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            createUser(user: user) { data, error in
+            createUser(user: user, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -71,10 +73,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithArrayInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithArrayInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithArrayInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithArrayInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -87,11 +90,12 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func createUsersWithArrayInput(user: [User]) -> Observable<Void> {
+    open class func createUsersWithArrayInput(user: [User], queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            createUsersWithArrayInput(user: user) { data, error in
+            createUsersWithArrayInput(user: user, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -125,10 +129,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithListInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithListInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithListInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithListInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -141,11 +146,12 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func createUsersWithListInput(user: [User]) -> Observable<Void> {
+    open class func createUsersWithListInput(user: [User], queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            createUsersWithListInput(user: user) { data, error in
+            createUsersWithListInput(user: user, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -179,10 +185,11 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteUser(username: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func deleteUser(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteUserWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -195,11 +202,12 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func deleteUser(username: String) -> Observable<Void> {
+    open class func deleteUser(username: String, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            deleteUser(username: username) { data, error in
+            deleteUser(username: username, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -237,10 +245,11 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
-        getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func getUserByName(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
+        getUserByNameWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -249,11 +258,12 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<User>
      */
-    open class func getUserByName(username: String) -> Observable<User> {
+    open class func getUserByName(username: String, queue: DispatchQueue? = nil) -> Observable<User> {
         return Observable.create { observer -> Disposable in
-            getUserByName(username: username) { data, error in
+            getUserByName(username: username, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -291,10 +301,11 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+    open class func loginUser(username: String, password: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        loginUserWithRequestBuilder(username: username, password: password).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -304,11 +315,12 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<String>
      */
-    open class func loginUser(username: String, password: String) -> Observable<String> {
+    open class func loginUser(username: String, password: String, queue: DispatchQueue? = nil) -> Observable<String> {
         return Observable.create { observer -> Disposable in
-            loginUser(username: username, password: password) { data, error in
+            loginUser(username: username, password: password, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -347,10 +359,11 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func logoutUser(completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+    open class func logoutUser(queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        logoutUserWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -362,11 +375,12 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func logoutUser() -> Observable<Void> {
+    open class func logoutUser(queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            logoutUser() { data, error in
+            logoutUser(queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {
@@ -400,10 +414,11 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updateUser(username: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updateUserWithRequestBuilder(username: username, user: user).execute { (response, error) -> Void in
+    open class func updateUser(username: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updateUserWithRequestBuilder(username: username, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -417,11 +432,12 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - returns: Observable<Void>
      */
-    open class func updateUser(username: String, user: User) -> Observable<Void> {
+    open class func updateUser(username: String, user: User, queue: DispatchQueue? = nil) -> Observable<Void> {
         return Observable.create { observer -> Disposable in
-            updateUser(username: username, user: user) { data, error in
+            updateUser(username: username, user: user, queue: queue) { data, error in
                 if let error = error {
                     observer.on(.error(error))
                 } else {

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs.swift
@@ -40,7 +40,7 @@ open class RequestBuilder<T> {
         }
     }
 
-    open func execute(_ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
+    open func execute(queue: DispatchQueue? = nil, _ completion: @escaping (_ response: Response<T>?, _ error: Error?) -> Void) { }
 
     public func addHeader(name: String, value: String) -> Self {
         if !value.isEmpty {

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -15,10 +15,11 @@ open class AnotherFakeAPI {
      To test special tags
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func call123testSpecialTags(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        call123testSpecialTagsWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func call123testSpecialTags(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        call123testSpecialTagsWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -14,10 +14,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input boolean as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterBooleanSerialize(body: Bool? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
-        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterBooleanSerialize(body: Bool? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Bool?,_ error: Error?) -> Void)) {
+        fakeOuterBooleanSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -44,10 +45,11 @@ open class FakeAPI {
     /**
 
      - parameter outerComposite: (body) Input composite as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
-        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute { (response, error) -> Void in
+    open class func fakeOuterCompositeSerialize(outerComposite: OuterComposite? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: OuterComposite?,_ error: Error?) -> Void)) {
+        fakeOuterCompositeSerializeWithRequestBuilder(outerComposite: outerComposite).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -74,10 +76,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input number as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterNumberSerialize(body: Double? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
-        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterNumberSerialize(body: Double? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Double?,_ error: Error?) -> Void)) {
+        fakeOuterNumberSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -104,10 +107,11 @@ open class FakeAPI {
     /**
 
      - parameter body: (body) Input string as post body (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func fakeOuterStringSerialize(body: String? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        fakeOuterStringSerializeWithRequestBuilder(body: body).execute { (response, error) -> Void in
+    open class func fakeOuterStringSerialize(body: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        fakeOuterStringSerializeWithRequestBuilder(body: body).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -134,10 +138,11 @@ open class FakeAPI {
     /**
 
      - parameter fileSchemaTestClass: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute { (response, error) -> Void in
+    open class func testBodyWithFileSchema(fileSchemaTestClass: FileSchemaTestClass, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithFileSchemaWithRequestBuilder(fileSchemaTestClass: fileSchemaTestClass).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -169,10 +174,11 @@ open class FakeAPI {
 
      - parameter query: (query)  
      - parameter user: (body)  
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testBodyWithQueryParams(query: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute { (response, error) -> Void in
+    open class func testBodyWithQueryParams(query: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testBodyWithQueryParamsWithRequestBuilder(query: query, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -207,10 +213,11 @@ open class FakeAPI {
      To test \"client\" model
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClientModel(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClientModelWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClientModel(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClientModelWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -252,10 +259,11 @@ open class FakeAPI {
      - parameter dateTime: (form) None (optional)
      - parameter password: (form) None (optional)
      - parameter callback: (form) None (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute { (response, error) -> Void in
+    open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -396,10 +404,11 @@ open class FakeAPI {
      - parameter enumQueryDouble: (query) Query parameter enum test (double) (optional)
      - parameter enumFormStringArray: (form) Form parameter enum test (string array) (optional, default to .$)
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .-efg)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute { (response, error) -> Void in
+    open class func testEnumParameters(enumHeaderStringArray: [String]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [String]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [String]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -461,10 +470,11 @@ open class FakeAPI {
      - parameter stringGroup: (query) String in group parameters (optional)
      - parameter booleanGroup: (header) Boolean in group parameters (optional)
      - parameter int64Group: (query) Integer in group parameters (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute { (response, error) -> Void in
+    open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -513,10 +523,11 @@ open class FakeAPI {
      test inline additionalProperties
      
      - parameter requestBody: (body) request body 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testInlineAdditionalProperties(requestBody: [String:String], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute { (response, error) -> Void in
+    open class func testInlineAdditionalProperties(requestBody: [String:String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testInlineAdditionalPropertiesWithRequestBuilder(requestBody: requestBody).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -549,10 +560,11 @@ open class FakeAPI {
      
      - parameter param: (form) field1 
      - parameter param2: (form) field2 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testJsonFormData(param: String, param2: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute { (response, error) -> Void in
+    open class func testJsonFormData(param: String, param2: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        testJsonFormDataWithRequestBuilder(param: param, param2: param2).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -15,10 +15,11 @@ open class FakeClassnameTags123API {
      To test class name in snake case
      
      - parameter client: (body) client model 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func testClassname(client: Client, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
-        testClassnameWithRequestBuilder(client: client).execute { (response, error) -> Void in
+    open class func testClassname(client: Client, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Client?,_ error: Error?) -> Void)) {
+        testClassnameWithRequestBuilder(client: client).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -15,10 +15,11 @@ open class PetAPI {
      Add a new pet to the store
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func addPet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        addPetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func addPet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        addPetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -54,10 +55,11 @@ open class PetAPI {
      
      - parameter petId: (path) Pet id to delete 
      - parameter apiKey: (header)  (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deletePet(petId: Int64, apiKey: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute { (response, error) -> Void in
+    open class func deletePet(petId: Int64, apiKey: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deletePetWithRequestBuilder(petId: petId, apiKey: apiKey).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -109,10 +111,11 @@ open class PetAPI {
      Finds Pets by status
      
      - parameter status: (query) Status values that need to be considered for filter 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByStatus(status: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByStatusWithRequestBuilder(status: status).execute { (response, error) -> Void in
+    open class func findPetsByStatus(status: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByStatusWithRequestBuilder(status: status).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -147,10 +150,11 @@ open class PetAPI {
      Finds Pets by tags
      
      - parameter tags: (query) Tags to filter by 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func findPetsByTags(tags: [String], completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
-        findPetsByTagsWithRequestBuilder(tags: tags).execute { (response, error) -> Void in
+    open class func findPetsByTags(tags: [String], queue: DispatchQueue? = nil, completion: @escaping ((_ data: [Pet]?,_ error: Error?) -> Void)) {
+        findPetsByTagsWithRequestBuilder(tags: tags).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -185,10 +189,11 @@ open class PetAPI {
      Find pet by ID
      
      - parameter petId: (path) ID of pet to return 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getPetById(petId: Int64, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
-        getPetByIdWithRequestBuilder(petId: petId).execute { (response, error) -> Void in
+    open class func getPetById(petId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Pet?,_ error: Error?) -> Void)) {
+        getPetByIdWithRequestBuilder(petId: petId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -223,10 +228,11 @@ open class PetAPI {
      Update an existing pet
      
      - parameter pet: (body) Pet object that needs to be added to the store 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePet(pet: Pet, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithRequestBuilder(pet: pet).execute { (response, error) -> Void in
+    open class func updatePet(pet: Pet, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithRequestBuilder(pet: pet).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -263,10 +269,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet that needs to be updated 
      - parameter name: (form) Updated name of the pet (optional)
      - parameter status: (form) Updated status of the pet (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute { (response, error) -> Void in
+    open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -314,10 +321,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - parameter file: (form) file to upload (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute { (response, error) -> Void in
+    open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -361,10 +369,11 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to update 
      - parameter requiredFile: (form) file to upload 
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
-        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute { (response, error) -> Void in
+    open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, queue: DispatchQueue? = nil, completion: @escaping ((_ data: ApiResponse?,_ error: Error?) -> Void)) {
+        uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -15,10 +15,11 @@ open class StoreAPI {
      Delete purchase order by ID
      
      - parameter orderId: (path) ID of the order that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteOrder(orderId: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteOrderWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func deleteOrder(orderId: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteOrderWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -53,10 +54,11 @@ open class StoreAPI {
     /**
      Returns pet inventories by status
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getInventory(completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
-        getInventoryWithRequestBuilder().execute { (response, error) -> Void in
+    open class func getInventory(queue: DispatchQueue? = nil, completion: @escaping ((_ data: [String:Int]?,_ error: Error?) -> Void)) {
+        getInventoryWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -87,10 +89,11 @@ open class StoreAPI {
      Find purchase order by ID
      
      - parameter orderId: (path) ID of pet that needs to be fetched 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getOrderById(orderId: Int64, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        getOrderByIdWithRequestBuilder(orderId: orderId).execute { (response, error) -> Void in
+    open class func getOrderById(orderId: Int64, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        getOrderByIdWithRequestBuilder(orderId: orderId).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -122,10 +125,11 @@ open class StoreAPI {
      Place an order for a pet
      
      - parameter order: (body) order placed for purchasing the pet 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func placeOrder(order: Order, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
-        placeOrderWithRequestBuilder(order: order).execute { (response, error) -> Void in
+    open class func placeOrder(order: Order, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Order?,_ error: Error?) -> Void)) {
+        placeOrderWithRequestBuilder(order: order).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -15,10 +15,11 @@ open class UserAPI {
      Create user
      
      - parameter user: (body) Created user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUser(user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUserWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUser(user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUserWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -51,10 +52,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithArrayInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithArrayInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithArrayInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithArrayInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -86,10 +88,11 @@ open class UserAPI {
      Creates list of users with given input array
      
      - parameter user: (body) List of user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func createUsersWithListInput(user: [User], completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        createUsersWithListInputWithRequestBuilder(user: user).execute { (response, error) -> Void in
+    open class func createUsersWithListInput(user: [User], queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        createUsersWithListInputWithRequestBuilder(user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -121,10 +124,11 @@ open class UserAPI {
      Delete user
      
      - parameter username: (path) The name that needs to be deleted 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func deleteUser(username: String, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        deleteUserWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func deleteUser(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        deleteUserWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -160,10 +164,11 @@ open class UserAPI {
      Get user by user name
      
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func getUserByName(username: String, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
-        getUserByNameWithRequestBuilder(username: username).execute { (response, error) -> Void in
+    open class func getUserByName(username: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: User?,_ error: Error?) -> Void)) {
+        getUserByNameWithRequestBuilder(username: username).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -195,10 +200,11 @@ open class UserAPI {
      
      - parameter username: (query) The user name for login 
      - parameter password: (query) The password for login in clear text 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func loginUser(username: String, password: String, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
-        loginUserWithRequestBuilder(username: username, password: password).execute { (response, error) -> Void in
+    open class func loginUser(username: String, password: String, queue: DispatchQueue? = nil, completion: @escaping ((_ data: String?,_ error: Error?) -> Void)) {
+        loginUserWithRequestBuilder(username: username, password: password).execute(queue: queue) { (response, error) -> Void in
             completion(response?.body, error)
         }
     }
@@ -231,10 +237,11 @@ open class UserAPI {
     /**
      Logs out current logged in user session
      
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func logoutUser(completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        logoutUserWithRequestBuilder().execute { (response, error) -> Void in
+    open class func logoutUser(queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        logoutUserWithRequestBuilder().execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {
@@ -266,10 +273,11 @@ open class UserAPI {
      
      - parameter username: (path) name that need to be deleted 
      - parameter user: (body) Updated user object 
+     - parameter queue: The queue on which the completion handler is dispatched.
      - parameter completion: completion handler to receive the data and the error objects
      */
-    open class func updateUser(username: String, user: User, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
-        updateUserWithRequestBuilder(username: username, user: user).execute { (response, error) -> Void in
+    open class func updateUser(username: String, user: User, queue: DispatchQueue? = nil, completion: @escaping ((_ data: Void?,_ error: Error?) -> Void)) {
+        updateUserWithRequestBuilder(username: username, user: user).execute(queue: queue) { (response, error) -> Void in
             if error == nil {
                 completion((), error)
             } else {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fix for #230

Updates Swift4 templates to support the ability to pass in a dedicated queue for processing network response

cc @jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @d-date (2018/03) for review