### PR TITLE
[elixir] Fixes `BadMapError` for header parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
@@ -85,6 +85,10 @@ defmodule {{moduleName}}.RequestBuilder do
     |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)
     |> Map.update!(:body, &(Tesla.Multipart.add_field(&1, key, Poison.encode!(value), headers: [{:"Content-Type", "application/json"}])))
   end
+  def add_param(request, :headers, key, value) do
+    request
+    |> Map.update(:headers, %{key => value}, &(Map.put(&1, key, value)))
+  end
   def add_param(request, :file, name, path) do
     request
     |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)

--- a/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
@@ -88,6 +88,10 @@ defmodule OpenapiPetstore.RequestBuilder do
     |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)
     |> Map.update!(:body, &(Tesla.Multipart.add_field(&1, key, Poison.encode!(value), headers: [{:"Content-Type", "application/json"}])))
   end
+  def add_param(request, :headers, key, value) do
+    request
+    |> Map.update(:headers, %{key => value}, &(Map.put(&1, key, value)))
+  end
   def add_param(request, :file, name, path) do
     request
     |> Map.put_new_lazy(:body, &Tesla.Multipart.new/0)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

There's a issue with the current `request_builder.ex` since Tesla expects header parameters to be a map as they are unique. The request_builder.ex has in the current version no "special treatment" for the header parameters which will result in `BadMapError` since it tires to merge the map from tesla with the key-value list from the request_builder.

The full error message looks something like the following
```
iex(1)> SwaggerPetstore.Api.Invoice.get_invoice(SwaggerPetstore.Connection.new(), "123")
** (BadMapError) expected a map, got: [invoiceItemId: "123"]
    (stdlib) :maps.merge([invoiceItemId: "123"], %{"User-Agent" => "Elixir"})
    (tesla) lib/tesla/middleware/core.ex:107: anonymous fn/2 in Tesla.Middleware.Headers.merge/2
    (elixir) lib/map.ex:752: Map.update!/3
    (tesla) lib/tesla/middleware/core.ex:101: Tesla.Middleware.Headers.call/3
    (swagger_petstore) lib/swagger_petstore/api/invoice.ex:33: SwaggerPetstore.Api.Invoice.get_invoice/3
```

I made a small yml to reproduce the issue:
```yml
---
swagger: "2.0"
info:
  version: "1.0.0"
  title: "Swagger Petstore"
host: "petstore.swagger.io"
basePath: "/v2"
tags:
  - name: "invoice"
schemes:
  - "http"
paths:
  /invoice:
    get:
      tags:
        - "invoice"
      operationId: "getInvoice"
      parameters:
        - name: invoiceItemId
          in: header
          required: true
          type: string
      responses:
        204:
          description: successful operation
```

then I ran the follwing command in my iex (`mix deps.get` and `iex -S mix`)
`SwaggerPetstore.Api.Invoice.get_invoice(SwaggerPetstore.Connection.new(), "123")`

Could you give me the honor and check my conclusion and code @wing328 ?