### PR TITLE
Restore Ruby tests after parser update

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -326,7 +326,7 @@ public class RubyClientCodegenTest {
         Assert.assertFalse(name.isNullable);
         CodegenParameter status = op.formParams.get(1);
         // TODO comment out the following until https://github.com/swagger-api/swagger-parser/issues/820 is solved
-        //Assert.assertTrue(status.isNullable);
+        Assert.assertTrue(status.isNullable);
     }
 
     @Test(description = "test anyOf (OAS3)")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -325,7 +325,6 @@ public class RubyClientCodegenTest {
         CodegenParameter name = op.formParams.get(0);
         Assert.assertFalse(name.isNullable);
         CodegenParameter status = op.formParams.get(1);
-        // TODO comment out the following until https://github.com/swagger-api/swagger-parser/issues/820 is solved
         Assert.assertTrue(status.isNullable);
     }
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Restore Ruby tests after parser update
