### PR TITLE
[kotlin-spring] Allow DateTime to be remapped to others (LocalDateTIme)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -101,6 +101,14 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         typeMapping.put("object", "Any");
         typeMapping.put("binary", "Array<kotlin.Byte>");
 
+        typeMapping.put("date", "java.time.LocalDate");
+        typeMapping.put("date-time", "java.time.OffsetDateTime");
+        typeMapping.put("Date", "java.time.LocalDate");
+        typeMapping.put("DateTime", "java.time.OffsetDateTime");
+
+        importMapping.put("Date", "java.time.LocalDate");
+        importMapping.put("DateTime", "java.time.OffsetDateTime");
+
         languageSpecificPrimitives.addAll(Arrays.asList(
                 "Any",
                 "Byte",
@@ -242,14 +250,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
     @Override
     public void processOpts() {
         super.processOpts();
-
-        typeMapping.put("date", "java.time.LocalDate");
-        typeMapping.put("date-time", "java.time.OffsetDateTime");
-        typeMapping.put("Date", "java.time.LocalDate");
-        typeMapping.put("DateTime", "java.time.OffsetDateTime");
-
-        importMapping.put("Date", "java.time.LocalDate");
-        importMapping.put("DateTime", "java.time.OffsetDateTime");
 
         // optional jackson mappings for BigDecimal support
         importMapping.put("ToStringSerializer", "com.fasterxml.jackson.databind.ser.std.ToStringSerializer");


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Allows kotlin-spring to override the DateTime mappings in order to use LocalDateTime (#1731)

Examples:
#### kotlin-spring

```bash
openapi-generator generate \
    -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml \
    -t modules/openapi-generator/src/main/resources/kotlin-spring \
    -g kotlin-spring \
    -o samples/server/petstore/kotlin-springboot \
    --additional-properties=library=spring-boot,beanValidations=true,swaggerAnnotations=true,serviceImplementation=true \
    --import-mappings=DateTime=java.time.LocalDateTime \
    --type-mappings=DateTime=java.time.LocalDateTime
```

This regenerates the kotlin-spring example with LocalDateTime:

```diff
diff --git a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
index e1065f56bd..ad989c3b46 100644
--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -18,22 +18,22 @@ import io.swagger.annotations.ApiModelProperty
  */
 data class Order (

-        @ApiModelProperty(value = "")
+        @ApiModelProperty(example = "null", value = "")
         @JsonProperty("id") val id: Long? = null,

-        @ApiModelProperty(value = "")
+        @ApiModelProperty(example = "null", value = "")
         @JsonProperty("petId") val petId: Long? = null,

-        @ApiModelProperty(value = "")
+        @ApiModelProperty(example = "null", value = "")
         @JsonProperty("quantity") val quantity: Int? = null,

-        @ApiModelProperty(value = "")
-        @JsonProperty("shipDate") val shipDate: java.time.OffsetDateTime? = null,
+        @ApiModelProperty(example = "null", value = "")
+        @JsonProperty("shipDate") val shipDate: java.time.LocalDateTime? = null,

-        @ApiModelProperty(value = "Order Status")
+        @ApiModelProperty(example = "null", value = "Order Status")
         @JsonProperty("status") val status: Order.Status? = null,

-        @ApiModelProperty(value = "")
+        @ApiModelProperty(example = "null", value = "")
         @JsonProperty("complete") val complete: Boolean? = null
 ) {
```

#### kotlin (client)

The client itself defaults to LocalDateTime, so here's how to change it to OffsetDateTime:

```bash
openapi-generator generate \
    -t modules/openapi-generator/src/main/resources/kotlin-client \
    -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml \
    -g kotlin --artifact-id kotlin-petstore-client \
    -D dateLibrary=java8 -o samples/client/petstore/kotlin \
    --import-mappings=DateTime=java.time.OffsetDateTime \
    --type-mappings=DateTime=java.time.OffsetDateTime
```

outputs:

```diff
diff --git a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
index 44a8b1f896..0a163169be 100644
--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -26,7 +26,7 @@ data class Order (
     val id: kotlin.Long? = null,
     val petId: kotlin.Long? = null,
     val quantity: kotlin.Int? = null,
-    val shipDate: java.time.LocalDateTime? = null,
+    val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
     val status: Order.Status? = null,
     val complete: kotlin.Boolean? = null
```

/cc @ackintosh 