### PR TITLE
[Slim] Add PHP CodeSniffer config template

### DIFF
--- a/docs/generators/php-slim.md
+++ b/docs/generators/php-slim.md
@@ -40,7 +40,4 @@ CONFIG OPTIONS for php-slim
 	artifactVersion
 	    The version to use in the composer package version field. e.g. 1.2.3
 
-	phpcsStandard
-	    PHP CodeSniffer <standard> option. Accepts name or path of the coding standard to use. (Default: PSR12)
-
 Back to the [generators list](README.md)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -35,12 +35,10 @@ import java.util.Map;
 public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(PhpSlimServerCodegen.class);
 
-    public static final String PHPCS_STANDARD = "phpcsStandard";
     public static final String USER_CLASSNAME_KEY = "userClassname";
 
     protected String groupId = "org.openapitools";
     protected String artifactId = "openapi-server";
-    protected String phpcsStandard = "PSR12";
 
     public PhpSlimServerCodegen() {
         super();
@@ -74,9 +72,6 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
                 break;
             }
         }
-
-        cliOptions.add(new CliOption(PHPCS_STANDARD, "PHP CodeSniffer <standard> option. Accepts name or path of the coding standard to use.")
-                .defaultValue("PSR12"));
     }
 
     @Override
@@ -116,12 +111,6 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey(PHPCS_STANDARD)) {
-            this.setPhpcsStandard((String) additionalProperties.get(PHPCS_STANDARD));
-        } else {
-            additionalProperties.put(PHPCS_STANDARD, phpcsStandard);
-        }
-
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("composer.mustache", "", "composer.json"));
         supportingFiles.add(new SupportingFile("index.mustache", "", "index.php"));
@@ -160,15 +149,6 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
             });
         }
         return objs;
