### PR TITLE
Re-enable Haskell HTTP client test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ addons:
 
 before_install:
   # install haskell
-  #- curl -sSL https://get.haskellstack.org/ | sh
-  #- stack upgrade
-  #- stack --version
+  - curl -sSL https://get.haskellstack.org/ | sh
+  - stack upgrade
+  - stack --version
   # install rust
   - curl https://sh.rustup.rs -sSf | sh -s -- -y -v
   # required when sudo: required for the Ruby petstore tests

--- a/pom.xml
+++ b/pom.xml
@@ -1023,7 +1023,7 @@
                 <!--<module>samples/client/petstore/dart-jaguar/openapi</module>
                 <module>samples/client/petstore/dart-jaguar/flutter_petstore/openapi</module>-->
                 <!--<module>samples/client/petstore/dart2/petstore</module>-->
-                <!--<module>samples/client/petstore/haskell-http-client</module>-->
+                <module>samples/client/petstore/haskell-http-client</module>
                 <module>samples/client/petstore/elm-0.18</module>
                 <module>samples/client/petstore/groovy</module>
                 <module>samples/client/petstore/rust</module>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Looks like Travis is able to cache the Haskell dependency (via another branch) and build timeout no longer occurs.
