### PR TITLE
[Slim] Encode path to support non-latin characters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -81,6 +81,8 @@ public interface CodegenConfig {
 
     String escapeTextWhileAllowingNewLines(String text);
 
+    String encodePath(String text);
+
     String escapeUnsafeCharacters(String input);
 
     String escapeReservedWord(String name);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -555,6 +555,12 @@ public class DefaultCodegen implements CodegenConfig {
                         .replace("\"", "\\\""));
     }
 
+    // override with any special encoding and escaping logic
+    @SuppressWarnings("static-method")
+    public String encodePath(String input) {
+        return escapeText(input);
+    }
+
     /**
      * override with any special text escaping logic to handle unsafe
      * characters so as to avoid code injection

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -537,9 +537,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                     }
                 });
                 Map<String, Object> operation = processOperations(config, tag, ops, allModels);
-
+                URL url = URLPathUtils.getServerURL(openAPI);
                 operation.put("basePath", basePath);
-                operation.put("basePathWithoutHost", basePathWithoutHost);
+                operation.put("basePathWithoutHost", config.encodePath(url.getPath()).replaceAll("/$", ""));
                 operation.put("contextPath", contextPath);
                 operation.put("baseName", tag);
                 operation.put("apiPackage", config.apiPackage());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -31,6 +31,13 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.net.URLEncoder;
+import org.apache.commons.lang3.StringEscapeUtils;
+import java.io.UnsupportedEncodingException;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
 
 public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(PhpSlimServerCodegen.class);
@@ -196,6 +203,59 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
         classname = classname.replaceAll("^" + abstractNamePrefix, "");
         classname = classname.replaceAll(abstractNameSuffix + "$", "");
         operations.put(USER_CLASSNAME_KEY, classname);
+    }
+
+    @Override
+    public String encodePath(String input) {
+        if (input == null) {
+            return input;
+        }
+
+        // from DefaultCodegen.java
+        // remove \t, \n, \r
+        // replace \ with \\
+        // replace " with \"
+        // outter unescape to retain the original multi-byte characters
+        // finally escalate characters avoiding code injection
+        input = super.escapeUnsafeCharacters(
+                StringEscapeUtils.unescapeJava(
+                        StringEscapeUtils.escapeJava(input)
+                                .replace("\\/", "/"))
+                        .replaceAll("[\\t\\n\\r]", " ")
+                        .replace("\\", "\\\\"));
+                        // .replace("\"", "\\\""));
+
+        // from AbstractPhpCodegen.java
+        // Trim the string to avoid leading and trailing spaces.
+        input = input.trim();
+        try {
+
+            input = URLEncoder.encode(input, "UTF-8")
+                    .replaceAll("\\+", "%20")
+                    .replaceAll("\\%2F", "/")
+                    .replaceAll("\\%7B", "{") // keep { part of complex placeholders
+                    .replaceAll("\\%7D", "}") // } part
+                    .replaceAll("\\%5B", "[") // [ part
+                    .replaceAll("\\%5D", "]") // ] part
+                    .replaceAll("\\%3A", ":") // : part
+                    .replaceAll("\\%2B", "+") // + part
+                    .replaceAll("\\%5C\\%5Cd", "\\\\d"); // \d part
+        } catch (UnsupportedEncodingException e) {
+            // continue
+            LOGGER.error(e.getMessage(), e);
+        }
+        return input;
+    }
+
+    @Override
+    public CodegenOperation fromOperation(String path,
+                                          String httpMethod,
+                                          Operation operation,
+                                          Map<String, Schema> schemas,
+                                          OpenAPI openAPI) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, schemas, openAPI);
+        op.path = encodePath(path);
+        return op;
     }
 
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
@@ -64,7 +64,7 @@ class SlimRouter
         [
             'httpMethod' => '{{httpMethod}}',
             'basePathWithoutHost' => '{{{basePathWithoutHost}}}',
-            'path' => '{{path}}',
+            'path' => '{{{path}}}',
             'apiPackage' => '{{apiPackage}}',
             'classname' => '{{classname}}',
             'userClassname' => '{{userClassname}}',

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.slim;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import org.openapitools.codegen.languages.PhpSlimServerCodegen;
+
+public class PhpSlimServerCodegenTest {
+
+    @Test
+    public void testEncodePath() {
+        final PhpSlimServerCodegen codegen = new PhpSlimServerCodegen();
+
+        Assert.assertEquals(codegen.encodePath("/ ' \" =end -- \\r\\n \\n \\r/v2 *_/ ' \" =end -- \\r\\n \\n \\r/fake"), "/%20%27%20%22%20%3Dend%20--%20%5C%5Cr%5C%5Cn%20%5C%5Cn%20%5C%5Cr/v2%20*_/%20%27%20%22%20%3Dend%20--%20%5C%5Cr%5C%5Cn%20%5C%5Cn%20%5C%5Cr/fake");
+        Assert.assertEquals(codegen.encodePath("/o\'\"briens/v2/o\'\"henry/fake"), "/o%27%22briens/v2/o%27%22henry/fake");
+        Assert.assertEquals(codegen.encodePath("/comedians/Chris D\'Elia"), "/comedians/Chris%20D%27Elia");
+        Assert.assertEquals(codegen.encodePath("/разработчики/Юрий Беленко"), "/%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D1%87%D0%B8%D0%BA%D0%B8/%D0%AE%D1%80%D0%B8%D0%B9%20%D0%91%D0%B5%D0%BB%D0%B5%D0%BD%D0%BA%D0%BE");
+        Assert.assertEquals(codegen.encodePath("/text with multilines \\\n\\\t\\\r"), "/text%20with%20multilines%20%5C%5C%20%5C%5C%20%5C%5C");
+        Assert.assertEquals(codegen.encodePath("/path with argument {value}"), "/path%20with%20argument%20{value}");
+
+        // few examples from Slim documentation
+        Assert.assertEquals(codegen.encodePath("/users[/{id}]"), "/users[/{id}]");
+        Assert.assertEquals(codegen.encodePath("/news[/{year}[/{month}]]"), "/news[/{year}[/{month}]]");
+        Assert.assertEquals(codegen.encodePath("/news[/{params:.*}]"), "/news[/{params:.*}]");
+        Assert.assertEquals(codegen.encodePath("/users/{id:[0-9]+}"), "/users/{id:[0-9]+}");
+
+        // from FastRoute\RouteParser\Std.php
+        Assert.assertEquals(codegen.encodePath("/user/{name}[/{id:[0-9]+}]"), "/user/{name}[/{id:[0-9]+}]");
+        Assert.assertEquals(codegen.encodePath("/fixedRoutePart/{varName}[/moreFixed/{varName2:\\d+}]"), "/fixedRoutePart/{varName}[/moreFixed/{varName2:\\d+}]");
+    }
+}

--- a/samples/server/petstore-security-test/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore-security-test/php-slim/lib/SlimRouter.php
@@ -53,7 +53,7 @@ class SlimRouter
     private $operations = [
         [
             'httpMethod' => 'PUT',
-            'basePathWithoutHost' => '/ ' \" =end -- \\r\\n \\n \\r/v2 *_/ ' \" =end -- \\r\\n \\n \\r',
+            'basePathWithoutHost' => '/%20%27%20%22%20%3Dend%20--%20%5C%5Cr%5C%5Cn%20%5C%5Cn%20%5C%5Cr/v2%20*_/%20%27%20%22%20%3Dend%20--%20%5C%5Cr%5C%5Cn%20%5C%5Cn%20%5C%5Cr',
             'path' => '/fake',
             'apiPackage' => 'OpenAPIServer\Api',
             'classname' => 'AbstractFakeApi',


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Closes: #766
This PR should be reviewed carefully, because I didn't find a way to fix it without DefaultGenerator modification.

As it turns out `{{basePathWithoutHost}}` construction doesn't solve issue when path contains non-latin characters. For instance, Slim router cannot find related API controller when path looks like `/статьи/авторы`, because escaped mustache variable output is `/статьи/авторы` without any difference, while HTTP clients and web browsers encodes non-latin characters by default.  When I use this link in Chrome I see in server logs that url has been automatically encoded into `/%D1%81%D1%82%D0%B0%D1%82%D1%8C%D0%B8/%D0%B0%D0%B2%D1%82%D0%BE%D1%80%D1%8B`. The same behaviour with Insomnia app. With new method `encodePath` Slim router works as expected.

I've also added few tests to check `encodePath` method output of `PhpSlimServerCodegen`.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @renepardon

