### PR TITLE
[BUG-1633] Keep first underscore as it breaks mappings.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/StringUtils.java
@@ -96,6 +96,7 @@ public class StringUtils {
             word = m.replaceAll(rep);
         }
 
+        boolean startWithUnderscore = word.startsWith("_");
         // Remove all underscores (underscore_case to camelCase)
         p = Pattern.compile("(_)(.)");
         m = p.matcher(word);
@@ -131,6 +132,10 @@ public class StringUtils {
 
         // remove all underscore
         word = word.replaceAll("_", "");
+        if (startWithUnderscore) {
+            // As a leading underscore is intentional we need to re-append it
+            word = "_" + word;
+        }
 
         return word;
     }
@@ -138,9 +143,9 @@ public class StringUtils {
     /**
      * Return the name with escaped characters.
      *
-     * @param name the name to be escaped
-     * @param replacementMap map of replacement characters for non-allowed characters
-     * @param charactersToAllow characters that are not escaped
+     * @param name                the name to be escaped
+     * @param replacementMap      map of replacement characters for non-allowed characters
+     * @param charactersToAllow   characters that are not escaped
      * @param appendToReplacement String to append to replaced characters.
      * @return the escaped word
      * <p>
@@ -153,13 +158,15 @@ public class StringUtils {
             if (charactersToAllow != null && charactersToAllow.contains(character)) {
                 return character;
             } else if (replacementMap.containsKey(character)) {
-                return replacementMap.get(character) + (appendToReplacement != null ? appendToReplacement: "");
+                return replacementMap.get(character) + (appendToReplacement != null ? appendToReplacement : "");
             } else {
                 return character;
             }
-        }).reduce( (c1, c2) -> "" + c1 + c2).orElse(null);
+        }).reduce((c1, c2) -> "" + c1 + c2).orElse(null);
 
-        if (result != null) return result;
+        if (result != null) {
+            return result;
+        }
         throw new RuntimeException("Word '" + name + "' could not be escaped.");
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -275,7 +275,7 @@ public class DartModelTest {
             {"/sample", "Sample"},
             {"\\sample", "\\Sample"},
             {"sample.name", "SampleName"},
-            {"_sample", "Sample"},
+            {"_sample", "_Sample"},
         };
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -279,7 +279,7 @@ public class GoModelTest {
             {"/sample", "Sample"},
             {"\\sample", "Sample"},
             {"sample.name", "SampleName"},
-            {"_sample", "Sample"},
+            {"_sample", "_Sample"},
         };
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -581,10 +581,10 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "_");
-        Assert.assertEquals(property.getter, "getU");
-        Assert.assertEquals(property.setter, "setU");
+        Assert.assertEquals(property.getter, "get_U");
+        Assert.assertEquals(property.setter, "set_U");
         Assert.assertEquals(property.dataType, "String");
-        Assert.assertEquals(property.name, "u");
+        Assert.assertEquals(property.name, "_u");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
         Assert.assertFalse(property.hasMore);
@@ -633,7 +633,7 @@ public class JavaModelTest {
                 {"/sample", "Sample"},
                 {"\\sample", "Sample"},
                 {"sample.name", "SampleName"},
-                {"_sample", "Sample"},
+                {"_sample", "_Sample"},
                 {"Sample", "Sample"},
         };
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -278,10 +278,10 @@ public class PhpModelTest {
             {"sample", "Sample"},
             {"sample_name", "SampleName"},
             {"sample__name", "SampleName"},
-            {"/sample", "Sample"},
+            {"/sample", "_Sample"},
             {"\\sample", "\\Sample"},
             {"sample.name", "SampleName"},
-            {"_sample", "Sample"},
+            {"_sample", "_Sample"},
         };
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/StringUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/StringUtilsTest.java
@@ -13,11 +13,13 @@ public class StringUtilsTest {
         Assert.assertEquals(camelize("abcd"), "Abcd");
         Assert.assertEquals(camelize("some-value"), "SomeValue");
         Assert.assertEquals(camelize("some_value"), "SomeValue");
+        Assert.assertEquals(camelize("_some_value"), "_SomeValue");
         Assert.assertEquals(camelize("$type"), "$Type");
 
         Assert.assertEquals(camelize("abcd", true), "abcd");
         Assert.assertEquals(camelize("some-value", true), "someValue");
         Assert.assertEquals(camelize("some_value", true), "someValue");
+        Assert.assertEquals(camelize("_some_value", true), "_someValue");
         Assert.assertEquals(camelize("Abcd", true), "abcd");
         Assert.assertEquals(camelize("$type", true), "$type");
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
- [ ] resolved #1633

### Description of the PR

This PR fixes the issues described in issue #1633. Only merge when this issue is resolved.
