### PR TITLE
Generate setters for readonly properties in server code

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -480,10 +480,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     }
                 }
 
-                if (config.getTag() == CodegenType.SERVER) {
-                    removeReadOnly(modelTemplate);
-                }
-
                 allModels.add(modelTemplate);
 
                 // to generate model files
@@ -506,18 +502,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             Json.prettyPrint(allModels);
         }
 
-    }
-
-    private void removeReadOnly(Map<String, Object> modelTemplate) {
-        if (modelTemplate != null
-                && modelTemplate.containsKey("model")
-                && modelTemplate.get("model") instanceof CodegenModel) {
-            CodegenModel model = (CodegenModel) modelTemplate.get("model");
-
-            if (model != null && model.vars != null) {
-                model.vars.forEach((var) -> var.isReadOnly = false);
-            }
-        }
     }
 
     private void generateApis(List<File> files, List<Object> allOperations, List<Object> allModels) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -480,6 +480,10 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     }
                 }
 
+                if (config.getTag() == CodegenType.SERVER) {
+                    removeReadOnly(modelTemplate);
+                }
+
                 allModels.add(modelTemplate);
 
                 // to generate model files
@@ -502,6 +506,18 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
             Json.prettyPrint(allModels);
         }
 
+    }
+
+    private void removeReadOnly(Map<String, Object> modelTemplate) {
+        if (modelTemplate != null
+                && modelTemplate.containsKey("model")
+                && modelTemplate.get("model") instanceof CodegenModel) {
+            CodegenModel model = (CodegenModel) modelTemplate.get("model");
+
+            if (model != null && model.vars != null) {
+                model.vars.forEach((var) -> var.isReadOnly = false);
+            }
+        }
     }
 
     private void generateApis(List<File> files, List<Object> allOperations, List<Object> allModels) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -11,7 +11,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     {{/isContainer}}
     {{#isContainer}}
     {{#mostInnerItems}}
-{{>enumClass}} 
+{{>enumClass}}
     {{/mostInnerItems}}
     {{/isContainer}}
     {{/isEnum}}
@@ -30,7 +30,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
-  {{^isReadOnly}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;
@@ -60,7 +59,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   }
   {{/isMapContainer}}
 
-  {{/isReadOnly}}
   /**
   {{#description}}
    * {{description}}
@@ -87,12 +85,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
-  {{^isReadOnly}}
 
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
   }
-  {{/isReadOnly}}
 
   {{/vars}}
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -94,7 +94,7 @@ public class EnumArrays  implements Serializable {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = null;
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -33,6 +33,11 @@ public class HasOnlyReadOnly  implements Serializable {
   @JsonProperty("foo")
   private String foo;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -44,6 +49,15 @@ public class HasOnlyReadOnly  implements Serializable {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
   /**
    * Get foo
    * @return foo
@@ -53,6 +67,10 @@ public class HasOnlyReadOnly  implements Serializable {
   
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
@@ -64,7 +64,7 @@ public class MapTest  implements Serializable {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = null;
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Name.java
@@ -61,6 +61,11 @@ public class Name  implements Serializable {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
   /**
    * Get snakeCase
    * @return snakeCase
@@ -70,6 +75,10 @@ public class Name  implements Serializable {
   
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -92,6 +101,11 @@ public class Name  implements Serializable {
     this.property = property;
   }
 
+  public Name _123number(Integer _123number) {
+    this._123number = _123number;
+    return this;
+  }
+
   /**
    * Get _123number
    * @return _123number
@@ -101,6 +115,10 @@ public class Name  implements Serializable {
   
   public Integer get123number() {
     return _123number;
+  }
+
+  public void set123number(Integer _123number) {
+    this._123number = _123number;
   }
 
 

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -33,6 +33,11 @@ public class ReadOnlyFirst  implements Serializable {
   @JsonProperty("baz")
   private String baz;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -42,6 +47,10 @@ public class ReadOnlyFirst  implements Serializable {
   
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -93,7 +93,7 @@ public class EnumArrays   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = null;
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -32,6 +32,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -43,6 +48,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
   /**
    * Get foo
    * @return foo
@@ -52,6 +66,10 @@ public class HasOnlyReadOnly   {
   
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject2.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject2.java
@@ -59,7 +59,7 @@ public class InlineObject2   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("enum_form_string_array")
   private List<EnumFormStringArrayEnum> enumFormStringArray = null;
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MapTest.java
@@ -63,7 +63,7 @@ public class MapTest   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = null;
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Name.java
@@ -60,6 +60,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
   /**
    * Get snakeCase
    * @return snakeCase
@@ -69,6 +74,10 @@ public class Name   {
   
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -91,6 +100,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123number(Integer _123number) {
+    this._123number = _123number;
+    return this;
+  }
+
   /**
    * Get _123number
    * @return _123number
@@ -100,6 +114,10 @@ public class Name   {
   
   public Integer get123number() {
     return _123number;
+  }
+
+  public void set123number(Integer _123number) {
+    this._123number = _123number;
   }
 
 

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -32,6 +32,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -41,6 +46,10 @@ public class ReadOnlyFirst   {
   
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -93,7 +93,7 @@ public class EnumArrays   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = null;
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -32,6 +32,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -43,6 +48,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
   /**
    * Get foo
    * @return foo
@@ -52,6 +66,10 @@ public class HasOnlyReadOnly   {
   
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -63,7 +63,7 @@ public class MapTest   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = null;
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Name.java
@@ -60,6 +60,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
   /**
    * Get snakeCase
    * @return snakeCase
@@ -69,6 +74,10 @@ public class Name   {
   
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -91,6 +100,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123number(Integer _123number) {
+    this._123number = _123number;
+    return this;
+  }
+
   /**
    * Get _123number
    * @return _123number
@@ -100,6 +114,10 @@ public class Name   {
   
   public Integer get123number() {
     return _123number;
+  }
+
+  public void set123number(Integer _123number) {
+    this._123number = _123number;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -32,6 +32,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -41,6 +46,10 @@ public class ReadOnlyFirst   {
   
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -93,7 +93,7 @@ public class EnumArrays   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = null;
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -32,6 +32,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -43,6 +48,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
   /**
    * Get foo
    * @return foo
@@ -52,6 +66,10 @@ public class HasOnlyReadOnly   {
   
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
@@ -63,7 +63,7 @@ public class MapTest   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = null;
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Name.java
@@ -60,6 +60,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
   /**
    * Get snakeCase
    * @return snakeCase
@@ -69,6 +74,10 @@ public class Name   {
   
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -91,6 +100,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123number(Integer _123number) {
+    this._123number = _123number;
+    return this;
+  }
+
   /**
    * Get _123number
    * @return _123number
@@ -100,6 +114,10 @@ public class Name   {
   
   public Integer get123number() {
     return _123number;
+  }
+
+  public void set123number(Integer _123number) {
+    this._123number = _123number;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -32,6 +32,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -41,6 +46,10 @@ public class ReadOnlyFirst   {
   
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -93,7 +93,7 @@ public class EnumArrays   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = null;
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -32,6 +32,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -43,6 +48,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
   /**
    * Get foo
    * @return foo
@@ -52,6 +66,10 @@ public class HasOnlyReadOnly   {
   
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -63,7 +63,7 @@ public class MapTest   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = null;
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Name.java
@@ -60,6 +60,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
   /**
    * Get snakeCase
    * @return snakeCase
@@ -69,6 +74,10 @@ public class Name   {
   
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -91,6 +100,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123number(Integer _123number) {
+    this._123number = _123number;
+    return this;
+  }
+
   /**
    * Get _123number
    * @return _123number
@@ -100,6 +114,10 @@ public class Name   {
   
   public Integer get123number() {
     return _123number;
+  }
+
+  public void set123number(Integer _123number) {
+    this._123number = _123number;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -32,6 +32,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -41,6 +46,10 @@ public class ReadOnlyFirst   {
   
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -93,7 +93,7 @@ public class EnumArrays   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("array_enum")
   private List<ArrayEnumEnum> arrayEnum = null;
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -32,6 +32,11 @@ public class HasOnlyReadOnly   {
   @JsonProperty("foo")
   private String foo;
 
+  public HasOnlyReadOnly bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -43,6 +48,15 @@ public class HasOnlyReadOnly   {
     return bar;
   }
 
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+  public HasOnlyReadOnly foo(String foo) {
+    this.foo = foo;
+    return this;
+  }
+
   /**
    * Get foo
    * @return foo
@@ -52,6 +66,10 @@ public class HasOnlyReadOnly   {
   
   public String getFoo() {
     return foo;
+  }
+
+  public void setFoo(String foo) {
+    this.foo = foo;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
@@ -63,7 +63,7 @@ public class MapTest   {
       throw new IllegalArgumentException("Unexpected value '" + text + "'");
     }
   }
- 
+
   @JsonProperty("map_of_enum_string")
   private Map<String, InnerEnum> mapOfEnumString = null;
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Name.java
@@ -60,6 +60,11 @@ public class Name   {
     this.name = name;
   }
 
+  public Name snakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
+    return this;
+  }
+
   /**
    * Get snakeCase
    * @return snakeCase
@@ -69,6 +74,10 @@ public class Name   {
   
   public Integer getSnakeCase() {
     return snakeCase;
+  }
+
+  public void setSnakeCase(Integer snakeCase) {
+    this.snakeCase = snakeCase;
   }
 
   public Name property(String property) {
@@ -91,6 +100,11 @@ public class Name   {
     this.property = property;
   }
 
+  public Name _123number(Integer _123number) {
+    this._123number = _123number;
+    return this;
+  }
+
   /**
    * Get _123number
    * @return _123number
@@ -100,6 +114,10 @@ public class Name   {
   
   public Integer get123number() {
     return _123number;
+  }
+
+  public void set123number(Integer _123number) {
+    this._123number = _123number;
   }
 
 

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -32,6 +32,11 @@ public class ReadOnlyFirst   {
   @JsonProperty("baz")
   private String baz;
 
+  public ReadOnlyFirst bar(String bar) {
+    this.bar = bar;
+    return this;
+  }
+
   /**
    * Get bar
    * @return bar
@@ -41,6 +46,10 @@ public class ReadOnlyFirst   {
   
   public String getBar() {
     return bar;
+  }
+
+  public void setBar(String bar) {
+    this.bar = bar;
   }
 
   public ReadOnlyFirst baz(String baz) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes https://github.com/OpenAPITools/openapi-generator/issues/1376.

I explored a couple of other alternatives, namely passing the tag (i.e. `CodegenType`) to the template and switching there or adding another property to the data passed to the template to indicate that a setter should be generated.  Unfortunately, they didn't really work or were horrendously messy.

Please note I have run only `./bin/jaxrs-petstore-server.sh` which generated new methods which can be seen in this PR and `./bin/java-petstore-jersey2.sh` which generated no changes as expected.  This change does impact all generators and I ran `./bin/run-all-petstore` locally successfully but the message that printed said not to run it.  It also changed some 900 files under samples which I thought would massively pollute this PR.  Happy to do that if it's necessary though.
