### PR TITLE
[cpp rest-sdk] Add status code to response handler

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
@@ -260,9 +260,9 @@ pplx::task<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/r
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("{{httpMethod}}"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/apiclient-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/apiclient-header.mustache
@@ -33,10 +33,10 @@ public:
     ApiClient( std::shared_ptr<ApiConfiguration> configuration = nullptr );
     virtual ~ApiClient();
 
-    typedef std::function<void(const web::http::http_headers&)> ResponseHeadersHandlerType;
+    typedef std::function<void(web::http::status_code, const web::http::http_headers&)> ResponseHandlerType;
 
-    const ResponseHeadersHandlerType& getResponseHeadersHandler() const;
-    void setResponseHeadersHandler(const ResponseHeadersHandlerType& responseHeadersHandler);
+    const ResponseHandlerType& getResponseHandler() const;
+    void setResponseHandler(const ResponseHandlerType& responseHandler);
 
     std::shared_ptr<ApiConfiguration> getConfiguration() const;
     void setConfiguration(std::shared_ptr<ApiConfiguration> configuration);
@@ -63,7 +63,7 @@ public:
 
 protected:
 
-    ResponseHeadersHandlerType m_ResponseHeadersHandler;
+    ResponseHandlerType m_ResponseHandler;
     std::shared_ptr<ApiConfiguration> m_Configuration;
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/apiclient-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/apiclient-source.mustache
@@ -29,12 +29,12 @@ ApiClient::~ApiClient()
 {
 }
 
-const ApiClient::ResponseHeadersHandlerType& ApiClient::getResponseHeadersHandler() const {
-    return m_ResponseHeadersHandler;
+const ApiClient::ResponseHandlerType& ApiClient::getResponseHandler() const {
+    return m_ResponseHandler;
 }
 
-void ApiClient::setResponseHeadersHandler(const ResponseHeadersHandlerType& responseHeadersHandler) {
-    m_ResponseHeadersHandler = responseHeadersHandler;
+void ApiClient::setResponseHandler(const ResponseHandlerType& responseHandler) {
+    m_ResponseHandler = responseHandler;
 }
 
 std::shared_ptr<ApiConfiguration> ApiClient::getConfiguration() const

--- a/samples/client/petstore/cpp-restsdk/ApiClient.cpp
+++ b/samples/client/petstore/cpp-restsdk/ApiClient.cpp
@@ -40,12 +40,12 @@ ApiClient::~ApiClient()
 {
 }
 
-const ApiClient::ResponseHeadersHandlerType& ApiClient::getResponseHeadersHandler() const {
-    return m_ResponseHeadersHandler;
+const ApiClient::ResponseHandlerType& ApiClient::getResponseHandler() const {
+    return m_ResponseHandler;
 }
 
-void ApiClient::setResponseHeadersHandler(const ResponseHeadersHandlerType& responseHeadersHandler) {
-    m_ResponseHeadersHandler = responseHeadersHandler;
+void ApiClient::setResponseHandler(const ResponseHandlerType& responseHandler) {
+    m_ResponseHandler = responseHandler;
 }
 
 std::shared_ptr<ApiConfiguration> ApiClient::getConfiguration() const

--- a/samples/client/petstore/cpp-restsdk/ApiClient.h
+++ b/samples/client/petstore/cpp-restsdk/ApiClient.h
@@ -44,10 +44,10 @@ public:
     ApiClient( std::shared_ptr<ApiConfiguration> configuration = nullptr );
     virtual ~ApiClient();
 
-    typedef std::function<void(const web::http::http_headers&)> ResponseHeadersHandlerType;
+    typedef std::function<void(web::http::status_code, const web::http::http_headers&)> ResponseHandlerType;
 
-    const ResponseHeadersHandlerType& getResponseHeadersHandler() const;
-    void setResponseHeadersHandler(const ResponseHeadersHandlerType& responseHeadersHandler);
+    const ResponseHandlerType& getResponseHandler() const;
+    void setResponseHandler(const ResponseHandlerType& responseHandler);
 
     std::shared_ptr<ApiConfiguration> getConfiguration() const;
     void setConfiguration(std::shared_ptr<ApiConfiguration> configuration);
@@ -74,7 +74,7 @@ public:
 
 protected:
 
-    ResponseHeadersHandlerType m_ResponseHeadersHandler;
+    ResponseHandlerType m_ResponseHandler;
     std::shared_ptr<ApiConfiguration> m_Configuration;
 };
 

--- a/samples/client/petstore/cpp-restsdk/api/PetApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/api/PetApi.cpp
@@ -123,9 +123,9 @@ pplx::task<void> PetApi::addPet(std::shared_ptr<Pet> pet)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -229,9 +229,9 @@ pplx::task<void> PetApi::deletePet(int64_t petId, boost::optional<utility::strin
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("DELETE"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -335,9 +335,9 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByStatus(std::vect
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -466,9 +466,9 @@ pplx::task<std::vector<std::shared_ptr<Pet>>> PetApi::findPetsByTags(std::vector
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -601,9 +601,9 @@ pplx::task<std::shared_ptr<Pet>> PetApi::getPetById(int64_t petId)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -743,9 +743,9 @@ pplx::task<void> PetApi::updatePet(std::shared_ptr<Pet> pet)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("PUT"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -854,9 +854,9 @@ pplx::task<void> PetApi::updatePetWithForm(int64_t petId, boost::optional<utilit
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -966,9 +966,9 @@ pplx::task<std::shared_ptr<ApiResponse>> PetApi::uploadFile(int64_t petId, boost
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK

--- a/samples/client/petstore/cpp-restsdk/api/StoreApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/api/StoreApi.cpp
@@ -99,9 +99,9 @@ pplx::task<void> StoreApi::deleteOrder(utility::string_t orderId)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("DELETE"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -207,9 +207,9 @@ pplx::task<std::map<utility::string_t, int32_t>> StoreApi::getInventory()
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -332,9 +332,9 @@ pplx::task<std::shared_ptr<Order>> StoreApi::getOrderById(int64_t orderId)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -472,9 +472,9 @@ pplx::task<std::shared_ptr<Order>> StoreApi::placeOrder(std::shared_ptr<Order> o
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK

--- a/samples/client/petstore/cpp-restsdk/api/UserApi.cpp
+++ b/samples/client/petstore/cpp-restsdk/api/UserApi.cpp
@@ -119,9 +119,9 @@ pplx::task<void> UserApi::createUser(std::shared_ptr<User> user)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -244,9 +244,9 @@ pplx::task<void> UserApi::createUsersWithArrayInput(std::vector<std::shared_ptr<
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -369,9 +369,9 @@ pplx::task<void> UserApi::createUsersWithListInput(std::vector<std::shared_ptr<U
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("POST"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -469,9 +469,9 @@ pplx::task<void> UserApi::deleteUser(utility::string_t username)
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("DELETE"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -571,9 +571,9 @@ pplx::task<std::shared_ptr<User>> UserApi::getUserByName(utility::string_t usern
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -701,9 +701,9 @@ pplx::task<utility::string_t> UserApi::loginUser(utility::string_t username, uti
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -823,9 +823,9 @@ pplx::task<void> UserApi::logoutUser()
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("GET"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK
@@ -944,9 +944,9 @@ pplx::task<void> UserApi::updateUser(utility::string_t username, std::shared_ptr
     return m_ApiClient->callApi(localVarPath, utility::conversions::to_string_t("PUT"), localVarQueryParams, localVarHttpBody, localVarHeaderParams, localVarFormParams, localVarFileParams, localVarRequestHttpContentType)
     .then([=](web::http::http_response localVarResponse)
     {
-        if (m_ApiClient->getResponseHeadersHandler())
+        if (m_ApiClient->getResponseHandler())
         {
-            m_ApiClient->getResponseHeadersHandler()(localVarResponse.headers());
+            m_ApiClient->getResponseHandler()(localVarResponse.status_code(), localVarResponse.headers());
         }
 
         // 1xx - informational : OK


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add _status code_ param to the response handler, which currently only can process the response headers. See this related PR #1511.

Ping @ravinikam @stkrwork @fvarose @etherealjoy @martindelille