### PR TITLE
Improve error message when the spec is not found

### DIFF
--- a/bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.sh
+++ b/bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -i modules/openapi-generator/src/test\resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.json -o samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm -D providedInRoot=false --additional-properties ngVersion=6.0.0 $@"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.json -o samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm -D providedInRoot=false --additional-properties ngVersion=6.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v6-petstore-not-provided-in-root.sh
+++ b/bin/typescript-angular-v6-petstore-not-provided-in-root.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -i modules/openapi-generator/src/test\resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default -D providedInRoot=false --additional-properties ngVersion=6.0.0 $@"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default -D providedInRoot=false --additional-properties ngVersion=6.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.*;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -246,6 +247,11 @@ public class Generate implements Runnable {
         }
 
         if (isNotEmpty(spec)) {
+            if (!spec.matches("^http(s)?://.*") && !new File(spec).exists()) {
+                System.out.println("[error] The spec file is not found: " + spec);
+                System.err.println("[error] Check the path of the OpenAPI spec and try again.");
+                System.exit(1);
+            }
             configurator.setInputSpec(spec);
         }
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -248,7 +248,7 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(spec)) {
             if (!spec.matches("^http(s)?://.*") && !new File(spec).exists()) {
-                System.out.println("[error] The spec file is not found: " + spec);
+                System.err.println("[error] The spec file is not found: " + spec);
                 System.err.println("[error] Check the path of the OpenAPI spec and try again.");
                 System.exit(1);
             }

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -64,7 +64,7 @@ public class GenerateTest {
 
     @Test
     public void testRequiredArgs_ShortArgs() throws Exception {
-        setupAndRunTest("-i", "swagger.yaml", "-g", "java", "-o", "src/main/java", false, null);
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null);
         new FullVerifications() {
             {
             }
@@ -73,7 +73,7 @@ public class GenerateTest {
 
     @Test
     public void testRequiredArgs_LongArgs() throws Exception {
-        setupAndRunTest("--input-spec", "swagger.yaml", "--generator-name", "java", "--output",
+        setupAndRunTest("--input-spec", "src/test/resources/swagger.yaml", "--generator-name", "java", "--output",
                 "src/main/java", false, null);
         new FullVerifications() {
             {
@@ -220,7 +220,7 @@ public class GenerateTest {
     @Test
     public void testConfig() throws Exception {
 
-        setupAndRunTest("-i", "swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
                 "config.json", "-c", "config.json");
 
         new FullVerifications() {
@@ -228,7 +228,7 @@ public class GenerateTest {
             }
         };
 
-        setupAndRunTest("-i", "swagger.yaml", "-g", "java", "-o", "src/main/java", true,
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", true,
                 "config.json", "--config", "config.json");
 
         new FullVerifications() {
@@ -570,7 +570,7 @@ public class GenerateTest {
     }
 
     private void setupAndRunGenericTest(String... additionalParameters) {
-        setupAndRunTest("-i", "swagger.yaml", "-g", "java", "-o", "src/main/java", false, null,
+        setupAndRunTest("-i", "src/test/resources/swagger.yaml", "-g", "java", "-o", "src/main/java", false, null,
                 additionalParameters);
     }
 }

--- a/modules/openapi-generator-cli/src/test/resources/swagger.yaml
+++ b/modules/openapi-generator-cli/src/test/resources/swagger.yaml
@@ -1,0 +1,109 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR closes https://github.com/OpenAPITools/openapi-generator/issues/1449 

