### PR TITLE
[php] bugfix: Array and Map inner schema definition can be missing.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -18,6 +18,7 @@ package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
@@ -345,9 +346,17 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         if (ModelUtils.isArraySchema(p)) {
             ArraySchema ap = (ArraySchema) p;
             Schema inner = ap.getItems();
+            if (inner == null) {
+                LOGGER.warn(ap.getName() + "(array property) does not have a proper inner type defined.Default to string");
+                inner = new StringSchema().description("TODO default missing array inner type to string");
+            }
             return getTypeDeclaration(inner) + "[]";
         } else if (ModelUtils.isMapSchema(p)) {
             Schema inner = ModelUtils.getAdditionalProperties(p);
+            if (inner == null) {
+                LOGGER.warn(p.getName() + "(map property) does not have a proper inner type defined. Default to string");
+                inner = new StringSchema().description("TODO default missing map inner type to string");
+            }
             return getSchemaType(p) + "[string," + getTypeDeclaration(inner) + "]";
         } else if (StringUtils.isNotBlank(p.get$ref())) { // model
             String type = super.getTypeDeclaration(p);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

/cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko 

Bugfix is the same to #1363 but for PHP code generator.

This bug appeared during mattermost v4 api code generation (at least for the master version. At the moment of test it was 87a2f9b014f07e4431aa5e884029a5bb4e9f0b68)

The error produced by missing schema definition is listed below.

> [main] WARN  o.o.codegen.utils.ModelUtils - Multiple schemas found, returning only the first one
Exception in thread "main" java.lang.RuntimeException: Could not process model 'inline_object_43'.Please make sure that your schema is correct!
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:434)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:865)
	at org.openapitools.codegen.cmd.Generate.run(Generate.java:349)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:62)
Caused by: java.lang.NullPointerException
	at org.openapitools.codegen.utils.ModelUtils.isArraySchema(ModelUtils.java:339)
	at org.openapitools.codegen.languages.AbstractPhpCodegen.getTypeDeclaration(AbstractPhpCodegen.java:345)
	at org.openapitools.codegen.languages.AbstractPhpCodegen.getTypeDeclaration(AbstractPhpCodegen.java:348)
	at org.openapitools.codegen.DefaultCodegen.fromProperty(DefaultCodegen.java:1966)
	at org.openapitools.codegen.DefaultCodegen.addVars(DefaultCodegen.java:3391)
	at org.openapitools.codegen.DefaultCodegen.addVars(DefaultCodegen.java:3362)
	at org.openapitools.codegen.DefaultCodegen.addVars(DefaultCodegen.java:3349)
	at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:1675)
	at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1103)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:429)