### PR TITLE
[elixir]  Decode list with primitivs

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -693,6 +693,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
             // Primitive return type, don't even try to decode
             if (returnBaseType == null || (returnSimpleType && returnTypeIsPrimitive)) {
                 return "false";
+            } else if (isListContainer && languageSpecificPrimitives().contains(returnBaseType)) {
+                return "[]";
             }
             StringBuilder sb = new StringBuilder();
             if (isListContainer) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

In case a endpoint responds with a list of primitiv, the current elixir codegen tries to decode thouse to a struct which does not exist. 

For example:
The following should return a list of strings, this is what the codegen does (take a note at: `%SwaggerPetstore.Model.String{}`:
```elixir
  @spec get_invoice(Tesla.Env.client, String.t, keyword()) :: {:ok, list(String.t)} | {:error, Tesla.Env.t}
  def get_invoice(connection, invoice_item_id, _opts \\ []) do
    %{}
    |> method(:get)
    |> url("/invoice/#{invoice_item_id}")
    |> Enum.into([])
    |> (&Connection.request(connection, &1)).()
    |> decode([%SwaggerPetstore.Model.String{}])
  end
```

This is what it does with this PR
```elixir
  @spec get_invoice(Tesla.Env.client, String.t, keyword()) :: {:ok, list(String.t)} | {:error, Tesla.Env.t}
  def get_invoice(connection, invoice_item_id, _opts \\ []) do
    %{}
    |> method(:get)
    |> url("/invoice/#{invoice_item_id}")
    |> Enum.into([])
    |> (&Connection.request(connection, &1)).()
    |> decode([])
  end
```

To reproduce this, I made a small swagger sample - would be awesome if we coulde add this somehow to the samples

```yml
---
swagger: "2.0"
info:
  version: "1.0.0"
  title: "Swagger Petstore"
host: "petstore.swagger.io"
basePath: "/v2"
tags:
  - name: "invoice"
schemes:
  - "http"
paths:
  /invoice/{invoiceItemId}:
    get:
      tags:
        - "invoice"
      operationId: "getInvoice"
      parameters:
        - name: invoiceItemId
          in: path
          required: true
          type: string
      responses:
        200:
          description: successful operation
          schema:
            type: array
            items:
              type: string
```

cc: @wing328
