### PR TITLE
fix: force to decode as utf-8 when header contains application/json to avoid text garbling.

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/api.mustache
@@ -89,7 +89,7 @@ class {{classname}} {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw new ApiException(response.statusCode, response.body);
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       {{#isListContainer}}
         {{#returnType}}

--- a/modules/openapi-generator/src/main/resources/dart/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/api.mustache
@@ -93,18 +93,18 @@ class {{classname}} {
     } else if(response.body != null) {
       {{#isListContainer}}
         {{#returnType}}
-      return (apiClient.deserialize(response.body, '{{{returnType}}}') as List).map((item) => item as {{returnBaseType}}).toList();
+      return (apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}') as List).map((item) => item as {{returnBaseType}}).toList();
         {{/returnType}}
       {{/isListContainer}}
       {{^isListContainer}}
         {{#isMapContainer}}
           {{#returnType}}
-      return new {{{returnType}}}.from(apiClient.deserialize(response.body, '{{{returnType}}}'));
+      return new {{{returnType}}}.from(apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}'));
           {{/returnType}};
         {{/isMapContainer}}
         {{^isMapContainer}}
           {{#returnType}}
-      return apiClient.deserialize(response.body, '{{{returnType}}}') as {{{returnType}}};
+      return apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}') as {{{returnType}}};
           {{/returnType}}
         {{/isMapContainer}}
       {{/isListContainer}}

--- a/modules/openapi-generator/src/main/resources/dart/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/api_helper.mustache
@@ -50,3 +50,15 @@ String parameterToString(dynamic value) {
     return value.toString();
   }
 }
+
+/// Returns the decoded body by utf-8 if application/json with the given headers.
+/// Else, returns the decoded body by default algorithm of dart:http.
+/// Because avoid to text garbling when header only contains "application/json" without "; charset=utf-8".
+String _decodeBodyBytes(Response response) {
+  var contentType = response.headers['content-type'];
+  if (contentType != null && contentType.contains("application/json")) {
+    return utf8.decode(response.bodyBytes);
+  } else {
+    return response.body;
+  }
+}

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -89,7 +89,7 @@ class {{classname}} {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw new ApiException(response.statusCode, response.body);
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       {{#isListContainer}}
         {{#returnType}}

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -93,18 +93,18 @@ class {{classname}} {
     } else if(response.body != null) {
       {{#isListContainer}}
         {{#returnType}}
-      return (apiClient.deserialize(response.body, '{{{returnType}}}') as List).map((item) => item as {{returnBaseType}}).toList();
+      return (apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}') as List).map((item) => item as {{returnBaseType}}).toList();
         {{/returnType}}
       {{/isListContainer}}
       {{^isListContainer}}
         {{#isMapContainer}}
           {{#returnType}}
-      return new {{{returnType}}}.from(apiClient.deserialize(response.body, '{{{returnType}}}'));
+      return new {{{returnType}}}.from(apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}'));
           {{/returnType}};
         {{/isMapContainer}}
         {{^isMapContainer}}
           {{#returnType}}
-      return apiClient.deserialize(response.body, '{{{returnType}}}') as {{{returnType}}};
+      return apiClient.deserialize(_decodeBodyBytes(response), '{{{returnType}}}') as {{{returnType}}};
           {{/returnType}}
         {{/isMapContainer}}
       {{/isListContainer}}

--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -50,3 +50,15 @@ String parameterToString(dynamic value) {
     return value.toString();
   }
 }
+
+/// Returns the decoded body by utf-8 if application/json with the given headers.
+/// Else, returns the decoded body by default algorithm of dart:http.
+/// Because avoid to text garbling when header only contains "application/json" without "; charset=utf-8".
+String _decodeBodyBytes(Response response) {
+  var contentType = response.headers['content-type'];
+  if (contentType != null && contentType.contains("application/json")) {
+    return utf8.decode(response.bodyBytes);
+  } else {
+    return response.body;
+  }
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
  - dart is not exists.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
  - @ircecho, @swipesight, @jaumard

### Description of the PR

The original processing is using `response.body` to deserialize as json in `api.mustache`.
However, this is decoded by latin1 if the header contains only `application/json` instead of `application/json; charset=utf-8`.

Because of this behavior, if the response body is encoded UTF-8 but the headers doesn't contain charset, the body will garbling.

cf: https://github.com/dart-lang/http/issues/175

Since playframework 2.6 returns `Content-Type: application/json` without `charset=utf-8`, I changed this parsing algolithm.


