### PR TITLE
[cpp-qt5] client response headers and validation of properties for client and server

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -53,6 +53,10 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
 {{prefix}}HttpRequestWorker::~{{prefix}}HttpRequestWorker() {
 }
 
+QMap<QByteArray, QByteArray> {{prefix}}HttpRequestWorker::getResponseHeaders() const {
+    return headers;
+}
+
 QString {{prefix}}HttpRequestWorker::http_attribute_encode(QString attribute_name, QString input) {
     // result structure follows RFC 5987
     bool need_utf_encoding = false;
@@ -305,7 +309,11 @@ void {{prefix}}HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
     error_type = reply->error();
     response = reply->readAll();
     error_str = reply->errorString();
-
+    if(reply->rawHeaderPairs().count() > 0){
+        for(const auto& item: reply->rawHeaderPairs()){
+            headers.insert(item.first, item.second);
+        }
+    }
     reply->deleteLater();
 
     emit on_execution_finished(this);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -61,9 +61,10 @@ public:
     QNetworkReply::NetworkError error_type;
     QString error_str;
 
-    explicit {{prefix}}HttpRequestWorker(QObject *parent = 0);
+    explicit {{prefix}}HttpRequestWorker(QObject *parent = nullptr);
     virtual ~{{prefix}}HttpRequestWorker();
 
+    QMap<QByteArray, QByteArray> getResponseHeaders() const;
     QString http_attribute_encode(QString attribute_name, QString input);
     void execute({{prefix}}HttpRequestInput *input);
     static QSslConfiguration* sslDefaultConfiguration;
@@ -73,7 +74,7 @@ signals:
 
 private:
     QNetworkAccessManager *manager;
-
+    QMap<QByteArray, QByteArray> headers;
 private slots:
     void on_manager_finished(QNetworkReply *reply);
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
@@ -193,88 +193,126 @@ fromStringValue(const QString &inStr, double &value){
     return ok;
 }
 
-void
+bool
 fromJsonValue(QString &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         if(jval.isString()){
             value = jval.toString();
         } else if(jval.isBool()) {
             value =  jval.toBool() ? "true" : "false";
         } else if(jval.isDouble()){
             value = QString::number(jval.toDouble());
+        } else {
+            ok = false;    
         }
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
+        ok = value.size() > 0 ;
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint32 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toInt();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint64 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toVariant().toLongLong();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(bool &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isBool()){
         value = jval.toBool();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(float &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = static_cast<float>(jval.toDouble());
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
-void
+bool
 fromJsonValue(double &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = jval.toDouble();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue({{prefix}}Object  &value, const QJsonValue &jval){
+    bool ok = true;    
     if(jval.isObject()){
         value.fromJsonObject(jval.toObject());
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-body.mustache
@@ -47,7 +47,7 @@ toStringValue(const bool &value) {
 
 QString
 toStringValue(const float &value){
-    return QString::number(value);
+    return QString::number(static_cast<double>(value));
 }
 
 QString
@@ -92,7 +92,7 @@ toJsonValue(const bool &value){
 
 QJsonValue
 toJsonValue(const float &value){
-    return QJsonValue(value);
+    return QJsonValue(static_cast<double>(value));
 }
 
 QJsonValue
@@ -215,7 +215,7 @@ fromJsonValue(QString &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {
@@ -227,7 +227,7 @@ fromJsonValue(QDateTime &value, const QJsonValue &jval){
 bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
     bool ok = true;
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()) {
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
         ok = value.size() > 0 ;
     } else {
@@ -239,7 +239,7 @@ fromJsonValue(QByteArray &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/helpers-header.mustache
@@ -30,7 +30,7 @@ namespace {{this}} {
     template <typename T>
     QString toStringValue(const QList<T> &val) {
         QString strArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             strArray.append(toStringValue(item) + ",");
         }
         if(val.count() > 0) {
@@ -53,7 +53,7 @@ namespace {{this}} {
     template <typename T>
     QJsonValue toJsonValue(const QList<T> &val) {
         QJsonArray jArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             jArray.append(toJsonValue(item));
         }
         return jArray;
@@ -62,7 +62,7 @@ namespace {{this}} {
     template <typename T>
     QJsonValue toJsonValue(const QMap<QString, T> &val) {
         QJsonObject jObject;
-        for(auto itemkey : val.keys()) {
+        for(const auto& itemkey : val.keys()) {
             jObject.insert(itemkey, toJsonValue(val.value(itemkey)));
         }
         return jObject;
@@ -79,56 +79,69 @@ namespace {{this}} {
     bool fromStringValue(const QString &inStr, double &value);
 
     template <typename T>
-    void fromStringValue(const QList<QString> &inStr, QList<T> &val) {
-        for(auto item: inStr){
+    bool fromStringValue(const QList<QString> &inStr, QList<T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& item: inStr){
             T itemVal;
-            fromStringValue(item, itemVal);
+            ok &= fromStringValue(item, itemVal);
             val.push_back(itemVal);
         }
+        return ok;
     }
 
     template <typename T>
-    void fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
-        for(auto itemkey : inStr.keys()){
+    bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& itemkey : inStr.keys()){
             T itemVal;
-            fromStringValue(inStr.value(itemkey), itemVal);
+            ok &= fromStringValue(inStr.value(itemkey), itemVal);
             val.insert(itemkey, itemVal);
         }
+        return ok;
     }
 
-    void fromJsonValue(QString &value, const QJsonValue &jval);
-    void fromJsonValue(QDateTime &value, const QJsonValue &jval);
-    void fromJsonValue(QByteArray &value, const QJsonValue &jval);
-    void fromJsonValue(QDate &value, const QJsonValue &jval);
-    void fromJsonValue(qint32 &value, const QJsonValue &jval);
-    void fromJsonValue(qint64 &value, const QJsonValue &jval);
-    void fromJsonValue(bool &value, const QJsonValue &jval);
-    void fromJsonValue(float &value, const QJsonValue &jval);
-    void fromJsonValue(double &value, const QJsonValue &jval);
-    void fromJsonValue({{prefix}}Object &value, const QJsonValue &jval);
+    bool fromJsonValue(QString &value, const QJsonValue &jval);
+    bool fromJsonValue(QDateTime &value, const QJsonValue &jval);
+    bool fromJsonValue(QByteArray &value, const QJsonValue &jval);
+    bool fromJsonValue(QDate &value, const QJsonValue &jval);
+    bool fromJsonValue(qint32 &value, const QJsonValue &jval);
+    bool fromJsonValue(qint64 &value, const QJsonValue &jval);
+    bool fromJsonValue(bool &value, const QJsonValue &jval);
+    bool fromJsonValue(float &value, const QJsonValue &jval);
+    bool fromJsonValue(double &value, const QJsonValue &jval);
+    bool fromJsonValue({{prefix}}Object &value, const QJsonValue &jval);
 
     template <typename T>
-    void fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+    bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+        bool ok = true;
         if(jval.isArray()){
-            for(const QJsonValue &jitem : jval.toArray()){
+            for(const auto& jitem : jval.toArray()){
                 T item;
-                fromJsonValue(item, jitem);
+                ok &= fromJsonValue(item, jitem);
                 val.push_back(item);
             }
+        } else {
+            ok = false;
         }
-    }
+        return ok;
+    } 
 
     template <typename T>
-    void fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
-        auto varmap = jval.toObject().toVariantMap();
-        if(varmap.count() > 0){
-            for(auto itemkey : varmap.keys() ){
-                T itemVal;
-                fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
-                val.insert(itemkey, itemVal);
+    bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
+        bool ok = true;
+        if(jval.isObject()){
+            auto varmap = jval.toObject().toVariantMap();
+            if(varmap.count() > 0){
+                for(const auto& itemkey : varmap.keys() ){
+                    T itemVal;
+                    ok &= fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
+                    val.insert(itemkey, itemVal);
+                }
             }
+        } else {
+            ok = false;
         }
-        return;
+        return ok;
     }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-body.mustache
@@ -29,6 +29,7 @@ void
 {{classname}}::init() {
     {{#vars}}
     m_{{name}}_isSet = false;
+    m_{{name}}_isValid = false;
     {{/vars}}
 }
 
@@ -43,23 +44,25 @@ void
 void
 {{classname}}::fromJsonObject(QJsonObject json) {
     {{#vars}}
-    {{^isContainer}}::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/isContainer}}
-    {{#isContainer}}{{^items.isContainer}}::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/items.isContainer}}{{#items.isContainer}}{{#isListContainer}}
+    {{^isContainer}}m_{{name}}_isValid = ::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/isContainer}}
+    {{#isContainer}}{{^items.isContainer}}m_{{name}}_isValid = ::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/items.isContainer}}{{#items.isContainer}}{{#isListContainer}}
     if(json["{{baseName}}"].isArray()){
         auto arr = json["{{baseName}}"].toArray();
+        m_{{name}}_isValid = true;
         for (const QJsonValue & jval : arr) {
             {{^items.isContainer}}{{items.baseType}}{{/items.isContainer}}{{#items.isListContainer}}QList<{{items.items.baseType}}>{{/items.isListContainer}}{{#items.isMapContainer}}QMap<QString, {{items.items.baseType}}>{{/items.isMapContainer}} item;
-            ::{{cppNamespace}}::fromJsonValue(item, jval)
+            m_{{name}}_isValid &=  ::{{cppNamespace}}::fromJsonValue(item, jval)
             {{name}}.push_back(item);
         }
     }{{/isListContainer}}{{#isMapContainer}}
     if(json["{{baseName}}"].isObject()){
         auto varmap = json["{{baseName}}"].toObject().toVariantMap();
+        m_{{name}}_isValid = true;
         if(varmap.count() > 0){
             for(auto val : varmap.keys()){
                 {{^items.isContainer}}{{items.baseType}}{{/items.isContainer}}{{#items.isListContainer}}QList<{{items.items.baseType}}>{{/items.isListContainer}}{{#items.isMapContainer}}QMap<QString, {{items.items.baseType}}>{{/items.isMapContainer}} item;
     		    auto jval = QJsonValue::fromVariant(varmap.value(val));
-                ::{{cppNamespace}}::fromJsonValue(item, jval);
+                m_{{name}}_isValid &= ::{{cppNamespace}}::fromJsonValue(item, jval);
                 {{name}}.insert({{name}}.end(), val, item);
             }
         }
@@ -102,7 +105,6 @@ void
 }
 
 {{/vars}}
-
 bool
 {{classname}}::isSet() const {
     bool isObjectUpdated = false;
@@ -110,6 +112,12 @@ bool
         {{#isContainer}}if({{name}}.size() > 0){{/isContainer}}{{^isContainer}}{{#complexType}}if({{name}}.isSet()){{/complexType}}{{^complexType}}if(m_{{name}}_isSet){{/complexType}}{{/isContainer}}{ isObjectUpdated = true; break;}
     {{/vars}}}while(false);
     return isObjectUpdated;
+}
+
+bool
+{{classname}}::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return {{#vars}}{{#required}}m_{{name}}_isValid && {{/required}}{{/vars}}true;
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-body.mustache
@@ -14,6 +14,7 @@ namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
 {{classname}}::{{classname}}(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
@@ -40,12 +40,13 @@ public:
 
     {{/vars}}
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     {{#vars}}
     {{{dataType}}} {{name}};
     bool m_{{name}}_isSet;
-
+    bool m_{{name}}_isValid;
     {{/vars}}
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/object.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/object.mustache
@@ -36,6 +36,10 @@ class {{prefix}}Object {
     virtual bool isSet() const {
         return false;
     }
+
+    virtual bool isValid() const {
+        return true;
+    }
 private :
    QJsonObject jObj;
 };

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -140,13 +140,19 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
 
 {{/operation}}{{/operations}}
 void {{classname}}Request::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
     Q_UNUSED(error_type); // TODO
+    socket->write(res);
+    if(socket->isOpen()){
+        socket->close();
+    }    
 }
 
 void {{classname}}Request::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
-    Q_UNUSED(error_type); // TODO
+    Q_UNUSED(error_type);  // TODO
+    socket->write(res->readAll());
+    if(socket->isOpen()){
+        socket->close();
+    }
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-body.mustache
@@ -193,88 +193,126 @@ fromStringValue(const QString &inStr, double &value){
     return ok;
 }
 
-void
+bool
 fromJsonValue(QString &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         if(jval.isString()){
             value = jval.toString();
         } else if(jval.isBool()) {
             value =  jval.toBool() ? "true" : "false";
         } else if(jval.isDouble()){
             value = QString::number(jval.toDouble());
+        } else {
+            ok = false;    
         }
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
+        ok = value.size() > 0 ;
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint32 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toInt();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint64 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toVariant().toLongLong();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(bool &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isBool()){
         value = jval.toBool();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(float &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = static_cast<float>(jval.toDouble());
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
-void
+bool
 fromJsonValue(double &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = jval.toDouble();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue({{prefix}}Object  &value, const QJsonValue &jval){
+    bool ok = true;    
     if(jval.isObject()){
         value.fromJsonObject(jval.toObject());
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-body.mustache
@@ -47,7 +47,7 @@ toStringValue(const bool &value) {
 
 QString
 toStringValue(const float &value){
-    return QString::number(value);
+    return QString::number(static_cast<double>(value));
 }
 
 QString
@@ -92,7 +92,7 @@ toJsonValue(const bool &value){
 
 QJsonValue
 toJsonValue(const float &value){
-    return QJsonValue(value);
+    return QJsonValue(static_cast<double>(value));
 }
 
 QJsonValue
@@ -215,7 +215,7 @@ fromJsonValue(QString &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {
@@ -227,7 +227,7 @@ fromJsonValue(QDateTime &value, const QJsonValue &jval){
 bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
     bool ok = true;
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()) {
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
         ok = value.size() > 0 ;
     } else {
@@ -239,7 +239,7 @@ fromJsonValue(QByteArray &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/helpers-header.mustache
@@ -30,7 +30,7 @@ namespace {{this}} {
     template <typename T>
     QString toStringValue(const QList<T> &val) {
         QString strArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             strArray.append(toStringValue(item) + ",");
         }
         if(val.count() > 0) {
@@ -53,7 +53,7 @@ namespace {{this}} {
     template <typename T>
     QJsonValue toJsonValue(const QList<T> &val) {
         QJsonArray jArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             jArray.append(toJsonValue(item));
         }
         return jArray;
@@ -62,7 +62,7 @@ namespace {{this}} {
     template <typename T>
     QJsonValue toJsonValue(const QMap<QString, T> &val) {
         QJsonObject jObject;
-        for(auto itemkey : val.keys()) {
+        for(const auto& itemkey : val.keys()) {
             jObject.insert(itemkey, toJsonValue(val.value(itemkey)));
         }
         return jObject;
@@ -79,56 +79,69 @@ namespace {{this}} {
     bool fromStringValue(const QString &inStr, double &value);
 
     template <typename T>
-    void fromStringValue(const QList<QString> &inStr, QList<T> &val) {
-        for(auto item: inStr){
+    bool fromStringValue(const QList<QString> &inStr, QList<T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& item: inStr){
             T itemVal;
-            fromStringValue(item, itemVal);
+            ok &= fromStringValue(item, itemVal);
             val.push_back(itemVal);
         }
+        return ok;
     }
 
     template <typename T>
-    void fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
-        for(auto itemkey : inStr.keys()){
+    bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& itemkey : inStr.keys()){
             T itemVal;
-            fromStringValue(inStr.value(itemkey), itemVal);
+            ok &= fromStringValue(inStr.value(itemkey), itemVal);
             val.insert(itemkey, itemVal);
         }
+        return ok;
     }
 
-    void fromJsonValue(QString &value, const QJsonValue &jval);
-    void fromJsonValue(QDateTime &value, const QJsonValue &jval);
-    void fromJsonValue(QByteArray &value, const QJsonValue &jval);
-    void fromJsonValue(QDate &value, const QJsonValue &jval);
-    void fromJsonValue(qint32 &value, const QJsonValue &jval);
-    void fromJsonValue(qint64 &value, const QJsonValue &jval);
-    void fromJsonValue(bool &value, const QJsonValue &jval);
-    void fromJsonValue(float &value, const QJsonValue &jval);
-    void fromJsonValue(double &value, const QJsonValue &jval);
-    void fromJsonValue({{prefix}}Object &value, const QJsonValue &jval);
+    bool fromJsonValue(QString &value, const QJsonValue &jval);
+    bool fromJsonValue(QDateTime &value, const QJsonValue &jval);
+    bool fromJsonValue(QByteArray &value, const QJsonValue &jval);
+    bool fromJsonValue(QDate &value, const QJsonValue &jval);
+    bool fromJsonValue(qint32 &value, const QJsonValue &jval);
+    bool fromJsonValue(qint64 &value, const QJsonValue &jval);
+    bool fromJsonValue(bool &value, const QJsonValue &jval);
+    bool fromJsonValue(float &value, const QJsonValue &jval);
+    bool fromJsonValue(double &value, const QJsonValue &jval);
+    bool fromJsonValue({{prefix}}Object &value, const QJsonValue &jval);
 
     template <typename T>
-    void fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+    bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+        bool ok = true;
         if(jval.isArray()){
-            for(const QJsonValue &jitem : jval.toArray()){
+            for(const auto& jitem : jval.toArray()){
                 T item;
-                fromJsonValue(item, jitem);
+                ok &= fromJsonValue(item, jitem);
                 val.push_back(item);
             }
+        } else {
+            ok = false;
         }
-    }
+        return ok;
+    } 
 
     template <typename T>
-    void fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
-        auto varmap = jval.toObject().toVariantMap();
-        if(varmap.count() > 0){
-            for(auto itemkey : varmap.keys() ){
-                T itemVal;
-                fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
-                val.insert(itemkey, itemVal);
+    bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
+        bool ok = true;
+        if(jval.isObject()){
+            auto varmap = jval.toObject().toVariantMap();
+            if(varmap.count() > 0){
+                for(const auto& itemkey : varmap.keys() ){
+                    T itemVal;
+                    ok &= fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
+                    val.insert(itemkey, itemVal);
+                }
             }
+        } else {
+            ok = false;
         }
-        return;
+        return ok;
     }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-body.mustache
@@ -29,6 +29,7 @@ void
 {{classname}}::init() {
     {{#vars}}
     m_{{name}}_isSet = false;
+    m_{{name}}_isValid = false;
     {{/vars}}
 }
 
@@ -43,23 +44,25 @@ void
 void
 {{classname}}::fromJsonObject(QJsonObject json) {
     {{#vars}}
-    {{^isContainer}}::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/isContainer}}
-    {{#isContainer}}{{^items.isContainer}}::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/items.isContainer}}{{#items.isContainer}}{{#isListContainer}}
+    {{^isContainer}}m_{{name}}_isValid = ::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/isContainer}}
+    {{#isContainer}}{{^items.isContainer}}m_{{name}}_isValid = ::{{cppNamespace}}::fromJsonValue({{name}}, json[QString("{{baseName}}")]);{{/items.isContainer}}{{#items.isContainer}}{{#isListContainer}}
     if(json["{{baseName}}"].isArray()){
         auto arr = json["{{baseName}}"].toArray();
+        m_{{name}}_isValid = true;
         for (const QJsonValue & jval : arr) {
             {{^items.isContainer}}{{items.baseType}}{{/items.isContainer}}{{#items.isListContainer}}QList<{{items.items.baseType}}>{{/items.isListContainer}}{{#items.isMapContainer}}QMap<QString, {{items.items.baseType}}>{{/items.isMapContainer}} item;
-            ::{{cppNamespace}}::fromJsonValue(item, jval)
+            m_{{name}}_isValid &=  ::{{cppNamespace}}::fromJsonValue(item, jval)
             {{name}}.push_back(item);
         }
     }{{/isListContainer}}{{#isMapContainer}}
     if(json["{{baseName}}"].isObject()){
         auto varmap = json["{{baseName}}"].toObject().toVariantMap();
+        m_{{name}}_isValid = true;
         if(varmap.count() > 0){
             for(auto val : varmap.keys()){
                 {{^items.isContainer}}{{items.baseType}}{{/items.isContainer}}{{#items.isListContainer}}QList<{{items.items.baseType}}>{{/items.isListContainer}}{{#items.isMapContainer}}QMap<QString, {{items.items.baseType}}>{{/items.isMapContainer}} item;
     		    auto jval = QJsonValue::fromVariant(varmap.value(val));
-                ::{{cppNamespace}}::fromJsonValue(item, jval);
+                m_{{name}}_isValid &= ::{{cppNamespace}}::fromJsonValue(item, jval);
                 {{name}}.insert({{name}}.end(), val, item);
             }
         }
@@ -102,7 +105,6 @@ void
 }
 
 {{/vars}}
-
 bool
 {{classname}}::isSet() const {
     bool isObjectUpdated = false;
@@ -110,6 +112,12 @@ bool
         {{#isContainer}}if({{name}}.size() > 0){{/isContainer}}{{^isContainer}}{{#complexType}}if({{name}}.isSet()){{/complexType}}{{^complexType}}if(m_{{name}}_isSet){{/complexType}}{{/isContainer}}{ isObjectUpdated = true; break;}
     {{/vars}}}while(false);
     return isObjectUpdated;
+}
+
+bool
+{{classname}}::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return {{#vars}}{{#required}}m_{{name}}_isValid && {{/required}}{{/vars}}true;
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-body.mustache
@@ -14,6 +14,7 @@ namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
 {{classname}}::{{classname}}(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-header.mustache
@@ -40,12 +40,13 @@ public:
 
     {{/vars}}
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     {{#vars}}
     {{{dataType}}} {{name}};
     bool m_{{name}}_isSet;
-
+    bool m_{{name}}_isValid;
     {{/vars}}
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/object.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/object.mustache
@@ -36,6 +36,10 @@ class {{prefix}}Object {
     virtual bool isSet() const {
         return false;
     }
+
+    virtual bool isValid() const {
+        return true;
+    }
 private :
    QJsonObject jObj;
 };

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
@@ -8,7 +8,7 @@
 PetApiTests::PetApiTests () {}
 
 PetApiTests::~PetApiTests () {
-    exit(1);
+
 }
 
 OAIPetApi* PetApiTests::getApi() {
@@ -35,7 +35,6 @@ void PetApiTests::runTests() {
 
 void PetApiTests::findPetsByStatusTest() {
     OAIPetApi* api = getApi();
-
     QEventLoop loop;
     QTimer timer;
     timer.setInterval(14000);

--- a/samples/client/petstore/cpp-qt5/PetStore/PetStore.pro
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetStore.pro
@@ -19,6 +19,8 @@ TEMPLATE = app
 include(../client/client.pri)
 
 SOURCES += main.cpp \
-	PetApiTests.cpp
+	PetApiTests.cpp \
+        StoreApiTests.cpp
 
-HEADERS += PetApiTests.h
+HEADERS += PetApiTests.h \
+           StoreApiTests.h

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
@@ -1,0 +1,117 @@
+#include "StoreApiTests.h"
+
+#include <QJsonDocument>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QDebug>
+
+StoreApiTests::StoreApiTests () {}
+
+StoreApiTests::~StoreApiTests () {
+    exit(1);
+}
+
+OAIStoreApi* StoreApiTests::getApi() {
+    auto api = new OAIStoreApi();
+    api->host = "http://petstore.swagger.io";
+    api->basePath = "/v2";
+    return api;
+}
+
+void StoreApiTests::runTests() {
+    StoreApiTests* tests = new StoreApiTests();
+    QTest::qExec(tests);
+    delete tests;
+}
+
+void StoreApiTests::placeOrderTest() {
+    auto api = getApi();
+
+    QEventLoop loop;
+    QTimer timer;
+    timer.setInterval(14000);
+    timer.setSingleShot(true);
+
+    auto validator = [this](OAIOrder order) {
+        QVERIFY(order.getPetId() == 10000);
+        QVERIFY((order.getId() == 500));
+        qDebug() << order.getShipDate();
+        emit quit();
+    };
+    auto finalizer = [&]() {
+        loop.quit();
+    };
+    connect(this, &StoreApiTests::quit, finalizer);
+    connect(api, &OAIStoreApi::placeOrderSignal, this, validator);
+    connect(&timer, &QTimer::timeout, &loop, finalizer);
+
+    OAIOrder order;
+    order.setId(500);
+    order.setQuantity(10);
+    order.setPetId(10000);
+    order.setComplete(false);
+    order.setStatus(QString("shipping"));
+    order.setShipDate(QDateTime::currentDateTime());
+    api->placeOrder(order);
+    timer.start();
+    loop.exec();
+    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    disconnect(this, nullptr, nullptr, nullptr);
+    delete api;
+}
+
+void StoreApiTests::getOrderByIdTest() {
+    auto api = getApi();
+
+    QEventLoop loop;
+    QTimer timer;
+    timer.setInterval(14000);
+    timer.setSingleShot(true);
+
+    auto validator = [this](OAIOrder order) {
+        QVERIFY(order.getPetId() == 10000);
+        QVERIFY((order.getId() == 500));
+        qDebug() << order.getShipDate();
+        emit quit();
+    };
+    auto finalizer = [&]() {
+        loop.quit();
+    };
+    connect(this, &StoreApiTests::quit, finalizer);
+    connect(api, &OAIStoreApi::getOrderByIdSignal, this, validator);
+    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    api->getOrderById(500);
+    timer.start();
+    loop.exec();
+    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    disconnect(this, nullptr, nullptr, nullptr);
+    delete api;
+}
+
+void StoreApiTests::getInventoryTest() {
+    auto api = getApi();
+
+    QEventLoop loop;
+    QTimer timer;
+    timer.setInterval(14000);
+    timer.setSingleShot(true);
+
+    auto validator = [this](QMap<QString, qint32> status) {
+        for(const auto& key : status.keys()) {
+            qDebug() << (key) << " Quantities " << status.value(key);
+        }
+        emit quit();
+    };
+    auto finalizer = [&]() {
+        loop.quit();
+    };
+    connect(this, &StoreApiTests::quit, finalizer);
+    connect(api, &OAIStoreApi::getInventorySignal, this, validator);
+    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    api->getInventory();
+    timer.start();
+    loop.exec();
+    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    disconnect(this, nullptr, nullptr, nullptr);
+    delete api;
+}

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
@@ -1,0 +1,32 @@
+#ifndef STOREAPITESTS_H
+#define STOREAPITESTS_H
+#include <QtTest/QtTest>
+#include <QTimer>
+
+#include "../client/OAIStoreApi.h"
+
+using namespace OpenAPI;
+
+class StoreApiTests: public QObject {
+Q_OBJECT
+public:
+    StoreApiTests();
+    virtual ~StoreApiTests();
+
+    static void runTests();
+
+private:
+    OAIStoreApi* getApi();
+    OAIOrder createRandomOrder();
+
+signals:
+    void quit();
+    bool success();
+
+private slots:
+    void placeOrderTest();
+    void getOrderByIdTest();
+    void getInventoryTest();
+};
+
+#endif // STOREAPITESTS_H

--- a/samples/client/petstore/cpp-qt5/PetStore/main.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/main.cpp
@@ -1,8 +1,10 @@
 #include <QCoreApplication>
 #include "PetApiTests.h"
+#include "StoreApiTests.h"
 
 int main(int argc, char *argv[]) {
     QCoreApplication a(argc, argv);
     PetApiTests::runTests();
+    StoreApiTests::runTests();
     return a.exec();
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIApiResponse.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIApiResponse.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIApiResponse::OAIApiResponse(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/client/petstore/cpp-qt5/client/OAIApiResponse.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIApiResponse.cpp
@@ -37,8 +37,11 @@ OAIApiResponse::~OAIApiResponse() {
 void
 OAIApiResponse::init() {
     m_code_isSet = false;
+    m_code_isValid = false;
     m_type_isSet = false;
+    m_type_isValid = false;
     m_message_isSet = false;
+    m_message_isValid = false;
 }
 
 void
@@ -51,11 +54,11 @@ OAIApiResponse::fromJson(QString jsonString) {
 
 void
 OAIApiResponse::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(code, json[QString("code")]);
+    m_code_isValid = ::OpenAPI::fromJsonValue(code, json[QString("code")]);
     
-    ::OpenAPI::fromJsonValue(type, json[QString("type")]);
+    m_type_isValid = ::OpenAPI::fromJsonValue(type, json[QString("type")]);
     
-    ::OpenAPI::fromJsonValue(message, json[QString("message")]);
+    m_message_isValid = ::OpenAPI::fromJsonValue(message, json[QString("message")]);
     
 }
 
@@ -112,7 +115,6 @@ OAIApiResponse::setMessage(const QString &message) {
     this->m_message_isSet = true;
 }
 
-
 bool
 OAIApiResponse::isSet() const {
     bool isObjectUpdated = false;
@@ -124,6 +126,12 @@ OAIApiResponse::isSet() const {
         if(m_message_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIApiResponse::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIApiResponse.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIApiResponse.h
@@ -50,17 +50,18 @@ public:
     void setMessage(const QString &message);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint32 code;
     bool m_code_isSet;
-
+    bool m_code_isValid;
     QString type;
     bool m_type_isSet;
-
+    bool m_type_isValid;
     QString message;
     bool m_message_isSet;
-
+    bool m_message_isValid;
 };
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAICategory.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAICategory.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAICategory::OAICategory(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/client/petstore/cpp-qt5/client/OAICategory.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAICategory.cpp
@@ -37,7 +37,9 @@ OAICategory::~OAICategory() {
 void
 OAICategory::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_name_isSet = false;
+    m_name_isValid = false;
 }
 
 void
@@ -50,9 +52,9 @@ OAICategory::fromJson(QString jsonString) {
 
 void
 OAICategory::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(name, json[QString("name")]);
+    m_name_isValid = ::OpenAPI::fromJsonValue(name, json[QString("name")]);
     
 }
 
@@ -96,7 +98,6 @@ OAICategory::setName(const QString &name) {
     this->m_name_isSet = true;
 }
 
-
 bool
 OAICategory::isSet() const {
     bool isObjectUpdated = false;
@@ -106,6 +107,12 @@ OAICategory::isSet() const {
         if(m_name_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAICategory::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAICategory.h
+++ b/samples/client/petstore/cpp-qt5/client/OAICategory.h
@@ -47,14 +47,15 @@ public:
     void setName(const QString &name);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     QString name;
     bool m_name_isSet;
-
+    bool m_name_isValid;
 };
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIHelpers.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIHelpers.cpp
@@ -56,7 +56,7 @@ toStringValue(const bool &value) {
 
 QString
 toStringValue(const float &value){
-    return QString::number(value);
+    return QString::number(static_cast<double>(value));
 }
 
 QString
@@ -101,7 +101,7 @@ toJsonValue(const bool &value){
 
 QJsonValue
 toJsonValue(const float &value){
-    return QJsonValue(value);
+    return QJsonValue(static_cast<double>(value));
 }
 
 QJsonValue
@@ -224,7 +224,7 @@ fromJsonValue(QString &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {
@@ -236,7 +236,7 @@ fromJsonValue(QDateTime &value, const QJsonValue &jval){
 bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
     bool ok = true;
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()) {
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
         ok = value.size() > 0 ;
     } else {
@@ -248,7 +248,7 @@ fromJsonValue(QByteArray &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {

--- a/samples/client/petstore/cpp-qt5/client/OAIHelpers.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIHelpers.cpp
@@ -202,88 +202,126 @@ fromStringValue(const QString &inStr, double &value){
     return ok;
 }
 
-void
+bool
 fromJsonValue(QString &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         if(jval.isString()){
             value = jval.toString();
         } else if(jval.isBool()) {
             value =  jval.toBool() ? "true" : "false";
         } else if(jval.isDouble()){
             value = QString::number(jval.toDouble());
+        } else {
+            ok = false;    
         }
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
+        ok = value.size() > 0 ;
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint32 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toInt();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint64 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toVariant().toLongLong();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(bool &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isBool()){
         value = jval.toBool();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(float &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = static_cast<float>(jval.toDouble());
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
-void
+bool
 fromJsonValue(double &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = jval.toDouble();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(OAIObject  &value, const QJsonValue &jval){
+    bool ok = true;    
     if(jval.isObject()){
         value.fromJsonObject(jval.toObject());
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIHelpers.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIHelpers.h
@@ -39,7 +39,7 @@ namespace OpenAPI {
     template <typename T>
     QString toStringValue(const QList<T> &val) {
         QString strArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             strArray.append(toStringValue(item) + ",");
         }
         if(val.count() > 0) {
@@ -62,7 +62,7 @@ namespace OpenAPI {
     template <typename T>
     QJsonValue toJsonValue(const QList<T> &val) {
         QJsonArray jArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             jArray.append(toJsonValue(item));
         }
         return jArray;
@@ -71,7 +71,7 @@ namespace OpenAPI {
     template <typename T>
     QJsonValue toJsonValue(const QMap<QString, T> &val) {
         QJsonObject jObject;
-        for(auto itemkey : val.keys()) {
+        for(const auto& itemkey : val.keys()) {
             jObject.insert(itemkey, toJsonValue(val.value(itemkey)));
         }
         return jObject;
@@ -88,56 +88,69 @@ namespace OpenAPI {
     bool fromStringValue(const QString &inStr, double &value);
 
     template <typename T>
-    void fromStringValue(const QList<QString> &inStr, QList<T> &val) {
-        for(auto item: inStr){
+    bool fromStringValue(const QList<QString> &inStr, QList<T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& item: inStr){
             T itemVal;
-            fromStringValue(item, itemVal);
+            ok &= fromStringValue(item, itemVal);
             val.push_back(itemVal);
         }
+        return ok;
     }
 
     template <typename T>
-    void fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
-        for(auto itemkey : inStr.keys()){
+    bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& itemkey : inStr.keys()){
             T itemVal;
-            fromStringValue(inStr.value(itemkey), itemVal);
+            ok &= fromStringValue(inStr.value(itemkey), itemVal);
             val.insert(itemkey, itemVal);
         }
+        return ok;
     }
 
-    void fromJsonValue(QString &value, const QJsonValue &jval);
-    void fromJsonValue(QDateTime &value, const QJsonValue &jval);
-    void fromJsonValue(QByteArray &value, const QJsonValue &jval);
-    void fromJsonValue(QDate &value, const QJsonValue &jval);
-    void fromJsonValue(qint32 &value, const QJsonValue &jval);
-    void fromJsonValue(qint64 &value, const QJsonValue &jval);
-    void fromJsonValue(bool &value, const QJsonValue &jval);
-    void fromJsonValue(float &value, const QJsonValue &jval);
-    void fromJsonValue(double &value, const QJsonValue &jval);
-    void fromJsonValue(OAIObject &value, const QJsonValue &jval);
+    bool fromJsonValue(QString &value, const QJsonValue &jval);
+    bool fromJsonValue(QDateTime &value, const QJsonValue &jval);
+    bool fromJsonValue(QByteArray &value, const QJsonValue &jval);
+    bool fromJsonValue(QDate &value, const QJsonValue &jval);
+    bool fromJsonValue(qint32 &value, const QJsonValue &jval);
+    bool fromJsonValue(qint64 &value, const QJsonValue &jval);
+    bool fromJsonValue(bool &value, const QJsonValue &jval);
+    bool fromJsonValue(float &value, const QJsonValue &jval);
+    bool fromJsonValue(double &value, const QJsonValue &jval);
+    bool fromJsonValue(OAIObject &value, const QJsonValue &jval);
 
     template <typename T>
-    void fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+    bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+        bool ok = true;
         if(jval.isArray()){
-            for(const QJsonValue &jitem : jval.toArray()){
+            for(const auto& jitem : jval.toArray()){
                 T item;
-                fromJsonValue(item, jitem);
+                ok &= fromJsonValue(item, jitem);
                 val.push_back(item);
             }
+        } else {
+            ok = false;
         }
-    }
+        return ok;
+    } 
 
     template <typename T>
-    void fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
-        auto varmap = jval.toObject().toVariantMap();
-        if(varmap.count() > 0){
-            for(auto itemkey : varmap.keys() ){
-                T itemVal;
-                fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
-                val.insert(itemkey, itemVal);
+    bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
+        bool ok = true;
+        if(jval.isObject()){
+            auto varmap = jval.toObject().toVariantMap();
+            if(varmap.count() > 0){
+                for(const auto& itemkey : varmap.keys() ){
+                    T itemVal;
+                    ok &= fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
+                    val.insert(itemkey, itemVal);
+                }
             }
+        } else {
+            ok = false;
         }
-        return;
+        return ok;
     }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIHttpRequest.cpp
@@ -62,6 +62,10 @@ OAIHttpRequestWorker::OAIHttpRequestWorker(QObject *parent)
 OAIHttpRequestWorker::~OAIHttpRequestWorker() {
 }
 
+QMap<QByteArray, QByteArray> OAIHttpRequestWorker::getResponseHeaders() const {
+    return headers;
+}
+
 QString OAIHttpRequestWorker::http_attribute_encode(QString attribute_name, QString input) {
     // result structure follows RFC 5987
     bool need_utf_encoding = false;
@@ -314,7 +318,11 @@ void OAIHttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
     error_type = reply->error();
     response = reply->readAll();
     error_str = reply->errorString();
-
+    if(reply->rawHeaderPairs().count() > 0){
+        for(const auto& item: reply->rawHeaderPairs()){
+            headers.insert(item.first, item.second);
+        }
+    }
     reply->deleteLater();
 
     emit on_execution_finished(this);

--- a/samples/client/petstore/cpp-qt5/client/OAIHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIHttpRequest.h
@@ -70,9 +70,10 @@ public:
     QNetworkReply::NetworkError error_type;
     QString error_str;
 
-    explicit OAIHttpRequestWorker(QObject *parent = 0);
+    explicit OAIHttpRequestWorker(QObject *parent = nullptr);
     virtual ~OAIHttpRequestWorker();
 
+    QMap<QByteArray, QByteArray> getResponseHeaders() const;
     QString http_attribute_encode(QString attribute_name, QString input);
     void execute(OAIHttpRequestInput *input);
     static QSslConfiguration* sslDefaultConfiguration;
@@ -82,7 +83,7 @@ signals:
 
 private:
     QNetworkAccessManager *manager;
-
+    QMap<QByteArray, QByteArray> headers;
 private slots:
     void on_manager_finished(QNetworkReply *reply);
 

--- a/samples/client/petstore/cpp-qt5/client/OAIObject.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIObject.h
@@ -45,6 +45,10 @@ class OAIObject {
     virtual bool isSet() const {
         return false;
     }
+
+    virtual bool isValid() const {
+        return true;
+    }
 private :
    QJsonObject jObj;
 };

--- a/samples/client/petstore/cpp-qt5/client/OAIOrder.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIOrder.cpp
@@ -37,11 +37,17 @@ OAIOrder::~OAIOrder() {
 void
 OAIOrder::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_pet_id_isSet = false;
+    m_pet_id_isValid = false;
     m_quantity_isSet = false;
+    m_quantity_isValid = false;
     m_ship_date_isSet = false;
+    m_ship_date_isValid = false;
     m_status_isSet = false;
+    m_status_isValid = false;
     m_complete_isSet = false;
+    m_complete_isValid = false;
 }
 
 void
@@ -54,17 +60,17 @@ OAIOrder::fromJson(QString jsonString) {
 
 void
 OAIOrder::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(pet_id, json[QString("petId")]);
+    m_pet_id_isValid = ::OpenAPI::fromJsonValue(pet_id, json[QString("petId")]);
     
-    ::OpenAPI::fromJsonValue(quantity, json[QString("quantity")]);
+    m_quantity_isValid = ::OpenAPI::fromJsonValue(quantity, json[QString("quantity")]);
     
-    ::OpenAPI::fromJsonValue(ship_date, json[QString("shipDate")]);
+    m_ship_date_isValid = ::OpenAPI::fromJsonValue(ship_date, json[QString("shipDate")]);
     
-    ::OpenAPI::fromJsonValue(status, json[QString("status")]);
+    m_status_isValid = ::OpenAPI::fromJsonValue(status, json[QString("status")]);
     
-    ::OpenAPI::fromJsonValue(complete, json[QString("complete")]);
+    m_complete_isValid = ::OpenAPI::fromJsonValue(complete, json[QString("complete")]);
     
 }
 
@@ -160,7 +166,6 @@ OAIOrder::setComplete(const bool &complete) {
     this->m_complete_isSet = true;
 }
 
-
 bool
 OAIOrder::isSet() const {
     bool isObjectUpdated = false;
@@ -178,6 +183,12 @@ OAIOrder::isSet() const {
         if(m_complete_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIOrder::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIOrder.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIOrder.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIOrder::OAIOrder(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/client/petstore/cpp-qt5/client/OAIOrder.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIOrder.h
@@ -60,26 +60,27 @@ public:
     void setComplete(const bool &complete);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     qint64 pet_id;
     bool m_pet_id_isSet;
-
+    bool m_pet_id_isValid;
     qint32 quantity;
     bool m_quantity_isSet;
-
+    bool m_quantity_isValid;
     QDateTime ship_date;
     bool m_ship_date_isSet;
-
+    bool m_ship_date_isValid;
     QString status;
     bool m_status_isSet;
-
+    bool m_status_isValid;
     bool complete;
     bool m_complete_isSet;
-
+    bool m_complete_isValid;
 };
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIPet.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIPet.cpp
@@ -37,11 +37,17 @@ OAIPet::~OAIPet() {
 void
 OAIPet::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_category_isSet = false;
+    m_category_isValid = false;
     m_name_isSet = false;
+    m_name_isValid = false;
     m_photo_urls_isSet = false;
+    m_photo_urls_isValid = false;
     m_tags_isSet = false;
+    m_tags_isValid = false;
     m_status_isSet = false;
+    m_status_isValid = false;
 }
 
 void
@@ -54,17 +60,17 @@ OAIPet::fromJson(QString jsonString) {
 
 void
 OAIPet::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(category, json[QString("category")]);
+    m_category_isValid = ::OpenAPI::fromJsonValue(category, json[QString("category")]);
     
-    ::OpenAPI::fromJsonValue(name, json[QString("name")]);
+    m_name_isValid = ::OpenAPI::fromJsonValue(name, json[QString("name")]);
     
     
-    ::OpenAPI::fromJsonValue(photo_urls, json[QString("photoUrls")]);
+    m_photo_urls_isValid = ::OpenAPI::fromJsonValue(photo_urls, json[QString("photoUrls")]);
     
-    ::OpenAPI::fromJsonValue(tags, json[QString("tags")]);
-    ::OpenAPI::fromJsonValue(status, json[QString("status")]);
+    m_tags_isValid = ::OpenAPI::fromJsonValue(tags, json[QString("tags")]);
+    m_status_isValid = ::OpenAPI::fromJsonValue(status, json[QString("status")]);
     
 }
 
@@ -162,7 +168,6 @@ OAIPet::setStatus(const QString &status) {
     this->m_status_isSet = true;
 }
 
-
 bool
 OAIPet::isSet() const {
     bool isObjectUpdated = false;
@@ -180,6 +185,12 @@ OAIPet::isSet() const {
         if(m_status_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIPet::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return m_name_isValid && m_photo_urls_isValid && true;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIPet.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIPet.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIPet::OAIPet(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/client/petstore/cpp-qt5/client/OAIPet.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIPet.h
@@ -62,26 +62,27 @@ public:
     void setStatus(const QString &status);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     OAICategory category;
     bool m_category_isSet;
-
+    bool m_category_isValid;
     QString name;
     bool m_name_isSet;
-
+    bool m_name_isValid;
     QList<QString> photo_urls;
     bool m_photo_urls_isSet;
-
+    bool m_photo_urls_isValid;
     QList<OAITag> tags;
     bool m_tags_isSet;
-
+    bool m_tags_isValid;
     QString status;
     bool m_status_isSet;
-
+    bool m_status_isValid;
 };
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAITag.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAITag.cpp
@@ -37,7 +37,9 @@ OAITag::~OAITag() {
 void
 OAITag::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_name_isSet = false;
+    m_name_isValid = false;
 }
 
 void
@@ -50,9 +52,9 @@ OAITag::fromJson(QString jsonString) {
 
 void
 OAITag::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(name, json[QString("name")]);
+    m_name_isValid = ::OpenAPI::fromJsonValue(name, json[QString("name")]);
     
 }
 
@@ -96,7 +98,6 @@ OAITag::setName(const QString &name) {
     this->m_name_isSet = true;
 }
 
-
 bool
 OAITag::isSet() const {
     bool isObjectUpdated = false;
@@ -106,6 +107,12 @@ OAITag::isSet() const {
         if(m_name_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAITag::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAITag.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAITag.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAITag::OAITag(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/client/petstore/cpp-qt5/client/OAITag.h
+++ b/samples/client/petstore/cpp-qt5/client/OAITag.h
@@ -47,14 +47,15 @@ public:
     void setName(const QString &name);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     QString name;
     bool m_name_isSet;
-
+    bool m_name_isValid;
 };
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIUser.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIUser.cpp
@@ -37,13 +37,21 @@ OAIUser::~OAIUser() {
 void
 OAIUser::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_username_isSet = false;
+    m_username_isValid = false;
     m_first_name_isSet = false;
+    m_first_name_isValid = false;
     m_last_name_isSet = false;
+    m_last_name_isValid = false;
     m_email_isSet = false;
+    m_email_isValid = false;
     m_password_isSet = false;
+    m_password_isValid = false;
     m_phone_isSet = false;
+    m_phone_isValid = false;
     m_user_status_isSet = false;
+    m_user_status_isValid = false;
 }
 
 void
@@ -56,21 +64,21 @@ OAIUser::fromJson(QString jsonString) {
 
 void
 OAIUser::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(username, json[QString("username")]);
+    m_username_isValid = ::OpenAPI::fromJsonValue(username, json[QString("username")]);
     
-    ::OpenAPI::fromJsonValue(first_name, json[QString("firstName")]);
+    m_first_name_isValid = ::OpenAPI::fromJsonValue(first_name, json[QString("firstName")]);
     
-    ::OpenAPI::fromJsonValue(last_name, json[QString("lastName")]);
+    m_last_name_isValid = ::OpenAPI::fromJsonValue(last_name, json[QString("lastName")]);
     
-    ::OpenAPI::fromJsonValue(email, json[QString("email")]);
+    m_email_isValid = ::OpenAPI::fromJsonValue(email, json[QString("email")]);
     
-    ::OpenAPI::fromJsonValue(password, json[QString("password")]);
+    m_password_isValid = ::OpenAPI::fromJsonValue(password, json[QString("password")]);
     
-    ::OpenAPI::fromJsonValue(phone, json[QString("phone")]);
+    m_phone_isValid = ::OpenAPI::fromJsonValue(phone, json[QString("phone")]);
     
-    ::OpenAPI::fromJsonValue(user_status, json[QString("userStatus")]);
+    m_user_status_isValid = ::OpenAPI::fromJsonValue(user_status, json[QString("userStatus")]);
     
 }
 
@@ -192,7 +200,6 @@ OAIUser::setUserStatus(const qint32 &user_status) {
     this->m_user_status_isSet = true;
 }
 
-
 bool
 OAIUser::isSet() const {
     bool isObjectUpdated = false;
@@ -214,6 +221,12 @@ OAIUser::isSet() const {
         if(m_user_status_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIUser::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIUser.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIUser.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIUser::OAIUser(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/client/petstore/cpp-qt5/client/OAIUser.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIUser.h
@@ -65,32 +65,33 @@ public:
     void setUserStatus(const qint32 &user_status);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     QString username;
     bool m_username_isSet;
-
+    bool m_username_isValid;
     QString first_name;
     bool m_first_name_isSet;
-
+    bool m_first_name_isValid;
     QString last_name;
     bool m_last_name_isSet;
-
+    bool m_last_name_isValid;
     QString email;
     bool m_email_isSet;
-
+    bool m_email_isValid;
     QString password;
     bool m_password_isSet;
-
+    bool m_password_isValid;
     QString phone;
     bool m_phone_isSet;
-
+    bool m_phone_isValid;
     qint32 user_status;
     bool m_user_status_isSet;
-
+    bool m_user_status_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIApiResponse::OAIApiResponse(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.cpp
@@ -37,8 +37,11 @@ OAIApiResponse::~OAIApiResponse() {
 void
 OAIApiResponse::init() {
     m_code_isSet = false;
+    m_code_isValid = false;
     m_type_isSet = false;
+    m_type_isValid = false;
     m_message_isSet = false;
+    m_message_isValid = false;
 }
 
 void
@@ -51,11 +54,11 @@ OAIApiResponse::fromJson(QString jsonString) {
 
 void
 OAIApiResponse::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(code, json[QString("code")]);
+    m_code_isValid = ::OpenAPI::fromJsonValue(code, json[QString("code")]);
     
-    ::OpenAPI::fromJsonValue(type, json[QString("type")]);
+    m_type_isValid = ::OpenAPI::fromJsonValue(type, json[QString("type")]);
     
-    ::OpenAPI::fromJsonValue(message, json[QString("message")]);
+    m_message_isValid = ::OpenAPI::fromJsonValue(message, json[QString("message")]);
     
 }
 
@@ -112,7 +115,6 @@ OAIApiResponse::setMessage(const QString &message) {
     this->m_message_isSet = true;
 }
 
-
 bool
 OAIApiResponse::isSet() const {
     bool isObjectUpdated = false;
@@ -124,6 +126,12 @@ OAIApiResponse::isSet() const {
         if(m_message_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIApiResponse::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.h
@@ -50,17 +50,18 @@ public:
     void setMessage(const QString &message);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint32 code;
     bool m_code_isSet;
-
+    bool m_code_isValid;
     QString type;
     bool m_type_isSet;
-
+    bool m_type_isValid;
     QString message;
     bool m_message_isSet;
-
+    bool m_message_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAICategory::OAICategory(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.cpp
@@ -37,7 +37,9 @@ OAICategory::~OAICategory() {
 void
 OAICategory::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_name_isSet = false;
+    m_name_isValid = false;
 }
 
 void
@@ -50,9 +52,9 @@ OAICategory::fromJson(QString jsonString) {
 
 void
 OAICategory::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(name, json[QString("name")]);
+    m_name_isValid = ::OpenAPI::fromJsonValue(name, json[QString("name")]);
     
 }
 
@@ -96,7 +98,6 @@ OAICategory::setName(const QString &name) {
     this->m_name_isSet = true;
 }
 
-
 bool
 OAICategory::isSet() const {
     bool isObjectUpdated = false;
@@ -106,6 +107,12 @@ OAICategory::isSet() const {
         if(m_name_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAICategory::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.h
@@ -47,14 +47,15 @@ public:
     void setName(const QString &name);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     QString name;
     bool m_name_isSet;
-
+    bool m_name_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.cpp
@@ -56,7 +56,7 @@ toStringValue(const bool &value) {
 
 QString
 toStringValue(const float &value){
-    return QString::number(value);
+    return QString::number(static_cast<double>(value));
 }
 
 QString
@@ -101,7 +101,7 @@ toJsonValue(const bool &value){
 
 QJsonValue
 toJsonValue(const float &value){
-    return QJsonValue(value);
+    return QJsonValue(static_cast<double>(value));
 }
 
 QJsonValue
@@ -224,7 +224,7 @@ fromJsonValue(QString &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {
@@ -236,7 +236,7 @@ fromJsonValue(QDateTime &value, const QJsonValue &jval){
 bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
     bool ok = true;
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()) {
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
         ok = value.size() > 0 ;
     } else {
@@ -248,7 +248,7 @@ fromJsonValue(QByteArray &value, const QJsonValue &jval){
 bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
     bool ok = true;    
-    if(!jval.isUndefined() && !jval.isNull()){
+    if(!jval.isUndefined() && !jval.isNull() && jval.isString()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
         ok = value.isValid();
     } else {

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.cpp
@@ -202,88 +202,126 @@ fromStringValue(const QString &inStr, double &value){
     return ok;
 }
 
-void
+bool
 fromJsonValue(QString &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         if(jval.isString()){
             value = jval.toString();
         } else if(jval.isBool()) {
             value =  jval.toBool() ? "true" : "false";
         } else if(jval.isDouble()){
             value = QString::number(jval.toDouble());
+        } else {
+            ok = false;    
         }
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDateTime &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDateTime::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QByteArray &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QByteArray::fromBase64(QByteArray::fromStdString(jval.toString().toStdString()));
+        ok = value.size() > 0 ;
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(QDate &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull()){
         value = QDate::fromString(jval.toString(), Qt::ISODate);
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint32 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toInt();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(qint64 &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(!jval.isUndefined() && !jval.isNull() && !jval.isObject() && !jval.isArray()){
         value = jval.toVariant().toLongLong();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(bool &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isBool()){
         value = jval.toBool();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(float &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = static_cast<float>(jval.toDouble());
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
-void
+bool
 fromJsonValue(double &value, const QJsonValue &jval){
-    if(!(jval.isUndefined() || jval.isNull())){
+    bool ok = true;    
+    if(jval.isDouble()){
         value = jval.toDouble();
+    } else {
+        ok = false;
     }
-
+    return ok;
 }
 
-void
+bool
 fromJsonValue(OAIObject  &value, const QJsonValue &jval){
+    bool ok = true;    
     if(jval.isObject()){
         value.fromJsonObject(jval.toObject());
+        ok = value.isValid();
+    } else {
+        ok = false;
     }
+    return ok;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIHelpers.h
@@ -39,7 +39,7 @@ namespace OpenAPI {
     template <typename T>
     QString toStringValue(const QList<T> &val) {
         QString strArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             strArray.append(toStringValue(item) + ",");
         }
         if(val.count() > 0) {
@@ -62,7 +62,7 @@ namespace OpenAPI {
     template <typename T>
     QJsonValue toJsonValue(const QList<T> &val) {
         QJsonArray jArray;
-        for(auto item : val) {
+        for(const auto& item : val) {
             jArray.append(toJsonValue(item));
         }
         return jArray;
@@ -71,7 +71,7 @@ namespace OpenAPI {
     template <typename T>
     QJsonValue toJsonValue(const QMap<QString, T> &val) {
         QJsonObject jObject;
-        for(auto itemkey : val.keys()) {
+        for(const auto& itemkey : val.keys()) {
             jObject.insert(itemkey, toJsonValue(val.value(itemkey)));
         }
         return jObject;
@@ -88,56 +88,69 @@ namespace OpenAPI {
     bool fromStringValue(const QString &inStr, double &value);
 
     template <typename T>
-    void fromStringValue(const QList<QString> &inStr, QList<T> &val) {
-        for(auto item: inStr){
+    bool fromStringValue(const QList<QString> &inStr, QList<T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& item: inStr){
             T itemVal;
-            fromStringValue(item, itemVal);
+            ok &= fromStringValue(item, itemVal);
             val.push_back(itemVal);
         }
+        return ok;
     }
 
     template <typename T>
-    void fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
-        for(auto itemkey : inStr.keys()){
+    bool fromStringValue(const QMap<QString, QString> &inStr, QMap<QString, T> &val) {
+        bool ok = (inStr.count() > 0);
+        for(const auto& itemkey : inStr.keys()){
             T itemVal;
-            fromStringValue(inStr.value(itemkey), itemVal);
+            ok &= fromStringValue(inStr.value(itemkey), itemVal);
             val.insert(itemkey, itemVal);
         }
+        return ok;
     }
 
-    void fromJsonValue(QString &value, const QJsonValue &jval);
-    void fromJsonValue(QDateTime &value, const QJsonValue &jval);
-    void fromJsonValue(QByteArray &value, const QJsonValue &jval);
-    void fromJsonValue(QDate &value, const QJsonValue &jval);
-    void fromJsonValue(qint32 &value, const QJsonValue &jval);
-    void fromJsonValue(qint64 &value, const QJsonValue &jval);
-    void fromJsonValue(bool &value, const QJsonValue &jval);
-    void fromJsonValue(float &value, const QJsonValue &jval);
-    void fromJsonValue(double &value, const QJsonValue &jval);
-    void fromJsonValue(OAIObject &value, const QJsonValue &jval);
+    bool fromJsonValue(QString &value, const QJsonValue &jval);
+    bool fromJsonValue(QDateTime &value, const QJsonValue &jval);
+    bool fromJsonValue(QByteArray &value, const QJsonValue &jval);
+    bool fromJsonValue(QDate &value, const QJsonValue &jval);
+    bool fromJsonValue(qint32 &value, const QJsonValue &jval);
+    bool fromJsonValue(qint64 &value, const QJsonValue &jval);
+    bool fromJsonValue(bool &value, const QJsonValue &jval);
+    bool fromJsonValue(float &value, const QJsonValue &jval);
+    bool fromJsonValue(double &value, const QJsonValue &jval);
+    bool fromJsonValue(OAIObject &value, const QJsonValue &jval);
 
     template <typename T>
-    void fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+    bool fromJsonValue(QList<T> &val, const QJsonValue &jval) {
+        bool ok = true;
         if(jval.isArray()){
-            for(const QJsonValue &jitem : jval.toArray()){
+            for(const auto& jitem : jval.toArray()){
                 T item;
-                fromJsonValue(item, jitem);
+                ok &= fromJsonValue(item, jitem);
                 val.push_back(item);
             }
+        } else {
+            ok = false;
         }
-    }
+        return ok;
+    } 
 
     template <typename T>
-    void fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
-        auto varmap = jval.toObject().toVariantMap();
-        if(varmap.count() > 0){
-            for(auto itemkey : varmap.keys() ){
-                T itemVal;
-                fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
-                val.insert(itemkey, itemVal);
+    bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
+        bool ok = true;
+        if(jval.isObject()){
+            auto varmap = jval.toObject().toVariantMap();
+            if(varmap.count() > 0){
+                for(const auto& itemkey : varmap.keys() ){
+                    T itemVal;
+                    ok &= fromJsonValue(itemVal, QJsonValue::fromVariant(varmap.value(itemkey)));
+                    val.insert(itemkey, itemVal);
+                }
             }
+        } else {
+            ok = false;
         }
-        return;
+        return ok;
     }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIObject.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIObject.h
@@ -45,6 +45,10 @@ class OAIObject {
     virtual bool isSet() const {
         return false;
     }
+
+    virtual bool isValid() const {
+        return true;
+    }
 private :
    QJsonObject jObj;
 };

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.cpp
@@ -37,11 +37,17 @@ OAIOrder::~OAIOrder() {
 void
 OAIOrder::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_pet_id_isSet = false;
+    m_pet_id_isValid = false;
     m_quantity_isSet = false;
+    m_quantity_isValid = false;
     m_ship_date_isSet = false;
+    m_ship_date_isValid = false;
     m_status_isSet = false;
+    m_status_isValid = false;
     m_complete_isSet = false;
+    m_complete_isValid = false;
 }
 
 void
@@ -54,17 +60,17 @@ OAIOrder::fromJson(QString jsonString) {
 
 void
 OAIOrder::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(pet_id, json[QString("petId")]);
+    m_pet_id_isValid = ::OpenAPI::fromJsonValue(pet_id, json[QString("petId")]);
     
-    ::OpenAPI::fromJsonValue(quantity, json[QString("quantity")]);
+    m_quantity_isValid = ::OpenAPI::fromJsonValue(quantity, json[QString("quantity")]);
     
-    ::OpenAPI::fromJsonValue(ship_date, json[QString("shipDate")]);
+    m_ship_date_isValid = ::OpenAPI::fromJsonValue(ship_date, json[QString("shipDate")]);
     
-    ::OpenAPI::fromJsonValue(status, json[QString("status")]);
+    m_status_isValid = ::OpenAPI::fromJsonValue(status, json[QString("status")]);
     
-    ::OpenAPI::fromJsonValue(complete, json[QString("complete")]);
+    m_complete_isValid = ::OpenAPI::fromJsonValue(complete, json[QString("complete")]);
     
 }
 
@@ -160,7 +166,6 @@ OAIOrder::setComplete(const bool &complete) {
     this->m_complete_isSet = true;
 }
 
-
 bool
 OAIOrder::isSet() const {
     bool isObjectUpdated = false;
@@ -178,6 +183,12 @@ OAIOrder::isSet() const {
         if(m_complete_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIOrder::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIOrder::OAIOrder(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.h
@@ -60,26 +60,27 @@ public:
     void setComplete(const bool &complete);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     qint64 pet_id;
     bool m_pet_id_isSet;
-
+    bool m_pet_id_isValid;
     qint32 quantity;
     bool m_quantity_isSet;
-
+    bool m_quantity_isValid;
     QDateTime ship_date;
     bool m_ship_date_isSet;
-
+    bool m_ship_date_isValid;
     QString status;
     bool m_status_isSet;
-
+    bool m_status_isValid;
     bool complete;
     bool m_complete_isSet;
-
+    bool m_complete_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.cpp
@@ -37,11 +37,17 @@ OAIPet::~OAIPet() {
 void
 OAIPet::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_category_isSet = false;
+    m_category_isValid = false;
     m_name_isSet = false;
+    m_name_isValid = false;
     m_photo_urls_isSet = false;
+    m_photo_urls_isValid = false;
     m_tags_isSet = false;
+    m_tags_isValid = false;
     m_status_isSet = false;
+    m_status_isValid = false;
 }
 
 void
@@ -54,17 +60,17 @@ OAIPet::fromJson(QString jsonString) {
 
 void
 OAIPet::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(category, json[QString("category")]);
+    m_category_isValid = ::OpenAPI::fromJsonValue(category, json[QString("category")]);
     
-    ::OpenAPI::fromJsonValue(name, json[QString("name")]);
+    m_name_isValid = ::OpenAPI::fromJsonValue(name, json[QString("name")]);
     
     
-    ::OpenAPI::fromJsonValue(photo_urls, json[QString("photoUrls")]);
+    m_photo_urls_isValid = ::OpenAPI::fromJsonValue(photo_urls, json[QString("photoUrls")]);
     
-    ::OpenAPI::fromJsonValue(tags, json[QString("tags")]);
-    ::OpenAPI::fromJsonValue(status, json[QString("status")]);
+    m_tags_isValid = ::OpenAPI::fromJsonValue(tags, json[QString("tags")]);
+    m_status_isValid = ::OpenAPI::fromJsonValue(status, json[QString("status")]);
     
 }
 
@@ -162,7 +168,6 @@ OAIPet::setStatus(const QString &status) {
     this->m_status_isSet = true;
 }
 
-
 bool
 OAIPet::isSet() const {
     bool isObjectUpdated = false;
@@ -180,6 +185,12 @@ OAIPet::isSet() const {
         if(m_status_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIPet::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return m_name_isValid && m_photo_urls_isValid && true;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIPet::OAIPet(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.h
@@ -62,26 +62,27 @@ public:
     void setStatus(const QString &status);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     OAICategory category;
     bool m_category_isSet;
-
+    bool m_category_isValid;
     QString name;
     bool m_name_isSet;
-
+    bool m_name_isValid;
     QList<QString> photo_urls;
     bool m_photo_urls_isSet;
-
+    bool m_photo_urls_isValid;
     QList<OAITag> tags;
     bool m_tags_isSet;
-
+    bool m_tags_isValid;
     QString status;
     bool m_status_isSet;
-
+    bool m_status_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.cpp
@@ -37,7 +37,9 @@ OAITag::~OAITag() {
 void
 OAITag::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_name_isSet = false;
+    m_name_isValid = false;
 }
 
 void
@@ -50,9 +52,9 @@ OAITag::fromJson(QString jsonString) {
 
 void
 OAITag::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(name, json[QString("name")]);
+    m_name_isValid = ::OpenAPI::fromJsonValue(name, json[QString("name")]);
     
 }
 
@@ -96,7 +98,6 @@ OAITag::setName(const QString &name) {
     this->m_name_isSet = true;
 }
 
-
 bool
 OAITag::isSet() const {
     bool isObjectUpdated = false;
@@ -106,6 +107,12 @@ OAITag::isSet() const {
         if(m_name_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAITag::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAITag::OAITag(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.h
@@ -47,14 +47,15 @@ public:
     void setName(const QString &name);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     QString name;
     bool m_name_isSet;
-
+    bool m_name_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.cpp
@@ -37,13 +37,21 @@ OAIUser::~OAIUser() {
 void
 OAIUser::init() {
     m_id_isSet = false;
+    m_id_isValid = false;
     m_username_isSet = false;
+    m_username_isValid = false;
     m_first_name_isSet = false;
+    m_first_name_isValid = false;
     m_last_name_isSet = false;
+    m_last_name_isValid = false;
     m_email_isSet = false;
+    m_email_isValid = false;
     m_password_isSet = false;
+    m_password_isValid = false;
     m_phone_isSet = false;
+    m_phone_isValid = false;
     m_user_status_isSet = false;
+    m_user_status_isValid = false;
 }
 
 void
@@ -56,21 +64,21 @@ OAIUser::fromJson(QString jsonString) {
 
 void
 OAIUser::fromJsonObject(QJsonObject json) {
-    ::OpenAPI::fromJsonValue(id, json[QString("id")]);
+    m_id_isValid = ::OpenAPI::fromJsonValue(id, json[QString("id")]);
     
-    ::OpenAPI::fromJsonValue(username, json[QString("username")]);
+    m_username_isValid = ::OpenAPI::fromJsonValue(username, json[QString("username")]);
     
-    ::OpenAPI::fromJsonValue(first_name, json[QString("firstName")]);
+    m_first_name_isValid = ::OpenAPI::fromJsonValue(first_name, json[QString("firstName")]);
     
-    ::OpenAPI::fromJsonValue(last_name, json[QString("lastName")]);
+    m_last_name_isValid = ::OpenAPI::fromJsonValue(last_name, json[QString("lastName")]);
     
-    ::OpenAPI::fromJsonValue(email, json[QString("email")]);
+    m_email_isValid = ::OpenAPI::fromJsonValue(email, json[QString("email")]);
     
-    ::OpenAPI::fromJsonValue(password, json[QString("password")]);
+    m_password_isValid = ::OpenAPI::fromJsonValue(password, json[QString("password")]);
     
-    ::OpenAPI::fromJsonValue(phone, json[QString("phone")]);
+    m_phone_isValid = ::OpenAPI::fromJsonValue(phone, json[QString("phone")]);
     
-    ::OpenAPI::fromJsonValue(user_status, json[QString("userStatus")]);
+    m_user_status_isValid = ::OpenAPI::fromJsonValue(user_status, json[QString("userStatus")]);
     
 }
 
@@ -192,7 +200,6 @@ OAIUser::setUserStatus(const qint32 &user_status) {
     this->m_user_status_isSet = true;
 }
 
-
 bool
 OAIUser::isSet() const {
     bool isObjectUpdated = false;
@@ -214,6 +221,12 @@ OAIUser::isSet() const {
         if(m_user_status_isSet){ isObjectUpdated = true; break;}
     }while(false);
     return isObjectUpdated;
+}
+
+bool
+OAIUser::isValid() const {
+    // only required properties are required for the object to be considered valid
+    return true;
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.cpp
@@ -23,6 +23,7 @@
 namespace OpenAPI {
 
 OAIUser::OAIUser(QString json) {
+    this->init();
     this->fromJson(json);
 }
 

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.h
@@ -65,32 +65,33 @@ public:
     void setUserStatus(const qint32 &user_status);
 
     virtual bool isSet() const override;
+    virtual bool isValid() const override;
 
 private:
     qint64 id;
     bool m_id_isSet;
-
+    bool m_id_isValid;
     QString username;
     bool m_username_isSet;
-
+    bool m_username_isValid;
     QString first_name;
     bool m_first_name_isSet;
-
+    bool m_first_name_isValid;
     QString last_name;
     bool m_last_name_isSet;
-
+    bool m_last_name_isValid;
     QString email;
     bool m_email_isSet;
-
+    bool m_email_isValid;
     QString password;
     bool m_password_isSet;
-
+    bool m_password_isValid;
     QString phone;
     bool m_phone_isSet;
-
+    bool m_phone_isValid;
     qint32 user_status;
     bool m_user_status_isSet;
-
+    bool m_user_status_isValid;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -333,13 +333,19 @@ void OAIPetApiRequest::uploadFileError(const OAIApiResponse& res, QNetworkReply:
 
 
 void OAIPetApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
     Q_UNUSED(error_type); // TODO
+    socket->write(res);
+    if(socket->isOpen()){
+        socket->close();
+    }    
 }
 
 void OAIPetApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
-    Q_UNUSED(error_type); // TODO
+    Q_UNUSED(error_type);  // TODO
+    socket->write(res->readAll());
+    if(socket->isOpen()){
+        socket->close();
+    }
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -186,13 +186,19 @@ void OAIStoreApiRequest::placeOrderError(const OAIOrder& res, QNetworkReply::Net
 
 
 void OAIStoreApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
     Q_UNUSED(error_type); // TODO
+    socket->write(res);
+    if(socket->isOpen()){
+        socket->close();
+    }    
 }
 
 void OAIStoreApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
-    Q_UNUSED(error_type); // TODO
+    Q_UNUSED(error_type);  // TODO
+    socket->write(res->readAll());
+    if(socket->isOpen()){
+        socket->close();
+    }
 }
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -338,13 +338,19 @@ void OAIUserApiRequest::updateUserError(QNetworkReply::NetworkError error_type, 
 
 
 void OAIUserApiRequest::sendCustomResponse(QByteArray & res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
     Q_UNUSED(error_type); // TODO
+    socket->write(res);
+    if(socket->isOpen()){
+        socket->close();
+    }    
 }
 
 void OAIUserApiRequest::sendCustomResponse(QIODevice *res, QNetworkReply::NetworkError error_type){
-    Q_UNUSED(res);  // TODO
-    Q_UNUSED(error_type); // TODO
+    Q_UNUSED(error_type);  // TODO
+    socket->write(res->readAll());
+    if(socket->isOpen()){
+        socket->close();
+    }
 }
 
 }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
- Add checking of required properties for models
- Add Header extraction for client

@stkrwork @MartinDelille @fvarose @ravinikam 
