### PR TITLE
[core] Fix NPE for endpoints without responses

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -43,15 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.utils.StringUtils.escape;
@@ -1035,6 +1027,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 continue;
             }
             for (Operation operation : path.readOperations()) {
+                LOGGER.info("Processing operation " + operation.getOperationId());
                 if (hasBodyParameter(openAPI, operation) || hasFormParameter(openAPI, operation)) {
                     String defaultContentType = hasFormParameter(openAPI, operation) ? "application/x-www-form-urlencoded" : "application/json";
                     List<String> consumes = new ArrayList<String>(getConsumesInfo(openAPI, operation));
@@ -1051,8 +1044,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected static String getAccept(OpenAPI openAPI, Operation operation) {
         String accepts = null;
         String defaultContentType = "application/json";
-        ArrayList<String> produces = new ArrayList<String>(getProducesInfo(openAPI, operation));
-        if (produces != null && !produces.isEmpty()) {
+        Set<String> producesInfo = getProducesInfo(openAPI, operation);
+        if (producesInfo != null && !producesInfo.isEmpty()) {
+            ArrayList<String> produces = new ArrayList<String>(producesInfo);
             StringBuilder sb = new StringBuilder();
             for (String produce : produces) {
                 if (defaultContentType.equalsIgnoreCase(produce)) {


### PR DESCRIPTION
When generating Java client, generator was crashing with cryptic NPE. After debugging, it turned out, that one of the enpoints did not have 'responses' field defined, 
and there was no clue, what operation it was. The code looked like was supposed to deal with that situation, but by simple mistake it moved on and caused NPE.

Additional logging helped isolate the problem.

BTW: IntelliJ IDEA IDE suggested that change, so it is easy to spot it using static code analysis.

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)