### PR TITLE
Remove isNotContainer

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -53,7 +53,7 @@ public class CodegenProperty implements Cloneable {
     public boolean exclusiveMaximum;
     public boolean hasMore, required, secondaryParam;
     public boolean hasMoreNonReadOnly; // for model constructor, true if next property is not readonly
-    public boolean isPrimitiveType, isModel, isContainer, isNotContainer;
+    public boolean isPrimitiveType, isModel, isContainer;
     public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile,
             isBoolean, isDate, isDateTime, isUuid, isEmail, isFreeFormObject;
     public boolean isListContainer, isMapContainer;
@@ -434,7 +434,6 @@ public class CodegenProperty implements Cloneable {
         result = prime * result + ((hasMoreNonReadOnly ? 13 : 31));
         result = prime * result + ((isContainer ? 13 : 31));
         result = prime * result + (isEnum ? 1231 : 1237);
-        result = prime * result + ((isNotContainer ? 13 : 31));
         result = prime * result + ((isPrimitiveType ? 13 : 31));
         result = prime * result + ((isModel ? 13 : 31));
         result = prime * result + ((isReadOnly ? 13 : 31));
@@ -584,9 +583,6 @@ public class CodegenProperty implements Cloneable {
             return false;
         }
         if (this.isContainer != other.isContainer) {
-            return false;
-        }
-        if (this.isNotContainer != other.isNotContainer) {
             return false;
         }
         if (this.isEnum != other.isEnum) {
@@ -772,7 +768,6 @@ public class CodegenProperty implements Cloneable {
                 ", isPrimitiveType=" + isPrimitiveType +
                 ", isModel=" + isModel +
                 ", isContainer=" + isContainer +
-                ", isNotContainer=" + isNotContainer +
                 ", isString=" + isString +
                 ", isNumeric=" + isNumeric +
                 ", isInteger=" + isInteger +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2264,7 +2264,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     protected void setNonArrayMapProperty(CodegenProperty property, String type) {
-        property.isNotContainer = true;
+        property.isContainer = false;
         if (languageSpecificPrimitives().contains(type)) {
             property.isPrimitiveType = true;
         } else {

--- a/modules/openapi-generator/src/main/resources/Java/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/beanValidation.mustache
@@ -8,9 +8,9 @@
 {{/isEnum}}
 {{/isPrimitiveType}}
 {{/isContainer}}
-{{#isNotContainer}}
+{{^isContainer}}
 {{^isPrimitiveType}}
   @Valid
 {{/isPrimitiveType}}
-{{/isNotContainer}}
+{{/isContainer}}
 {{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/beanValidation.mustache
@@ -1,6 +1,6 @@
 {{#required}}
   @NotNull
 {{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
-  @Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{#isNotContainer}}{{^isPrimitiveType}}
-  @Valid{{/isPrimitiveType}}{{/isNotContainer}}
+  @Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}
+  @Valid{{/isPrimitiveType}}{{/isContainer}}
 {{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/model.mustache
@@ -83,17 +83,17 @@ namespace {{packageName}}.Models
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return {{#vars}}{{#isNotContainer}}
+            return {{#vars}}{{^isContainer}}
                 (
                     {{name}} == other.{{name}} ||
                     {{name}} != null &&
                     {{name}}.Equals(other.{{name}})
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{^isNotContainer}}
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{#isContainer}}
                 (
                     {{name}} == other.{{name}} ||
                     {{name}} != null &&
                     {{name}}.SequenceEqual(other.{{name}})
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{/vars}}{{^vars}}false{{/vars}};
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{/vars}}{{^vars}}false{{/vars}};
         }
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/model.mustache
@@ -83,17 +83,17 @@ namespace {{packageName}}.Models
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return {{#vars}}{{#isNotContainer}}
+            return {{#vars}}{{^isContainer}}
                 (
                     {{name}} == other.{{name}} ||
                     {{name}} != null &&
                     {{name}}.Equals(other.{{name}})
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{^isNotContainer}}
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{#isContainer}}
                 (
                     {{name}} == other.{{name}} ||
                     {{name}} != null &&
                     {{name}}.SequenceEqual(other.{{name}})
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{/vars}}{{^vars}}false{{/vars}};
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{/vars}}{{^vars}}false{{/vars}};
         }
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-header.mustache
@@ -43,10 +43,10 @@ public:
     /// <summary>
     /// {{description}}
     /// </summary>
-    {{^isNotContainer}}{{{dataType}}}& {{getter}}();
-    {{/isNotContainer}}{{#isNotContainer}}{{{dataType}}} {{getter}}() const;
+    {{#isContainer}}{{{dataType}}}& {{getter}}();
+    {{/isContainer}}{{^isContainer}}{{{dataType}}} {{getter}}() const;
     void {{setter}}({{{dataType}}} const{{^isPrimitiveType}}&{{/isPrimitiveType}} value);
-    {{/isNotContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
+    {{/isContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
     void unset{{name}}();
     {{/required}}
     {{/vars}}

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -9,10 +9,10 @@ namespace {{this}} {
 
 {{classname}}::{{classname}}()
 {
-    {{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}m_{{name}} = {{{defaultValue}}};
+    {{#vars}}{{^isContainer}}{{#isPrimitiveType}}m_{{name}} = {{{defaultValue}}};
     {{/isPrimitiveType}}{{^isPrimitiveType}}{{#isString}}m_{{name}} = {{{defaultValue}}};
     {{/isString}}{{#isDateTime}}m_{{name}} = {{{defaultValue}}};
-    {{/isDateTime}}{{/isPrimitiveType}}{{/isNotContainer}}{{^required}}m_{{name}}IsSet = false;
+    {{/isDateTime}}{{/isPrimitiveType}}{{/isContainer}}{{^required}}m_{{name}}IsSet = false;
     {{/required}}{{/vars}}
 }
 
@@ -145,11 +145,11 @@ void {{classname}}::fromJson(const nlohmann::json& val)
 }
 
 
-{{#vars}}{{^isNotContainer}}{{{dataType}}}& {{classname}}::{{getter}}()
+{{#vars}}{{#isContainer}}{{{dataType}}}& {{classname}}::{{getter}}()
 {
     return m_{{name}};
 }
-{{/isNotContainer}}{{#isNotContainer}}{{{dataType}}} {{classname}}::{{getter}}() const
+{{/isContainer}}{{^isContainer}}{{{dataType}}} {{classname}}::{{getter}}() const
 {
     return m_{{name}};
 }
@@ -158,7 +158,7 @@ void {{classname}}::{{setter}}({{{dataType}}} const{{^isPrimitiveType}}&{{/isPri
     m_{{name}} = value;
     {{^required}}m_{{name}}IsSet = true;{{/required}}
 }
-{{/isNotContainer}}
+{{/isContainer}}
 {{^required}}bool {{classname}}::{{nameInCamelCase}}IsSet() const
 {
     return m_{{name}}IsSet;

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -49,9 +49,9 @@ public:
     /// <summary>
     /// {{description}}
     /// </summary>
-    {{^isNotContainer}}{{{dataType}}}& {{getter}}();
-    {{/isNotContainer}}{{#isNotContainer}}{{{dataType}}} {{getter}}() const;
-    {{/isNotContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
+    {{#isContainer}}{{{dataType}}}& {{getter}}();
+    {{/isContainer}}{{^isContainer}}{{{dataType}}} {{getter}}() const;
+    {{/isContainer}}{{^required}}bool {{nameInCamelCase}}IsSet() const;
     void unset{{name}}();
     {{/required}}
 

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -11,7 +11,7 @@ namespace {{this}} {
 {
     {{#vars}}
     {{^isInherited}}
-    {{#isNotContainer}}
+    {{^isContainer}}
     {{#isPrimitiveType}}
     m_{{name}} = {{{defaultValue}}};
     {{/isPrimitiveType}}
@@ -23,7 +23,7 @@ namespace {{this}} {
     m_{{name}} = {{{defaultValue}}};
     {{/isDateTime}}
     {{/isPrimitiveType}}
-    {{/isNotContainer}}
+    {{/isContainer}}
     {{^required}}
     m_{{name}}IsSet = false;
     {{/required}}
@@ -591,18 +591,18 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
 
 {{#vars}}
 {{^isInherited}}
-{{^isNotContainer}}
+{{#isContainer}}
 {{{dataType}}}& {{classname}}::{{getter}}()
 {
     return m_{{name}};
 }
-{{/isNotContainer}}
-{{#isNotContainer}}
+{{/isContainer}}
+{{^isContainer}}
 {{{dataType}}} {{classname}}::{{getter}}() const
 {
     return m_{{name}};
 }
-{{/isNotContainer}}
+{{/isContainer}}
 
 {{#isPrimitiveType}}
 void {{classname}}::{{setter}}({{{dataType}}} value)

--- a/modules/openapi-generator/src/main/resources/cpp-restbed-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-restbed-server/model-source.mustache
@@ -18,10 +18,10 @@ namespace {{this}} {
 
 {{classname}}::{{classname}}()
 {
-    {{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}m_{{name}} = {{{defaultValue}}};
+    {{#vars}}{{^isContainer}}{{#isPrimitiveType}}m_{{name}} = {{{defaultValue}}};
     {{/isPrimitiveType}}{{^isPrimitiveType}}{{#isString}}m_{{name}} = {{{defaultValue}}};
     {{/isString}}{{#isDateTime}}m_{{name}} = {{{defaultValue}}};
-    {{/isDateTime}}{{/isPrimitiveType}}{{/isNotContainer}}{{/vars}}
+    {{/isDateTime}}{{/isPrimitiveType}}{{/isContainer}}{{/vars}}
 }
 
 {{classname}}::~{{classname}}()
@@ -33,7 +33,7 @@ std::string {{classname}}::toJsonString()
 	std::stringstream ss;
 	ptree pt;
 	{{#vars}}
-	{{#isNotContainer}}
+	{{^isContainer}}
 	{{#isPrimitiveType}}
 	pt.put("{{name}}", m_{{name}});
 	{{/isPrimitiveType}}
@@ -45,7 +45,7 @@ std::string {{classname}}::toJsonString()
 	pt.put("{{name}}", m_{{name}});
 	{{/isDateTime}}
 	{{/isPrimitiveType}}
-	{{/isNotContainer}}
+	{{/isContainer}}
 	{{/vars}}
 	write_json(ss, pt, false);
 	return ss.str();
@@ -57,7 +57,7 @@ void {{classname}}::fromJsonString(std::string const& jsonString)
 	ptree pt;
 	read_json(ss,pt);
 	{{#vars}}
-	{{#isNotContainer}}
+	{{^isContainer}}
 	{{#isPrimitiveType}}
 	m_{{name}} = pt.get("{{name}}", {{{defaultValue}}});
 	{{/isPrimitiveType}}
@@ -69,7 +69,7 @@ void {{classname}}::fromJsonString(std::string const& jsonString)
 	m_{{name}} = pt.get("{{name}}", {{{defaultValue}}});
 	{{/isDateTime}}
 	{{/isPrimitiveType}}
-	{{/isNotContainer}}
+	{{/isContainer}}
 	{{/vars}}
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-tizen-client/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-tizen-client/model-body.mustache
@@ -27,9 +27,9 @@ void
 	{{#isContainer}}
 	//{{defaultValue}}{{baseType}}> {{name}};
 	{{/isContainer}}
-	{{#isNotContainer}}
+	{{^isContainer}}
 	//{{name}} = {{defaultValue}};
-	{{/isNotContainer}}
+	{{/isContainer}}
 	{{/vars}}
 }
 

--- a/modules/openapi-generator/src/main/resources/csharp-refactor/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-refactor/modelGeneric.mustache
@@ -158,17 +158,17 @@ this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
             if (input == null)
                 return false;
 
-            return {{#vars}}{{#parent}}base.Equals(input) && {{/parent}}{{#isNotContainer}}
+            return {{#vars}}{{#parent}}base.Equals(input) && {{/parent}}{{^isContainer}}
                 (
                     this.{{name}} == input.{{name}} ||
                     (this.{{name}} != null &&
                     this.{{name}}.Equals(input.{{name}}))
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{^isNotContainer}}
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{#isContainer}}
                 (
                     this.{{name}} == input.{{name}} ||
                     this.{{name}} != null &&
                     this.{{name}}.SequenceEqual(input.{{name}})
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{/vars}}{{^vars}}{{#parent}}base.Equals(input){{/parent}}{{^parent}}false{{/parent}}{{/vars}};
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{/vars}}{{^vars}}{{#parent}}base.Equals(input){{/parent}}{{^parent}}false{{/parent}}{{/vars}};
         }
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/csharp/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/modelGeneric.mustache
@@ -158,17 +158,17 @@ this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
             if (input == null)
                 return false;
 
-            return {{#vars}}{{#parent}}base.Equals(input) && {{/parent}}{{#isNotContainer}}
+            return {{#vars}}{{#parent}}base.Equals(input) && {{/parent}}{{^isContainer}}
                 (
                     this.{{name}} == input.{{name}} ||
                     (this.{{name}} != null &&
                     this.{{name}}.Equals(input.{{name}}))
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{^isNotContainer}}
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{#isContainer}}
                 (
                     this.{{name}} == input.{{name}} ||
                     this.{{name}} != null &&
                     this.{{name}}.SequenceEqual(input.{{name}})
-                ){{#hasMore}} && {{/hasMore}}{{/isNotContainer}}{{/vars}}{{^vars}}{{#parent}}base.Equals(input){{/parent}}{{^parent}}false{{/parent}}{{/vars}};
+                ){{#hasMore}} && {{/hasMore}}{{/isContainer}}{{/vars}}{{^vars}}{{#parent}}base.Equals(input){{/parent}}{{^parent}}false{{/parent}}{{/vars}};
         }
 
         /// <summary>

--- a/modules/openapi-generator/src/main/resources/java-pkmst/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/beanValidation.mustache
@@ -1,6 +1,6 @@
 {{#required}}
   @NotNull
 {{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
-  @Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{#isNotContainer}}{{^isPrimitiveType}}
-  @Valid{{/isPrimitiveType}}{{/isNotContainer}}
+  @Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}
+  @Valid{{/isPrimitiveType}}{{/isContainer}}
 {{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/swift/model.mustache
+++ b/modules/openapi-generator/src/main/resources/swift/model.mustache
@@ -42,12 +42,12 @@ public class {{classname}}: JSONEncodable {
 
     // MARK: JSONEncodable
     func encodeToJSON() -> AnyObject {
-        var nillableDictionary = [String:AnyObject?](){{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
+        var nillableDictionary = [String:AnyObject?](){{#vars}}{{^isContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isInteger}}{{#isLong}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isLong}}{{^isLong}}{{^isInteger}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{/isInteger}}{{/isLong}}{{/isEnum}}{{/isPrimitiveType}}{{#isEnum}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.rawValue{{/isEnum}}{{^isPrimitiveType}}
-        nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isPrimitiveType}}{{/isNotContainer}}{{#isContainer}}
+        nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isPrimitiveType}}{{/isContainer}}{{#isContainer}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isContainer}}{{/vars}}
         let dictionary: [String:AnyObject] = APIHelper.rejectNil(nillableDictionary) ?? [:]
         return dictionary

--- a/modules/openapi-generator/src/main/resources/swift3/model.mustache
+++ b/modules/openapi-generator/src/main/resources/swift3/model.mustache
@@ -77,12 +77,12 @@ open class {{classname}}: {{#parent}}{{{parent}}}{{/parent}}{{^parent}}JSONEncod
 {{/additionalPropertiesType}}
     // MARK: JSONEncodable
     {{#parent}}override {{/parent}}open func encodeToJSON() -> Any {
-        var nillableDictionary = {{#parent}}super.encodeToJSON() as? [String:Any?] ?? {{/parent}}[String:Any?](){{#vars}}{{#isNotContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
+        var nillableDictionary = {{#parent}}super.encodeToJSON() as? [String:Any?] ?? {{/parent}}[String:Any?](){{#vars}}{{^isContainer}}{{#isPrimitiveType}}{{^isEnum}}{{#isInteger}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isInteger}}{{#isLong}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isLong}}{{^isLong}}{{^isInteger}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{/isInteger}}{{/isLong}}{{/isEnum}}{{/isPrimitiveType}}{{#isEnum}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.rawValue{{/isEnum}}{{^isPrimitiveType}}
-        nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isPrimitiveType}}{{/isNotContainer}}{{#isContainer}}{{^isEnum}}
+        nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isPrimitiveType}}{{/isContainer}}{{#isContainer}}{{^isEnum}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.encodeToJSON(){{/isEnum}}{{#isEnum}}{{#isListContainer}}
         nillableDictionary["{{baseName}}"] = self.{{name}}{{^unwrapRequired}}?{{/unwrapRequired}}{{#unwrapRequired}}{{^required}}?{{/required}}{{/unwrapRequired}}.map({$0.rawValue}).encodeToJSON(){{/isListContainer}}{{#isMapContainer}}//TODO: handle enum map scenario{{/isMapContainer}}{{/isEnum}}{{/isContainer}}{{/vars}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
@@ -30,7 +30,7 @@ let enumsMap: {[index: string]: any} = {
             {{#hasEnums}}
                 {{#vars}}
                     {{#isEnum}}
-        {{#isContainer}}"{{classname}}.{{enumName}}": {{classname}}.{{enumName}}{{/isContainer}}{{#isNotContainer}}"{{datatypeWithEnum}}": {{datatypeWithEnum}}{{/isNotContainer}},
+        {{#isContainer}}"{{classname}}.{{enumName}}": {{classname}}.{{enumName}}{{/isContainer}}{{^isContainer}}"{{datatypeWithEnum}}": {{datatypeWithEnum}}{{/isContainer}},
                     {{/isEnum}}
                 {{/vars}}
             {{/hasEnums}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -67,7 +67,7 @@ public class DartModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -78,7 +78,7 @@ public class DartModelTest {
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -89,7 +89,7 @@ public class DartModelTest {
         Assert.assertEquals(property3.baseType, "DateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -117,7 +117,7 @@ public class DartModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "urls");
@@ -176,7 +176,7 @@ public class DartModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")
@@ -228,7 +228,6 @@ public class DartModelTest {
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -101,7 +101,7 @@ public class JavaModelTest {
         Assert.assertEquals(property1.baseType, "Long");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -116,7 +116,7 @@ public class JavaModelTest {
         Assert.assertEquals(property2.example, "Tony");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -130,7 +130,7 @@ public class JavaModelTest {
         Assert.assertEquals(property3.baseType, "Date");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -264,7 +264,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "Boolean");
         Assert.assertFalse(property.required);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "convert a model with complex properties")
@@ -290,7 +290,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, "null");
         Assert.assertEquals(property.baseType, "Children");
         Assert.assertFalse(property.required);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")
@@ -348,8 +348,6 @@ public class JavaModelTest {
         Assert.assertEquals(property.containerType, "map");
         Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
-        Assert.assertFalse(property.isNotContainer);
-
     }
 
     @Test(description = "convert a model with an array property with item name")
@@ -385,7 +383,6 @@ public class JavaModelTest {
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
         Assert.assertTrue(property.isContainer);
-        Assert.assertFalse(property.isNotContainer);
 
         final CodegenProperty itemsProperty = property.items;
         Assert.assertEquals(itemsProperty.baseName,"child");
@@ -450,7 +447,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.baseType, "String");
         Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "convert a model with a 2nd char upper-case property names")
@@ -476,7 +473,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.baseType, "String");
         Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "convert a model starting with two upper-case letter property names")
@@ -502,7 +499,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.baseType, "String");
         Assert.assertFalse(property.hasMore);
         Assert.assertTrue(property.required);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "convert hyphens per issue 503")
@@ -564,7 +561,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.baseType, "byte[]");
         Assert.assertFalse(property.hasMore);
         Assert.assertFalse(property.required);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "translate an invalid param name")
@@ -588,7 +585,7 @@ public class JavaModelTest {
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
         Assert.assertFalse(property.hasMore);
-        Assert.assertTrue(property.isNotContainer);
+        Assert.assertFalse(property.isContainer);
     }
 
     @Test(description = "convert a parameter")
@@ -719,7 +716,7 @@ public class JavaModelTest {
         Assert.assertEquals(property2.example, "Tony");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
         Assert.assertTrue(property2.isXmlAttribute);
         Assert.assertEquals(property2.xmlName, "myName");
         Assert.assertNull(property2.xmlNamespace);
@@ -734,7 +731,7 @@ public class JavaModelTest {
         Assert.assertEquals(property3.baseType, "Date");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
         Assert.assertFalse(property3.isXmlAttribute);
         Assert.assertEquals(property3.xmlName, "myCreatedAt");
         Assert.assertEquals(property3.xmlNamespace, "myNamespace");
@@ -802,7 +799,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.dataType, "Boolean");
         Assert.assertEquals(cp.name, "property");
         Assert.assertEquals(cp.baseType, "Boolean");
-        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isContainer);
         Assert.assertTrue(cp.isBoolean);
         Assert.assertEquals(cp.getter, "isProperty");
     }
@@ -817,7 +814,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.dataType, "Integer");
         Assert.assertEquals(cp.name, "property");
         Assert.assertEquals(cp.baseType, "Integer");
-        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isContainer);
         Assert.assertTrue(cp.isInteger);
         Assert.assertFalse(cp.isLong);
         Assert.assertEquals(cp.getter, "getProperty");
@@ -835,7 +832,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.dataType, "Long");
         Assert.assertEquals(cp.name, "property");
         Assert.assertEquals(cp.baseType, "Long");
-        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isContainer);
         Assert.assertTrue(cp.isLong);
         Assert.assertFalse(cp.isInteger);
         Assert.assertEquals(cp.getter, "getProperty");
@@ -912,7 +909,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.dataType, "String");
         Assert.assertEquals(cp.name, "somePropertyWithMinMaxAndPattern");
         Assert.assertEquals(cp.baseType, "String");
-        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isContainer);
         Assert.assertFalse(cp.isLong);
         Assert.assertFalse(cp.isInteger);
         Assert.assertTrue(cp.isString);
@@ -938,7 +935,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.dataType, "String");
         Assert.assertEquals(cp.name, "somePropertyWithMinMaxAndPattern");
         Assert.assertEquals(cp.baseType, "String");
-        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isContainer);
         Assert.assertFalse(cp.isLong);
         Assert.assertFalse(cp.isInteger);
         Assert.assertTrue(cp.isString);
@@ -967,7 +964,7 @@ public class JavaModelTest {
         Assert.assertEquals(cp.dataType, "String");
         Assert.assertEquals(cp.name, "somePropertyWithMinMaxAndPattern");
         Assert.assertEquals(cp.baseType, "String");
-        Assert.assertTrue(cp.isNotContainer);
+        Assert.assertFalse(cp.isContainer);
         Assert.assertFalse(cp.isLong);
         Assert.assertFalse(cp.isInteger);
         Assert.assertTrue(cp.isString);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -90,7 +90,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -101,7 +101,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -111,7 +111,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseType, "java.time.LocalDateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a simple model: threetenbp")
@@ -131,7 +131,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseType, "org.threeten.bp.LocalDateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a simple model: date string")
@@ -151,7 +151,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseType, "kotlin.String");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a simple model: date java8")
@@ -171,7 +171,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseType, "java.time.LocalDateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with array property to default kotlin.Array")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
@@ -98,7 +98,7 @@ public class ObjcModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -109,7 +109,7 @@ public class ObjcModelTest {
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -119,7 +119,7 @@ public class ObjcModelTest {
         Assert.assertEquals(property3.baseType, "NSDate");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -147,7 +147,7 @@ public class ObjcModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "urls");
@@ -208,7 +208,7 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "OAIChildren");
         Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")
@@ -260,7 +260,6 @@ public class ObjcModelTest {
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -73,7 +73,7 @@ public class PhpModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -84,7 +84,7 @@ public class PhpModelTest {
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -95,7 +95,7 @@ public class PhpModelTest {
         Assert.assertEquals(property3.baseType, "\\DateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -123,7 +123,7 @@ public class PhpModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "urls");
@@ -182,7 +182,7 @@ public class PhpModelTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")
@@ -234,7 +234,6 @@ public class PhpModelTest {
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -197,7 +197,7 @@ public class PythonTest {
         Assert.assertEquals(property1.name, "children");
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalaakka/ScalaAkkaClientCodegenTest.java
@@ -67,7 +67,7 @@ public class ScalaAkkaClientCodegenTest {
         Assert.assertEquals(property1.baseType, "Long");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -79,7 +79,7 @@ public class ScalaAkkaClientCodegenTest {
         Assert.assertEquals(property2.baseType, "String");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -91,7 +91,7 @@ public class ScalaAkkaClientCodegenTest {
         Assert.assertEquals(property3.baseType, "DateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -173,7 +173,7 @@ public class ScalaAkkaClientCodegenTest {
         Assert.assertNull(property1.defaultValue);
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")
@@ -231,7 +231,6 @@ public class ScalaAkkaClientCodegenTest {
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalahttpclient/ScalaHttpClientModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scalahttpclient/ScalaHttpClientModelTest.java
@@ -66,7 +66,7 @@ public class ScalaHttpClientModelTest {
         Assert.assertEquals(property1.baseType, "Long");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -78,7 +78,7 @@ public class ScalaHttpClientModelTest {
         Assert.assertEquals(property2.baseType, "String");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -90,7 +90,7 @@ public class ScalaHttpClientModelTest {
         Assert.assertEquals(property3.baseType, "Date");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -172,7 +172,7 @@ public class ScalaHttpClientModelTest {
         Assert.assertNull(property1.defaultValue);
         Assert.assertEquals(property1.baseType, "Children");
         Assert.assertFalse(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
     }
 
     @Test(description = "convert a model with complex list property")
@@ -230,7 +230,6 @@ public class ScalaHttpClientModelTest {
         Assert.assertEquals(property1.containerType, "map");
         Assert.assertFalse(property1.required);
         Assert.assertTrue(property1.isContainer);
-        Assert.assertFalse(property1.isNotContainer);
     }
 
     @Test(description = "convert an array model")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4ModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4ModelTest.java
@@ -72,7 +72,7 @@ public class Swift4ModelTest {
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -83,7 +83,7 @@ public class Swift4ModelTest {
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
         Assert.assertTrue(property2.isPrimitiveType);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -93,7 +93,7 @@ public class Swift4ModelTest {
         Assert.assertEquals(property3.baseType, "Date");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "binary");
@@ -103,7 +103,7 @@ public class Swift4ModelTest {
         Assert.assertEquals(property4.baseType, "URL");
         Assert.assertTrue(property4.hasMore);
         Assert.assertFalse(property4.required);
-        Assert.assertTrue(property4.isNotContainer);
+        Assert.assertFalse(property4.isContainer);
 
         final CodegenProperty property5 = cm.vars.get(4);
         Assert.assertEquals(property5.baseName, "byte");
@@ -113,7 +113,7 @@ public class Swift4ModelTest {
         Assert.assertEquals(property5.baseType, "Data");
         Assert.assertTrue(property5.hasMore);
         Assert.assertFalse(property5.required);
-        Assert.assertTrue(property5.isNotContainer);
+        Assert.assertFalse(property5.isContainer);
 
         final CodegenProperty property6 = cm.vars.get(5);
         Assert.assertEquals(property6.baseName, "uuid");
@@ -123,7 +123,7 @@ public class Swift4ModelTest {
         Assert.assertEquals(property6.baseType, "UUID");
         Assert.assertTrue(property6.hasMore);
         Assert.assertFalse(property6.required);
-        Assert.assertTrue(property6.isNotContainer);
+        Assert.assertFalse(property6.isContainer);
 
         final CodegenProperty property7 = cm.vars.get(6);
         Assert.assertEquals(property7.baseName, "dateOfBirth");
@@ -133,7 +133,7 @@ public class Swift4ModelTest {
         Assert.assertEquals(property7.baseType, "Date");
         Assert.assertFalse(property7.hasMore);
         Assert.assertFalse(property7.required);
-        Assert.assertTrue(property7.isNotContainer);
+        Assert.assertFalse(property7.isContainer);
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -77,7 +77,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -87,7 +87,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -97,7 +97,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
@@ -107,7 +107,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
-        Assert.assertTrue(property4.isNotContainer);
+        Assert.assertFalse(property4.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -133,7 +133,7 @@ public class TypeScriptFetchModelTest {
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "urls");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -65,7 +65,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -75,7 +75,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -86,7 +86,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
@@ -97,7 +97,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
-        Assert.assertTrue(property4.isNotContainer);
+        Assert.assertFalse(property4.isContainer);
     }
 
     @Test(description = "convert a model with list property")
@@ -123,7 +123,7 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "urls");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangularjs/TypeScriptAngularJsModelTest.java
@@ -65,7 +65,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property1.baseType, "number");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
-        Assert.assertTrue(property1.isNotContainer);
+        Assert.assertFalse(property1.isContainer);
 
         final CodegenProperty property2 = cm.vars.get(1);
         Assert.assertEquals(property2.baseName, "name");
@@ -75,7 +75,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property2.baseType, "string");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
-        Assert.assertTrue(property2.isNotContainer);
+        Assert.assertFalse(property2.isContainer);
 
         final CodegenProperty property3 = cm.vars.get(2);
         Assert.assertEquals(property3.baseName, "createdAt");
@@ -85,7 +85,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property3.defaultValue, "undefined");
         Assert.assertTrue(property3.hasMore);
         Assert.assertFalse(property3.required);
-        Assert.assertTrue(property3.isNotContainer);
+        Assert.assertFalse(property3.isContainer);
 
         final CodegenProperty property4 = cm.vars.get(3);
         Assert.assertEquals(property4.baseName, "birthDate");
@@ -95,7 +95,7 @@ public class TypeScriptAngularJsModelTest {
         Assert.assertEquals(property4.defaultValue, "undefined");
         Assert.assertFalse(property4.hasMore);
         Assert.assertFalse(property4.required);
-        Assert.assertTrue(property4.isNotContainer);
+        Assert.assertFalse(property4.isContainer);
     }
 
     @Test(description = "convert a model with list property")


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Remove isNotContainer from codegen property and replace it with {{^isContainer}} instead in the templates

cc @OpenAPITools/generator-core-team 
