### PR TITLE
Kotlin collection type

### DIFF
--- a/docs/generators/kotlin.md
+++ b/docs/generators/kotlin.md
@@ -28,4 +28,9 @@ CONFIG OPTIONS for kotlin
 	        java8 - Java 8 native JSR310
 	        threetenbp - Threetenbp
 
+	collectionType
+	    Option. Collection type to use
+	        array - kotlin.Array
+	        list - kotlin.collections.List
+
 Back to the [generators list](README.md)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -31,9 +31,11 @@ import java.util.Map;
 public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
     public static final String DATE_LIBRARY = "dateLibrary";
+    public static final String COLLECTION_TYPE = "collectionType";
     private static final Logger LOGGER = LoggerFactory.getLogger(KotlinClientCodegen.class);
 
     protected String dateLibrary = DateLibrary.JAVA8.value;
+    protected String collectionType = CollectionType.ARRAY.value;
 
     public enum DateLibrary {
         STRING("string"),
@@ -43,6 +45,17 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         public final String value;
 
         DateLibrary(String value) {
+            this.value = value;
+        }
+    }
+
+    public enum CollectionType {
+        ARRAY("array"),
+        LIST("list");
+
+        public final String value;
+
+        CollectionType(String value) {
             this.value = value;
         }
     }
@@ -74,6 +87,13 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         dateOptions.put(DateLibrary.JAVA8.value, "Java 8 native JSR310");
         dateLibrary.setEnum(dateOptions);
         cliOptions.add(dateLibrary);
+
+        CliOption collectionType = new CliOption(COLLECTION_TYPE, "Option. Collection type to use");
+        Map<String, String> collectionOptions = new HashMap<>();
+        collectionOptions.put(CollectionType.ARRAY.value, "kotlin.Array");
+        collectionOptions.put(CollectionType.LIST.value, "kotlin.collections.List");
+        collectionType.setEnum(collectionOptions);
+        cliOptions.add(collectionType);
     }
 
     public CodegenType getTag() {
@@ -90,6 +110,10 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
     public void setDateLibrary(String library) {
         this.dateLibrary = library;
+    }
+
+    public void setCollectionType(String collectionType) {
+        this.collectionType = collectionType;
     }
 
     @Override
@@ -114,6 +138,18 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
             typeMapping.put("DateTime", "kotlin.String");
         } else if (DateLibrary.JAVA8.value.equals(dateLibrary)) {
             additionalProperties.put(DateLibrary.JAVA8.value, true);
+        }
+
+        if (additionalProperties.containsKey(COLLECTION_TYPE)) {
+            setCollectionType(additionalProperties.get(COLLECTION_TYPE).toString());
+        }
+
+        if (CollectionType.ARRAY.value.equals(collectionType)) {
+            typeMapping.put("array", "kotlin.Array");
+            typeMapping.put("list", "kotlin.Array");
+        } else if (CollectionType.LIST.value.equals(collectionType)) {
+            typeMapping.put("array", "kotlin.collections.List");
+            typeMapping.put("list", "kotlin.collections.List");
         }
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -144,10 +144,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
             setCollectionType(additionalProperties.get(COLLECTION_TYPE).toString());
         }
 
-        if (CollectionType.ARRAY.value.equals(collectionType)) {
-            typeMapping.put("array", "kotlin.Array");
-            typeMapping.put("list", "kotlin.Array");
-        } else if (CollectionType.LIST.value.equals(collectionType)) {
+        if (CollectionType.LIST.value.equals(collectionType)) {
             typeMapping.put("array", "kotlin.collections.List");
             typeMapping.put("list", "kotlin.collections.List");
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -199,6 +199,33 @@ public class KotlinClientCodegenModelTest {
         Assert.assertTrue(property.isContainer);
     }
 
+    @Test(description = "convert a model with array property to a kotlin.collections.List")
+    public void listPropertyTest() {
+        final Schema model = getArrayTestSchema();
+
+        final KotlinClientCodegen codegen = new KotlinClientCodegen();
+        codegen.setCollectionType(KotlinClientCodegen.CollectionType.LIST.value);
+        codegen.processOpts();
+        final CodegenModel generated = codegen.fromModel("sample", model, Collections.singletonMap("sample", model));
+
+        Assert.assertEquals(generated.name, "sample");
+        Assert.assertEquals(generated.classname, "Sample");
+        Assert.assertEquals(generated.description, "a sample model");
+        Assert.assertEquals(generated.vars.size(), 2);
+
+        final CodegenProperty property = generated.vars.get(1);
+        Assert.assertEquals(property.baseName, "examples");
+        Assert.assertEquals(property.getter, "getExamples");
+        Assert.assertEquals(property.setter, "setExamples");
+        Assert.assertEquals(property.dataType, "kotlin.collections.List<kotlin.String>");
+        Assert.assertEquals(property.name, "examples");
+        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.baseType, "kotlin.collections.List");
+        Assert.assertEquals(property.containerType, "array");
+        Assert.assertFalse(property.required);
+        Assert.assertTrue(property.isContainer);
+    }
+
     @Test(description = "convert a model with a map property")
     public void mapPropertyTest() {
         final Schema schema = getMapSchema();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Swagger spec file contains only array types thus it is always the preferred choice when converting to kotlin. Allow specifying which collection type to convert to.

@jimschubert @dr4ke616
