### PR TITLE
[C++][QT5] Emit worker also in response signal

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -172,6 +172,7 @@ void
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit {{nickname}}Signal({{#returnType}}output{{/returnType}});
+        emit {{nickname}}SignalFull(worker{{#returnType}}, output{{/returnType}});
     } else {
         emit {{nickname}}SignalE({{#returnType}}output, {{/returnType}}error_type, error_str);
         emit {{nickname}}SignalEFull(worker, error_type, error_str);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -33,6 +33,8 @@ private:
 signals:
     {{#operations}}{{#operation}}void {{nickname}}Signal({{#returnType}}{{{returnType}}} summary{{/returnType}});
     {{/operation}}{{/operations}}
+    {{#operations}}{{#operation}}void {{nickname}}SignalFull({{prefix}}HttpRequestWorker* worker{{#returnType}}, {{{returnType}}} summary{{/returnType}});
+    {{/operation}}{{/operations}}
     {{#operations}}{{#operation}}void {{nickname}}SignalE({{#returnType}}{{{returnType}}} summary, {{/returnType}}QNetworkReply::NetworkError error_type, QString& error_str);
     {{/operation}}{{/operations}}
     {{#operations}}{{#operation}}void {{nickname}}SignalEFull({{prefix}}HttpRequestWorker* worker, QNetworkReply::NetworkError error_type, QString& error_str);

--- a/samples/client/petstore/cpp-qt5/client/OAIPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIPetApi.cpp
@@ -32,7 +32,7 @@ OAIPetApi::OAIPetApi(QString host, QString basePath) {
 }
 
 void
-OAIPetApi::addPet(const OAIPet& oai_pet) {
+OAIPetApi::addPet(const OAIPet& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/pet");
     
@@ -40,7 +40,7 @@ OAIPetApi::addPet(const OAIPet& oai_pet) {
     OAIHttpRequestInput input(fullPath, "POST");
 
     
-    QString output = oai_pet.asJson();
+    QString output = body.asJson();
     input.request_body.append(output);
     
 
@@ -72,6 +72,7 @@ OAIPetApi::addPetCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit addPetSignal();
+        emit addPetSignalFull(worker);
     } else {
         emit addPetSignalE(error_type, error_str);
         emit addPetSignalEFull(worker, error_type, error_str);
@@ -121,6 +122,7 @@ OAIPetApi::deletePetCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit deletePetSignal();
+        emit deletePetSignalFull(worker);
     } else {
         emit deletePetSignalE(error_type, error_str);
         emit deletePetSignalEFull(worker, error_type, error_str);
@@ -214,6 +216,7 @@ OAIPetApi::findPetsByStatusCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit findPetsByStatusSignal(output);
+        emit findPetsByStatusSignalFull(worker, output);
     } else {
         emit findPetsByStatusSignalE(output, error_type, error_str);
         emit findPetsByStatusSignalEFull(worker, error_type, error_str);
@@ -307,6 +310,7 @@ OAIPetApi::findPetsByTagsCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit findPetsByTagsSignal(output);
+        emit findPetsByTagsSignalFull(worker, output);
     } else {
         emit findPetsByTagsSignalE(output, error_type, error_str);
         emit findPetsByTagsSignalEFull(worker, error_type, error_str);
@@ -354,6 +358,7 @@ OAIPetApi::getPetByIdCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit getPetByIdSignal(output);
+        emit getPetByIdSignalFull(worker, output);
     } else {
         emit getPetByIdSignalE(output, error_type, error_str);
         emit getPetByIdSignalEFull(worker, error_type, error_str);
@@ -361,7 +366,7 @@ OAIPetApi::getPetByIdCallback(OAIHttpRequestWorker * worker) {
 }
 
 void
-OAIPetApi::updatePet(const OAIPet& oai_pet) {
+OAIPetApi::updatePet(const OAIPet& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/pet");
     
@@ -369,7 +374,7 @@ OAIPetApi::updatePet(const OAIPet& oai_pet) {
     OAIHttpRequestInput input(fullPath, "PUT");
 
     
-    QString output = oai_pet.asJson();
+    QString output = body.asJson();
     input.request_body.append(output);
     
 
@@ -401,6 +406,7 @@ OAIPetApi::updatePetCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit updatePetSignal();
+        emit updatePetSignalFull(worker);
     } else {
         emit updatePetSignalE(error_type, error_str);
         emit updatePetSignalEFull(worker, error_type, error_str);
@@ -453,6 +459,7 @@ OAIPetApi::updatePetWithFormCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit updatePetWithFormSignal();
+        emit updatePetWithFormSignalFull(worker);
     } else {
         emit updatePetWithFormSignalE(error_type, error_str);
         emit updatePetWithFormSignalEFull(worker, error_type, error_str);
@@ -506,6 +513,7 @@ OAIPetApi::uploadFileCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit uploadFileSignal(output);
+        emit uploadFileSignalFull(worker, output);
     } else {
         emit uploadFileSignalE(output, error_type, error_str);
         emit uploadFileSignalEFull(worker, error_type, error_str);

--- a/samples/client/petstore/cpp-qt5/client/OAIPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIPetApi.h
@@ -36,12 +36,12 @@ public:
     QString basePath;
     QMap<QString, QString> defaultHeaders;
 
-    void addPet(const OAIPet& oai_pet);
+    void addPet(const OAIPet& body);
     void deletePet(const qint64& pet_id, const QString& api_key);
     void findPetsByStatus(const QList<QString>& status);
     void findPetsByTags(const QList<QString>& tags);
     void getPetById(const qint64& pet_id);
-    void updatePet(const OAIPet& oai_pet);
+    void updatePet(const OAIPet& body);
     void updatePetWithForm(const qint64& pet_id, const QString& name, const QString& status);
     void uploadFile(const qint64& pet_id, const QString& additional_metadata, const OAIHttpRequestInputFileElement*& file);
     
@@ -64,6 +64,15 @@ signals:
     void updatePetSignal();
     void updatePetWithFormSignal();
     void uploadFileSignal(OAIApiResponse summary);
+    
+    void addPetSignalFull(OAIHttpRequestWorker* worker);
+    void deletePetSignalFull(OAIHttpRequestWorker* worker);
+    void findPetsByStatusSignalFull(OAIHttpRequestWorker* worker, QList<OAIPet> summary);
+    void findPetsByTagsSignalFull(OAIHttpRequestWorker* worker, QList<OAIPet> summary);
+    void getPetByIdSignalFull(OAIHttpRequestWorker* worker, OAIPet summary);
+    void updatePetSignalFull(OAIHttpRequestWorker* worker);
+    void updatePetWithFormSignalFull(OAIHttpRequestWorker* worker);
+    void uploadFileSignalFull(OAIHttpRequestWorker* worker, OAIApiResponse summary);
     
     void addPetSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
     void deletePetSignalE(QNetworkReply::NetworkError error_type, QString& error_str);

--- a/samples/client/petstore/cpp-qt5/client/OAIStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIStoreApi.cpp
@@ -71,6 +71,7 @@ OAIStoreApi::deleteOrderCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit deleteOrderSignal();
+        emit deleteOrderSignalFull(worker);
     } else {
         emit deleteOrderSignalE(error_type, error_str);
         emit deleteOrderSignalEFull(worker, error_type, error_str);
@@ -124,6 +125,7 @@ OAIStoreApi::getInventoryCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit getInventorySignal(output);
+        emit getInventorySignalFull(worker, output);
     } else {
         emit getInventorySignalE(output, error_type, error_str);
         emit getInventorySignalEFull(worker, error_type, error_str);
@@ -171,6 +173,7 @@ OAIStoreApi::getOrderByIdCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit getOrderByIdSignal(output);
+        emit getOrderByIdSignalFull(worker, output);
     } else {
         emit getOrderByIdSignalE(output, error_type, error_str);
         emit getOrderByIdSignalEFull(worker, error_type, error_str);
@@ -178,7 +181,7 @@ OAIStoreApi::getOrderByIdCallback(OAIHttpRequestWorker * worker) {
 }
 
 void
-OAIStoreApi::placeOrder(const OAIOrder& oai_order) {
+OAIStoreApi::placeOrder(const OAIOrder& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/store/order");
     
@@ -186,7 +189,7 @@ OAIStoreApi::placeOrder(const OAIOrder& oai_order) {
     OAIHttpRequestInput input(fullPath, "POST");
 
     
-    QString output = oai_order.asJson();
+    QString output = body.asJson();
     input.request_body.append(output);
     
 
@@ -219,6 +222,7 @@ OAIStoreApi::placeOrderCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit placeOrderSignal(output);
+        emit placeOrderSignalFull(worker, output);
     } else {
         emit placeOrderSignalE(output, error_type, error_str);
         emit placeOrderSignalEFull(worker, error_type, error_str);

--- a/samples/client/petstore/cpp-qt5/client/OAIStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIStoreApi.h
@@ -38,7 +38,7 @@ public:
     void deleteOrder(const QString& order_id);
     void getInventory();
     void getOrderById(const qint64& order_id);
-    void placeOrder(const OAIOrder& oai_order);
+    void placeOrder(const OAIOrder& body);
     
 private:
     void deleteOrderCallback (OAIHttpRequestWorker * worker);
@@ -51,6 +51,11 @@ signals:
     void getInventorySignal(QMap<QString, qint32> summary);
     void getOrderByIdSignal(OAIOrder summary);
     void placeOrderSignal(OAIOrder summary);
+    
+    void deleteOrderSignalFull(OAIHttpRequestWorker* worker);
+    void getInventorySignalFull(OAIHttpRequestWorker* worker, QMap<QString, qint32> summary);
+    void getOrderByIdSignalFull(OAIHttpRequestWorker* worker, OAIOrder summary);
+    void placeOrderSignalFull(OAIHttpRequestWorker* worker, OAIOrder summary);
     
     void deleteOrderSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
     void getInventorySignalE(QMap<QString, qint32> summary, QNetworkReply::NetworkError error_type, QString& error_str);

--- a/samples/client/petstore/cpp-qt5/client/OAIUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIUserApi.cpp
@@ -32,7 +32,7 @@ OAIUserApi::OAIUserApi(QString host, QString basePath) {
 }
 
 void
-OAIUserApi::createUser(const OAIUser& oai_user) {
+OAIUserApi::createUser(const OAIUser& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user");
     
@@ -40,7 +40,7 @@ OAIUserApi::createUser(const OAIUser& oai_user) {
     OAIHttpRequestInput input(fullPath, "POST");
 
     
-    QString output = oai_user.asJson();
+    QString output = body.asJson();
     input.request_body.append(output);
     
 
@@ -72,6 +72,7 @@ OAIUserApi::createUserCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit createUserSignal();
+        emit createUserSignalFull(worker);
     } else {
         emit createUserSignalE(error_type, error_str);
         emit createUserSignalEFull(worker, error_type, error_str);
@@ -79,7 +80,7 @@ OAIUserApi::createUserCallback(OAIHttpRequestWorker * worker) {
 }
 
 void
-OAIUserApi::createUsersWithArrayInput(const QList<OAIUser>& oai_user) {
+OAIUserApi::createUsersWithArrayInput(const QList<OAIUser>& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user/createWithArray");
     
@@ -87,7 +88,7 @@ OAIUserApi::createUsersWithArrayInput(const QList<OAIUser>& oai_user) {
     OAIHttpRequestInput input(fullPath, "POST");
 
     
-    QJsonDocument doc(::OpenAPI::toJsonValue(oai_user).toArray());
+    QJsonDocument doc(::OpenAPI::toJsonValue(body).toArray());
     QByteArray bytes = doc.toJson();
     input.request_body.append(bytes);
     
@@ -120,6 +121,7 @@ OAIUserApi::createUsersWithArrayInputCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit createUsersWithArrayInputSignal();
+        emit createUsersWithArrayInputSignalFull(worker);
     } else {
         emit createUsersWithArrayInputSignalE(error_type, error_str);
         emit createUsersWithArrayInputSignalEFull(worker, error_type, error_str);
@@ -127,7 +129,7 @@ OAIUserApi::createUsersWithArrayInputCallback(OAIHttpRequestWorker * worker) {
 }
 
 void
-OAIUserApi::createUsersWithListInput(const QList<OAIUser>& oai_user) {
+OAIUserApi::createUsersWithListInput(const QList<OAIUser>& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user/createWithList");
     
@@ -135,7 +137,7 @@ OAIUserApi::createUsersWithListInput(const QList<OAIUser>& oai_user) {
     OAIHttpRequestInput input(fullPath, "POST");
 
     
-    QJsonDocument doc(::OpenAPI::toJsonValue(oai_user).toArray());
+    QJsonDocument doc(::OpenAPI::toJsonValue(body).toArray());
     QByteArray bytes = doc.toJson();
     input.request_body.append(bytes);
     
@@ -168,6 +170,7 @@ OAIUserApi::createUsersWithListInputCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit createUsersWithListInputSignal();
+        emit createUsersWithListInputSignalFull(worker);
     } else {
         emit createUsersWithListInputSignalE(error_type, error_str);
         emit createUsersWithListInputSignalEFull(worker, error_type, error_str);
@@ -214,6 +217,7 @@ OAIUserApi::deleteUserCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit deleteUserSignal();
+        emit deleteUserSignalFull(worker);
     } else {
         emit deleteUserSignalE(error_type, error_str);
         emit deleteUserSignalEFull(worker, error_type, error_str);
@@ -261,6 +265,7 @@ OAIUserApi::getUserByNameCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit getUserByNameSignal(output);
+        emit getUserByNameSignalFull(worker, output);
     } else {
         emit getUserByNameSignalE(output, error_type, error_str);
         emit getUserByNameSignalEFull(worker, error_type, error_str);
@@ -322,6 +327,7 @@ OAIUserApi::loginUserCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit loginUserSignal(output);
+        emit loginUserSignalFull(worker, output);
     } else {
         emit loginUserSignalE(output, error_type, error_str);
         emit loginUserSignalEFull(worker, error_type, error_str);
@@ -365,6 +371,7 @@ OAIUserApi::logoutUserCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit logoutUserSignal();
+        emit logoutUserSignalFull(worker);
     } else {
         emit logoutUserSignalE(error_type, error_str);
         emit logoutUserSignalEFull(worker, error_type, error_str);
@@ -372,7 +379,7 @@ OAIUserApi::logoutUserCallback(OAIHttpRequestWorker * worker) {
 }
 
 void
-OAIUserApi::updateUser(const QString& username, const OAIUser& oai_user) {
+OAIUserApi::updateUser(const QString& username, const OAIUser& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user/{username}");
     QString usernamePathParam("{"); 
@@ -383,7 +390,7 @@ OAIUserApi::updateUser(const QString& username, const OAIUser& oai_user) {
     OAIHttpRequestInput input(fullPath, "PUT");
 
     
-    QString output = oai_user.asJson();
+    QString output = body.asJson();
     input.request_body.append(output);
     
 
@@ -415,6 +422,7 @@ OAIUserApi::updateUserCallback(OAIHttpRequestWorker * worker) {
 
     if (worker->error_type == QNetworkReply::NoError) {
         emit updateUserSignal();
+        emit updateUserSignalFull(worker);
     } else {
         emit updateUserSignalE(error_type, error_str);
         emit updateUserSignalEFull(worker, error_type, error_str);

--- a/samples/client/petstore/cpp-qt5/client/OAIUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/OAIUserApi.h
@@ -35,14 +35,14 @@ public:
     QString basePath;
     QMap<QString, QString> defaultHeaders;
 
-    void createUser(const OAIUser& oai_user);
-    void createUsersWithArrayInput(const QList<OAIUser>& oai_user);
-    void createUsersWithListInput(const QList<OAIUser>& oai_user);
+    void createUser(const OAIUser& body);
+    void createUsersWithArrayInput(const QList<OAIUser>& body);
+    void createUsersWithListInput(const QList<OAIUser>& body);
     void deleteUser(const QString& username);
     void getUserByName(const QString& username);
     void loginUser(const QString& username, const QString& password);
     void logoutUser();
-    void updateUser(const QString& username, const OAIUser& oai_user);
+    void updateUser(const QString& username, const OAIUser& body);
     
 private:
     void createUserCallback (OAIHttpRequestWorker * worker);
@@ -63,6 +63,15 @@ signals:
     void loginUserSignal(QString summary);
     void logoutUserSignal();
     void updateUserSignal();
+    
+    void createUserSignalFull(OAIHttpRequestWorker* worker);
+    void createUsersWithArrayInputSignalFull(OAIHttpRequestWorker* worker);
+    void createUsersWithListInputSignalFull(OAIHttpRequestWorker* worker);
+    void deleteUserSignalFull(OAIHttpRequestWorker* worker);
+    void getUserByNameSignalFull(OAIHttpRequestWorker* worker, OAIUser summary);
+    void loginUserSignalFull(OAIHttpRequestWorker* worker, QString summary);
+    void logoutUserSignalFull(OAIHttpRequestWorker* worker);
+    void updateUserSignalFull(OAIHttpRequestWorker* worker);
     
     void createUserSignalE(QNetworkReply::NetworkError error_type, QString& error_str);
     void createUsersWithArrayInputSignalE(QNetworkReply::NetworkError error_type, QString& error_str);


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Continuation of #1508
The `worker` parameter has the method `getResponseHeaders` which is needed in case the headers are to be extracted from the response.

To use, 
Connect to the response signal with the `worker` parameter
e.g.
```
addPetSignalFull(OAIHttpRequestWorker* worker)
```
to extract headers use
```
auto headers = worker->getResponseHeaders();
```
the changes related to parameter names is not related to this PR.

@stkrwork @MartinDelille @fvarose @ravinikam 
