### PR TITLE
[elixir] Typespec: Fixes issue with formated primitivs as parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -654,6 +654,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                 sb.append(param.dataType);
             } else if (param.isFile || param.isBinary) {
                 sb.append("String.t");
+            } else if (param.dataFormat != null) {
+                sb.append(param.dataType);
             } else {
                 // <module>.Model.<type>.t
                 sb.append(moduleName);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I had a issue that formatted strings as parameter won't be treated as primitivs ( this might be a issue in the global scope? ) which will result in Typespec like `MyApi.Model.String.t.t`. With this PR, the resulting typespec will be `String.t` (or what ever datetype mapping has been done before).  

To proof my point, the yml for the sample need to have something like the following lines. I'm not quite sure how to do that - could you help me out on this one? @wing328 

```yml
---
swagger: "2.0"
info:
  version: "1.0.0"
  title: "Swagger Petstore"
host: "petstore.swagger.io"
basePath: "/v2"
tags:
  - name: "invoice"
schemes:
  - "http"
paths:
  /invoice/{invoiceItemId}:
    get:
      tags:
        - "invoice"
      operationId: "getInvoice"
      parameters:
        - name: invoiceItemId
          in: path
          required: true
          type: string
          pattern: \w+-\w+-\w+-\w+-\w+
          format: uuid
      responses:
        405:
          description: "Invalid input"
```

Here's a sample of the difference:
old:
```elixir
  @spec get_invoice(Tesla.Env.client, SwaggerPetstore.Model.String.t.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
  def get_invoice(connection, invoice_item_id, _opts \\ []) do
```

new:
```elixir
  @spec get_invoice(Tesla.Env.client, String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
  def get_invoice(connection, invoice_item_id, _opts \\ []) do
```

