### PR TITLE
Use JsonNullable wrapper on nullable/x-nullable fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/openapi2SpringBoot.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/openapi2SpringBoot.mustache
@@ -1,5 +1,7 @@
 package {{basePackage}};
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -67,6 +69,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
             }
 {{/useSpringfox}}
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -137,6 +137,11 @@
             <version>2.8.4</version>
         </dependency>
         {{/threetenbp}}
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
 {{#useBeanValidation}}
     <!-- Bean Validation API support -->
         <dependency>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -82,6 +82,11 @@
         </dependency>
         {{/threetenbp}}
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/openapiUiConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/openapiUiConfiguration.mustache
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 {{#threetenbp}}
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 {{/threetenbp}}
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -94,9 +95,7 @@ public class OpenAPIUiConfiguration extends WebMvcConfigurerAdapter {
     return new Jackson2ObjectMapperBuilder()
         .indentOutput(true)
         .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        {{#threetenbp}}
-        .modulesToInstall(module)
-        {{/threetenbp}}
+        .modulesToInstall({{#threetenbp}}module, {{/threetenbp}}new JsonNullableModule())
         .dateFormat(new RFC3339DateFormat());
   }
 

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -203,6 +203,11 @@
         </dependency>
         {{/threetenbp}}
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
@@ -3,6 +3,7 @@ package {{package}};
 import java.util.Objects;
 {{#imports}}import {{import}};
 {{/imports}}
+import org.openapitools.jackson.nullable.JsonNullable;
 {{#serializableModel}}
 import java.io.Serializable;
 {{/serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/nullableDataType.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/nullableDataType.mustache
@@ -1,0 +1,1 @@
+{{#isNullable}}JsonNullable<{{{datatypeWithEnum}}}>{{/isNullable}}{{^isNullable}}{{{datatypeWithEnum}}}{{/isNullable}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -28,16 +28,16 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
   {{/gson}}
   {{#isContainer}}
   {{#useBeanValidation}}@Valid{{/useBeanValidation}}
-  private {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};
+  private {{>nullableDataType}} {{name}} = {{#isNullable}}JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#required}}{{{defaultValue}}}{{/required}}{{^required}}null{{/required}}{{/isNullable}};
   {{/isContainer}}
   {{^isContainer}}
-  private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
   {{/isContainer}}
 
   {{/vars}}
   {{#vars}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
-    this.{{name}} = {{name}};
+    this.{{name}} = {{#isNullable}}JsonNullable.of({{name}}){{/isNullable}}{{^isNullable}}{{name}}{{/isNullable}};
     return this;
   }
   {{#isListContainer}}
@@ -84,11 +84,11 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
   {{{vendorExtensions.extraAnnotation}}}
   {{/vendorExtensions.extraAnnotation}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}{{#isReadOnly}}readOnly = {{{isReadOnly}}}, {{/isReadOnly}}value = "{{{description}}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{>nullableDataType}} {{getter}}() {
     return {{name}};
   }
 
-  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+  public void {{setter}}({{>nullableDataType}} {{name}}) {
     this.{{name}} = {{name}};
   }
 

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-stubs/pom.xml
+++ b/samples/client/petstore/spring-stubs/pom.xml
@@ -39,6 +39,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Category.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/User.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-async/pom.xml
@@ -118,6 +118,11 @@
             <version>${jackson-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/configuration/OpenAPIUiConfiguration.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/configuration/OpenAPIUiConfiguration.java
@@ -2,6 +2,7 @@ package org.openapitools.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -71,6 +72,7 @@ public class OpenAPIUiConfiguration extends WebMvcConfigurerAdapter {
     return new Jackson2ObjectMapperBuilder()
         .indentOutput(true)
         .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .modulesToInstall(new JsonNullableModule())
         .dateFormat(new RFC3339DateFormat());
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/pom.xml
@@ -118,6 +118,11 @@
             <version>${jackson-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/configuration/OpenAPIUiConfiguration.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/configuration/OpenAPIUiConfiguration.java
@@ -2,6 +2,7 @@ package org.openapitools.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -71,6 +72,7 @@ public class OpenAPIUiConfiguration extends WebMvcConfigurerAdapter {
     return new Jackson2ObjectMapperBuilder()
         .indentOutput(true)
         .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .modulesToInstall(new JsonNullableModule())
         .dateFormat(new RFC3339DateFormat());
   }
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/pom.xml
+++ b/samples/server/petstore/spring-mvc/pom.xml
@@ -118,6 +118,11 @@
             <version>${jackson-threetenbp-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit-version}</version>

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/configuration/OpenAPIUiConfiguration.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/configuration/OpenAPIUiConfiguration.java
@@ -3,6 +3,7 @@ package org.openapitools.configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -79,7 +80,7 @@ public class OpenAPIUiConfiguration extends WebMvcConfigurerAdapter {
     return new Jackson2ObjectMapperBuilder()
         .indentOutput(true)
         .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        .modulesToInstall(module)
+        .modulesToInstall(module, new JsonNullableModule())
         .dateFormat(new RFC3339DateFormat());
   }
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.springframework.core.io.Resource;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>jackson-datatype-threetenbp</artifactId>
             <version>2.8.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -46,6 +48,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.springframework.core.io.Resource;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -52,6 +52,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -45,6 +47,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>jackson-datatype-threetenbp</artifactId>
             <version>2.8.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -46,6 +48,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.springframework.core.io.Resource;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.threeten.bp.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders/pom.xml
@@ -52,6 +52,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -45,6 +47,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -54,6 +54,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -51,6 +53,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                 registry.addResourceHandler("/swagger-ui/**").addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/3.14.2/");
             }
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -52,6 +52,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -45,6 +47,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -52,6 +52,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -45,6 +47,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.virtualan.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Capitalization.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Cat.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.virtualan.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Category.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ClassModel.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Client.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Dog.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.virtualan.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.virtualan.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.virtualan.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.virtualan.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Model200Response.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelReturn.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Name.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NumberOnly.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterComposite.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterEnum.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.virtualan.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.virtualan.model.Category;
 import org.openapitools.virtualan.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Tag.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/User.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/pom.xml
+++ b/samples/server/petstore/springboot/pom.xml
@@ -52,6 +52,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
     <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/OpenAPI2SpringBoot.java
@@ -1,5 +1,7 @@
 package org.openapitools;
 
+import com.fasterxml.jackson.databind.Module;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.boot.SpringApplication;
@@ -45,6 +47,11 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                         .allowedHeaders("Content-Type");
             }*/
         };
+    }
+
+    @Bean
+    public Module jsonNullableModule() {
+        return new JsonNullableModule();
     }
 
 }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Animal.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ArrayTest.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.ReadOnlyFirst;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Capitalization.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Cat.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Category.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ClassModel.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Client.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Dog.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumArrays.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumClass.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/EnumTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.openapitools.model.OuterEnum;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.springframework.core.io.Resource;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MapTest.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.openapitools.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Model200Response.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ModelApiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ModelReturn.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Name.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/NumberOnly.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Order.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.OffsetDateTime;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterComposite.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/OuterEnum.java
@@ -2,6 +2,7 @@ package org.openapitools.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openapitools.model.Category;
 import org.openapitools.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ReadOnlyFirst.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/SpecialModelName.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Tag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/User.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.openapitools.jackson.nullable.JsonNullable;
 import javax.validation.Valid;
 import javax.validation.constraints.*;
 


### PR DESCRIPTION
Fix #1250

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

cc @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

