### PR TITLE
[C++][Pistache] Fix missing const keyword in array and maps

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -36,7 +36,7 @@ nlohmann::json {{classname}}::toJson() const
     {{/required}}{{#required}}val["{{baseName}}"] = m_{{name}};
     {{/required}}{{/isListContainer}}{{/isPrimitiveType}}{{#isListContainer}}{
         nlohmann::json jsonArray;
-        for( auto& item : m_{{name}} )
+        for( const auto& item : m_{{name}} )
         {
             jsonArray.push_back({{prefix}}ModelBase::toJson(item));
         }
@@ -49,7 +49,7 @@ nlohmann::json {{classname}}::toJson() const
     }
     {{/isListContainer}}{{#isMapContainer}}{
         nlohmann::json jsonObj;
-        for( auto const& item : m_{{name}} )
+        for( const auto& item : m_{{name}} )
         {   {{^items.isContainer}} 
             jsonObj[item.first] = {{prefix}}ModelBase::toJson(item.second);{{/items.isContainer}} {{#items.isListContainer}} 
             jsonObj[item.first] = {{prefix}}ArrayHelper::toJson<{{{items.items.datatype}}}>(item.second);
@@ -84,7 +84,7 @@ void {{classname}}::fromJson(const nlohmann::json& val)
         {{^required}}if(val.find("{{baseName}}") != val.end())
         {
         {{/required}}
-            for( auto& item : val["{{baseName}}"] )
+            for( const auto& item : val["{{baseName}}"] )
             {
                 {{#isPrimitiveType}}m_{{name}}.push_back(item);
                 {{/isPrimitiveType}}{{^isPrimitiveType}}{{#items.isString}}m_{{name}}.push_back(item);
@@ -114,7 +114,7 @@ void {{classname}}::fromJson(const nlohmann::json& val)
             if(val["{{baseName}}"].is_object()) { {{^items.isContainer}}
                 m_{{name}} = {{prefix}}MapHelper::fromJson<{{{items.datatype}}}>(val["{{baseName}}"]);
                 {{/items.isContainer}} {{#items.isContainer}}
-                for( auto& item : val["{{baseName}}"].items() )
+                for( const auto& item : val["{{baseName}}"].items() )
                 {   {{#items.isMapContainer}}
                     {{{items.datatype}}} newItem = {{prefix}}MapHelper::fromJson<{{{items.items.datatype}}}>(item.value());
                     {{/items.isMapContainer}}{{#items.isListContainer}} 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fixes #1801 

Missing `const` keyword after rework 

@stkrwork @MartinDelille @fvarose @ravinikam 
