### PR TITLE
Typescript Fetch - Add support for file response type

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/api.mustache
@@ -269,7 +269,7 @@ export const {{classname}}Fp = function(configuration?: Configuration) {
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
                     if (response.status >= 200 && response.status < 300) {
-                        return response{{#returnType}}.json(){{/returnType}};
+                        return response{{>responseType}};
                     } else {
                         throw response;
                     }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/responseType.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/responseType.mustache
@@ -1,0 +1,1 @@
+{{#returnType}}{{#isResponseFile}}.blob{{/isResponseFile}}{{^isResponseFile}}.json{{/isResponseFile}}(){{/returnType}}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### Description of the PR

Changed the return type to a blob instead of json when the response type is a file.

