### PR TITLE
[core] support for 'x-enum-varnames' for enums in arrays

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4049,7 +4049,8 @@ public class DefaultCodegen implements CodegenConfig {
             enumVars.add(enumVar);
         }
         // if "x-enum-varnames" defined, update varnames
-        updateEnumVarsWithExtensions(enumVars, var.getVendorExtensions());
+        Map<String, Object> extensions = var.mostInnerItems != null ? var.mostInnerItems.getVendorExtensions() : var.getVendorExtensions();
+        updateEnumVarsWithExtensions(enumVars, extensions);
         allowableValues.put("enumVars", enumVars);
 
         // handle default value for enum, e.g. available => StatusEnum.AVAILABLE

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -233,6 +233,22 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void updateCodegenPropertyEnumWithCustomNames() {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        CodegenProperty array = codegenPropertyWithArrayOfIntegerValues();
+        array.getItems().setVendorExtensions(Collections.singletonMap("x-enum-varnames", Collections.singletonList("ONE")));
+
+        codegen.updateCodegenPropertyEnum(array);
+
+        List<Map<String, String>> enumVars = (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
+        Assert.assertNotNull(enumVars);
+        Map<String, String> testedEnumVar = enumVars.get(0);
+        Assert.assertNotNull(testedEnumVar);
+        Assert.assertEquals(testedEnumVar.getOrDefault("name", ""),"ONE");
+        Assert.assertEquals(testedEnumVar.getOrDefault("value", ""), "1");
+    }
+
+    @Test
     public void testGeneratePing() throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put(JavaClientCodegen.JAVA8_MODE, true);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @OpenAPITools/generator-core-team 

### Description of the PR

Fix for #1701

