### PR TITLE
Fix discriminator name not following variable naming convention

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -235,6 +235,7 @@ public class DefaultCodegen implements CodegenConfig {
                 allModels.put(modelName, cm);
             }
         }
+
         // Fix up all parent and interface CodegenModel references.
         for (CodegenModel cm : allModels.values()) {
             if (cm.getParent() != null) {
@@ -250,6 +251,7 @@ public class DefaultCodegen implements CodegenConfig {
                 }
             }
         }
+
         // Let parent know about all its children
         for (String name : allModels.keySet()) {
             CodegenModel cm = allModels.get(name);
@@ -1820,7 +1822,7 @@ public class DefaultCodegen implements CodegenConfig {
             return null;
         }
         CodegenDiscriminator discriminator = new CodegenDiscriminator();
-        discriminator.setPropertyName(schema.getDiscriminator().getPropertyName());
+        discriminator.setPropertyName(toVarName(schema.getDiscriminator().getPropertyName()));
         discriminator.setMapping(schema.getDiscriminator().getMapping());
         if (schema.getDiscriminator().getMapping() != null && !schema.getDiscriminator().getMapping().isEmpty()) {
             for (Entry<String, String> e : schema.getDiscriminator().getMapping().entrySet()) {

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -166,7 +166,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{#discriminator}}
 
         // Initialize discriminator property with the model name.
-        $this->container[{{discriminatorName}}] = static::$openAPIModelName;
+        $this->container['{{discriminatorName}}'] = static::$openAPIModelName;
         {{/discriminator}}
     }
 

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -166,8 +166,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{#discriminator}}
 
         // Initialize discriminator property with the model name.
-        $discriminator = array_search('{{discriminatorName}}', self::$attributeMap, true);
-        $this->container[$discriminator] = static::$openAPIModelName;
+        $this->container[{{discriminatorName}}] = static::$openAPIModelName;
         {{/discriminator}}
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -534,7 +534,7 @@ public class DefaultCodegenTest {
 
     private void verifyPersonDiscriminator(CodegenDiscriminator discriminator) {
         CodegenDiscriminator test = new CodegenDiscriminator();
-        test.setPropertyName("$_type");
+        test.setPropertyName("DollarUnderscoretype");
         test.setMapping(new HashMap<>());
         test.getMapping().put("a", "#/components/schemas/Adult");
         test.getMapping().put("c", "#/components/schemas/Child");

--- a/modules/openapi-generator/src/test/resources/3_0/allOfMultiParent.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOfMultiParent.yaml
@@ -44,9 +44,9 @@ components:
         firstName:
           type: string
         duplicated_optional:
-           type: string
+           type: integer
         duplicated_required:
-           type: string
+           type: integer
         person_required:
            type: string
            format: date-time

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Animal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// Animal
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(JsonSubtypes), "className")]
+    [JsonConverter(typeof(JsonSubtypes), "ClassName")]
     [JsonSubtypes.KnownSubType(typeof(Dog), "Dog")]
     [JsonSubtypes.KnownSubType(typeof(Cat), "Cat")]
     public partial class Animal :  IEquatable<Animal>, IValidatableObject

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -186,8 +186,7 @@ class Animal implements ModelInterface, ArrayAccess
         $this->container['color'] = isset($data['color']) ? $data['color'] : 'red';
 
         // Initialize discriminator property with the model name.
-        $discriminator = array_search('class_name', self::$attributeMap, true);
-        $this->container[$discriminator] = static::$openAPIModelName;
+        $this->container[class_name] = static::$openAPIModelName;
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -42,7 +42,7 @@ use \OpenAPI\Client\ObjectSerializer;
  */
 class Animal implements ModelInterface, ArrayAccess
 {
-    const DISCRIMINATOR = 'className';
+    const DISCRIMINATOR = 'class_name';
 
     /**
       * The original name of the model.
@@ -186,7 +186,7 @@ class Animal implements ModelInterface, ArrayAccess
         $this->container['color'] = isset($data['color']) ? $data['color'] : 'red';
 
         // Initialize discriminator property with the model name.
-        $discriminator = array_search('className', self::$attributeMap, true);
+        $discriminator = array_search('class_name', self::$attributeMap, true);
         $this->container[$discriminator] = static::$openAPIModelName;
     }
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -186,7 +186,7 @@ class Animal implements ModelInterface, ArrayAccess
         $this->container['color'] = isset($data['color']) ? $data['color'] : 'red';
 
         // Initialize discriminator property with the model name.
-        $this->container[class_name] = static::$openAPIModelName;
+        $this->container['class_name'] = static::$openAPIModelName;
     }
 
     /**

--- a/samples/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -36,7 +36,7 @@ module Petstore
 
     # discriminator's property name in OpenAPI v3
     def self.openapi_discriminator_name
-      :'className'
+      :'class_name'
     end
 
     # Initializes the object

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -186,8 +186,7 @@ class Animal implements ModelInterface, ArrayAccess
         $this->container['color'] = isset($data['color']) ? $data['color'] : 'red';
 
         // Initialize discriminator property with the model name.
-        $discriminator = array_search('class_name', self::$attributeMap, true);
-        $this->container[$discriminator] = static::$openAPIModelName;
+        $this->container[class_name] = static::$openAPIModelName;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -42,7 +42,7 @@ use \OpenAPI\Client\ObjectSerializer;
  */
 class Animal implements ModelInterface, ArrayAccess
 {
-    const DISCRIMINATOR = 'className';
+    const DISCRIMINATOR = 'class_name';
 
     /**
       * The original name of the model.
@@ -186,7 +186,7 @@ class Animal implements ModelInterface, ArrayAccess
         $this->container['color'] = isset($data['color']) ? $data['color'] : 'red';
 
         // Initialize discriminator property with the model name.
-        $discriminator = array_search('className', self::$attributeMap, true);
+        $discriminator = array_search('class_name', self::$attributeMap, true);
         $this->container[$discriminator] = static::$openAPIModelName;
     }
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -186,7 +186,7 @@ class Animal implements ModelInterface, ArrayAccess
         $this->container['color'] = isset($data['color']) ? $data['color'] : 'red';
 
         // Initialize discriminator property with the model name.
-        $this->container[class_name] = static::$openAPIModelName;
+        $this->container['class_name'] = static::$openAPIModelName;
     }
 
     /**

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -36,7 +36,7 @@ module Petstore
 
     # discriminator's property name in OpenAPI v3
     def self.openapi_discriminator_name
-      :'className'
+      :'class_name'
     end
 
     # Initializes the object


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix discriminator name not following variable naming convention by using `toVarName`

cc @OpenAPITools/generator-core-team 
