### PR TITLE
Fix NPE in the C# Nancy generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNancyFXServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNancyFXServerCodegen.java
@@ -285,10 +285,12 @@ public class CSharpNancyFXServerCodegen extends AbstractCSharpCodegen {
         LOGGER.debug("Processing parents:  " + parentModels);
         for (final String parent : parentModels) {
             final CodegenModel parentModel = ModelUtils.getModelByName(parent, models);
-            parentModel.hasChildren = true;
-            final Collection<CodegenModel> childrenModels = childrenByParent.get(parent);
-            for (final CodegenModel child : childrenModels) {
-                processParentPropertiesInChildModel(parentModel, child);
+            if (parentModel != null) {
+                parentModel.hasChildren = true;
+                final Collection<CodegenModel> childrenModels = childrenByParent.get(parent);
+                for (final CodegenModel child : childrenModels) {
+                    processParentPropertiesInChildModel(parentModel, child);
+                }
             }
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix the following NPE:
```
[main] WARN  o.o.codegen.utils.ModelUtils - Multiple schemas found, returning only the first one
[main] INFO  o.o.codegen.DefaultGenerator - Model periodicPaymentInitiationMultipartBody (marked as unused due to form parameters) is generated due to skipFormModel=false (default)
[main] INFO  o.o.codegen.DefaultGenerator - Model periodicPaymentInitiation_xml-Part2-standingorderType_json (marked as unused due to form parameters) is generated due to skipFormModel=false (default)
Exception in thread "main" java.lang.NullPointerException
	at org.openapitools.codegen.languages.CSharpNancyFXServerCodegen.postProcessParentModels(CSharpNancyFXServerCodegen.java:288)
	at org.openapitools.codegen.languages.CSharpNancyFXServerCodegen.postProcessAllModels(CSharpNancyFXServerCodegen.java:280)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:439)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:865)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:349)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
```

cc @mandrean (2017/08) @jimschubert (2017/09)

