### PR TITLE
SpringCodeGen - Use InputStreamResource To Allow Streaming of File From Body

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -277,8 +277,8 @@ public class SpringCodegen extends AbstractJavaCodegen
             this.setHateoas(Boolean.valueOf(additionalProperties.get(HATEOAS).toString()));
         }
 
-        typeMapping.put("file", "Resource");
-        importMapping.put("Resource", "org.springframework.core.io.Resource");
+        typeMapping.put("file", "InputStreamResource");
+        importMapping.put("InputStreamResource", "org.springframework.core.io.InputStreamResource");
 
         if (useOptional) {
             writePropertyBack(USE_OPTIONAL, useOptional);


### PR DESCRIPTION
Currently the SpringCodeGen uses the class org.springframework.core.io.Resource to handle a file type which results in the input stream being read into a byte[] in memory.  This is a problem if an API is to handle large files or used in a high concurrency environment as it means you need a large heap/likely to get OutOfMemoryExceptions. 

When debugging against spring-web 5.0.6.RELEASE we can see that in 
org.springframework.http.converter.ResourceHttpMessageConverter#readInternal if the class is org.springframework.core.io.Resource then a ByteArrayResource is produced containing the entire body as a byte[], however if the supplied class is org.springframework.core.io.InputStreamResource then we get an instance of InputStreamResource  which just wraps the underlying stream.

So we have switched to use org.springframework.core.io.InputStreamResource instead of Resource and we can now handle the body as a stream. This leaves it to developer to decide the optimal approach for their given use case.

In the PR checklist it says to update the Petstore samples, however we saw that for windows there are a limited number of spring related batch files when compared to the shell scripts. We ran the batch files and we found that in addition to our change there were a number of other changes which look to be related to JDK version (we are using jdk 8), so we didn't commit them just in case this caused confusion.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

