### PR TITLE
Replace a deprecated method ( java.lang.Class.newInstance )

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfigLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfigLoader.java
@@ -45,7 +45,7 @@ public class CodegenConfigLoader {
 
         // else try to load directly
         try {
-            return (CodegenConfig) Class.forName(name).newInstance();
+            return (CodegenConfig) Class.forName(name).getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new GeneratorNotFoundException("Can't load config class with name '".concat(name) + "'\nAvailable:\n" + availableConfigs.toString(), e);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModelFactory.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModelFactory.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public final class CodegenModelFactory {
             throw new IllegalArgumentException(implementation.getSimpleName() + " doesn't extend " + type.getDefaultImplementation().getSimpleName());
         }
         try {
-            implementation.newInstance();
+            implementation.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
@@ -46,8 +47,8 @@ public final class CodegenModelFactory {
     public static <T> T newInstance(CodegenModelType type) {
         Class<?> classType = typeMapping.get(type);
         try {
-            return (T) (classType != null ? classType : type.getDefaultImplementation()).newInstance();
-        } catch (IllegalAccessException | InstantiationException e) {
+            return (T) (classType != null ? classType : type.getDefaultImplementation()).getDeclaredConstructor().newInstance();
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Since Java9, [java.lang.Class.newInstance() is deprecated](https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--). 📝 

