### PR TITLE
[elm] Enable setting Http request trackers

### DIFF
--- a/docs/generators/elm.md
+++ b/docs/generators/elm.md
@@ -12,4 +12,7 @@ CONFIG OPTIONS for elm
 	elmEnableCustomBasePaths
 	    Enable setting the base path for each request (Default: false)
 
+	elmEnableHttpRequestTrackers
+	    Enable adding a tracker to each http request (Default: false)
+
 Back to the [generators list](README.md)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -64,6 +64,7 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final String ELM_VERSION = "elmVersion";
     private static final String ELM_PREFIX_CUSTOM_TYPE_VARIANTS = "elmPrefixCustomTypeVariants";
     private static final String ELM_ENABLE_CUSTOM_BASE_PATHS = "elmEnableCustomBasePaths";
+    private static final String ELM_ENABLE_HTTP_REQUEST_TRACKERS = "elmEnableHttpRequestTrackers";
     private static final String ENCODER = "elmEncoder";
     private static final String DECODER = "elmDecoder";
     private static final String DISCRIMINATOR_NAME = "discriminatorName";
@@ -171,6 +172,8 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(elmPrefixCustomTypeVariants);
         final CliOption elmEnableCustomBasePaths = CliOption.newBoolean(ELM_ENABLE_CUSTOM_BASE_PATHS, "Enable setting the base path for each request");
         cliOptions.add(elmEnableCustomBasePaths);
+        final CliOption elmEnableHttpRequestTrackers = CliOption.newBoolean(ELM_ENABLE_HTTP_REQUEST_TRACKERS, "Enable adding a tracker to each http request");
+        cliOptions.add(elmEnableHttpRequestTrackers);
     }
 
     @Override
@@ -193,6 +196,11 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(ELM_ENABLE_CUSTOM_BASE_PATHS)) {
             final boolean enable = Boolean.TRUE.equals(Boolean.valueOf(additionalProperties.get(ELM_ENABLE_CUSTOM_BASE_PATHS).toString()));
             additionalProperties.put("enableCustomBasePaths", enable);
+        }
+
+        if (additionalProperties.containsKey(ELM_ENABLE_HTTP_REQUEST_TRACKERS)) {
+            final boolean enable = Boolean.TRUE.equals(Boolean.valueOf(additionalProperties.get(ELM_ENABLE_HTTP_REQUEST_TRACKERS).toString()));
+            additionalProperties.put("enableHttpRequestTrackers", enable);
         }
 
         if (StringUtils.isEmpty(System.getenv("ELM_POST_PROCESS_FILE"))) {

--- a/modules/openapi-generator/src/main/resources/elm/api.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/api.mustache
@@ -23,6 +23,7 @@ basePath =
 {{operationId}} :
     { onSend : Result Http.Error {{^responses}}(){{/responses}}{{#responses}}{{#-first}}{{^dataType}}(){{/dataType}}{{#isMapContainer}}(Dict.Dict String {{/isMapContainer}}{{#isListContainer}}(List {{/isListContainer}}{{dataType}}{{#isListContainer}}){{/isListContainer}}{{#isMapContainer}}){{/isMapContainer}}{{/-first}}{{/responses}} -> msg
 {{#enableCustomBasePaths}}    , basePath : String{{/enableCustomBasePaths}}
+{{#enableHttpRequestTrackers}}    , tracker : Maybe String{{/enableHttpRequestTrackers}}
 {{#bodyParam}}    , body : {{^required}}Maybe {{/required}}{{dataType}}{{/bodyParam}}
 {{#pathParams}}    , {{paramName}} : {{#isListContainer}}List {{/isListContainer}}{{dataType}}{{/pathParams}}
 {{#queryParams}}    , {{paramName}} : {{^required}}Maybe ({{/required}}{{#isListContainer}}List {{/isListContainer}}{{dataType}}{{^required}}){{/required}}{{/queryParams}}
@@ -38,7 +39,7 @@ basePath =
         , body = {{#bodyParam}}{{^required}}Maybe.withDefault Http.emptyBody <| Maybe.map ({{/required}}Http.jsonBody {{#required}}<|{{/required}}{{^required}}<<{{/required}} {{vendorExtensions.elmEncoder}}{{^required}}){{/required}} params.body{{/bodyParam}}{{^bodyParam}}Http.emptyBody{{/bodyParam}}
         , expect = {{^responses}}Http.expectWhatever params.onSend{{/responses}}{{#responses}}{{#-first}}{{^dataType}}Http.expectWhatever params.onSend{{/dataType}}{{#dataType}}Http.expectJson params.onSend {{#isMapContainer}}(Decode.dict {{/isMapContainer}}{{#isListContainer}}(Decode.list {{/isListContainer}}{{#vendorExtensions}}{{elmDecoder}}{{/vendorExtensions}}{{#isListContainer}}){{/isListContainer}}{{#isMapContainer}}){{/isMapContainer}}{{/dataType}}{{/-first}}{{/responses}}
         , timeout = Just 30000
-        , tracker = Nothing
+        , tracker = {{#enableHttpRequestTrackers}}params.tracker{{/enableHttpRequestTrackers}}{{^enableHttpRequestTrackers}}Nothing{{/enableHttpRequestTrackers}}
         }
   {{/operation}}
 {{/operations}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Allow setting a tracker `Maybe String` for your Elm Http Requests, instead of the hardcoded `Nothing`.

Can you have a look, @wing328 ?
