### PR TITLE
Support custom headers in elm client

### DIFF
--- a/docs/generators/elm.md
+++ b/docs/generators/elm.md
@@ -12,6 +12,9 @@ CONFIG OPTIONS for elm
 	elmEnableCustomBasePaths
 	    Enable setting the base path for each request (Default: false)
 
+	elmEnableCustomHeaders
+	    Enable setting custom headers for each request (Default: false)
+
 	elmEnableHttpRequestTrackers
 	    Enable adding a tracker to each http request (Default: false)
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -65,6 +65,7 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
     private static final String ELM_VERSION = "elmVersion";
     private static final String ELM_PREFIX_CUSTOM_TYPE_VARIANTS = "elmPrefixCustomTypeVariants";
     private static final String ELM_ENABLE_CUSTOM_BASE_PATHS = "elmEnableCustomBasePaths";
+    private static final String ELM_ENABLE_CUSTOM_HEADERS = "elmEnableCustomHeaders";
     private static final String ELM_ENABLE_HTTP_REQUEST_TRACKERS = "elmEnableHttpRequestTrackers";
     private static final String ENCODER = "elmEncoder";
     private static final String DECODER = "elmDecoder";
@@ -173,6 +174,8 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(elmPrefixCustomTypeVariants);
         final CliOption elmEnableCustomBasePaths = CliOption.newBoolean(ELM_ENABLE_CUSTOM_BASE_PATHS, "Enable setting the base path for each request");
         cliOptions.add(elmEnableCustomBasePaths);
+        final CliOption elmEnableCustomHeaders = CliOption.newBoolean(ELM_ENABLE_CUSTOM_HEADERS, "Enable setting custom headers for each request");
+        cliOptions.add(elmEnableCustomHeaders);
         final CliOption elmEnableHttpRequestTrackers = CliOption.newBoolean(ELM_ENABLE_HTTP_REQUEST_TRACKERS, "Enable adding a tracker to each http request");
         cliOptions.add(elmEnableHttpRequestTrackers);
     }
@@ -197,6 +200,11 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(ELM_ENABLE_CUSTOM_BASE_PATHS)) {
             final boolean enable = Boolean.TRUE.equals(Boolean.valueOf(additionalProperties.get(ELM_ENABLE_CUSTOM_BASE_PATHS).toString()));
             additionalProperties.put("enableCustomBasePaths", enable);
+        }
+
+        if (additionalProperties.containsKey(ELM_ENABLE_CUSTOM_HEADERS)) {
+            final boolean enable = Boolean.TRUE.equals(Boolean.valueOf(additionalProperties.get(ELM_ENABLE_CUSTOM_HEADERS).toString()));
+            additionalProperties.put("enableCustomHeaders", enable);
         }
 
         if (additionalProperties.containsKey(ELM_ENABLE_HTTP_REQUEST_TRACKERS)) {

--- a/modules/openapi-generator/src/main/resources/elm/api.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/api.mustache
@@ -23,6 +23,7 @@ basePath =
 {{operationId}} :
     { onSend : Result Http.Error {{^responses}}(){{/responses}}{{#responses}}{{#-first}}{{^dataType}}(){{/dataType}}{{#isMapContainer}}(Dict.Dict String {{/isMapContainer}}{{#isListContainer}}(List {{/isListContainer}}{{dataType}}{{#isListContainer}}){{/isListContainer}}{{#isMapContainer}}){{/isMapContainer}}{{/-first}}{{/responses}} -> msg
 {{#enableCustomBasePaths}}    , basePath : String{{/enableCustomBasePaths}}
+{{#enableCustomHeaders}}    , headers : List Http.Header{{/enableCustomHeaders}}
 {{#enableHttpRequestTrackers}}    , tracker : Maybe String{{/enableHttpRequestTrackers}}
 {{#bodyParam}}    , body : {{^required}}Maybe {{/required}}{{dataType}}{{/bodyParam}}
 {{#pathParams}}    , {{paramName}} : {{#isListContainer}}List {{/isListContainer}}{{dataType}}{{/pathParams}}
@@ -32,7 +33,7 @@ basePath =
 {{operationId}} params =
     Http.request
         { method = "{{httpMethod}}"
-        , headers = []
+        , headers = {{#enableCustomHeaders}}params.headers{{/enableCustomHeaders}}{{^enableCustomHeaders}}[]{{/enableCustomHeaders}}
         , url = Url.crossOrigin {{#enableCustomBasePaths}}params.{{/enableCustomBasePaths}}basePath
             [{{{path}}}]
             (List.filterMap identity [{{{vendorExtensions.query}}}])


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This change adds a new option to the Elm generator: `enableCustomHeaders`. When enabled, the generated request functions will allow you to set your own headers (e.g. for authorisation). It's very similar to the `basePath` option. I would really like to make this change without introducing another option or breaking existing code, but Elm's records don't support optional fields or default values, so this is the best I could do.

Very interested to hear feedback if there's a better approach here!

cc @trenneman