### PR TITLE
set isEnum when model is enum

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2181,12 +2181,12 @@ public class DefaultCodegen implements CodegenConfig {
 
             // set is enum to true when a model is enum and type is non-primitive.
             if (StringUtils.isNotBlank(p.get$ref()) && globalSchemas != null) {
-               Schema ref = globalSchemas.get(ModelUtils.getSimpleRef(p.get$ref()));
-               if (ref != null) {
-                   if (ref.getEnum() != null) {
-                       property.isEnum = true;
-                   }
-               }
+                Schema ref = globalSchemas.get(ModelUtils.getSimpleRef(p.get$ref()));
+                if (ref != null) {
+                    if (ref.getEnum() != null) {
+                        property.isEnum = true;
+                    }
+                }
             }
 
             setNonArrayMapProperty(property, type);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2180,7 +2180,7 @@ public class DefaultCodegen implements CodegenConfig {
             // --END of revision
 
             // set is enum to true when a model is enum and type is non-primitive.
-            if (!StringUtils.isBlank(p.get$ref())) {
+            if (StringUtils.isNotBlank(p.get$ref()) && globalSchemas != null) {
                Schema ref = globalSchemas.get(ModelUtils.getSimpleRef(p.get$ref()));
                if (ref != null) {
                    if (ref.getEnum() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2178,6 +2178,17 @@ public class DefaultCodegen implements CodegenConfig {
             //    property.baseType = getSimpleRef(p.get$ref());
             //}
             // --END of revision
+
+            // set is enum to true when a model is enum and type is non-primitive.
+            if (!StringUtils.isBlank(p.get$ref())) {
+               Schema ref = globalSchemas.get(ModelUtils.getSimpleRef(p.get$ref()));
+               if (ref != null) {
+                   if (ref.getEnum() != null) {
+                       property.isEnum = true;
+                   }
+               }
+            }
+
             setNonArrayMapProperty(property, type);
         }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fix #1780 , Along with setting isModel to true, set isEnum to true when a model is generated for enum. This will allow better handling for enum variables when enum is of nonPrimitiveType.
 
@wing328 @OpenAPITools/generator-core-team 