-    }
-
-    /**
-     * Sets PHP CodeSniffer &lt;standard&gt; option. Accepts name or path of the coding standard to use.
-     *
-     * @param phpcsStandard standard option value
-     */
-    public void setPhpcsStandard(String phpcsStandard) {
-        this.phpcsStandard = phpcsStandard;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -128,6 +128,7 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
         supportingFiles.add(new SupportingFile(".htaccess", "", ".htaccess"));
         supportingFiles.add(new SupportingFile("SlimRouter.mustache", toSrcPath(invokerPackage, srcBasePath), "SlimRouter.php"));
         supportingFiles.add(new SupportingFile("phpunit.xml.mustache", "", "phpunit.xml.dist"));
+        supportingFiles.add(new SupportingFile("phpcs.xml.mustache", "", "phpcs.xml.dist"));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/php-slim-server/.gitignore
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/.gitignore
@@ -9,3 +9,9 @@ composer.phar
 
 # phplint tool creates cache file which is not necessary in a codebase
 /.phplint-cache
+
+# Do not commit local PHPUnit config
+/phpunit.xml
+
+# Do not commit local PHP_CodeSniffer config
+/phpcs.xml

--- a/modules/openapi-generator/src/main/resources/php-slim-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/README.mustache
@@ -28,21 +28,54 @@ $ php -S localhost:8888 -t php-slim-server
 > It may also be useful for testing purposes or for application demonstrations that are run in controlled environments.
 > It is not intended to be a full-featured web server. It should not be used on a public network.
 
-## Run tests
+## Tests
 
-This package uses PHPUnit 6 or 7(depends from your PHP version) for unit testing and PHP Codesniffer to check source code against user defined coding standard(`phpcsStandard` generator config option).
+### PHPUnit
+
+This package uses PHPUnit 6 or 7(depends from your PHP version) for unit testing.
 [Test folder]({{testBasePath}}) contains templates which you can fill with real test assertions.
 How to write tests read at [PHPUnit Manual - Chapter 2. Writing Tests for PHPUnit](https://phpunit.de/manual/6.5/en/writing-tests-for-phpunit.html).
-How to configure PHP CodeSniffer read at [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
-There is [phplint](https://github.com/overtrue/phplint) tool to check php syntax automatically.
 
-Command | Tool | Target
----- | ---- | ----
-`$ composer test` | PHPUnit | All tests
-`$ composer run test-apis` | PHPUnit | Apis tests
-`$ composer run test-models` | PHPUnit | Models tests
-`$ composer run phpcs` | PHP CodeSniffer | All files
-`$ composer run phplint` | phplint | All files
+#### Run
+
+Command | Target
+---- | ----
+`$ composer test` | All tests
+`$ composer test-apis` | Apis tests
+`$ composer test-models` | Models tests
+
+#### Config
+
+Package contains fully functional config `./phpunit.xml.dist` file. Create `./phpunit.xml` in root folder to override it.
+
+Quote from [3. The Command-Line Test Runner — PHPUnit 7.4 Manual](https://phpunit.readthedocs.io/en/7.4/textui.html#command-line-options):
+
+> If phpunit.xml or phpunit.xml.dist (in that order) exist in the current working directory and --configuration is not used, the configuration will be automatically read from that file.
+
+### PHP CodeSniffer
+
+[PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki). This tool helps to follow coding style and avoid common PHP coding mistakes.
+
+#### Run
+
+```bash
+$ composer phpcs
+```
+
+#### Config
+
+Package contains fully functional config `./phpcs.xml.dist` file. It checks source code against PSR-1 and PSR-2 coding standards.
+Create `./phpcs.xml` in root folder to override it. More info at [Using a Default Configuration File](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
+
+### PHPLint
+
+[PHPLint Documentation](https://github.com/overtrue/phplint). Checks PHP syntax only.
+
+#### Run
+
+```bash
+$ composer phplint
+```
 
 ## Show errors
 

--- a/modules/openapi-generator/src/main/resources/php-slim-server/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/composer.mustache
@@ -26,7 +26,7 @@
     ],
     "test-apis": "phpunit --testsuite Apis",
     "test-models": "phpunit --testsuite Models",
-    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0 --standard={{phpcsStandard}}",
+    "phpcs": "phpcs",
     "phplint": "phplint ./ --exclude=vendor"
   }
 }

--- a/modules/openapi-generator/src/main/resources/php-slim-server/phpcs.xml.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/phpcs.xml.mustache
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="{{appName}} Config" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>PHP_CodeSniffer config for {{appName}}</description>
+
+    <!-- Path to inspected files -->
+    <file>./</file>
+
+    <!-- Don't need to inspect installed packages -->
+    <exclude-pattern>./vendor</exclude-pattern>
+
+    <!-- <basepath>     A path to strip from the front of file paths inside reports -->
+    <arg name="basepath" value="."/>
+
+    <!-- colors              Use colors in output -->
+    <arg name="colors"/>
+
+    <!-- Do not print warnings -->
+    <!-- <arg name="warning-severity" value="0"/> -->
+
+    <!-- -p    Show progress of the run -->
+    <!-- -s    Show sniff codes in all reports -->
+    <arg value="ps"/>
+
+    <!-- Include the whole PSR12 standard -->
+    <rule ref="PSR12">
+        <!-- There is no way to wrap generated comments, just disable that rule for now -->
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <!-- Codegen generates variables with underscore on purpose -->
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
+    </rule>
+</ruleset>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
@@ -19,7 +19,6 @@ package org.openapitools.codegen.options;
 
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.AbstractPhpCodegen;
-import org.openapitools.codegen.languages.PhpSlimServerCodegen;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -39,7 +38,6 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
-    public static final String PHPCS_STANDARD_VALUE = "PSR12";
 
     @Override
     public String getLanguage() {
@@ -62,7 +60,6 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)
-                .put(PhpSlimServerCodegen.PHPCS_STANDARD, PHPCS_STANDARD_VALUE)
                 .build();
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
@@ -63,8 +63,6 @@ public class PhpSlimServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlimServerOptionsProvider.SORT_PARAMS_VALUE));
             times = 1;
-            clientCodegen.setPhpcsStandard(PhpSlimServerOptionsProvider.PHPCS_STANDARD_VALUE);
-            times = 1;
         }};
     }
 }

--- a/samples/server/petstore-security-test/php-slim/.gitignore
+++ b/samples/server/petstore-security-test/php-slim/.gitignore
@@ -9,3 +9,9 @@ composer.phar
 
 # phplint tool creates cache file which is not necessary in a codebase
 /.phplint-cache
+
+# Do not commit local PHPUnit config
+/phpunit.xml
+
+# Do not commit local PHP_CodeSniffer config
+/phpcs.xml

--- a/samples/server/petstore-security-test/php-slim/README.md
+++ b/samples/server/petstore-security-test/php-slim/README.md
@@ -28,21 +28,54 @@ $ php -S localhost:8888 -t php-slim-server
 > It may also be useful for testing purposes or for application demonstrations that are run in controlled environments.
 > It is not intended to be a full-featured web server. It should not be used on a public network.
 
-## Run tests
+## Tests
 
