### PR TITLE
[Swift 4] Use Info.version for podspec version

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift4/Podspec.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/Podspec.mustache
@@ -4,8 +4,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '{{#podVersion}}{{podVersion}}{{/podVersion}}{{^podVersion}}0.0.1{{/podVersion}}'
-  s.source = {{#podSource}}{{& podSource}}{{/podSource}}{{^podSource}}{ :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }{{/podSource}}
+  s.version = '{{#podVersion}}{{podVersion}}{{/podVersion}}{{^podVersion}}{{#apiInfo}}{{version}}{{/apiInfo}}{{^apiInfo}}}0.0.1{{/apiInfo}}{{/podVersion}}'
+  s.source = {{#podSource}}{{& podSource}}{{/podSource}}{{^podSource}}{ :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v{{#apiInfo}}{{version}}{{/apiInfo}}{{^apiInfo}}}0.0.1{{/apiInfo}}' }{{/podSource}}
   {{#podAuthors}}
   s.authors = '{{podAuthors}}'
   {{/podAuthors}}

--- a/samples/client/petstore/swift4/default/PetstoreClient.podspec
+++ b/samples/client/petstore/swift4/default/PetstoreClient.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '0.0.1'
+  s.version = '1.0.0'
   s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }
   s.authors = ''
   s.license = 'Proprietary'

--- a/samples/client/petstore/swift4/objcCompatible/PetstoreClient.podspec
+++ b/samples/client/petstore/swift4/objcCompatible/PetstoreClient.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '0.0.1'
+  s.version = '1.0.0'
   s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }
   s.authors = ''
   s.license = 'Proprietary'

--- a/samples/client/petstore/swift4/promisekit/PetstoreClient.podspec
+++ b/samples/client/petstore/swift4/promisekit/PetstoreClient.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '0.0.1'
+  s.version = '1.0.0'
   s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }
   s.authors = ''
   s.license = 'Proprietary'

--- a/samples/client/petstore/swift4/rxswift/PetstoreClient.podspec
+++ b/samples/client/petstore/swift4/rxswift/PetstoreClient.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '0.0.1'
+  s.version = '1.0.0'
   s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }
   s.authors = ''
   s.license = 'Proprietary'

--- a/samples/client/petstore/swift4/unwrapRequired/PetstoreClient.podspec
+++ b/samples/client/petstore/swift4/unwrapRequired/PetstoreClient.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '0.0.1'
+  s.version = '1.0.0'
   s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }
   s.authors = ''
   s.license = 'Proprietary'

--- a/samples/client/test/swift4/default/TestClient.podspec
+++ b/samples/client/test/swift4/default/TestClient.podspec
@@ -3,8 +3,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
-  s.version = '0.0.1'
-  s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0.0' }
+  s.version = '1.0'
+  s.source = { :git => 'git@github.com:OpenAPITools/openapi-generator.git', :tag => 'v1.0' }
   s.authors = ''
   s.license = 'Proprietary'
   s.homepage = 'https://github.com/openapitools/openapi-generator'


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

When `podVersion` doesn't specified, use `Info.version` instead.

