### PR TITLE
Fix NPE in ModelUtils.isFreeFormObject()

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -545,20 +545,17 @@ public class ModelUtils {
         if ("object".equals(schema.getType())) {
             // no properties
             if ((schema.getProperties() == null || schema.getProperties().isEmpty())) {
-                if (schema.getAdditionalProperties() == null) {
+                Schema addlProps = getAdditionalProperties(schema);
+                // additionalProperties not defined
+                if (addlProps == null) {
                     return true;
                 } else {
-                    // additionalProperties set to true
-                    if (schema.getAdditionalProperties() instanceof Boolean
-                            && (Boolean) schema.getAdditionalProperties()) {
-                        return true;
-                    }
-
-                    // additionalProperties is set to {}
-                    if (schema.getAdditionalProperties() instanceof Schema && schema.getAdditionalProperties() != null
-                            && schema.getAdditionalProperties() instanceof ObjectSchema
-                            && ((Schema) schema.getAdditionalProperties()).getProperties().isEmpty()) {
-                        return true;
+                    if (addlProps instanceof ObjectSchema) {
+                        ObjectSchema objSchema = (ObjectSchema) addlProps;
+                        // additionalProperties defined as {}
+                        if (objSchema.getProperties() == null || objSchema.getProperties().isEmpty()) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -199,4 +199,32 @@ public class ModelUtilsTest {
 
         Assert.assertEquals(refToComposedSchema, ModelUtils.unaliasSchema(allSchemas, refToComposedSchema));
     }
+
+    /**
+     * Issue https://github.com/OpenAPITools/openapi-generator/issues/1624.
+     * ModelUtils.isFreeFormObject() should not throw an NPE when passed an empty
+     * object schema that has additionalProperties defined as an empty object schema.
+     */
+    @Test
+    public void testIsFreeFormObject() {
+        // Create initial "empty" object schema.
+        ObjectSchema objSchema = new ObjectSchema();
+        Assert.assertTrue(ModelUtils.isFreeFormObject(objSchema));
+
+        // Set additionalProperties to an empty ObjectSchema.
+        objSchema.setAdditionalProperties(new ObjectSchema());
+        Assert.assertTrue(ModelUtils.isFreeFormObject(objSchema));
+
+        // Add a single property to the schema (no longer a free-form object).
+        Map<String, Schema> props = new HashMap<>();
+        props.put("prop1", new StringSchema());
+        objSchema.setProperties(props);
+        Assert.assertFalse(ModelUtils.isFreeFormObject(objSchema));
+
+        // Test a non-object schema
+        Assert.assertFalse(ModelUtils.isFreeFormObject(new StringSchema()));
+
+        // Test a null schema
+        Assert.assertFalse(ModelUtils.isFreeFormObject(null));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/1624

An object schema containing no properties that also has additionalProperties
set to an object schema with no properties will cause
ModelUtils.isFreeFormObject to throw an NPE.
This PR adds additional checking to avoid the NPE.

### PR checklist

- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
The change essentially just adds an extra check to make sure the "additionalProperties" schema's properties list is not null before calling "isEmpty()" on it.
