### PR TITLE
Fix NPE for Scala Gatling generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaGatlingCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaGatlingCodegen.java
@@ -239,6 +239,11 @@ public class ScalaGatlingCodegen extends AbstractScalaCodegen implements Codegen
                 continue;
             }
             for (Operation operation : path.readOperations()) {
+
+                if (operation.getExtensions() == null) {
+                    operation.setExtensions(new HashMap());
+                }
+
                 if (!operation.getExtensions().keySet().contains("x-gatling-path")) {
                     if (pathname.contains("{")) {
                         String gatlingPath = pathname.replaceAll("\\{", "\\$\\{");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix the following NPE:
```
[main] INFO  o.o.c.languages.AbstractScalaCodegen - Environment variable SCALA_POST_PROCESS_FILE not defined so the Scala code may not be properly formatted. To define it, try 'export SCALA_POST_PROCESS_FILE=/usr/local/bin/scalafmt' (Linux/Mac)
[main] INFO  o.o.c.languages.AbstractScalaCodegen - NOTE: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).
Exception in thread "main" java.lang.NullPointerException
	at org.openapitools.codegen.languages.ScalaGatlingCodegen.preprocessOpenAPI(ScalaGatlingCodegen.java:242)
	at org.openapitools.codegen.DefaultGenerator.configureGeneratorProperties(DefaultGenerator.java:183)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:854)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:349)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
```

cc @clasnake (2017/07) @jimschubert (2017/09) @shijinkui (2018/01) @ramzimaalej (2018/03)
