### PR TITLE
Fix regexp in ruby-client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -147,20 +147,7 @@ abstract class AbstractRubyCodegen extends DefaultCodegen implements CodegenConf
     }
 
     public String toRegularExpression(String pattern) {
-        if (StringUtils.isEmpty(pattern)) {
-            return pattern;
-        }
-
-        // We don't escape \ in string since Ruby doesn't like \ escaped in regex literal
-        String regexString = pattern;
-        if (!regexString.startsWith("/")) {
-            regexString = "/" + regexString;
-        }
-        if (StringUtils.countMatches(regexString, '/') == 1) {
-            // we only have forward slash inserted at start... adding one to end
-            regexString = regexString + "/";
-        }
-        return regexString;
+        return addRegularExpressionDelimiter(pattern);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -319,13 +319,7 @@ public class RubyClientCodegenTest {
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/i'
         Assert.assertEquals(op.allParams.get(1).pattern, "/^pattern$/i");
-        // pattern_one_slash_start '/^pattern$'
-        Assert.assertEquals(op.allParams.get(2).pattern, "/^pattern$/");
-        // pattern_one_slash_end '^pattern$/'
-        Assert.assertEquals(op.allParams.get(3).pattern, "/^pattern$/");
-        // pattern_one_slash_near_end '^pattern$/im'
-        Assert.assertEquals(op.allParams.get(4).pattern, "/^pattern$/im");
         // pattern_dont_escape_backslash '/^pattern\d{3}$/i' NOTE: the double \ is to escape \ in string but is read as single \
-        Assert.assertEquals(op.allParams.get(5).pattern, "/^pattern\\d{3}$/i");
+        Assert.assertEquals(op.allParams.get(2).pattern, "/^pattern\\d{3}$/i");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/test_regex.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/test_regex.yaml
@@ -25,21 +25,6 @@ paths:
           schema:
             type: string
             pattern: '/^pattern$/i'
-        - name: pattern_one_slash_start
-          in: header
-          schema:
-            type: string
-            pattern: '/^pattern$'
-        - name: pattern_one_slash_end
-          in: header
-          schema:
-            type: string
-            pattern: '^pattern$/'
-        - name: pattern_one_slash_near_end
-          in: header
-          schema:
-            type: string
-            pattern: '^pattern$/im'
         - name: pattern_dont_escape_backslash
           in: header
           schema:

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -195,8 +195,8 @@ module Petstore
         invalid_properties.push('invalid value for "byte", byte cannot be nil.')
       end
 
-      if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$)
-        invalid_properties.push('invalid value for "byte", must conform to the pattern /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$.')
+      if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
+        invalid_properties.push('invalid value for "byte", must conform to the pattern /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/.')
       end
 
       if @date.nil?
@@ -234,7 +234,7 @@ module Petstore
       return false if !@double.nil? && @double < 67.8
       return false if !@string.nil? && @string !~ Regexp.new(/[a-z]/i)
       return false if @byte.nil?
-      return false if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$)
+      return false if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
       return false if @date.nil?
       return false if @password.nil?
       return false if @password.to_s.length > 64
@@ -333,8 +333,8 @@ module Petstore
         fail ArgumentError, 'byte cannot be nil'
       end
 
-      if byte !~ Regexp.new(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$)
-        fail ArgumentError, 'invalid value for "byte", must conform to the pattern /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$.'
+      if byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
+        fail ArgumentError, 'invalid value for "byte", must conform to the pattern /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/.'
       end
 
       @byte = byte


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

This fixes #1520.