### PR TITLE
Replace <tt> tags with <code> to make new javadoc work.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2231,7 +2231,7 @@ public class DefaultCodegen implements CodegenConfig {
      * Override with any special handling of response codes
      *
      * @param responses OAS Operation's responses
-     * @return default method response or <tt>null</tt> if not found
+     * @return default method response or <code>null</code> if not found
      */
     protected ApiResponse findMethodResponse(ApiResponses responses) {
         String code = null;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/GeneratorNotFoundException.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/GeneratorNotFoundException.java
@@ -34,7 +34,7 @@ public class GeneratorNotFoundException extends RuntimeException {
      * @param message the detail message (which is saved for later retrieval
      *                by the {@link #getMessage()} method).
      * @param cause   the cause (which is saved for later retrieval by the
-     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                {@link #getCause()} method).  (A <code>null</code> value is
      *                permitted, and indicates that the cause is nonexistent or
      *                unknown.)
      * @since 1.4
@@ -45,13 +45,13 @@ public class GeneratorNotFoundException extends RuntimeException {
 
     /**
      * Constructs a new runtime exception with the specified cause and a
-     * detail message of <tt>(cause==null ? null : cause.toString())</tt>
+     * detail message of <code>(cause==null ? null : cause.toString())</code>
      * (which typically contains the class and detail message of
-     * <tt>cause</tt>).  This constructor is useful for runtime exceptions
+     * <code>cause</code>).  This constructor is useful for runtime exceptions
      * that are little more than wrappers for other throwables.
      *
      * @param cause the cause (which is saved for later retrieval by the
-     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              {@link #getCause()} method).  (A <code>null</code> value is
      *              permitted, and indicates that the cause is nonexistent or
      *              unknown.)
      * @since 1.4

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/SpecValidationException.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/SpecValidationException.java
@@ -36,7 +36,7 @@ public class SpecValidationException extends RuntimeException {
      * @param message the detail message (which is saved for later retrieval
      *                by the {@link #getMessage()} method).
      * @param cause   the cause (which is saved for later retrieval by the
-     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                {@link #getCause()} method).  (A <code>null</code> value is
      *                permitted, and indicates that the cause is nonexistent or
      *                unknown.)
      * @since 1.4
@@ -47,13 +47,13 @@ public class SpecValidationException extends RuntimeException {
 
     /**
      * Constructs a new runtime exception with the specified cause and a
-     * detail message of <tt>(cause==null ? null : cause.toString())</tt>
+     * detail message of <code>(cause==null ? null : cause.toString())</code>
      * (which typically contains the class and detail message of
-     * <tt>cause</tt>).  This constructor is useful for runtime exceptions
+     * <code>cause</code>).  This constructor is useful for runtime exceptions
      * that are little more than wrappers for other throwables.
      *
      * @param cause the cause (which is saved for later retrieval by the
-     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              {@link #getCause()} method).  (A <code>null</code> value is
      *              permitted, and indicates that the cause is nonexistent or
      *              unknown.)
      * @since 1.4

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -578,7 +578,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     }
 
     /**
-     * Converts the original name according to the current <tt>fileNaming</tt> strategy.
+     * Converts the original name according to the current <code>fileNaming</code> strategy.
      * @param originalName the original name to transform
      * @return the transformed name
      */


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Modern version of JavaDoc refuses to generate documentation with <tt> usages messaging 'unknown tag' error. <tt> is qualified as [obsolete](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt). <code> is the one of the tags recommended instead of <tt>