### PR TITLE
Add support for 'x-enum-values' extension as used by Bungie

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3962,11 +3962,28 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     private void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions) {
-        if (vendorExtensions != null && vendorExtensions.containsKey("x-enum-varnames")) {
+        if (null == vendorExtensions) {
+            return;
+        }
+
+        if (vendorExtensions.containsKey("x-enum-varnames")) {
             List<String> alias = (List<String>) vendorExtensions.get("x-enum-varnames");
             int size = Math.min(enumVars.size(), alias.size());
             for (int i = 0; i < size; i++) {
                 enumVars.get(i).put("name", alias.get(i));
+            }
+        }
+
+        if (vendorExtensions.containsKey("x-enum-values")) {
+            List<Map<String, String>> enumValues = (List<Map<String, String>>) vendorExtensions.get("x-enum-values");
+
+            for (Map<String, String> enumValue : enumValues) {
+                for (Map<String, Object> enumVar : enumVars) {
+                    if (enumValue.get("numericValue").equals(enumVar.get("value"))) {
+                        enumVar.put("name", enumValue.get("identifier").toUpperCase());
+                        break;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### PR checklist

- [√] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [√] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [√] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [√] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR adds support for the 'x-enum-values' extensions as proposed by the Bungie.net API spec. See: [https://github.com/Bungie-net/api](https://github.com/Bungie-net/api#extension-properties-on-openapi-specs-or-how-to-generate-much-cooler-clients-for-the-bnet-api-if-you-want-to-take-the-time-to-do-so)