### PR TITLE
Fix NPE with `cpp-restsdk` client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -285,8 +285,8 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
         List<CodegenOperation> operationList = (List<CodegenOperation>) operations.get("operation");
         for (CodegenOperation op : operationList) {
-            for(String hdr : op.imports) {
-                if(importMapping.containsKey(hdr)) {
+            for (String hdr : op.imports) {
+                if (importMapping.containsKey(hdr)) {
                     continue;
                 }
                 operations.put("hasModelImport", true);
@@ -295,7 +295,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
         }
         return objs;
     }
-    
+
     protected boolean isFileSchema(CodegenProperty property) {
         return property.baseType.equals("HttpContent");
     }
@@ -432,13 +432,20 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
      */
     private void processParentPropertiesInChildModel(final CodegenModel parent, final CodegenModel child) {
         final Map<String, CodegenProperty> childPropertiesByName = new HashMap<>(child.vars.size());
-        for (final CodegenProperty childSchema : child.vars) {
-            childPropertiesByName.put(childSchema.name, childSchema);
+        if (child != null && child.vars != null && !child.vars.isEmpty()) {
+            for (final CodegenProperty childSchema : child.vars) {
+                childPropertiesByName.put(childSchema.name, childSchema);
+            }
         }
-        for (final CodegenProperty parentSchema : parent.vars) {
-            final CodegenProperty duplicatedByParent = childPropertiesByName.get(parentSchema.name);
-            if (duplicatedByParent != null) {
-                duplicatedByParent.isInherited = true;
+
+        if (parent != null && parent.vars != null && !parent.vars.isEmpty())
+
+        {
+            for (final CodegenProperty parentSchema : parent.vars) {
+                final CodegenProperty duplicatedByParent = childPropertiesByName.get(parentSchema.name);
+                if (duplicatedByParent != null) {
+                    duplicatedByParent.isInherited = true;
+                }
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -411,7 +411,6 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
 
     @Override
     public Map<String, Object> postProcessAllModels(final Map<String, Object> models) {
-
         final Map<String, Object> processed = super.postProcessAllModels(models);
         postProcessParentModels(models);
         return processed;
@@ -438,9 +437,7 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
             }
         }
 
-        if (parent != null && parent.vars != null && !parent.vars.isEmpty())
-
-        {
+        if (parent != null && parent.vars != null && !parent.vars.isEmpty()) {
             for (final CodegenProperty parentSchema : parent.vars) {
                 final CodegenProperty duplicatedByParent = childPropertiesByName.get(parentSchema.name);
                 if (duplicatedByParent != null) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix the following NPE:
```
[main] WARN  o.o.codegen.utils.ModelUtils - Multiple schemas found, returning only the first one
[main] WARN  o.o.codegen.utils.ModelUtils - Multiple schemas found, returning only the first one
[main] INFO  o.o.codegen.DefaultGenerator - Model periodicPaymentInitiationMultipartBody (marked as unused due to form parameters) is generated due to skipFormModel=false (default)
[main] INFO  o.o.codegen.DefaultGenerator - Model periodicPaymentInitiation_xml-Part2-standingorderType_json (marked as unused due to form parameters) is generated due to skipFormModel=false (default)
Exception in thread "main" java.lang.NullPointerException
	at org.openapitools.codegen.languages.CppRestSdkClientCodegen.processParentPropertiesInChildModel(CppRestSdkClientCodegen.java:438)
	at org.openapitools.codegen.languages.CppRestSdkClientCodegen.postProcessParentModels(CppRestSdkClientCodegen.java:425)
	at org.openapitools.codegen.languages.CppRestSdkClientCodegen.postProcessAllModels(CppRestSdkClientCodegen.java:416)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:439)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:865)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:349)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
```

cc @ravinikam (2017/07) @stkrwork (2017/07) @fvarose (2017/11) @etherealjoy (2018/02) @martindelille (2018/03)
