### PR TITLE
[C] Support for authentication methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -310,7 +310,9 @@
     {{/returnContainer}}
     //return type
     {{/returnTypeIsPrimitive}}
-    apiClient_free(apiClient);
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+    }
     {{#hasQueryParams}}list_free(localVarQueryParameters);{{/hasQueryParams}}
     {{#hasHeaderParams}}list_free(localVarHeaderParameters);{{/hasHeaderParams}}
     {{#hasFormParams}}list_free(localVarFormParameters);{{/hasFormParams}}
@@ -380,7 +382,10 @@ end:
     {{/returnType}}
     {{^returnType}}
     //No return type
-end:    apiClient_free(apiClient);
+end:
+    if (apiClient->dataReceived) {
+        free(apiClient->dataReceived);
+    }
     {{#hasQueryParams}}list_free(localVarQueryParameters);{{/hasQueryParams}}
     {{#hasHeaderParams}}list_free(localVarHeaderParameters);{{/hasHeaderParams}}
     {{#hasFormParams}}list_free(localVarFormParameters);{{/hasFormParams}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -385,7 +385,13 @@ void apiClient_invoke(apiClient_t    *apiClient,
         if(res == CURLE_OK) {
             curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &apiClient->response_code);
         } else {
-            fprintf(stderr, "curl_easy_perform() failed: %s\n",
+            char *url,*ip,*scheme;
+            long port;
+            curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_URL, &url);
+            curl_easy_getinfo(handle, CURLINFO_PRIMARY_IP, &ip);
+            curl_easy_getinfo(handle, CURLINFO_PRIMARY_PORT, &port);
+            curl_easy_getinfo(handle, CURLINFO_SCHEME, &scheme);
+            fprintf(stderr, "curl_easy_perform() failed\n\nURL: %s\nIP: %s\nPORT: %li\nSCHEME: %s\nStrERROR: %s\n",url,ip,port,scheme,
             curl_easy_strerror(res));
         }
         {{#hasAuthMethods}}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -12,13 +12,18 @@ apiClient_t *apiClient_create() {
     apiClient->basePath = "{{{basePath}}}";
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
-    #ifdef BASIC_AUTH
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isBasic}}
     apiClient->username = NULL;
     apiClient->password = NULL;
-    #endif // BASIC_AUTH
-    #ifdef OAUTH2
+    {{/isBasic}}
+    {{#isOAuth}}
     apiClient->accessToken = NULL;
-    #endif // OAUTH2
+    {{/isOAuth}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+
     return apiClient;
 }
 
@@ -287,8 +292,12 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 free(headerValueToWrite);
             }
         }
+        {{#hasAuthMethods}}
+        {{#authMethods}}
+        {{#isApiKey}}
         // this would only be generated for apiKey authentication
-        #ifdef API_KEY
+        if (apiClient->apiKeys != NULL)
+        {
         list_ForEach(listEntry, apiClient->apiKeys) {
         keyValuePair_t *apiKey = listEntry->data;
         if((apiKey->key != NULL) &&
@@ -300,7 +309,10 @@ void apiClient_invoke(apiClient_t    *apiClient,
             free(headerValueToWrite);
         }
         }
-        #endif // API_KEY
+        }
+        {{/isApiKey}}
+        {{/authMethods}}
+        {{/hasAuthMethods}}
 
         char *targetUrl =
             assembleTargetUrl(apiClient->basePath,
@@ -316,19 +328,11 @@ void apiClient_invoke(apiClient_t    *apiClient,
                          &apiClient->dataReceived);
         curl_easy_setopt(handle, CURLOPT_HTTPHEADER, headers);
         curl_easy_setopt(handle, CURLOPT_VERBOSE, 0); // to get curl debug msg 0: to disable, 1L:to enable
-        // this would only be generated for OAuth2 authentication
-        #ifdef OAUTH2
-        if(apiClient->accessToken != NULL) {
-            // curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
-            curl_easy_setopt(handle,
-                             CURLOPT_XOAUTH2_BEARER,
-                             apiClient->accessToken);
-        }
-        #endif
 
-
+        {{#hasAuthMethods}}
+        {{#authMethods}}
+        {{#isBasic}}
         // this would only be generated for basic authentication:
-        #ifdef BASIC_AUTH
         char *authenticationToken;
 
         if((apiClient->username != NULL) &&
@@ -351,8 +355,18 @@ void apiClient_invoke(apiClient_t    *apiClient,
                              CURLOPT_USERPWD,
                              authenticationToken);
         }
-
-        #endif // BASIC_AUTH
+        {{/isBasic}}
+        {{#isOAuth}}
+        // this would only be generated for OAuth2 authentication
+        if(apiClient->accessToken != NULL) {
+            // curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
+            curl_easy_setopt(handle,
+                             CURLOPT_XOAUTH2_BEARER,
+                             apiClient->accessToken);
+        }
+        {{/isOAuth}}
+        {{/authMethods}}
+        {{/hasAuthMethods}}
 
         if(bodyParameters != NULL) {
             postData(handle, bodyParameters);
@@ -374,13 +388,18 @@ void apiClient_invoke(apiClient_t    *apiClient,
             fprintf(stderr, "curl_easy_perform() failed: %s\n",
             curl_easy_strerror(res));
         }
-        #ifdef BASIC_AUTH
+        {{#hasAuthMethods}}
+        {{#authMethods}}
+        {{#isBasic}}
         if((apiClient->username != NULL) &&
         (apiClient->password != NULL) )
         {
         free(authenticationToken);
         }
-        #endif // BASIC_AUTH
+        {{/isBasic}}
+        {{/authMethods}}
+        {{/hasAuthMethods}}
+
         curl_easy_cleanup(handle);
         if(formParameters != NULL) {
             free(formString);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -262,11 +262,9 @@ void apiClient_invoke(apiClient_t    *apiClient,
                         if(strcmp(keyValuePair->key,
                                   "file") == 0)
                         {
-                            printf("Size of fileVar - %p\n",fileVar);
                             memcpy(&fileVar,
                                    keyValuePair->value,
                                    sizeof(fileVar));
-                            printf("Size of fileVar1 - %p\n",fileVar);
                             curl_mime_data(part,
                                            fileVar->fileData,
                                            fileVar->fileSize);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -34,7 +34,7 @@ void apiClient_free(apiClient_t *apiClient) {
     if(apiClient->dataReceived) {
         free(apiClient->dataReceived);
     }
-    free(apiClient);
+    //free(apiClient);
     curl_global_cleanup();
 }
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -21,6 +21,9 @@ apiClient_t *apiClient_create() {
     {{#isOAuth}}
     apiClient->accessToken = NULL;
     {{/isOAuth}}
+    {{#isApiKey}}
+    apiClient->apiKeys = NULL;
+    {{/isApiKey}}
     {{/authMethods}}
     {{/hasAuthMethods}}
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -31,10 +31,30 @@ apiClient_t *apiClient_create() {
 }
 
 void apiClient_free(apiClient_t *apiClient) {
-    if(apiClient->dataReceived) {
-        free(apiClient->dataReceived);
+    if(apiClient->basePath) {
+        free(apiClient->basePath);
     }
-    //free(apiClient);
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isBasic}}
+    if(apiClient->username) {
+        free(apiClient->username);
+    }
+    if(apiClient->password) {
+        free(apiClient->password);
+    }
+    {{/isBasic}}
+    {{#isOAuth}}
+    if(apiClient->accessToken) {
+        free(apiClient->accessToken);
+    }
+    {{/isOAuth}}
+    {{#isApiKey}}
+    list_free(apiClient->apiKeys);
+    {{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
+    free(apiClient);
     curl_global_cleanup();
 }
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -12,19 +12,20 @@ typedef struct apiClient_t {
     char *basePath;
     void *dataReceived;
     long response_code;
-    // this would only be generated for basic authentication
-    #ifdef BASIC_AUTH
+    {{#hasAuthMethods}}
+    {{#authMethods}}
+    {{#isBasic}}
     char *username;
     char *password;
-    #endif // BASIC_AUTH
-    // this would only be generated for OAUTH2 authentication
-    #ifdef OAUTH2
+    {{/isBasic}}
+    {{#isOAuth}}
     char *accessToken;
-    #endif // OAUTH2
-    #ifdef API_KEY
-    //this would only be generated for apiKey authentication
+    {{/isOAuth}}
+    {{#isApiKey}}
     list_t *apiKeys;
-    #endif // API_KEY
+    {{/isApiKey}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
 } apiClient_t;
 
 typedef struct FileStruct


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adding support for generating code related to authentication methods (basic, oauth and api-key).

Added error printing in case of the server is not available(curl perform failed).

Make apiClient object reusable(url, authentication are not freed and have to be freed manually)  (dataReceived in apiclient will still be freed. As it is not necessay outside the API function).

