### PR TITLE
#1506 Bump Zone.js to remove warnings when using angular >=6.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/package.mustache
@@ -30,7 +30,7 @@
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "{{#useRxJS6}}^6.1.0{{/useRxJS6}}{{^useRxJS6}}^5.4.0{{/useRxJS6}}",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.26"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^{{ngVersion}}",
@@ -42,7 +42,7 @@
     "ng-packagr": {{#useOldNgPackagr}}"^1.6.0"{{/useOldNgPackagr}}{{^useOldNgPackagr}}"^2.4.1"{{/useOldNgPackagr}},{{/useNgPackagr}}
     "reflect-metadata": "^0.1.3",
     "rxjs": "{{#useRxJS6}}^6.1.0{{/useRxJS6}}{{^useRxJS6}}^5.4.0{{/useRxJS6}}",
-    "zone.js": "^0.7.6",
+    "zone.js": "^0.7.6 || ^0.8.26",
     "typescript": ">=2.1.5 <2.8"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/package.mustache
@@ -29,8 +29,7 @@
     "@angular/compiler": "^{{ngVersion}}",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "{{#useRxJS6}}^6.1.0{{/useRxJS6}}{{^useRxJS6}}^5.4.0{{/useRxJS6}}",
-    "zone.js": "^0.7.6 || ^0.8.26"
+    "rxjs": "{{#useRxJS6}}^6.1.0{{/useRxJS6}}{{^useRxJS6}}^5.4.0{{/useRxJS6}}"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^{{ngVersion}}",

--- a/samples/client/petstore/typescript-angular-v2/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v2/npm/package.json
@@ -23,7 +23,7 @@
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.26"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^2.0.0",
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "^2.0.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6",
+    "zone.js": "^0.7.6 || ^0.8.26",
     "typescript": ">=2.1.5 <2.8"
   },
   "publishConfig": {

--- a/samples/client/petstore/typescript-angular-v2/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v2/npm/package.json
@@ -22,8 +22,7 @@
     "@angular/compiler": "^2.0.0",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6 || ^0.8.26"
+    "rxjs": "^5.4.0"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^2.0.0",

--- a/samples/client/petstore/typescript-angular-v4.3/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/package.json
@@ -18,8 +18,7 @@
     "@angular/compiler": "^4.3.0",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6 || ^0.8.26"
+    "rxjs": "^5.4.0"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^4.3.0",

--- a/samples/client/petstore/typescript-angular-v4.3/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/package.json
@@ -19,7 +19,7 @@
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.26"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^4.3.0",
@@ -31,7 +31,7 @@
     "ng-packagr": "^1.6.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6",
+    "zone.js": "^0.7.6 || ^0.8.26",
     "typescript": ">=2.1.5 <2.8"
   },
   "publishConfig": {

--- a/samples/client/petstore/typescript-angular-v4/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4/npm/package.json
@@ -18,8 +18,7 @@
     "@angular/compiler": "^4.0.0",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6 || ^0.8.26"
+    "rxjs": "^5.4.0"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^4.0.0",

--- a/samples/client/petstore/typescript-angular-v4/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4/npm/package.json
@@ -19,7 +19,7 @@
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.26"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^4.0.0",
@@ -31,7 +31,7 @@
     "ng-packagr": "^1.6.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6",
+    "zone.js": "^0.7.6 || ^0.8.26",
     "typescript": ">=2.1.5 <2.8"
   },
   "publishConfig": {

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
@@ -18,8 +18,7 @@
     "@angular/compiler": "^6.0.0",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^6.1.0",
-    "zone.js": "^0.7.6 || ^0.8.26"
+    "rxjs": "^6.1.0"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^6.0.0",

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
@@ -19,7 +19,7 @@
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.26"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^6.0.0",
@@ -31,7 +31,7 @@
     "ng-packagr": "^2.4.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
-    "zone.js": "^0.7.6",
+    "zone.js": "^0.7.6 || ^0.8.26",
     "typescript": ">=2.1.5 <2.8"
   },
   "publishConfig": {

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
@@ -18,8 +18,7 @@
     "@angular/compiler": "^6.0.0",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^6.1.0",
-    "zone.js": "^0.7.6 || ^0.8.26"
+    "rxjs": "^6.1.0"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^6.0.0",

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
@@ -19,7 +19,7 @@
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.7.6 || ^0.8.26"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^6.0.0",
@@ -31,7 +31,7 @@
     "ng-packagr": "^2.4.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
-    "zone.js": "^0.7.6",
+    "zone.js": "^0.7.6 || ^0.8.26",
     "typescript": ">=2.1.5 <2.8"
   },
   "publishConfig": {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)
### Description of the PR

Fixed #1506 . Bump Zone.js peer dependency. Angular 6 and 7 is using Zone.js 0.8.26. I tested zone.js 0.8.26 in our environment with Angular 6.

Since it shouldn't break anything, the current master branch is correct, or?

@Committee: I used the syntax  `^0.7.6 || ^0.8.26` to support a wider range of angular versions. What do you think about this?

And why `./bin/typescript-angular-petstore-all.sh` doesn't put this syntax into the generated package.jsons?