### PR TITLE
Include mavenCentral in java build.gradle

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -6,6 +6,7 @@ version = '{{artifactVersion}}'
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -15,6 +16,7 @@ buildscript {
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

the android dep is currently missing from jcenter. This adds
mavenCentral as an additional repository to the default java generator's
build.gradle.

This addresses an issue my team at work has on a PR verification job we run on each commit. We're seeing this problem:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'openapi-java-client'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Could not find any matches for com.android.tools.build:gradle:2.3.+ as no versions of com.android.tools.build:gradle are available.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/maven-metadata.xml
         https://jcenter.bintray.com/com/android/tools/build/gradle/
     Required by:
         :openapi-java-client:unspecified

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 3.901 secs
```

/cc technical committee:
@bbdouglas @JFCote @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger
