### PR TITLE
[haskell-http-client] fix typename generation bug for array params; update deps

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -891,7 +891,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         if (appendDataType
                 && uniqueParamNameTypes.containsKey(paramNameType)
                 && !isDuplicate(paramNameType, dataType)) {
-            paramNameType = paramNameType + dataType;
+            paramNameType = toTypeName("", paramNameType + dataType);
         }
 
         while (typeNames.contains(paramNameType)) {

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/stack.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/stack.mustache
@@ -1,8 +1,8 @@
-resolver: lts-10.10
+resolver: lts-12.18
 build:
   haddock-arguments:
     haddock-args:
     - "--odir=./docs"
-extra-deps: []
+extra-deps: [ {{^x-useMonadLogger}}katip-0.5.5.1{{/x-useMonadLogger}} ]
 packages:
 - '.'

--- a/samples/client/petstore/haskell-http-client/example-app/Main.hs
+++ b/samples/client/petstore/haskell-http-client/example-app/Main.hs
@@ -118,7 +118,7 @@ runPet mgr config = do
         -- updatePet
         let updatePetRequest = S.updatePet (S.ContentType S.MimeJSON) $ pet
                 { S.petStatus   = Just S.E'Status2'Available
-                , S.petCategory = Just (S.Category (Just 3) (Just "catname"))
+                , S.petCategory = Just (S.Category (Just 3) "catname")
                 }
         _ <- S.dispatchLbs mgr config updatePetRequest
 

--- a/samples/client/petstore/haskell-http-client/stack.yaml
+++ b/samples/client/petstore/haskell-http-client/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-10.10
+resolver: lts-12.18
 build:
   haddock-arguments:
     haddock-args:
     - "--odir=./docs"
-extra-deps: []
+extra-deps: [ katip-0.5.5.1 ]
 packages:
 - '.'

--- a/samples/client/petstore/haskell-http-client/tests-integration/tests/Test.hs
+++ b/samples/client/petstore/haskell-http-client/tests-integration/tests/Test.hs
@@ -122,7 +122,7 @@ testPetOps mgr config =
         let updatePetRequest = S.updatePet (S.ContentType S.MimeJSON)
               (pet
                  { S.petStatus   = Just S.E'Status2'Available
-                 , S.petCategory = Just (S.Category (Just 3) (Just "catname"))
+                 , S.petCategory = Just (S.Category (Just 3) "catname")
                  })
         updatePetResponse <- S.dispatchLbs mgr config updatePetRequest 
         NH.responseStatus updatePetResponse `shouldBe` NH.status200


### PR DESCRIPTION
- fix build for example-app + tests-integration in Samples (due to change in Category)

- upgrade stack to 12.18

- fix typename generation bug for array params