### PR TITLE
[C++][QT5] plain object compilation fix

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/model-header.mustache
@@ -27,7 +27,6 @@ public:
     {{classname}}();
     {{classname}}(QString json);
     ~{{classname}}() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -43,6 +42,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     {{#vars}}
     {{{dataType}}} {{name}};
     bool m_{{name}}_isSet;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/object.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/object.mustache
@@ -11,6 +11,14 @@ namespace {{this}} {
 
 class {{prefix}}Object {
   public:
+    {{prefix}}Object() {
+
+    }
+    
+    {{prefix}}Object(QString jsonString) {
+        fromJson(jsonString);
+    }
+
     virtual ~{{prefix}}Object(){
 
     }
@@ -41,7 +49,7 @@ class {{prefix}}Object {
         return true;
     }
 private :
-   QJsonObject jObj;
+    QJsonObject jObj;
 };
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/model-header.mustache
@@ -27,7 +27,6 @@ public:
     {{classname}}();
     {{classname}}(QString json);
     ~{{classname}}() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -43,6 +42,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     {{#vars}}
     {{{dataType}}} {{name}};
     bool m_{{name}}_isSet;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/object.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/object.mustache
@@ -11,6 +11,14 @@ namespace {{this}} {
 
 class {{prefix}}Object {
   public:
+    {{prefix}}Object() {
+
+    }
+    
+    {{prefix}}Object(QString jsonString) {
+        fromJson(jsonString);
+    }
+
     virtual ~{{prefix}}Object(){
 
     }
@@ -41,7 +49,7 @@ class {{prefix}}Object {
         return true;
     }
 private :
-   QJsonObject jObj;
+    QJsonObject jObj;
 };
 
 {{#cppNamespaceDeclarations}}

--- a/samples/client/petstore/cpp-qt5/client/OAIApiResponse.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIApiResponse.h
@@ -33,7 +33,6 @@ public:
     OAIApiResponse();
     OAIApiResponse(QString json);
     ~OAIApiResponse() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -53,6 +52,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint32 code;
     bool m_code_isSet;
     bool m_code_isValid;

--- a/samples/client/petstore/cpp-qt5/client/OAICategory.h
+++ b/samples/client/petstore/cpp-qt5/client/OAICategory.h
@@ -33,7 +33,6 @@ public:
     OAICategory();
     OAICategory(QString json);
     ~OAICategory() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -50,6 +49,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/client/petstore/cpp-qt5/client/OAIObject.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIObject.h
@@ -20,6 +20,14 @@ namespace OpenAPI {
 
 class OAIObject {
   public:
+    OAIObject() {
+
+    }
+    
+    OAIObject(QString jsonString) {
+        fromJson(jsonString);
+    }
+
     virtual ~OAIObject(){
 
     }
@@ -50,7 +58,7 @@ class OAIObject {
         return true;
     }
 private :
-   QJsonObject jObj;
+    QJsonObject jObj;
 };
 
 }

--- a/samples/client/petstore/cpp-qt5/client/OAIOrder.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIOrder.h
@@ -34,7 +34,6 @@ public:
     OAIOrder();
     OAIOrder(QString json);
     ~OAIOrder() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -63,6 +62,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/client/petstore/cpp-qt5/client/OAIPet.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIPet.h
@@ -36,7 +36,6 @@ public:
     OAIPet();
     OAIPet(QString json);
     ~OAIPet() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -65,6 +64,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/client/petstore/cpp-qt5/client/OAITag.h
+++ b/samples/client/petstore/cpp-qt5/client/OAITag.h
@@ -33,7 +33,6 @@ public:
     OAITag();
     OAITag(QString json);
     ~OAITag() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -50,6 +49,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/client/petstore/cpp-qt5/client/OAIUser.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIUser.h
@@ -33,7 +33,6 @@ public:
     OAIUser();
     OAIUser(QString json);
     ~OAIUser() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -68,6 +67,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIApiResponse.h
@@ -33,7 +33,6 @@ public:
     OAIApiResponse();
     OAIApiResponse(QString json);
     ~OAIApiResponse() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -53,6 +52,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint32 code;
     bool m_code_isSet;
     bool m_code_isValid;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAICategory.h
@@ -33,7 +33,6 @@ public:
     OAICategory();
     OAICategory(QString json);
     ~OAICategory() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -50,6 +49,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIObject.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIObject.h
@@ -20,6 +20,14 @@ namespace OpenAPI {
 
 class OAIObject {
   public:
+    OAIObject() {
+
+    }
+    
+    OAIObject(QString jsonString) {
+        fromJson(jsonString);
+    }
+
     virtual ~OAIObject(){
 
     }
@@ -50,7 +58,7 @@ class OAIObject {
         return true;
     }
 private :
-   QJsonObject jObj;
+    QJsonObject jObj;
 };
 
 }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIOrder.h
@@ -34,7 +34,6 @@ public:
     OAIOrder();
     OAIOrder(QString json);
     ~OAIOrder() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -63,6 +62,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIPet.h
@@ -36,7 +36,6 @@ public:
     OAIPet();
     OAIPet(QString json);
     ~OAIPet() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -65,6 +64,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAITag.h
@@ -33,7 +33,6 @@ public:
     OAITag();
     OAITag(QString json);
     ~OAITag() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -50,6 +49,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/models/OAIUser.h
@@ -33,7 +33,6 @@ public:
     OAIUser();
     OAIUser(QString json);
     ~OAIUser() override;
-    void init();
 
     QString asJson () const override;
     QJsonObject asJsonObject() const override;
@@ -68,6 +67,7 @@ public:
     virtual bool isValid() const override;
 
 private:
+    void init();
     qint64 id;
     bool m_id_isSet;
     bool m_id_isValid;


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fix 
- Models which are plain objects failed to compile due to missing constructor in the base class
- make model `init` function private

cc
@stkrwork @ravinikam @MartinDelille @fvarose 