-This package uses PHPUnit 6 or 7(depends from your PHP version) for unit testing and PHP Codesniffer to check source code against user defined coding standard(`phpcsStandard` generator config option).
+### PHPUnit
+
+This package uses PHPUnit 6 or 7(depends from your PHP version) for unit testing.
 [Test folder](test) contains templates which you can fill with real test assertions.
 How to write tests read at [PHPUnit Manual - Chapter 2. Writing Tests for PHPUnit](https://phpunit.de/manual/6.5/en/writing-tests-for-phpunit.html).
-How to configure PHP CodeSniffer read at [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
-There is [phplint](https://github.com/overtrue/phplint) tool to check php syntax automatically.
 
-Command | Tool | Target
----- | ---- | ----
-`$ composer test` | PHPUnit | All tests
-`$ composer run test-apis` | PHPUnit | Apis tests
-`$ composer run test-models` | PHPUnit | Models tests
-`$ composer run phpcs` | PHP CodeSniffer | All files
-`$ composer run phplint` | phplint | All files
+#### Run
+
+Command | Target
+---- | ----
+`$ composer test` | All tests
+`$ composer test-apis` | Apis tests
+`$ composer test-models` | Models tests
+
+#### Config
+
+Package contains fully functional config `./phpunit.xml.dist` file. Create `./phpunit.xml` in root folder to override it.
+
+Quote from [3. The Command-Line Test Runner — PHPUnit 7.4 Manual](https://phpunit.readthedocs.io/en/7.4/textui.html#command-line-options):
+
+> If phpunit.xml or phpunit.xml.dist (in that order) exist in the current working directory and --configuration is not used, the configuration will be automatically read from that file.
+
+### PHP CodeSniffer
+
+[PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki). This tool helps to follow coding style and avoid common PHP coding mistakes.
+
+#### Run
+
+```bash
+$ composer phpcs
+```
+
+#### Config
+
+Package contains fully functional config `./phpcs.xml.dist` file. It checks source code against PSR-1 and PSR-2 coding standards.
+Create `./phpcs.xml` in root folder to override it. More info at [Using a Default Configuration File](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
+
+### PHPLint
+
+[PHPLint Documentation](https://github.com/overtrue/phplint). Checks PHP syntax only.
+
+#### Run
+
+```bash
+$ composer phplint
+```
 
 ## Show errors
 

--- a/samples/server/petstore-security-test/php-slim/composer.json
+++ b/samples/server/petstore-security-test/php-slim/composer.json
@@ -26,7 +26,7 @@
     ],
     "test-apis": "phpunit --testsuite Apis",
     "test-models": "phpunit --testsuite Models",
-    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0 --standard=PSR12",
+    "phpcs": "phpcs",
     "phplint": "phplint ./ --exclude=vendor"
   }
 }

--- a/samples/server/petstore-security-test/php-slim/phpcs.xml.dist
+++ b/samples/server/petstore-security-test/php-slim/phpcs.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="OpenAPI Petstore *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r Config" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>PHP_CodeSniffer config for OpenAPI Petstore *_/ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r</description>
+
+    <!-- Path to inspected files -->
+    <file>./</file>
+
+    <!-- Don't need to inspect installed packages -->
+    <exclude-pattern>./vendor</exclude-pattern>
+
+    <!-- <basepath>     A path to strip from the front of file paths inside reports -->
+    <arg name="basepath" value="."/>
+
+    <!-- colors              Use colors in output -->
+    <arg name="colors"/>
+
+    <!-- Do not print warnings -->
+    <!-- <arg name="warning-severity" value="0"/> -->
+
+    <!-- -p    Show progress of the run -->
+    <!-- -s    Show sniff codes in all reports -->
+    <arg value="ps"/>
+
+    <!-- Include the whole PSR12 standard -->
+    <rule ref="PSR12">
+        <!-- There is no way to wrap generated comments, just disable that rule for now -->
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <!-- Codegen generates variables with underscore on purpose -->
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
+    </rule>
+</ruleset>

--- a/samples/server/petstore/php-slim/.gitignore
+++ b/samples/server/petstore/php-slim/.gitignore
@@ -9,3 +9,9 @@ composer.phar
 
 # phplint tool creates cache file which is not necessary in a codebase
 /.phplint-cache
+
+# Do not commit local PHPUnit config
+/phpunit.xml
+
+# Do not commit local PHP_CodeSniffer config
+/phpcs.xml

--- a/samples/server/petstore/php-slim/README.md
+++ b/samples/server/petstore/php-slim/README.md
@@ -28,21 +28,54 @@ $ php -S localhost:8888 -t php-slim-server
 > It may also be useful for testing purposes or for application demonstrations that are run in controlled environments.
 > It is not intended to be a full-featured web server. It should not be used on a public network.
 
-## Run tests
+## Tests
 
-This package uses PHPUnit 6 or 7(depends from your PHP version) for unit testing and PHP Codesniffer to check source code against user defined coding standard(`phpcsStandard` generator config option).
+### PHPUnit
+
+This package uses PHPUnit 6 or 7(depends from your PHP version) for unit testing.
 [Test folder](test) contains templates which you can fill with real test assertions.
 How to write tests read at [PHPUnit Manual - Chapter 2. Writing Tests for PHPUnit](https://phpunit.de/manual/6.5/en/writing-tests-for-phpunit.html).
-How to configure PHP CodeSniffer read at [PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
-There is [phplint](https://github.com/overtrue/phplint) tool to check php syntax automatically.
 
-Command | Tool | Target
----- | ---- | ----
-`$ composer test` | PHPUnit | All tests
-`$ composer run test-apis` | PHPUnit | Apis tests
-`$ composer run test-models` | PHPUnit | Models tests
-`$ composer run phpcs` | PHP CodeSniffer | All files
-`$ composer run phplint` | phplint | All files
+#### Run
+
+Command | Target
+---- | ----
+`$ composer test` | All tests
+`$ composer test-apis` | Apis tests
+`$ composer test-models` | Models tests
+
+#### Config
+
+Package contains fully functional config `./phpunit.xml.dist` file. Create `./phpunit.xml` in root folder to override it.
+
+Quote from [3. The Command-Line Test Runner — PHPUnit 7.4 Manual](https://phpunit.readthedocs.io/en/7.4/textui.html#command-line-options):
+
+> If phpunit.xml or phpunit.xml.dist (in that order) exist in the current working directory and --configuration is not used, the configuration will be automatically read from that file.
+
+### PHP CodeSniffer
+
+[PHP CodeSniffer Documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki). This tool helps to follow coding style and avoid common PHP coding mistakes.
+
+#### Run
+
+```bash
+$ composer phpcs
+```
+
+#### Config
+
+Package contains fully functional config `./phpcs.xml.dist` file. It checks source code against PSR-1 and PSR-2 coding standards.
+Create `./phpcs.xml` in root folder to override it. More info at [Using a Default Configuration File](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
+
+### PHPLint
+
+[PHPLint Documentation](https://github.com/overtrue/phplint). Checks PHP syntax only.
+
+#### Run
+
+```bash
+$ composer phplint
+```
 
 ## Show errors
 

--- a/samples/server/petstore/php-slim/composer.json
+++ b/samples/server/petstore/php-slim/composer.json
@@ -26,7 +26,7 @@
     ],
     "test-apis": "phpunit --testsuite Apis",
     "test-models": "phpunit --testsuite Models",
-    "phpcs": "phpcs ./ --ignore=vendor --warning-severity=0 --standard=PSR12",
+    "phpcs": "phpcs",
     "phplint": "phplint ./ --exclude=vendor"
   }
 }

--- a/samples/server/petstore/php-slim/phpcs.xml.dist
+++ b/samples/server/petstore/php-slim/phpcs.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="OpenAPI Petstore Config" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>PHP_CodeSniffer config for OpenAPI Petstore</description>
+
+    <!-- Path to inspected files -->
+    <file>./</file>
+
+    <!-- Don't need to inspect installed packages -->
+    <exclude-pattern>./vendor</exclude-pattern>
+
+    <!-- <basepath>     A path to strip from the front of file paths inside reports -->
+    <arg name="basepath" value="."/>
+
+    <!-- colors              Use colors in output -->
+    <arg name="colors"/>
+
+    <!-- Do not print warnings -->
+    <!-- <arg name="warning-severity" value="0"/> -->
+
+    <!-- -p    Show progress of the run -->
+    <!-- -s    Show sniff codes in all reports -->
+    <arg value="ps"/>
+
+    <!-- Include the whole PSR12 standard -->
+    <rule ref="PSR12">
+        <!-- There is no way to wrap generated comments, just disable that rule for now -->
+        <exclude name="Generic.Files.LineLength.TooLong" />
+        <!-- Codegen generates variables with underscore on purpose -->
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
+    </rule>
+</ruleset>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Recommended way to configure PHP CodeSniffer:
> If you run PHP_CodeSniffer without specifying a coding standard, PHP_CodeSniffer will look in the current directory, and all parent directories, for a file called either `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, or `phpcs.xml.dist`. If found, configuration information will be read from this file, including the files to check, the coding standard to use, and any command line arguments to apply.

> Note: If multiple default configuration files are found, PHP_CodeSniffer will select one using the following order: `.phpcs.xml`, `phpcs.xml`, `.phpcs.xml.dist`, `phpcs.xml.dist`

Ref: [Using a Default Configuration File](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)

Generator cli option `phpcsStandard` is deprecated as not necessary anymore.

### Upgrade note

Do not use `phpcsStandard` cli option during server stubs generation.
Override `phpcs.xml.dist` in root folder with `phpcs.xml` to change config.

