### PR TITLE
Fix UUID support

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -1,7 +1,11 @@
 package {{packageName}}.infrastructure
 
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
 import okhttp3.*
 import java.io.File
+import java.util.*
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -51,7 +55,12 @@ open class ApiClient(val baseUrl: String) {
     protected inline fun <reified T: Any?> responseBody(body: ResponseBody?, mediaType: String = JsonMediaType): T? {
         if(body == null) return null
         return when(mediaType) {
-            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(body.source())
+            JsonMediaType -> Moshi.Builder().add(object {
+                    @ToJson
+                    fun toJson(uuid: UUID) = uuid.toString()
+                    @FromJson
+                    fun fromJson(s: String) = UUID.fromString(s)
+                }).build().adapter(T::class.java).fromJson(body.source())
             else -> TODO()
         }
     }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,7 +1,11 @@
 package org.openapitools.client.infrastructure
 
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
 import okhttp3.*
 import java.io.File
+import java.util.*
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -51,7 +55,12 @@ open class ApiClient(val baseUrl: String) {
     protected inline fun <reified T: Any?> responseBody(body: ResponseBody?, mediaType: String = JsonMediaType): T? {
         if(body == null) return null
         return when(mediaType) {
-            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(body.source())
+            JsonMediaType -> Moshi.Builder().add(object {
+                    @ToJson
+                    fun toJson(uuid: UUID) = uuid.toString()
+                    @FromJson
+                    fun fromJson(s: String) = UUID.fromString(s)
+                }).build().adapter(T::class.java).fromJson(body.source())
             else -> TODO()
         }
     }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,7 +1,11 @@
 package org.openapitools.client.infrastructure
 
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
 import okhttp3.*
 import java.io.File
+import java.util.*
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -51,7 +55,12 @@ open class ApiClient(val baseUrl: String) {
     protected inline fun <reified T: Any?> responseBody(body: ResponseBody?, mediaType: String = JsonMediaType): T? {
         if(body == null) return null
         return when(mediaType) {
-            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(body.source())
+            JsonMediaType -> Moshi.Builder().add(object {
+                    @ToJson
+                    fun toJson(uuid: UUID) = uuid.toString()
+                    @FromJson
+                    fun fromJson(s: String) = UUID.fromString(s)
+                }).build().adapter(T::class.java).fromJson(body.source())
             else -> TODO()
         }
     }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,7 +1,11 @@
 package org.openapitools.client.infrastructure
 
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.ToJson
 import okhttp3.*
 import java.io.File
+import java.util.*
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -51,7 +55,12 @@ open class ApiClient(val baseUrl: String) {
     protected inline fun <reified T: Any?> responseBody(body: ResponseBody?, mediaType: String = JsonMediaType): T? {
         if(body == null) return null
         return when(mediaType) {
-            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(body.source())
+            JsonMediaType -> Moshi.Builder().add(object {
+                    @ToJson
+                    fun toJson(uuid: UUID) = uuid.toString()
+                    @FromJson
+                    fun fromJson(s: String) = UUID.fromString(s)
+                }).build().adapter(T::class.java).fromJson(body.source())
             else -> TODO()
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR fixes #1733 

---

#### Sample spec

<details>
<summary>Sample spec</summary>

```yaml
openapi: 3.0.0
info:
  description: >-
    This spec is mainly for testing Petstore server and contains fake endpoints,
    models. Please do not use this for any other purpose. Special characters: "
    \
  version: 1.0.0
  title: OpenAPI Petstore
  license:
    name: Apache-2.0
    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
paths:
  /foo:
    get:
      parameters:
        - $ref: '#/components/parameters/TestQuery'
      responses:
        default:
          description: response
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Foo'
servers:
  - url: http://localhost:8080/
    description: The local server
components:
  parameters:
    TestQuery:
        name: testQuery
        description: test query
        in: query
        schema:
          $ref: '#/components/schemas/Bar'
  schemas:
    Foo:
      type: object
      properties:
        bar:
          $ref: '#/components/schemas/Bar'
    Bar:
      type: string
      format: uuid
```
</details>

#### Sample code using a generated codes from the spec

```kotlin
fun main(args: Array<String>) {
    val api = DefaultApi()
    println(api.fooGet(UUID.randomUUID()))
}
```

#### Before

```
Exception in thread "main" java.lang.IllegalArgumentException: Platform class java.util.UUID annotated [] requires explicit JsonAdapter to be registered
	at com.squareup.moshi.ClassJsonAdapter$1.create(ClassJsonAdapter.java:51)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:100)
	at com.squareup.moshi.KotlinJsonAdapterFactory.create(KotlinJsonAdapter.kt:184)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:100)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:62)
	at org.openapitools.client.apis.DefaultApi.fooGet(DefaultApi.kt:173)
	at org.openapitools.client.MainKt.main(Main.kt:8)
```

#### After

```
Foo(bar=ce5b8513-fd5b-4b25-98e2-c40dc1b3c7c4)
```


