### PR TITLE
Add nullable support to C# client (refactor)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -776,7 +776,6 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         }
     }
 
-
     public void setPackageName(String packageName) {
         this.packageName = packageName;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpRefactorClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpRefactorClientCodegen.java
@@ -890,45 +890,4 @@ public class CSharpRefactorClientCodegen extends AbstractCSharpCodegen {
             return null;
         }
     }
-
-    /**
-     * Provides C# strongly typed declaration for simple arrays of some type and arrays of arrays of some type.
-     *
-     * @param arr The input array property
-     * @return The type declaration when the type is an array of arrays.
-     */
-    private String getArrayTypeDeclaration(ArraySchema arr) {
-        // TODO: collection type here should be fully qualified namespace to avoid model conflicts
-        // This supports arrays of arrays.
-        String arrayType = typeMapping.get("array");
-        StringBuilder instantiationType = new StringBuilder(arrayType);
-        Schema items = arr.getItems();
-        String nestedType = getTypeDeclaration(items);
-        // TODO: We may want to differentiate here between generics and primitive arrays.
-        instantiationType.append("<").append(nestedType).append(">");
-        return instantiationType.toString();
-    }
-
-    @Override
-    public String toInstantiationType(Schema p) {
-        if (ModelUtils.isArraySchema(p)) {
-            return getArrayTypeDeclaration((ArraySchema) p);
-        }
-        return super.toInstantiationType(p);
-    }
-
-    @Override
-    public String getTypeDeclaration(Schema p) {
-        if (ModelUtils.isArraySchema(p)) {
-            return getArrayTypeDeclaration((ArraySchema) p);
-        } else if (ModelUtils.isMapSchema(p)) {
-            // Should we also support maps of maps?
-            Schema inner = ModelUtils.getAdditionalProperties(p);
-            return getSchemaType(p) + "<string, " + getTypeDeclaration(inner) + ">";
-        }
-
-        return getSchemaType(p);
-
-    }
-
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpRefactorClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpRefactorClientCodegen.java
@@ -90,6 +90,26 @@ public class CSharpRefactorClientCodegen extends AbstractCSharpCodegen {
     public CSharpRefactorClientCodegen() {
         super();
 
+        // mapped non-nullable type without ?
+        typeMapping = new HashMap<String, String>();
+        typeMapping.put("string", "string");
+        typeMapping.put("binary", "byte[]");
+        typeMapping.put("ByteArray", "byte[]");
+        typeMapping.put("boolean", "bool");
+        typeMapping.put("integer", "int");
+        typeMapping.put("float", "float");
+        typeMapping.put("long", "long");
+        typeMapping.put("double", "double");
+        typeMapping.put("number", "decimal");
+        typeMapping.put("DateTime", "DateTime");
+        typeMapping.put("date", "DateTime");
+        typeMapping.put("file", "System.IO.Stream");
+        typeMapping.put("array", "List");
+        typeMapping.put("list", "List");
+        typeMapping.put("map", "Dictionary");
+        typeMapping.put("object", "Object");
+        typeMapping.put("UUID", "Guid");
+
         setSupportNullable(Boolean.TRUE);
         hideGenerationTimestamp = Boolean.TRUE;
         supportsInheritance = true;
@@ -210,26 +230,6 @@ public class CSharpRefactorClientCodegen extends AbstractCSharpCodegen {
 
     @Override
     public void processOpts() {
-        // mapped non-nullable type without ?
-        typeMapping = new HashMap<String, String>();
-        typeMapping.put("string", "string");
-        typeMapping.put("binary", "byte[]");
-        typeMapping.put("ByteArray", "byte[]");
-        typeMapping.put("boolean", "bool");
-        typeMapping.put("integer", "int");
-        typeMapping.put("float", "float");
-        typeMapping.put("long", "long");
-        typeMapping.put("double", "double");
-        typeMapping.put("number", "decimal");
-        typeMapping.put("DateTime", "DateTime");
-        typeMapping.put("date", "DateTime");
-        typeMapping.put("file", "System.IO.Stream");
-        typeMapping.put("array", "List");
-        typeMapping.put("list", "List");
-        typeMapping.put("map", "Dictionary");
-        typeMapping.put("object", "Object");
-        typeMapping.put("UUID", "Guid");
-
         super.processOpts();
 
         /*

--- a/modules/openapi-generator/src/main/resources/csharp-refactor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-refactor/api.mustache
@@ -85,7 +85,7 @@ namespace {{packageName}}.{{apiPackage}}
     /// </summary>
     {{>visibility}} interface {{interfacePrefix}}{{classname}} : {{interfacePrefix}}{{classname}}Sync{{#supportsAsync}}, {{interfacePrefix}}{{classname}}Async{{/supportsAsync}}
     {
-        
+
     }
 
     /// <summary>
@@ -94,7 +94,7 @@ namespace {{packageName}}.{{apiPackage}}
     {{>visibility}} partial class {{classname}} : {{interfacePrefix}}{{classname}}
     {
         private {{packageName}}.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}"/> class.
         /// </summary>
@@ -151,7 +151,7 @@ namespace {{packageName}}.{{apiPackage}}
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             {{/supportsAsync}}
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             {{#supportsAsync}}
             this.AsynchronousClient = asyncClient;
@@ -225,13 +225,15 @@ namespace {{packageName}}.{{apiPackage}}
         public {{packageName}}.Client.ApiResponse<{{#returnType}} {{{returnType}}} {{/returnType}}{{^returnType}}Object{{/returnType}}> {{operationId}}WithHttpInfo ({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = null{{/optionalMethodArgument}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         {
             {{#allParams}}
+            {{^isNullable}}
             {{#required}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
                 throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
-            {{/required}}
-            {{/allParams}}
 
+            {{/required}}
+            {{/isNullable}}
+            {{/allParams}}
             {{packageName}}.Client.RequestOptions requestOptions = new {{packageName}}.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -362,11 +364,14 @@ namespace {{packageName}}.{{apiPackage}}
         public async System.Threading.Tasks.Task<{{packageName}}.Client.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Object{{/returnType}}>> {{operationId}}AsyncWithHttpInfo ({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = null{{/optionalMethodArgument}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
         {
             {{#allParams}}
+            {{^isNullable}}
             {{#required}}
             // verify the required parameter '{{paramName}}' is set
             if ({{paramName}} == null)
                 throw new {{packageName}}.Client.ApiException(400, "Missing required parameter '{{paramName}}' when calling {{classname}}->{{operationId}}");
+
             {{/required}}
+            {{/isNullable}}
             {{/allParams}}
 
             {{packageName}}.Client.RequestOptions requestOptions = new {{packageName}}.Client.RequestOptions();

--- a/modules/openapi-generator/src/main/resources/csharp-refactor/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-refactor/modelGeneric.mustache
@@ -58,6 +58,7 @@
             {{#vars}}
             {{^isInherited}}
             {{^isReadOnly}}
+            {{^isNullable}}
             {{#required}}
             {{^isEnum}}
             // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
@@ -74,6 +75,7 @@
             this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
             {{/isEnum}}
             {{/required}}
+            {{/isNullable}}
             {{/isReadOnly}}
             {{/isInherited}}
             {{/vars}}

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ApiResponse.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int?** |  | [optional] 
+**Code** | **int** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ArrayOfArrayOfNumberOnly.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayArrayNumber** | **List&lt;List&lt;decimal?&gt;&gt;** |  | [optional] 
+**ArrayArrayNumber** | **List&lt;List&lt;decimal&gt;&gt;** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ArrayOfNumberOnly.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayNumber** | **List&lt;decimal?&gt;** |  | [optional] 
+**ArrayNumber** | **List&lt;decimal&gt;** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ArrayTest.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/ArrayTest.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ArrayOfString** | **List&lt;string&gt;** |  | [optional] 
-**ArrayArrayOfInteger** | **List&lt;List&lt;long?&gt;&gt;** |  | [optional] 
+**ArrayArrayOfInteger** | **List&lt;List&lt;long&gt;&gt;** |  | [optional] 
 **ArrayArrayOfModel** | **List&lt;List&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Cat.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Cat.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool?** |  | [optional] 
+**Declawed** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Category.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Category.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] 
+**Id** | **long** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/EnumTest.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/EnumTest.md
@@ -5,8 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int?** |  | [optional] 
-**EnumNumber** | **double?** |  | [optional] 
+**EnumInteger** | **int** |  | [optional] 
+**EnumNumber** | **double** |  | [optional] 
 **OuterEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/FakeApi.md
@@ -20,7 +20,7 @@ Method | HTTP request | Description
 
 <a name="fakeouterbooleanserialize"></a>
 # **FakeOuterBooleanSerialize**
-> bool? FakeOuterBooleanSerialize (bool? body = null)
+> bool FakeOuterBooleanSerialize (bool? body = null)
 
 
 
@@ -45,7 +45,7 @@ namespace Example
 
             try
             {
-                bool? result = apiInstance.FakeOuterBooleanSerialize(body);
+                bool result = apiInstance.FakeOuterBooleanSerialize(body);
                 Debug.WriteLine(result);
             }
             catch (Exception e)
@@ -65,7 +65,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**bool?**
+**bool**
 
 ### Authorization
 
@@ -140,7 +140,7 @@ No authorization required
 
 <a name="fakeouternumberserialize"></a>
 # **FakeOuterNumberSerialize**
-> decimal? FakeOuterNumberSerialize (decimal? body = null)
+> decimal FakeOuterNumberSerialize (decimal? body = null)
 
 
 
@@ -165,7 +165,7 @@ namespace Example
 
             try
             {
-                decimal? result = apiInstance.FakeOuterNumberSerialize(body);
+                decimal result = apiInstance.FakeOuterNumberSerialize(body);
                 Debug.WriteLine(result);
             }
             catch (Exception e)
@@ -185,7 +185,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**decimal?**
+**decimal**
 
 ### Authorization
 
@@ -439,7 +439,7 @@ No authorization required
 
 <a name="testendpointparameters"></a>
 # **TestEndpointParameters**
-> void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
+> void TestEndpointParameters (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
@@ -464,8 +464,8 @@ namespace Example
             Configuration.Default.Password = "YOUR_PASSWORD";
 
             var apiInstance = new FakeApi();
-            var number = 8.14;  // decimal? | None
-            var _double = 1.2D;  // double? | None
+            var number = 8.14;  // decimal | None
+            var _double = 1.2D;  // double | None
             var patternWithoutDelimiter = patternWithoutDelimiter_example;  // string | None
             var _byte = BYTE_ARRAY_DATA_HERE;  // byte[] | None
             var integer = 56;  // int? | None (optional) 
@@ -497,8 +497,8 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **number** | **decimal?**| None | 
- **_double** | **double?**| None | 
+ **number** | **decimal**| None | 
+ **_double** | **double**| None | 
  **patternWithoutDelimiter** | **string**| None | 
  **_byte** | **byte[]**| None | 
  **integer** | **int?**| None | [optional] 
@@ -603,7 +603,7 @@ No authorization required
 
 <a name="testgroupparameters"></a>
 # **TestGroupParameters**
-> void TestGroupParameters (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
+> void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
 
 Fake endpoint to test group parameters (optional)
 
@@ -624,9 +624,9 @@ namespace Example
         public void main()
         {
             var apiInstance = new FakeApi();
-            var requiredStringGroup = 56;  // int? | Required String in group parameters
-            var requiredBooleanGroup = true;  // bool? | Required Boolean in group parameters
-            var requiredInt64Group = 789;  // long? | Required Integer in group parameters
+            var requiredStringGroup = 56;  // int | Required String in group parameters
+            var requiredBooleanGroup = true;  // bool | Required Boolean in group parameters
+            var requiredInt64Group = 789;  // long | Required Integer in group parameters
             var stringGroup = 56;  // int? | String in group parameters (optional) 
             var booleanGroup = true;  // bool? | Boolean in group parameters (optional) 
             var int64Group = 789;  // long? | Integer in group parameters (optional) 
@@ -649,9 +649,9 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **requiredStringGroup** | **int?**| Required String in group parameters | 
- **requiredBooleanGroup** | **bool?**| Required Boolean in group parameters | 
- **requiredInt64Group** | **long?**| Required Integer in group parameters | 
+ **requiredStringGroup** | **int**| Required String in group parameters | 
+ **requiredBooleanGroup** | **bool**| Required Boolean in group parameters | 
+ **requiredInt64Group** | **long**| Required Integer in group parameters | 
  **stringGroup** | **int?**| String in group parameters | [optional] 
  **booleanGroup** | **bool?**| Boolean in group parameters | [optional] 
  **int64Group** | **long?**| Integer in group parameters | [optional] 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/FormatTest.md
@@ -3,18 +3,18 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int?** |  | [optional] 
-**Int32** | **int?** |  | [optional] 
-**Int64** | **long?** |  | [optional] 
-**Number** | **decimal?** |  | 
-**Float** | **float?** |  | [optional] 
-**Double** | **double?** |  | [optional] 
+**Integer** | **int** |  | [optional] 
+**Int32** | **int** |  | [optional] 
+**Int64** | **long** |  | [optional] 
+**Number** | **decimal** |  | 
+**Float** | **float** |  | [optional] 
+**Double** | **double** |  | [optional] 
 **String** | **string** |  | [optional] 
 **Byte** | **byte[]** |  | 
 **Binary** | **System.IO.Stream** |  | [optional] 
-**Date** | **DateTime?** |  | 
-**DateTime** | **DateTime?** |  | [optional] 
-**Uuid** | **Guid?** |  | [optional] 
+**Date** | **DateTime** |  | 
+**DateTime** | **DateTime** |  | [optional] 
+**Uuid** | [**Guid**](Guid.md) |  | [optional] 
 **Password** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/MapTest.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/MapTest.md
@@ -5,8 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
 **MapOfEnumString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
-**DirectMap** | **Dictionary&lt;string, bool?&gt;** |  | [optional] 
-**IndirectMap** | **Dictionary&lt;string, bool?&gt;** |  | [optional] 
+**DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
+**IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -3,8 +3,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Uuid** | **Guid?** |  | [optional] 
-**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | [**Guid**](Guid.md) |  | [optional] 
+**DateTime** | **DateTime** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Model200Response.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Model200Response.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int?** |  | [optional] 
+**Name** | **int** |  | [optional] 
 **Class** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Name.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Name.md
@@ -3,10 +3,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**_Name** | **int?** |  | 
-**SnakeCase** | **int?** |  | [optional] 
+**_Name** | **int** |  | 
+**SnakeCase** | **int** |  | [optional] 
 **Property** | **string** |  | [optional] 
-**_123Number** | **int?** |  | [optional] 
+**_123Number** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/NumberOnly.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal?** |  | [optional] 
+**JustNumber** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Order.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Order.md
@@ -3,12 +3,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] 
-**PetId** | **long?** |  | [optional] 
-**Quantity** | **int?** |  | [optional] 
-**ShipDate** | **DateTime?** |  | [optional] 
+**Id** | **long** |  | [optional] 
+**PetId** | **long** |  | [optional] 
+**Quantity** | **int** |  | [optional] 
+**ShipDate** | **DateTime** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool?** |  | [optional] [default to false]
+**Complete** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/OuterComposite.md
@@ -3,9 +3,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal?** |  | [optional] 
+**MyNumber** | **decimal** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool?** |  | [optional] 
+**MyBoolean** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Pet.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Pet.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] 
+**Id** | **long** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/PetApi.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/PetApi.md
@@ -78,7 +78,7 @@ void (empty response body)
 
 <a name="deletepet"></a>
 # **DeletePet**
-> void DeletePet (long? petId, string apiKey = null)
+> void DeletePet (long petId, string apiKey = null)
 
 Deletes a pet
 
@@ -100,7 +100,7 @@ namespace Example
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
             var apiInstance = new PetApi();
-            var petId = 789;  // long? | Pet id to delete
+            var petId = 789;  // long | Pet id to delete
             var apiKey = apiKey_example;  // string |  (optional) 
 
             try
@@ -121,7 +121,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **long?**| Pet id to delete | 
+ **petId** | **long**| Pet id to delete | 
  **apiKey** | **string**|  | [optional] 
 
 ### Return type
@@ -269,7 +269,7 @@ Name | Type | Description  | Notes
 
 <a name="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long? petId)
+> Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -295,7 +295,7 @@ namespace Example
             // Configuration.Default.AddApiKeyPrefix("api_key", "Bearer");
 
             var apiInstance = new PetApi();
-            var petId = 789;  // long? | ID of pet to return
+            var petId = 789;  // long | ID of pet to return
 
             try
             {
@@ -316,7 +316,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **long?**| ID of pet to return | 
+ **petId** | **long**| ID of pet to return | 
 
 ### Return type
 
@@ -396,7 +396,7 @@ void (empty response body)
 
 <a name="updatepetwithform"></a>
 # **UpdatePetWithForm**
-> void UpdatePetWithForm (long? petId, string name = null, string status = null)
+> void UpdatePetWithForm (long petId, string name = null, string status = null)
 
 Updates a pet in the store with form data
 
@@ -418,7 +418,7 @@ namespace Example
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
             var apiInstance = new PetApi();
-            var petId = 789;  // long? | ID of pet that needs to be updated
+            var petId = 789;  // long | ID of pet that needs to be updated
             var name = name_example;  // string | Updated name of the pet (optional) 
             var status = status_example;  // string | Updated status of the pet (optional) 
 
@@ -440,7 +440,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **long?**| ID of pet that needs to be updated | 
+ **petId** | **long**| ID of pet that needs to be updated | 
  **name** | **string**| Updated name of the pet | [optional] 
  **status** | **string**| Updated status of the pet | [optional] 
 
@@ -461,7 +461,7 @@ void (empty response body)
 
 <a name="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long? petId, string additionalMetadata = null, System.IO.Stream file = null)
+> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -483,7 +483,7 @@ namespace Example
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
             var apiInstance = new PetApi();
-            var petId = 789;  // long? | ID of pet to update
+            var petId = 789;  // long | ID of pet to update
             var additionalMetadata = additionalMetadata_example;  // string | Additional data to pass to server (optional) 
             var file = BINARY_DATA_HERE;  // System.IO.Stream | file to upload (optional) 
 
@@ -506,7 +506,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **long?**| ID of pet to update | 
+ **petId** | **long**| ID of pet to update | 
  **additionalMetadata** | **string**| Additional data to pass to server | [optional] 
  **file** | **System.IO.Stream****System.IO.Stream**| file to upload | [optional] 
 
@@ -527,7 +527,7 @@ Name | Type | Description  | Notes
 
 <a name="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -549,7 +549,7 @@ namespace Example
             Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
             var apiInstance = new PetApi();
-            var petId = 789;  // long? | ID of pet to update
+            var petId = 789;  // long | ID of pet to update
             var requiredFile = BINARY_DATA_HERE;  // System.IO.Stream | file to upload
             var additionalMetadata = additionalMetadata_example;  // string | Additional data to pass to server (optional) 
 
@@ -572,7 +572,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **long?**| ID of pet to update | 
+ **petId** | **long**| ID of pet to update | 
  **requiredFile** | **System.IO.Stream****System.IO.Stream**| file to upload | 
  **additionalMetadata** | **string**| Additional data to pass to server | [optional] 
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Return.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Return.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**_Return** | **int?** |  | [optional] 
+**_Return** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/SpecialModelName.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long?** |  | [optional] 
+**SpecialPropertyName** | **long** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/StoreApi.md
@@ -72,7 +72,7 @@ No authorization required
 
 <a name="getinventory"></a>
 # **GetInventory**
-> Dictionary<string, int?> GetInventory ()
+> Dictionary<string, int> GetInventory ()
 
 Returns pet inventories by status
 
@@ -102,7 +102,7 @@ namespace Example
             try
             {
                 // Returns pet inventories by status
-                Dictionary&lt;string, int?&gt; result = apiInstance.GetInventory();
+                Dictionary&lt;string, int&gt; result = apiInstance.GetInventory();
                 Debug.WriteLine(result);
             }
             catch (Exception e)
@@ -119,7 +119,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-**Dictionary<string, int?>**
+**Dictionary<string, int>**
 
 ### Authorization
 
@@ -134,7 +134,7 @@ This endpoint does not need any parameter.
 
 <a name="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long? orderId)
+> Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -155,7 +155,7 @@ namespace Example
         public void main()
         {
             var apiInstance = new StoreApi();
-            var orderId = 789;  // long? | ID of pet that needs to be fetched
+            var orderId = 789;  // long | ID of pet that needs to be fetched
 
             try
             {
@@ -176,7 +176,7 @@ namespace Example
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **long?**| ID of pet that needs to be fetched | 
+ **orderId** | **long**| ID of pet that needs to be fetched | 
 
 ### Return type
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Tag.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/Tag.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] 
+**Id** | **long** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/User.md
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/docs/User.md
@@ -3,14 +3,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long?** |  | [optional] 
+**Id** | **long** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int?** | User Status | [optional] 
+**UserStatus** | **int** | User Status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools.Test/Model/ArrayOfArrayOfNumberOnlyTests.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools.Test/Model/ArrayOfArrayOfNumberOnlyTests.cs
@@ -74,22 +74,22 @@ namespace Org.OpenAPITools.Test
         {
             // 1st instance
             ArrayOfArrayOfNumberOnly instance1 = new ArrayOfArrayOfNumberOnly();
-            List<decimal?> list1 = new List<decimal?>();
+            List<decimal> list1 = new List<decimal>();
             list1.Add(11.1m);
             list1.Add(8.9m);
 
-            List<List<decimal?>> listOfList1 = new List<List<decimal?>>();
+            List<List<decimal>> listOfList1 = new List<List<decimal>>();
             listOfList1.Add(list1);
 
             instance1.ArrayArrayNumber = listOfList1;
 
             // 2nd instance
             ArrayOfArrayOfNumberOnly instance2 = new ArrayOfArrayOfNumberOnly();
-            List<decimal?> list2 = new List<decimal?>();
+            List<decimal> list2 = new List<decimal>();
             list2.Add(11.1m);
             list2.Add(8.9m);
 
-            List<List<decimal?>> listOfList2 = new List<List<decimal?>>();
+            List<List<decimal>> listOfList2 = new List<List<decimal>>();
             listOfList2.Add(list2);
 
             instance2.ArrayArrayNumber = listOfList2;
@@ -102,15 +102,14 @@ namespace Org.OpenAPITools.Test
 
             // 3rd instance
             ArrayOfArrayOfNumberOnly instance3 = new ArrayOfArrayOfNumberOnly();
-            List<decimal?> list3 = new List<decimal?>();
+            List<decimal> list3 = new List<decimal>();
             list3.Add(11.1m);
             list3.Add(1.1m); // not the same as 8.9
 
-            List<List<decimal?>> listOfList3 = new List<List<decimal?>>();
+            List<List<decimal>> listOfList3 = new List<List<decimal>>();
             instance2.ArrayArrayNumber = listOfList3;
 
             Assert.IsFalse(instance1.Equals(instance3));
-
         }
 
     }

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Api
     /// </summary>
     public interface IAnotherFakeApi : IAnotherFakeApiSync, IAnotherFakeApiAsync
     {
-        
+
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ namespace Org.OpenAPITools.Api
     public partial class AnotherFakeApi : IAnotherFakeApi
     {
         private Org.OpenAPITools.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AnotherFakeApi"/> class.
         /// </summary>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Api
             if(client == null) throw new ArgumentNullException("client");
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             this.AsynchronousClient = asyncClient;
             this.Configuration = configuration;
@@ -279,6 +279,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling AnotherFakeApi->Call123TestSpecialTags");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -35,8 +35,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>bool?</returns>
-        bool? FakeOuterBooleanSerialize (bool? body = null);
+        /// <returns>bool</returns>
+        bool FakeOuterBooleanSerialize (bool? body = null);
 
         /// <summary>
         /// 
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>ApiResponse of bool?</returns>
-        ApiResponse<bool?> FakeOuterBooleanSerializeWithHttpInfo (bool? body = null);
+        /// <returns>ApiResponse of bool</returns>
+        ApiResponse<bool> FakeOuterBooleanSerializeWithHttpInfo (bool? body = null);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>decimal?</returns>
-        decimal? FakeOuterNumberSerialize (decimal? body = null);
+        /// <returns>decimal</returns>
+        decimal FakeOuterNumberSerialize (decimal? body = null);
 
         /// <summary>
         /// 
@@ -88,8 +88,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>ApiResponse of decimal?</returns>
-        ApiResponse<decimal?> FakeOuterNumberSerializeWithHttpInfo (decimal? body = null);
+        /// <returns>ApiResponse of decimal</returns>
+        ApiResponse<decimal> FakeOuterNumberSerializeWithHttpInfo (decimal? body = null);
         /// <summary>
         /// 
         /// </summary>
@@ -198,7 +198,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns></returns>
-        void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
+        void TestEndpointParameters (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -222,7 +222,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
+        ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
         /// <summary>
         /// To test enum parameters
         /// </summary>
@@ -272,7 +272,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns></returns>
-        void TestGroupParameters (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
+        void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -288,7 +288,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> TestGroupParametersWithHttpInfo (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
+        ApiResponse<Object> TestGroupParametersWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
         /// <summary>
         /// test inline additionalProperties
         /// </summary>
@@ -350,8 +350,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>Task of bool?</returns>
-        System.Threading.Tasks.Task<bool?> FakeOuterBooleanSerializeAsync (bool? body = null);
+        /// <returns>Task of bool</returns>
+        System.Threading.Tasks.Task<bool> FakeOuterBooleanSerializeAsync (bool? body = null);
 
         /// <summary>
         /// 
@@ -361,8 +361,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>Task of ApiResponse (bool?)</returns>
-        System.Threading.Tasks.Task<ApiResponse<bool?>> FakeOuterBooleanSerializeAsyncWithHttpInfo (bool? body = null);
+        /// <returns>Task of ApiResponse (bool)</returns>
+        System.Threading.Tasks.Task<ApiResponse<bool>> FakeOuterBooleanSerializeAsyncWithHttpInfo (bool? body = null);
         /// <summary>
         /// 
         /// </summary>
@@ -392,8 +392,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>Task of decimal?</returns>
-        System.Threading.Tasks.Task<decimal?> FakeOuterNumberSerializeAsync (decimal? body = null);
+        /// <returns>Task of decimal</returns>
+        System.Threading.Tasks.Task<decimal> FakeOuterNumberSerializeAsync (decimal? body = null);
 
         /// <summary>
         /// 
@@ -403,8 +403,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>Task of ApiResponse (decimal?)</returns>
-        System.Threading.Tasks.Task<ApiResponse<decimal?>> FakeOuterNumberSerializeAsyncWithHttpInfo (decimal? body = null);
+        /// <returns>Task of ApiResponse (decimal)</returns>
+        System.Threading.Tasks.Task<ApiResponse<decimal>> FakeOuterNumberSerializeAsyncWithHttpInfo (decimal? body = null);
         /// <summary>
         /// 
         /// </summary>
@@ -513,7 +513,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task TestEndpointParametersAsync (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
+        System.Threading.Tasks.Task TestEndpointParametersAsync (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
 
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -537,7 +537,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null);
         /// <summary>
         /// To test enum parameters
         /// </summary>
@@ -587,7 +587,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task TestGroupParametersAsync (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
+        System.Threading.Tasks.Task TestGroupParametersAsync (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
 
         /// <summary>
         /// Fake endpoint to test group parameters (optional)
@@ -603,7 +603,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> TestGroupParametersAsyncWithHttpInfo (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestGroupParametersAsyncWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null);
         /// <summary>
         /// test inline additionalProperties
         /// </summary>
@@ -656,7 +656,7 @@ namespace Org.OpenAPITools.Api
     /// </summary>
     public interface IFakeApi : IFakeApiSync, IFakeApiAsync
     {
-        
+
     }
 
     /// <summary>
@@ -665,7 +665,7 @@ namespace Org.OpenAPITools.Api
     public partial class FakeApi : IFakeApi
     {
         private Org.OpenAPITools.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FakeApi"/> class.
         /// </summary>
@@ -720,7 +720,7 @@ namespace Org.OpenAPITools.Api
             if(client == null) throw new ArgumentNullException("client");
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             this.AsynchronousClient = asyncClient;
             this.Configuration = configuration;
@@ -773,10 +773,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>bool?</returns>
-        public bool? FakeOuterBooleanSerialize (bool? body = null)
+        /// <returns>bool</returns>
+        public bool FakeOuterBooleanSerialize (bool? body = null)
         {
-             Org.OpenAPITools.Client.ApiResponse<bool?> localVarResponse = FakeOuterBooleanSerializeWithHttpInfo(body);
+             Org.OpenAPITools.Client.ApiResponse<bool> localVarResponse = FakeOuterBooleanSerializeWithHttpInfo(body);
              return localVarResponse.Data;
         }
 
@@ -785,10 +785,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>ApiResponse of bool?</returns>
-        public Org.OpenAPITools.Client.ApiResponse< bool? > FakeOuterBooleanSerializeWithHttpInfo (bool? body = null)
+        /// <returns>ApiResponse of bool</returns>
+        public Org.OpenAPITools.Client.ApiResponse< bool > FakeOuterBooleanSerializeWithHttpInfo (bool? body = null)
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -810,7 +809,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var response = this.Client.Post< bool? >("/fake/outer/boolean", requestOptions, this.Configuration);
+            var response = this.Client.Post< bool >("/fake/outer/boolean", requestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -826,10 +825,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>Task of bool?</returns>
-        public async System.Threading.Tasks.Task<bool?> FakeOuterBooleanSerializeAsync (bool? body = null)
+        /// <returns>Task of bool</returns>
+        public async System.Threading.Tasks.Task<bool> FakeOuterBooleanSerializeAsync (bool? body = null)
         {
-             Org.OpenAPITools.Client.ApiResponse<bool?> localVarResponse = await FakeOuterBooleanSerializeAsyncWithHttpInfo(body);
+             Org.OpenAPITools.Client.ApiResponse<bool> localVarResponse = await FakeOuterBooleanSerializeAsyncWithHttpInfo(body);
              return localVarResponse.Data;
 
         }
@@ -839,8 +838,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input boolean as post body (optional)</param>
-        /// <returns>Task of ApiResponse (bool?)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<bool?>> FakeOuterBooleanSerializeAsyncWithHttpInfo (bool? body = null)
+        /// <returns>Task of ApiResponse (bool)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<bool>> FakeOuterBooleanSerializeAsyncWithHttpInfo (bool? body = null)
         {
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -864,7 +863,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var response = await this.AsynchronousClient.PostAsync<bool?>("/fake/outer/boolean", requestOptions, this.Configuration);
+            var response = await this.AsynchronousClient.PostAsync<bool>("/fake/outer/boolean", requestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -895,7 +894,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of OuterComposite</returns>
         public Org.OpenAPITools.Client.ApiResponse< OuterComposite > FakeOuterCompositeSerializeWithHttpInfo (OuterComposite body = null)
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -987,10 +985,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>decimal?</returns>
-        public decimal? FakeOuterNumberSerialize (decimal? body = null)
+        /// <returns>decimal</returns>
+        public decimal FakeOuterNumberSerialize (decimal? body = null)
         {
-             Org.OpenAPITools.Client.ApiResponse<decimal?> localVarResponse = FakeOuterNumberSerializeWithHttpInfo(body);
+             Org.OpenAPITools.Client.ApiResponse<decimal> localVarResponse = FakeOuterNumberSerializeWithHttpInfo(body);
              return localVarResponse.Data;
         }
 
@@ -999,10 +997,9 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>ApiResponse of decimal?</returns>
-        public Org.OpenAPITools.Client.ApiResponse< decimal? > FakeOuterNumberSerializeWithHttpInfo (decimal? body = null)
+        /// <returns>ApiResponse of decimal</returns>
+        public Org.OpenAPITools.Client.ApiResponse< decimal > FakeOuterNumberSerializeWithHttpInfo (decimal? body = null)
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1024,7 +1021,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var response = this.Client.Post< decimal? >("/fake/outer/number", requestOptions, this.Configuration);
+            var response = this.Client.Post< decimal >("/fake/outer/number", requestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1040,10 +1037,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>Task of decimal?</returns>
-        public async System.Threading.Tasks.Task<decimal?> FakeOuterNumberSerializeAsync (decimal? body = null)
+        /// <returns>Task of decimal</returns>
+        public async System.Threading.Tasks.Task<decimal> FakeOuterNumberSerializeAsync (decimal? body = null)
         {
-             Org.OpenAPITools.Client.ApiResponse<decimal?> localVarResponse = await FakeOuterNumberSerializeAsyncWithHttpInfo(body);
+             Org.OpenAPITools.Client.ApiResponse<decimal> localVarResponse = await FakeOuterNumberSerializeAsyncWithHttpInfo(body);
              return localVarResponse.Data;
 
         }
@@ -1053,8 +1050,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="body">Input number as post body (optional)</param>
-        /// <returns>Task of ApiResponse (decimal?)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<decimal?>> FakeOuterNumberSerializeAsyncWithHttpInfo (decimal? body = null)
+        /// <returns>Task of ApiResponse (decimal)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<decimal>> FakeOuterNumberSerializeAsyncWithHttpInfo (decimal? body = null)
         {
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1078,7 +1075,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var response = await this.AsynchronousClient.PostAsync<decimal?>("/fake/outer/number", requestOptions, this.Configuration);
+            var response = await this.AsynchronousClient.PostAsync<decimal>("/fake/outer/number", requestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1109,7 +1106,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of string</returns>
         public Org.OpenAPITools.Client.ApiResponse< string > FakeOuterStringSerializeWithHttpInfo (string body = null)
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1275,6 +1271,7 @@ namespace Org.OpenAPITools.Api
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling FakeApi->TestBodyWithFileSchema");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1331,6 +1328,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'query' is set
             if (query == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'query' when calling FakeApi->TestBodyWithQueryParams");
+
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling FakeApi->TestBodyWithQueryParams");
@@ -1402,9 +1400,11 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'query' is set
             if (query == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'query' when calling FakeApi->TestBodyWithQueryParams");
+
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling FakeApi->TestBodyWithQueryParams");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1530,6 +1530,7 @@ namespace Org.OpenAPITools.Api
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling FakeApi->TestClientModel");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1582,7 +1583,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns></returns>
-        public void TestEndpointParameters (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
+        public void TestEndpointParameters (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
              TestEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password, callback);
         }
@@ -1606,17 +1607,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
+        public Org.OpenAPITools.Client.ApiResponse<Object> TestEndpointParametersWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
             // verify the required parameter 'number' is set
             if (number == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'number' when calling FakeApi->TestEndpointParameters");
+
             // verify the required parameter '_double' is set
             if (_double == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_double' when calling FakeApi->TestEndpointParameters");
+
             // verify the required parameter 'patternWithoutDelimiter' is set
             if (patternWithoutDelimiter == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'patternWithoutDelimiter' when calling FakeApi->TestEndpointParameters");
+
             // verify the required parameter '_byte' is set
             if (_byte == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_byte' when calling FakeApi->TestEndpointParameters");
@@ -1733,7 +1737,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task TestEndpointParametersAsync (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
+        public async System.Threading.Tasks.Task TestEndpointParametersAsync (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
              await TestEndpointParametersAsyncWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, _string, binary, date, dateTime, password, callback);
 
@@ -1758,20 +1762,24 @@ namespace Org.OpenAPITools.Api
         /// <param name="password">None (optional)</param>
         /// <param name="callback">None (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal? number, double? _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestEndpointParametersAsyncWithHttpInfo (decimal number, double _double, string patternWithoutDelimiter, byte[] _byte, int? integer = null, int? int32 = null, long? int64 = null, float? _float = null, string _string = null, System.IO.Stream binary = null, DateTime? date = null, DateTime? dateTime = null, string password = null, string callback = null)
         {
             // verify the required parameter 'number' is set
             if (number == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'number' when calling FakeApi->TestEndpointParameters");
+
             // verify the required parameter '_double' is set
             if (_double == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_double' when calling FakeApi->TestEndpointParameters");
+
             // verify the required parameter 'patternWithoutDelimiter' is set
             if (patternWithoutDelimiter == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'patternWithoutDelimiter' when calling FakeApi->TestEndpointParameters");
+
             // verify the required parameter '_byte' is set
             if (_byte == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter '_byte' when calling FakeApi->TestEndpointParameters");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1899,7 +1907,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> TestEnumParametersWithHttpInfo (List<string> enumHeaderStringArray = null, string enumHeaderString = null, List<string> enumQueryStringArray = null, string enumQueryString = null, int? enumQueryInteger = null, double? enumQueryDouble = null, List<string> enumFormStringArray = null, string enumFormString = null)
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -2112,7 +2119,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns></returns>
-        public void TestGroupParameters (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
+        public void TestGroupParameters (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
         {
              TestGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
         }
@@ -2128,14 +2135,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Object> TestGroupParametersWithHttpInfo (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
+        public Org.OpenAPITools.Client.ApiResponse<Object> TestGroupParametersWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
         {
             // verify the required parameter 'requiredStringGroup' is set
             if (requiredStringGroup == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredStringGroup' when calling FakeApi->TestGroupParameters");
+
             // verify the required parameter 'requiredBooleanGroup' is set
             if (requiredBooleanGroup == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredBooleanGroup' when calling FakeApi->TestGroupParameters");
+
             // verify the required parameter 'requiredInt64Group' is set
             if (requiredInt64Group == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredInt64Group' when calling FakeApi->TestGroupParameters");
@@ -2225,7 +2234,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task TestGroupParametersAsync (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
+        public async System.Threading.Tasks.Task TestGroupParametersAsync (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
         {
              await TestGroupParametersAsyncWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
 
@@ -2242,17 +2251,20 @@ namespace Org.OpenAPITools.Api
         /// <param name="booleanGroup">Boolean in group parameters (optional)</param>
         /// <param name="int64Group">Integer in group parameters (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestGroupParametersAsyncWithHttpInfo (int? requiredStringGroup, bool? requiredBooleanGroup, long? requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestGroupParametersAsyncWithHttpInfo (int requiredStringGroup, bool requiredBooleanGroup, long requiredInt64Group, int? stringGroup = null, bool? booleanGroup = null, long? int64Group = null)
         {
             // verify the required parameter 'requiredStringGroup' is set
             if (requiredStringGroup == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredStringGroup' when calling FakeApi->TestGroupParameters");
+
             // verify the required parameter 'requiredBooleanGroup' is set
             if (requiredBooleanGroup == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredBooleanGroup' when calling FakeApi->TestGroupParameters");
+
             // verify the required parameter 'requiredInt64Group' is set
             if (requiredInt64Group == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredInt64Group' when calling FakeApi->TestGroupParameters");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2407,6 +2419,7 @@ namespace Org.OpenAPITools.Api
             if (param == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'param' when calling FakeApi->TestInlineAdditionalProperties");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -2463,6 +2476,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'param' is set
             if (param == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'param' when calling FakeApi->TestJsonFormData");
+
             // verify the required parameter 'param2' is set
             if (param2 == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'param2' when calling FakeApi->TestJsonFormData");
@@ -2531,9 +2545,11 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'param' is set
             if (param == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'param' when calling FakeApi->TestJsonFormData");
+
             // verify the required parameter 'param2' is set
             if (param2 == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'param2' when calling FakeApi->TestJsonFormData");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Api
     /// </summary>
     public interface IFakeClassnameTags123Api : IFakeClassnameTags123ApiSync, IFakeClassnameTags123ApiAsync
     {
-        
+
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ namespace Org.OpenAPITools.Api
     public partial class FakeClassnameTags123Api : IFakeClassnameTags123Api
     {
         private Org.OpenAPITools.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FakeClassnameTags123Api"/> class.
         /// </summary>
@@ -150,7 +150,7 @@ namespace Org.OpenAPITools.Api
             if(client == null) throw new ArgumentNullException("client");
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             this.AsynchronousClient = asyncClient;
             this.Configuration = configuration;
@@ -290,6 +290,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling FakeClassnameTags123Api->TestClassname");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns></returns>
-        void DeletePet (long? petId, string apiKey = null);
+        void DeletePet (long petId, string apiKey = null);
 
         /// <summary>
         /// Deletes a pet
@@ -70,7 +70,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> DeletePetWithHttpInfo (long? petId, string apiKey = null);
+        ApiResponse<Object> DeletePetWithHttpInfo (long petId, string apiKey = null);
         /// <summary>
         /// Finds Pets by status
         /// </summary>
@@ -122,7 +122,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>Pet</returns>
-        Pet GetPetById (long? petId);
+        Pet GetPetById (long petId);
 
         /// <summary>
         /// Find pet by ID
@@ -133,7 +133,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo (long? petId);
+        ApiResponse<Pet> GetPetByIdWithHttpInfo (long petId);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns></returns>
-        void UpdatePetWithForm (long? petId, string name = null, string status = null);
+        void UpdatePetWithForm (long petId, string name = null, string status = null);
 
         /// <summary>
         /// Updates a pet in the store with form data
@@ -179,7 +179,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> UpdatePetWithFormWithHttpInfo (long? petId, string name = null, string status = null);
+        ApiResponse<Object> UpdatePetWithFormWithHttpInfo (long petId, string name = null, string status = null);
         /// <summary>
         /// uploads an image
         /// </summary>
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile (long? petId, string additionalMetadata = null, System.IO.Stream file = null);
+        ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null);
 
         /// <summary>
         /// uploads an image
@@ -204,7 +204,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo (long? petId, string additionalMetadata = null, System.IO.Stream file = null);
+        ApiResponse<ApiResponse> UploadFileWithHttpInfo (long petId, string additionalMetadata = null, System.IO.Stream file = null);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,7 +216,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null);
+        ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null);
 
         /// <summary>
         /// uploads an image (required)
@@ -229,7 +229,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null);
+        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = null);
         #endregion Synchronous Operations
     }
 
@@ -270,7 +270,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task DeletePetAsync (long? petId, string apiKey = null);
+        System.Threading.Tasks.Task DeletePetAsync (long petId, string apiKey = null);
 
         /// <summary>
         /// Deletes a pet
@@ -282,7 +282,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long? petId, string apiKey = null);
+        System.Threading.Tasks.Task<ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long petId, string apiKey = null);
         /// <summary>
         /// Finds Pets by status
         /// </summary>
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync (long? petId);
+        System.Threading.Tasks.Task<Pet> GetPetByIdAsync (long petId);
 
         /// <summary>
         /// Find pet by ID
@@ -345,7 +345,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdAsyncWithHttpInfo (long? petId);
+        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdAsyncWithHttpInfo (long petId);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -378,7 +378,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task UpdatePetWithFormAsync (long? petId, string name = null, string status = null);
+        System.Threading.Tasks.Task UpdatePetWithFormAsync (long petId, string name = null, string status = null);
 
         /// <summary>
         /// Updates a pet in the store with form data
@@ -391,7 +391,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> UpdatePetWithFormAsyncWithHttpInfo (long? petId, string name = null, string status = null);
+        System.Threading.Tasks.Task<ApiResponse<Object>> UpdatePetWithFormAsyncWithHttpInfo (long petId, string name = null, string status = null);
         /// <summary>
         /// uploads an image
         /// </summary>
@@ -403,7 +403,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync (long? petId, string additionalMetadata = null, System.IO.Stream file = null);
+        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync (long petId, string additionalMetadata = null, System.IO.Stream file = null);
 
         /// <summary>
         /// uploads an image
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileAsyncWithHttpInfo (long? petId, string additionalMetadata = null, System.IO.Stream file = null);
+        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileAsyncWithHttpInfo (long petId, string additionalMetadata = null, System.IO.Stream file = null);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -428,7 +428,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null);
+        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync (long petId, System.IO.Stream requiredFile, string additionalMetadata = null);
 
         /// <summary>
         /// uploads an image (required)
@@ -441,7 +441,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileAsyncWithHttpInfo (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null);
+        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileAsyncWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = null);
         #endregion Asynchronous Operations
     }
 
@@ -450,7 +450,7 @@ namespace Org.OpenAPITools.Api
     /// </summary>
     public interface IPetApi : IPetApiSync, IPetApiAsync
     {
-        
+
     }
 
     /// <summary>
@@ -459,7 +459,7 @@ namespace Org.OpenAPITools.Api
     public partial class PetApi : IPetApi
     {
         private Org.OpenAPITools.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PetApi"/> class.
         /// </summary>
@@ -514,7 +514,7 @@ namespace Org.OpenAPITools.Api
             if(client == null) throw new ArgumentNullException("client");
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             this.AsynchronousClient = asyncClient;
             this.Configuration = configuration;
@@ -648,6 +648,7 @@ namespace Org.OpenAPITools.Api
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling PetApi->AddPet");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -694,7 +695,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns></returns>
-        public void DeletePet (long? petId, string apiKey = null)
+        public void DeletePet (long petId, string apiKey = null)
         {
              DeletePetWithHttpInfo(petId, apiKey);
         }
@@ -706,7 +707,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Object> DeletePetWithHttpInfo (long? petId, string apiKey = null)
+        public Org.OpenAPITools.Client.ApiResponse<Object> DeletePetWithHttpInfo (long petId, string apiKey = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
@@ -759,7 +760,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeletePetAsync (long? petId, string apiKey = null)
+        public async System.Threading.Tasks.Task DeletePetAsync (long petId, string apiKey = null)
         {
              await DeletePetAsyncWithHttpInfo(petId, apiKey);
 
@@ -772,11 +773,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">Pet id to delete</param>
         /// <param name="apiKey"> (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long? petId, string apiKey = null)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> DeletePetAsyncWithHttpInfo (long petId, string apiKey = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->DeletePet");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -914,6 +916,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'status' is set
             if (status == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'status' when calling PetApi->FindPetsByStatus");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1060,6 +1063,7 @@ namespace Org.OpenAPITools.Api
             if (tags == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'tags' when calling PetApi->FindPetsByTags");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1114,7 +1118,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>Pet</returns>
-        public Pet GetPetById (long? petId)
+        public Pet GetPetById (long petId)
         {
              Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
              return localVarResponse.Data;
@@ -1126,7 +1130,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse< Pet > GetPetByIdWithHttpInfo (long? petId)
+        public Org.OpenAPITools.Client.ApiResponse< Pet > GetPetByIdWithHttpInfo (long petId)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
@@ -1177,7 +1181,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync (long? petId)
+        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync (long petId)
         {
              Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdAsyncWithHttpInfo(petId);
              return localVarResponse.Data;
@@ -1190,11 +1194,12 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdAsyncWithHttpInfo (long? petId)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdAsyncWithHttpInfo (long petId)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->GetPetById");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1321,6 +1326,7 @@ namespace Org.OpenAPITools.Api
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling PetApi->UpdatePet");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1368,7 +1374,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns></returns>
-        public void UpdatePetWithForm (long? petId, string name = null, string status = null)
+        public void UpdatePetWithForm (long petId, string name = null, string status = null)
         {
              UpdatePetWithFormWithHttpInfo(petId, name, status);
         }
@@ -1381,7 +1387,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Object> UpdatePetWithFormWithHttpInfo (long? petId, string name = null, string status = null)
+        public Org.OpenAPITools.Client.ApiResponse<Object> UpdatePetWithFormWithHttpInfo (long petId, string name = null, string status = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
@@ -1442,7 +1448,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task UpdatePetWithFormAsync (long? petId, string name = null, string status = null)
+        public async System.Threading.Tasks.Task UpdatePetWithFormAsync (long petId, string name = null, string status = null)
         {
              await UpdatePetWithFormAsyncWithHttpInfo(petId, name, status);
 
@@ -1456,11 +1462,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="name">Updated name of the pet (optional)</param>
         /// <param name="status">Updated status of the pet (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> UpdatePetWithFormAsyncWithHttpInfo (long? petId, string name = null, string status = null)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> UpdatePetWithFormAsyncWithHttpInfo (long petId, string name = null, string status = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UpdatePetWithForm");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1517,7 +1524,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile (long? petId, string additionalMetadata = null, System.IO.Stream file = null)
+        public ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
         {
              Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
              return localVarResponse.Data;
@@ -1531,7 +1538,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithHttpInfo (long? petId, string additionalMetadata = null, System.IO.Stream file = null)
+        public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithHttpInfo (long petId, string additionalMetadata = null, System.IO.Stream file = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
@@ -1593,7 +1600,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync (long? petId, string additionalMetadata = null, System.IO.Stream file = null)
+        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync (long petId, string additionalMetadata = null, System.IO.Stream file = null)
         {
              Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileAsyncWithHttpInfo(petId, additionalMetadata, file);
              return localVarResponse.Data;
@@ -1608,11 +1615,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileAsyncWithHttpInfo (long? petId, string additionalMetadata = null, System.IO.Stream file = null)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileAsyncWithHttpInfo (long petId, string additionalMetadata = null, System.IO.Stream file = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFile");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1670,7 +1678,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+        public ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
         {
              Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
              return localVarResponse.Data;
@@ -1684,11 +1692,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithRequiredFileWithHttpInfo (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+        public Org.OpenAPITools.Client.ApiResponse< ApiResponse > UploadFileWithRequiredFileWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFileWithRequiredFile");
+
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredFile' when calling PetApi->UploadFileWithRequiredFile");
@@ -1749,7 +1758,7 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
         {
              Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileAsyncWithHttpInfo(petId, requiredFile, additionalMetadata);
              return localVarResponse.Data;
@@ -1764,14 +1773,16 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileAsyncWithHttpInfo (long? petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileAsyncWithHttpInfo (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
         {
             // verify the required parameter 'petId' is set
             if (petId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'petId' when calling PetApi->UploadFileWithRequiredFile");
+
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'requiredFile' when calling PetApi->UploadFileWithRequiredFile");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -55,8 +55,8 @@ namespace Org.OpenAPITools.Api
         /// Returns a map of status codes to quantities
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>Dictionary&lt;string, int?&gt;</returns>
-        Dictionary<string, int?> GetInventory ();
+        /// <returns>Dictionary&lt;string, int&gt;</returns>
+        Dictionary<string, int> GetInventory ();
 
         /// <summary>
         /// Returns pet inventories by status
@@ -65,8 +65,8 @@ namespace Org.OpenAPITools.Api
         /// Returns a map of status codes to quantities
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of Dictionary&lt;string, int?&gt;</returns>
-        ApiResponse<Dictionary<string, int?>> GetInventoryWithHttpInfo ();
+        /// <returns>ApiResponse of Dictionary&lt;string, int&gt;</returns>
+        ApiResponse<Dictionary<string, int>> GetInventoryWithHttpInfo ();
         /// <summary>
         /// Find purchase order by ID
         /// </summary>
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>Order</returns>
-        Order GetOrderById (long? orderId);
+        Order GetOrderById (long orderId);
 
         /// <summary>
         /// Find purchase order by ID
@@ -87,7 +87,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo (long? orderId);
+        ApiResponse<Order> GetOrderByIdWithHttpInfo (long orderId);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -146,8 +146,8 @@ namespace Org.OpenAPITools.Api
         /// Returns a map of status codes to quantities
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>Task of Dictionary&lt;string, int?&gt;</returns>
-        System.Threading.Tasks.Task<Dictionary<string, int?>> GetInventoryAsync ();
+        /// <returns>Task of Dictionary&lt;string, int&gt;</returns>
+        System.Threading.Tasks.Task<Dictionary<string, int>> GetInventoryAsync ();
 
         /// <summary>
         /// Returns pet inventories by status
@@ -156,8 +156,8 @@ namespace Org.OpenAPITools.Api
         /// Returns a map of status codes to quantities
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>Task of ApiResponse (Dictionary&lt;string, int?&gt;)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Dictionary<string, int?>>> GetInventoryAsyncWithHttpInfo ();
+        /// <returns>Task of ApiResponse (Dictionary&lt;string, int&gt;)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Dictionary<string, int>>> GetInventoryAsyncWithHttpInfo ();
         /// <summary>
         /// Find purchase order by ID
         /// </summary>
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync (long? orderId);
+        System.Threading.Tasks.Task<Order> GetOrderByIdAsync (long orderId);
 
         /// <summary>
         /// Find purchase order by ID
@@ -178,7 +178,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdAsyncWithHttpInfo (long? orderId);
+        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdAsyncWithHttpInfo (long orderId);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -208,7 +208,7 @@ namespace Org.OpenAPITools.Api
     /// </summary>
     public interface IStoreApi : IStoreApiSync, IStoreApiAsync
     {
-        
+
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Api
     public partial class StoreApi : IStoreApi
     {
         private Org.OpenAPITools.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="StoreApi"/> class.
         /// </summary>
@@ -272,7 +272,7 @@ namespace Org.OpenAPITools.Api
             if(client == null) throw new ArgumentNullException("client");
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             this.AsynchronousClient = asyncClient;
             this.Configuration = configuration;
@@ -399,6 +399,7 @@ namespace Org.OpenAPITools.Api
             if (orderId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'orderId' when calling StoreApi->DeleteOrder");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -435,10 +436,10 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>Dictionary&lt;string, int?&gt;</returns>
-        public Dictionary<string, int?> GetInventory ()
+        /// <returns>Dictionary&lt;string, int&gt;</returns>
+        public Dictionary<string, int> GetInventory ()
         {
-             Org.OpenAPITools.Client.ApiResponse<Dictionary<string, int?>> localVarResponse = GetInventoryWithHttpInfo();
+             Org.OpenAPITools.Client.ApiResponse<Dictionary<string, int>> localVarResponse = GetInventoryWithHttpInfo();
              return localVarResponse.Data;
         }
 
@@ -446,10 +447,9 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of Dictionary&lt;string, int?&gt;</returns>
-        public Org.OpenAPITools.Client.ApiResponse< Dictionary<string, int?> > GetInventoryWithHttpInfo ()
+        /// <returns>ApiResponse of Dictionary&lt;string, int&gt;</returns>
+        public Org.OpenAPITools.Client.ApiResponse< Dictionary<string, int> > GetInventoryWithHttpInfo ()
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -475,7 +475,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var response = this.Client.Get< Dictionary<string, int?> >("/store/inventory", requestOptions, this.Configuration);
+            var response = this.Client.Get< Dictionary<string, int> >("/store/inventory", requestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -490,10 +490,10 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>Task of Dictionary&lt;string, int?&gt;</returns>
-        public async System.Threading.Tasks.Task<Dictionary<string, int?>> GetInventoryAsync ()
+        /// <returns>Task of Dictionary&lt;string, int&gt;</returns>
+        public async System.Threading.Tasks.Task<Dictionary<string, int>> GetInventoryAsync ()
         {
-             Org.OpenAPITools.Client.ApiResponse<Dictionary<string, int?>> localVarResponse = await GetInventoryAsyncWithHttpInfo();
+             Org.OpenAPITools.Client.ApiResponse<Dictionary<string, int>> localVarResponse = await GetInventoryAsyncWithHttpInfo();
              return localVarResponse.Data;
 
         }
@@ -502,8 +502,8 @@ namespace Org.OpenAPITools.Api
         /// Returns pet inventories by status Returns a map of status codes to quantities
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>Task of ApiResponse (Dictionary&lt;string, int?&gt;)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Dictionary<string, int?>>> GetInventoryAsyncWithHttpInfo ()
+        /// <returns>Task of ApiResponse (Dictionary&lt;string, int&gt;)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Dictionary<string, int>>> GetInventoryAsyncWithHttpInfo ()
         {
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -531,7 +531,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var response = await this.AsynchronousClient.GetAsync<Dictionary<string, int?>>("/store/inventory", requestOptions, this.Configuration);
+            var response = await this.AsynchronousClient.GetAsync<Dictionary<string, int>>("/store/inventory", requestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -548,7 +548,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>Order</returns>
-        public Order GetOrderById (long? orderId)
+        public Order GetOrderById (long orderId)
         {
              Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
              return localVarResponse.Data;
@@ -560,7 +560,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse< Order > GetOrderByIdWithHttpInfo (long? orderId)
+        public Org.OpenAPITools.Client.ApiResponse< Order > GetOrderByIdWithHttpInfo (long orderId)
         {
             // verify the required parameter 'orderId' is set
             if (orderId == null)
@@ -606,7 +606,7 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync (long? orderId)
+        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync (long orderId)
         {
              Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdAsyncWithHttpInfo(orderId);
              return localVarResponse.Data;
@@ -619,11 +619,12 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdAsyncWithHttpInfo (long? orderId)
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdAsyncWithHttpInfo (long orderId)
         {
             // verify the required parameter 'orderId' is set
             if (orderId == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'orderId' when calling StoreApi->GetOrderById");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -740,6 +741,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling StoreApi->PlaceOrder");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Api/UserApi.cs
@@ -384,7 +384,7 @@ namespace Org.OpenAPITools.Api
     /// </summary>
     public interface IUserApi : IUserApiSync, IUserApiAsync
     {
-        
+
     }
 
     /// <summary>
@@ -393,7 +393,7 @@ namespace Org.OpenAPITools.Api
     public partial class UserApi : IUserApi
     {
         private Org.OpenAPITools.Client.ExceptionFactory _exceptionFactory = (name, response) => null;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="UserApi"/> class.
         /// </summary>
@@ -448,7 +448,7 @@ namespace Org.OpenAPITools.Api
             if(client == null) throw new ArgumentNullException("client");
             if(asyncClient == null) throw new ArgumentNullException("asyncClient");
             if(configuration == null) throw new ArgumentNullException("configuration");
-            
+
             this.Client = client;
             this.AsynchronousClient = asyncClient;
             this.Configuration = configuration;
@@ -574,6 +574,7 @@ namespace Org.OpenAPITools.Api
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling UserApi->CreateUser");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -682,6 +683,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling UserApi->CreateUsersWithArrayInput");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -792,6 +794,7 @@ namespace Org.OpenAPITools.Api
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling UserApi->CreateUsersWithListInput");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -901,6 +904,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'username' is set
             if (username == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'username' when calling UserApi->DeleteUser");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1017,6 +1021,7 @@ namespace Org.OpenAPITools.Api
             if (username == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'username' when calling UserApi->GetUserByName");
 
+
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1076,6 +1081,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'username' is set
             if (username == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'username' when calling UserApi->LoginUser");
+
             // verify the required parameter 'password' is set
             if (password == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'password' when calling UserApi->LoginUser");
@@ -1158,9 +1164,11 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'username' is set
             if (username == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'username' when calling UserApi->LoginUser");
+
             // verify the required parameter 'password' is set
             if (password == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'password' when calling UserApi->LoginUser");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1231,7 +1239,6 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of Object(void)</returns>
         public Org.OpenAPITools.Client.ApiResponse<Object> LogoutUserWithHttpInfo ()
         {
-
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
             String[] @contentTypes = new String[] {
@@ -1335,6 +1342,7 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'username' is set
             if (username == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'username' when calling UserApi->UpdateUser");
+
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling UserApi->UpdateUser");
@@ -1397,9 +1405,11 @@ namespace Org.OpenAPITools.Api
             // verify the required parameter 'username' is set
             if (username == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'username' when calling UserApi->UpdateUser");
+
             // verify the required parameter 'body' is set
             if (body == null)
                 throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'body' when calling UserApi->UpdateUser");
+
 
             Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
 

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
+        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name="code", EmitDefaultValue=false)]
-        public int? Code { get; set; }
+        public int Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
         /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal?>> arrayArrayNumber = default(List<List<decimal?>>))
+        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
         {
             this.ArrayArrayNumber = arrayArrayNumber;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [DataMember(Name="ArrayArrayNumber", EmitDefaultValue=false)]
-        public List<List<decimal?>> ArrayArrayNumber { get; set; }
+        public List<List<decimal>> ArrayArrayNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
         /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal?> arrayNumber = default(List<decimal?>))
+        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
         {
             this.ArrayNumber = arrayNumber;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [DataMember(Name="ArrayNumber", EmitDefaultValue=false)]
-        public List<decimal?> ArrayNumber { get; set; }
+        public List<decimal> ArrayNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="arrayOfString">arrayOfString.</param>
         /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
         /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long?>> arrayArrayOfInteger = default(List<List<long?>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
         {
             this.ArrayOfString = arrayOfString;
             this.ArrayArrayOfInteger = arrayArrayOfInteger;
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [DataMember(Name="array_array_of_integer", EmitDefaultValue=false)]
-        public List<List<long?>> ArrayArrayOfInteger { get; set; }
+        public List<List<long>> ArrayArrayOfInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayArrayOfModel

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool? declawed = default(bool?), string className = default(string), string color = "red") : base(className, color)
+        public Cat(bool declawed = default(bool), string className = default(string), string color = "red") : base(className, color)
         {
             this.Declawed = declawed;
         }
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name="declawed", EmitDefaultValue=false)]
-        public bool? Declawed { get; set; }
+        public bool Declawed { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long? id = default(long?), string name = "default-name")
+        public Category(long id = default(long), string name = "default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name="id", EmitDefaultValue=false)]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="dateTime">dateTime.</param>
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
-        public FormatTest(int? integer = default(int?), int? int32 = default(int?), long? int64 = default(long?), decimal? number = default(decimal?), float? _float = default(float?), double? _double = default(double?), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime? date = default(DateTime?), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string))
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -106,37 +106,37 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name="integer", EmitDefaultValue=false)]
-        public int? Integer { get; set; }
+        public int Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name="int32", EmitDefaultValue=false)]
-        public int? Int32 { get; set; }
+        public int Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name="int64", EmitDefaultValue=false)]
-        public long? Int64 { get; set; }
+        public long Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
         /// </summary>
         [DataMember(Name="number", EmitDefaultValue=false)]
-        public decimal? Number { get; set; }
+        public decimal Number { get; set; }
 
         /// <summary>
         /// Gets or Sets Float
         /// </summary>
         [DataMember(Name="float", EmitDefaultValue=false)]
-        public float? Float { get; set; }
+        public float Float { get; set; }
 
         /// <summary>
         /// Gets or Sets Double
         /// </summary>
         [DataMember(Name="double", EmitDefaultValue=false)]
-        public double? Double { get; set; }
+        public double Double { get; set; }
 
         /// <summary>
         /// Gets or Sets String
@@ -161,19 +161,19 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name="date", EmitDefaultValue=false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime? Date { get; set; }
+        public DateTime Date { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name="dateTime", EmitDefaultValue=false)]
-        public DateTime? DateTime { get; set; }
+        public DateTime DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name="uuid", EmitDefaultValue=false)]
-        public Guid? Uuid { get; set; }
+        public Guid Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -281,62 +281,62 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int?) maximum
-            if(this.Integer > (int?)100)
+            // Integer (int) maximum
+            if(this.Integer > (int)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int?) minimum
-            if(this.Integer < (int?)10)
+            // Integer (int) minimum
+            if(this.Integer < (int)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int?) maximum
-            if(this.Int32 > (int?)200)
+            // Int32 (int) maximum
+            if(this.Int32 > (int)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int?) minimum
-            if(this.Int32 < (int?)20)
+            // Int32 (int) minimum
+            if(this.Int32 < (int)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // Number (decimal?) maximum
-            if(this.Number > (decimal?)543.2)
+            // Number (decimal) maximum
+            if(this.Number > (decimal)543.2)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value less than or equal to 543.2.", new [] { "Number" });
             }
 
-            // Number (decimal?) minimum
-            if(this.Number < (decimal?)32.1)
+            // Number (decimal) minimum
+            if(this.Number < (decimal)32.1)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // Float (float?) maximum
-            if(this.Float > (float?)987.6)
+            // Float (float) maximum
+            if(this.Float > (float)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Float, must be a value less than or equal to 987.6.", new [] { "Float" });
             }
 
-            // Float (float?) minimum
-            if(this.Float < (float?)54.3)
+            // Float (float) minimum
+            if(this.Float < (float)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Float, must be a value greater than or equal to 54.3.", new [] { "Float" });
             }
 
-            // Double (double?) maximum
-            if(this.Double > (double?)123.4)
+            // Double (double) maximum
+            if(this.Double > (double)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Double, must be a value less than or equal to 123.4.", new [] { "Double" });
             }
 
-            // Double (double?) minimum
-            if(this.Double < (double?)67.8)
+            // Double (double) minimum
+            if(this.Double < (double)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Double, must be a value greater than or equal to 67.8.", new [] { "Double" });
             }

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/MapTest.cs
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="mapOfEnumString">mapOfEnumString.</param>
         /// <param name="directMap">directMap.</param>
         /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool?> directMap = default(Dictionary<string, bool?>), Dictionary<string, bool?> indirectMap = default(Dictionary<string, bool?>))
+        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
         {
             this.MapMapOfString = mapMapOfString;
             this.MapOfEnumString = mapOfEnumString;
@@ -83,13 +83,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DirectMap
         /// </summary>
         [DataMember(Name="direct_map", EmitDefaultValue=false)]
-        public Dictionary<string, bool?> DirectMap { get; set; }
+        public Dictionary<string, bool> DirectMap { get; set; }
 
         /// <summary>
         /// Gets or Sets IndirectMap
         /// </summary>
         [DataMember(Name="indirect_map", EmitDefaultValue=false)]
-        public Dictionary<string, bool?> IndirectMap { get; set; }
+        public Dictionary<string, bool> IndirectMap { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this.Uuid = uuid;
             this.DateTime = dateTime;
@@ -49,13 +49,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name="uuid", EmitDefaultValue=false)]
-        public Guid? Uuid { get; set; }
+        public Guid Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name="dateTime", EmitDefaultValue=false)]
-        public DateTime? DateTime { get; set; }
+        public DateTime DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="_class">_class.</param>
-        public Model200Response(int? name = default(int?), string _class = default(string))
+        public Model200Response(int name = default(int), string _class = default(string))
         {
             this.Name = name;
             this.Class = _class;
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name="name", EmitDefaultValue=false)]
-        public int? Name { get; set; }
+        public int Name { get; set; }
 
         /// <summary>
         /// Gets or Sets Class

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name (required).</param>
         /// <param name="property">property.</param>
-        public Name(int? name = default(int?), string property = default(string))
+        public Name(int name = default(int), string property = default(string))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -60,13 +60,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets _Name
         /// </summary>
         [DataMember(Name="name", EmitDefaultValue=false)]
-        public int? _Name { get; set; }
+        public int _Name { get; set; }
 
         /// <summary>
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name="snake_case", EmitDefaultValue=false)]
-        public int? SnakeCase { get; private set; }
+        public int SnakeCase { get; private set; }
 
         /// <summary>
         /// Gets or Sets Property
@@ -78,7 +78,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets _123Number
         /// </summary>
         [DataMember(Name="123Number", EmitDefaultValue=false)]
-        public int? _123Number { get; private set; }
+        public int _123Number { get; private set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal? justNumber = default(decimal?))
+        public NumberOnly(decimal justNumber = default(decimal))
         {
             this.JustNumber = justNumber;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name="JustNumber", EmitDefaultValue=false)]
-        public decimal? JustNumber { get; set; }
+        public decimal JustNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
+        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -96,31 +96,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name="id", EmitDefaultValue=false)]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name="petId", EmitDefaultValue=false)]
-        public long? PetId { get; set; }
+        public long PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name="quantity", EmitDefaultValue=false)]
-        public int? Quantity { get; set; }
+        public int Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         [DataMember(Name="shipDate", EmitDefaultValue=false)]
-        public DateTime? ShipDate { get; set; }
+        public DateTime ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name="complete", EmitDefaultValue=false)]
-        public bool? Complete { get; set; }
+        public bool Complete { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
+        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name="my_number", EmitDefaultValue=false)]
-        public decimal? MyNumber { get; set; }
+        public decimal MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name="my_boolean", EmitDefaultValue=false)]
-        public bool? MyBoolean { get; set; }
+        public bool MyBoolean { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -109,7 +109,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name="id", EmitDefaultValue=false)]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="_return">_return.</param>
-        public Return(int? _return = default(int?))
+        public Return(int _return = default(int))
         {
             this._Return = _return;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets _Return
         /// </summary>
         [DataMember(Name="return", EmitDefaultValue=false)]
-        public int? _Return { get; set; }
+        public int _Return { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
-        public SpecialModelName(long? specialPropertyName = default(long?))
+        public SpecialModelName(long specialPropertyName = default(long))
         {
             this.SpecialPropertyName = specialPropertyName;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name="$special[property.name]", EmitDefaultValue=false)]
-        public long? SpecialPropertyName { get; set; }
+        public long SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long? id = default(long?), string name = default(string))
+        public Tag(long id = default(long), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name="id", EmitDefaultValue=false)]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp-refactor/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="password">password.</param>
         /// <param name="phone">phone.</param>
         /// <param name="userStatus">User Status.</param>
-        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?))
+        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int))
         {
             this.Id = id;
             this.Username = username;
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name="id", EmitDefaultValue=false)]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name="userStatus", EmitDefaultValue=false)]
-        public int? UserStatus { get; set; }
+        public int UserStatus { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add support for nullable parameters and properties in the C# client (refactor)

cc @mandrean (2017/08) @jimschubert (2017/09)




