### PR TITLE
Use 4-space instead of tab in Perl templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/perl/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/ApiClient.mustache
@@ -26,7 +26,6 @@ use Module::Runtime qw(use_module);
 
 use {{moduleName}}::Configuration;
 
-
 sub new {
     my $class = shift;
 
@@ -41,7 +40,7 @@ sub new {
         'ua' => LWP::UserAgent->new,
         'config' => $config,
     );
-  
+
     return bless \%args, $class;
 }
 
@@ -76,23 +75,21 @@ sub set_timeout {
 sub call_api {
     my $self = shift;
     my ($resource_path, $method, $query_params, $post_params, $header_params, $body_data, $auth_settings) = @_;
-  
+
     # update parameters based on authentication settings
     $self->update_params_for_auth($header_params, $query_params, $auth_settings); 
-  
-  
+
     my $_url = $self->{config}{base_url} . $resource_path;
-  
+
     # build query 
     if (%$query_params) {
         $_url = ($_url . '?' . eval { URI::Query->new($query_params)->stringify });
     }
-  
-  
+
     # body data
     $body_data = to_json($body_data->to_hash) if defined $body_data && $body_data->can('to_hash'); # model to json string
     my $_body_data = %$post_params ? $post_params : $body_data;
-  
+
     # Make the HTTP request
     my $_request;
     if ($method eq 'POST') {
@@ -101,15 +98,15 @@ sub call_api {
             'form-data' : $header_params->{'Content-Type'};
         
         $_request = POST($_url, %$header_params, Content => $_body_data);
-  
+
     }
     elsif ($method eq 'PUT') {
         # multipart
         $header_params->{'Content-Type'}  = lc $header_params->{'Content-Type'} eq 'multipart/form' ? 
             'form-data' : $header_params->{'Content-Type'};
-  
+
         $_request = PUT($_url, %$header_params, Content => $_body_data);
-  
+
     }
     elsif ($method eq 'GET') {
         my $headers = HTTP::Headers->new(%$header_params);
@@ -130,17 +127,17 @@ sub call_api {
    
     $self->{ua}->timeout($self->{http_timeout} || $self->{config}{http_timeout});
     $self->{ua}->agent($self->{http_user_agent} || $self->{config}{http_user_agent});
-    
+
     $log->debugf("REQUEST: %s", $_request->as_string);
     my $_response = $self->{ua}->request($_request);
     $log->debugf("RESPONSE: %s", $_response->as_string);
-  
+
     unless ($_response->is_success) {
         croak(sprintf "API Exception(%s): %s\n%s", $_response->code, $_response->message, $_response->content);
     }
        
     return $_response->content;
-  
+
 }
 
 #  Take value and turn it into a string suitable for inclusion in
@@ -160,12 +157,12 @@ sub to_path_value {
 # @param object $object an object to be serialized to a string
 # @return string the serialized object
 sub to_query_value {
-      my ($self, $object) = @_;
-      if (ref($object) eq 'ARRAY') {
-          return join(',', @$object);
-      } else {
-          return $self->to_string($object);
-      }
+    my ($self, $object) = @_;
+    if (ref($object) eq 'ARRAY') {
+        return join(',', @$object);
+    } else {
+        return $self->to_string($object);
+    }
 }
 
 
@@ -213,7 +210,7 @@ sub deserialize
 {
     my ($self, $class, $data) = @_;
     $log->debugf("deserializing %s for %s", $data, $class);
-  
+
     if (not defined $data) {
         return undef;
     } elsif ( (substr($class, 0, 5)) eq 'HASH[') { #hash
@@ -232,10 +229,9 @@ sub deserialize
         } else {
           #TODO log error
         }
-    
     } elsif ( (substr($class, 0, 6)) eq 'ARRAY[' ) { # array of data
         return $data if $data eq '[]'; # return if empty array
-    
+
         my $_sub_class = substr($class, 6, -1);
         my $_json_data = decode_json $data;
         my @_values = ();
@@ -259,7 +255,6 @@ sub deserialize
             return $_instance->from_hash(decode_json $data);
         }
     }
-  
 }
 
 # return 'Accept' based on an array of accept provided
@@ -268,7 +263,7 @@ sub deserialize
 sub select_header_accept
 {
     my ($self, @header) = @_;
-  
+
     if (@header == 0 || (@header == 1 && $header[0] eq '')) {
         return undef;
     } elsif (grep(/^application\/json$/i, @header)) {
@@ -276,7 +271,7 @@ sub select_header_accept
     } else {
         return join(',', @header);
     }
-  
+
 }
 
 # return the content type based on an array of content-type provided
@@ -285,7 +280,7 @@ sub select_header_accept
 sub select_header_content_type
 {
     my ($self, @header) = @_;
-  
+
     if (@header == 0 || (@header == 1 && $header[0] eq '')) {
         return 'application/json'; # default to application/json
     } elsif (grep(/^application\/json$/i, @header)) {
@@ -293,7 +288,7 @@ sub select_header_content_type
     } else {
         return join(',', @header);
     }
-  
+
 }
 
 # Get API key (with prefix if set)
@@ -301,15 +296,15 @@ sub select_header_content_type
 # @return string API key with the prefix
 sub get_api_key_with_prefix
 {
-	my ($self, $key_name) = @_;
+    my ($self, $key_name) = @_;
 
-	my $api_key = $self->{config}{api_key}{$key_name};
-	
-	return unless $api_key;
-	
-	my $prefix = $self->{config}{api_key_prefix}{$key_name};
-	return $prefix ? "$prefix $api_key" : $api_key;
-}	
+    my $api_key = $self->{config}{api_key}{$key_name};
+
+    return unless $api_key;
+
+    my $prefix = $self->{config}{api_key_prefix}{$key_name};
+    return $prefix ? "$prefix $api_key" : $api_key;
+}    
 
 # update header and query param based on authentication setting
 #  
@@ -318,36 +313,46 @@ sub get_api_key_with_prefix
 # @param array $authSettings array of authentication scheme (e.g ['api_key'])
 sub update_params_for_auth {
     my ($self, $header_params, $query_params, $auth_settings) = @_;
-    
+
     return $self->_global_auth_setup($header_params, $query_params) 
-    	unless $auth_settings && @$auth_settings;
-  
+        unless $auth_settings && @$auth_settings;
+
     # one endpoint can have more than 1 auth settings
     foreach my $auth (@$auth_settings) {
         # determine which one to use
         if (!defined($auth)) {
             # TODO show warning about auth setting not defined
         }
-        {{#authMethods}}elsif ($auth eq '{{name}}') {
-            {{#isApiKey}}{{#isKeyInHeader}}
+        {{#authMethods}}
+        elsif ($auth eq '{{name}}') {
+            {{#isApiKey}}
+            {{#isKeyInHeader}}
             my $api_key = $self->get_api_key_with_prefix('{{keyParamName}}');
             if ($api_key) {
                 $header_params->{'{{keyParamName}}'} = $api_key;
-            }{{/isKeyInHeader}}{{#isKeyInQuery}}
+            }
+            {{/isKeyInHeader}}
+            {{#isKeyInQuery}}
             my $api_key = $self->get_api_key_with_prefix('{{keyParamName}}');
             if ($api_key) {
                 $query_params->{'{{keyParamName}}'} = $api_key;
-            }{{/isKeyInQuery}}{{/isApiKey}}{{#isBasic}}
+            }
+            {{/isKeyInQuery}}
+            {{/isApiKey}}
+            {{#isBasic}}
             if ($self->{config}{username} || $self->{config}{password}) {
                 $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
-            }{{/isBasic}}{{#isOAuth}}
+            }
+            {{/isBasic}}
+            {{#isOAuth}}
             if ($self->{config}{access_token}) {
                 $header_params->{'Authorization'} = 'Bearer ' . $self->{config}{access_token};
-            }{{/isOAuth}}
+            }
+            {{/isOAuth}}
         }
         {{/authMethods}}
         else {
-       	    # TODO show warning about security definition not found
+           # TODO show warning about security definition not found
         }
     }
 }
@@ -357,37 +362,36 @@ sub update_params_for_auth {
 # OpenAPI Spec does not describe the intended authorization. So we check in the config for any 
 # auth tokens and if we find any, we use them for all endpoints; 
 sub _global_auth_setup {
-	my ($self, $header_params, $query_params) = @_; 
-	
-	my $tokens = $self->{config}->get_tokens;
-	return unless keys %$tokens;
-	
-	# basic
-	if (my $uname = delete $tokens->{username}) {
-		my $pword = delete $tokens->{password};
-		$header_params->{'Authorization'} = 'Basic '.encode_base64($uname.":".$pword);
-	}
-	
-	# oauth
-	if (my $access_token = delete $tokens->{access_token}) {
-		$header_params->{'Authorization'} = 'Bearer ' . $access_token;
-	}
-	
-	# other keys
-	foreach my $token_name (keys %$tokens) {
-		my $in = $tokens->{$token_name}->{in};
-		my $token = $self->get_api_key_with_prefix($token_name);
-		if ($in eq 'head') {
-			$header_params->{$token_name} = $token;
-		}
-		elsif ($in eq 'query') {
-			$query_params->{$token_name} = $token;
-		}
-		else {
-			die "Don't know where to put token '$token_name' ('$in' is not 'head' or 'query')";
-		}
-	}
-}
+    my ($self, $header_params, $query_params) = @_; 
 
+    my $tokens = $self->{config}->get_tokens;
+    return unless keys %$tokens;
+
+    # basic
+    if (my $uname = delete $tokens->{username}) {
+        my $pword = delete $tokens->{password};
+        $header_params->{'Authorization'} = 'Basic '.encode_base64($uname.":".$pword);
+    }
+
+    # oauth
+    if (my $access_token = delete $tokens->{access_token}) {
+        $header_params->{'Authorization'} = 'Bearer ' . $access_token;
+    }
+
+    # other keys
+    foreach my $token_name (keys %$tokens) {
+        my $in = $tokens->{$token_name}->{in};
+        my $token = $self->get_api_key_with_prefix($token_name);
+        if ($in eq 'head') {
+            $header_params->{$token_name} = $token;
+        }
+        elsif ($in eq 'query') {
+            $query_params->{$token_name} = $token;
+        }
+        else {
+            die "Don't know where to put token '$token_name' ('$in' is not 'head' or 'query')";
+        }
+    }
+}
 
 1;

--- a/modules/openapi-generator/src/main/resources/perl/ApiFactory.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/ApiFactory.mustache
@@ -19,47 +19,47 @@ use {{moduleName}}::ApiClient;
 
 =head1 Name
 
-	{{moduleName}}::ApiFactory - constructs APIs to retrieve {{moduleName}} objects
+    {{moduleName}}::ApiFactory - constructs APIs to retrieve {{moduleName}} objects
 
 =head1 Synopsis
 
-	package My::Petstore::App;
-	
-	use {{moduleName}}::ApiFactory;
-	
-	my $api_factory = {{moduleName}}::ApiFactory->new( ... ); # any args for ApiClient constructor
-							  
-	# later...
-	my $pet_api = $api_factory->get_api('Pet');  
-	
-	# $pet_api isa {{moduleName}}::PetApi
-	
-	my $pet = $pet_api->get_pet_by_id(pet_id => $pet_id);
-	
-	# object attributes have proper accessors:
-	printf "Pet's name is %s", $pet->name;
-	
-	# change the value stored on the object:
-	$pet->name('Dave'); 
+    package My::Petstore::App;
+    
+    use {{moduleName}}::ApiFactory;
+    
+    my $api_factory = {{moduleName}}::ApiFactory->new( ... ); # any args for ApiClient constructor
+
+    # later...
+    my $pet_api = $api_factory->get_api('Pet');  
+    
+    # $pet_api isa {{moduleName}}::PetApi
+    
+    my $pet = $pet_api->get_pet_by_id(pet_id => $pet_id);
+
+    # object attributes have proper accessors:
+    printf "Pet's name is %s", $pet->name;
+
+    # change the value stored on the object:
+    $pet->name('Dave'); 
 
 =cut
 
 # Load all the API classes and construct a lookup table at startup time
 my %_apis = map { $_ =~ /^{{moduleName}}::(.*)$/; $1 => $_ } 
-			grep {$_ =~ /Api$/} 
-			usesub '{{moduleName}}';
+            grep {$_ =~ /Api$/} 
+            usesub '{{moduleName}}';
 
 =head1 new($api_client)
-	
-	create a new {{moduleName}}::ApiFactory instance with the given {{moduleName}}::ApiClient instance.
+    
+    create a new {{moduleName}}::ApiFactory instance with the given {{moduleName}}::ApiClient instance.
 
 =head1 new(%parameters)
 
-	Any parameters are optional, and are passed to and stored on the api_client object.
-	
-	See L<{{moduleName}}::ApiClient> and L<{{moduleName}}::Configuration> for valid parameters
+    Any parameters are optional, and are passed to and stored on the api_client object.
+    
+    See L<{{moduleName}}::ApiClient> and L<{{moduleName}}::Configuration> for valid parameters
 
-=cut	
+=cut    
 
 sub new {
     my ($class) = shift;
@@ -75,25 +75,25 @@ sub new {
 
 =head1 get_api($which)
 
-	Returns an API object of the requested type. 
-	
-	$which is a nickname for the class: 
-	
-		FooBarClient::BazApi has nickname 'Baz'
-		
+    Returns an API object of the requested type. 
+    
+    $which is a nickname for the class: 
+    
+        FooBarClient::BazApi has nickname 'Baz'
+        
 =cut
 
 sub get_api {
-	my ($self, $which) = @_;
-	croak "API not specified" unless $which;
-	my $api_class = $_apis{"${which}Api"} || croak "No known API for '$which'";
-	return $api_class->new($self->api_client); 
+    my ($self, $which) = @_;
+    croak "API not specified" unless $which;
+    my $api_class = $_apis{"${which}Api"} || croak "No known API for '$which'";
+    return $api_class->new($self->api_client); 
 }
 
 =head1 api_client()
 
-	Returns the api_client object, should you ever need it.
-	
+    Returns the api_client object, should you ever need it.
+    
 =cut
 
 sub api_client { $_[0]->{api_client} }
@@ -107,8 +107,8 @@ sub apis_available { return map { $_ =~ s/Api$//; $_ } sort keys %_apis }
 =cut
 
 sub classname_for {
-	my ($self, $api_name) = @_;
-	return $_apis{"${api_name}Api"};
+    my ($self, $api_name) = @_;
+    return $_apis{"${api_name}Api"};
 }
 
 

--- a/modules/openapi-generator/src/main/resources/perl/AutoDoc.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/AutoDoc.mustache
@@ -10,30 +10,30 @@ use List::MoreUtils qw(uniq);
 use Moose::Role;
 
 sub autodoc {
-	my ($self, $how) = @_;
-	
-	die "Unknown format '$how'" unless $how =~ /^(pod|wide|narrow)$/;
-	
-	$self->_printisa($how);
-	$self->_printmethods($how);
-	$self->_printattrs($how);
-	print "\n";
+    my ($self, $how) = @_;
+
+    die "Unknown format '$how'" unless $how =~ /^(pod|wide|narrow)$/;
+
+    $self->_printisa($how);
+    $self->_printmethods($how);
+    $self->_printattrs($how);
+    print "\n";
 }
 
 sub _printisa {
-	my ($self, $how) = @_;	
-	my $meta = $self->meta;
-	
-	my $myclass = ref $self;
-	
-	my $super = join ', ', $meta->superclasses;
-	my @roles = $meta->calculate_all_roles;
-	#shift(@roles) if @roles > 1; # if > 1, the first is a composite, the rest are the roles
+    my ($self, $how) = @_;
+    my $meta = $self->meta;
 
-	my $isa =   join ', ', grep {$_ ne $myclass} $meta->linearized_isa;
-	my $sub =   join ', ', $meta->subclasses;
-	my $dsub =  join ', ', $meta->direct_subclasses;
-	
+    my $myclass = ref $self;
+
+    my $super = join ', ', $meta->superclasses;
+    my @roles = $meta->calculate_all_roles;
+    #shift(@roles) if @roles > 1; # if > 1, the first is a composite, the rest are the roles
+
+    my $isa =   join ', ', grep {$_ ne $myclass} $meta->linearized_isa;
+    my $sub =   join ', ', $meta->subclasses;
+    my $dsub =  join ', ', $meta->direct_subclasses;
+
     my $app_name = $self->version_info->{app_name};
     my $app_version = $self->version_info->{app_version};
     my $generated_date = $self->version_info->{generated_date};
@@ -41,25 +41,25 @@ sub _printisa {
 
     $~ = $how eq 'pod' ? 'INHERIT_POD' : 'INHERIT';
     write;
-	
-	my ($rolepkg, $role_reqs);
-	
-	foreach my $role (@roles) {
-		$rolepkg = $role->{package} || next; # some are anonymous, or something
-		next if $rolepkg eq '{{moduleName}}::Role::AutoDoc';
-		$role_reqs = join ', ', keys %{$role->{required_methods}};
-		$role_reqs ||= '';
-		$~ = $how eq 'pod' ? 'ROLES_POD' : 'ROLES';
-		write;
-	}
-	
-	if ($how eq 'pod') {
-		$~ = 'ROLES_POD_CLOSE';
-		write;
-	}
-	
+
+    my ($rolepkg, $role_reqs);
+
+    foreach my $role (@roles) {
+        $rolepkg = $role->{package} || next; # some are anonymous, or something
+        next if $rolepkg eq '{{moduleName}}::Role::AutoDoc';
+        $role_reqs = join ', ', keys %{$role->{required_methods}};
+        $role_reqs ||= '';
+        $~ = $how eq 'pod' ? 'ROLES_POD' : 'ROLES';
+        write;
+    }
+
+    if ($how eq 'pod') {
+        $~ = 'ROLES_POD_CLOSE';
+        write;
+    }
+
 # ----- format specs -----
-	format INHERIT = 
+    format INHERIT = 
 
 @* -
 $myclass
@@ -78,7 +78,7 @@ $myclass
                        $generator_class
                        
 .
-	format ROLES =   
+    format ROLES =   
              Composes: ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ~
                        $rolepkg
                        requires: ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ~
@@ -87,7 +87,7 @@ $myclass
                                  $role_reqs
 .
 
-	format INHERIT_POD =
+    format INHERIT_POD =
 =head1 NAME
 
 @*
@@ -138,7 +138,7 @@ $myclass
 
 
 .
-	format ROLES_POD =
+    format ROLES_POD =
 =head2 C<@*>
        $rolepkg
        
@@ -148,7 +148,7 @@ Requires:
 $role_reqs
 
 .
-	format ROLES_POD_CLOSE =
+    format ROLES_POD_CLOSE =
 
 
 .
@@ -156,96 +156,96 @@ $role_reqs
 }
 
 sub _printmethods {
-	my ($self, $how) = @_;
-	
-	if ($how eq 'narrow') {
-		print <<HEAD;
+    my ($self, $how) = @_;
+
+    if ($how eq 'narrow') {
+        print <<HEAD;
 METHODS
 -------
 HEAD
-	}
-	elsif ($how eq 'wide') {
-		$~ = 'METHODHEAD';
-		write;
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'METHODHEAD_POD';
-		write;
-	}
-	else {
-		die "Don't know how to print '$how'";
-	}
-	
-	$self->_printmethod($_, $how) for uniq sort $self->meta->get_all_method_names; #$self->meta->get_method_list, 
-	
-	if ($how eq 'pod') {
-		$~ = 'METHOD_POD_CLOSE';
-		write;
-	}
+    }
+    elsif ($how eq 'wide') {
+        $~ = 'METHODHEAD';
+        write;
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'METHODHEAD_POD';
+        write;
+    }
+    else {
+        die "Don't know how to print '$how'";
+    }
+
+    $self->_printmethod($_, $how) for uniq sort $self->meta->get_all_method_names; #$self->meta->get_method_list, 
+
+    if ($how eq 'pod') {
+        $~ = 'METHOD_POD_CLOSE';
+        write;
+    }
 
 
 }
 
 sub _printmethod {
-	my ($self, $methodname, $how) = @_;
-	return if $methodname =~ /^_/;
-	return if $self->meta->has_attribute($methodname);
-	my %internal = map {$_ => 1} qw(BUILD BUILDARGS meta can new DEMOLISHALL DESTROY 
-		DOES isa BUILDALL does VERSION dump
-		);
-	return if $internal{$methodname};
-	my $method = $self->meta->get_method($methodname) or return; # symbols imported into namespaces i.e. not known by Moose
-	
-	return if $method->original_package_name eq __PACKAGE__;
-	
-	my $delegate_to = '';
-	my $via = '';
-	my $on = '';
-	my $doc = '';
-	my $original_pkg = $method->original_package_name;
-	if ($method->can('associated_attribute')) {
-		$delegate_to = $method->delegate_to_method;
-		my $aa = $method->associated_attribute;
-		$on = $aa->{isa};
-		$via = $aa->{name};
-		$original_pkg = $on; 
-		$doc = $original_pkg->method_documentation->{$delegate_to}->{summary};
-	}
-	else {
-	    $doc = $method->documentation;
-	}
-	
-	if ($how eq 'narrow') {
-		$~ = 'METHOD_NARROW';
-		write;
-	}
-	elsif ($how eq 'pod' and $delegate_to) {
-		$~ = 'METHOD_POD_DELEGATED';
-		write;
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'METHOD_POD';
-		write;
-	}
-	else {
-		$~ = 'METHOD';
-		write;
-	}
-	
+    my ($self, $methodname, $how) = @_;
+    return if $methodname =~ /^_/;
+    return if $self->meta->has_attribute($methodname);
+    my %internal = map {$_ => 1} qw(BUILD BUILDARGS meta can new DEMOLISHALL DESTROY 
+        DOES isa BUILDALL does VERSION dump
+        );
+    return if $internal{$methodname};
+    my $method = $self->meta->get_method($methodname) or return; # symbols imported into namespaces i.e. not known by Moose
+
+    return if $method->original_package_name eq __PACKAGE__;
+
+    my $delegate_to = '';
+    my $via = '';
+    my $on = '';
+    my $doc = '';
+    my $original_pkg = $method->original_package_name;
+    if ($method->can('associated_attribute')) {
+        $delegate_to = $method->delegate_to_method;
+        my $aa = $method->associated_attribute;
+        $on = $aa->{isa};
+        $via = $aa->{name};
+        $original_pkg = $on; 
+        $doc = $original_pkg->method_documentation->{$delegate_to}->{summary};
+    }
+    else {
+        $doc = $method->documentation;
+    }
+
+    if ($how eq 'narrow') {
+        $~ = 'METHOD_NARROW';
+        write;
+    }
+    elsif ($how eq 'pod' and $delegate_to) {
+        $~ = 'METHOD_POD_DELEGATED';
+        write;
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'METHOD_POD';
+        write;
+    }
+    else {
+        $~ = 'METHOD';
+        write;
+    }
+
 # ----- format specs -----
-	format METHODHEAD =
+    format METHODHEAD =
 
 METHODS
 -------
 Name                                                  delegates to                                             on                                      via
 ===========================================================================================================================================================================
 .
-	format METHOD = 
+    format METHOD = 
 @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<... @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<... @<<<<<<<<<<<<<<<<...
 $methodname,                                          $delegate_to,                                            $on,                                    $via
 .
 
-	format METHOD_NARROW =
+    format METHOD_NARROW =
 @*
 $methodname
     original pkg: @*
@@ -259,14 +259,14 @@ $methodname
 
 .
 
-	format METHODHEAD_POD = 
+    format METHODHEAD_POD = 
 
 =head1 METHODS
 
 .
-	
-	format METHOD_POD = 
-	
+    
+    format METHOD_POD = 
+    
 =head2 C<@*()>
        $methodname
 
@@ -275,13 +275,13 @@ $methodname
 
 
 .
-	format METHOD_POD_DELEGATED = 
+    format METHOD_POD_DELEGATED = 
 
 =head2 C<@*()>
        $methodname
 
        Defined in: @*
-       	           $original_pkg
+                      $original_pkg
      Delegates to: @*()
                    $delegate_to
                On: @* 
@@ -294,90 +294,90 @@ $methodname
                      $via, $delegate_to
 
 .
-	format METHOD_POD_CLOSE =
-	
+    format METHOD_POD_CLOSE =
+    
 .
 # ----- / format specs -----
 }
 
 sub _printattrs {
-	my ($self, $how) = @_;
-	
-	if ($how eq 'narrow') {
-		print <<HEAD;
+    my ($self, $how) = @_;
+
+    if ($how eq 'narrow') {
+        print <<HEAD;
 ATTRIBUTES
 ----------
 HEAD
-	}
-	elsif ($how eq 'wide') {
-		$~ = 'ATTRHEAD';
-		write;
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'ATTRHEAD_POD';
-		write;
-	}
-	else {
-		die "Don't know how to print attributes '$how'";
-	}
-	
-	$self->_printattr($_, $how) for sort $self->meta->get_attribute_list;
-	
-	if ($how eq 'pod') {
-		$~ = 'ATTR_POD_CLOSE';
-		write;
-	}
+    }
+    elsif ($how eq 'wide') {
+        $~ = 'ATTRHEAD';
+        write;
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'ATTRHEAD_POD';
+        write;
+    }
+    else {
+        die "Don't know how to print attributes '$how'";
+    }
+
+    $self->_printattr($_, $how) for sort $self->meta->get_attribute_list;
+
+    if ($how eq 'pod') {
+        $~ = 'ATTR_POD_CLOSE';
+        write;
+    }
 }
 
 sub _printattr {
-	my ($self, $attrname, $how) = @_;
-	return if $attrname =~ /^_/;
-	my $attr = $self->meta->get_attribute($attrname) or die "No attr for $attrname";
-	
-	my $is;
-	$is = 'rw' if $attr->get_read_method && $attr->get_write_method;
-	$is = 'ro' if $attr->get_read_method && ! $attr->get_write_method;
-	$is = 'wo' if $attr->get_write_method && ! $attr->get_read_method;
-	$is = '--' if ! $attr->get_write_method && ! $attr->get_read_method;
-	$is or die "No \$is for $attrname";
-	
-	my $tc = $attr->type_constraint || '';
-	my $from = $attr->associated_class->name || '';
-	my $reqd = $attr->is_required ? 'yes' : 'no';
-	my $lazy = $attr->is_lazy ? 'yes' : 'no';
-	my $has_doc = $attr->has_documentation ? 'yes' : 'no'; # *_api attributes will never have doc, but other attributes might have
-	my $doc = $attr->documentation || '';
-	my $handles = join ', ', sort @{$attr->handles || []};
-	$handles ||= '';
-	
-	if ($how eq 'narrow') {
-		$~ = 'ATTR_NARROW';
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'ATTR_POD';
-	}
-	else {
-		$~ = 'ATTR';
-	}
+    my ($self, $attrname, $how) = @_;
+    return if $attrname =~ /^_/;
+    my $attr = $self->meta->get_attribute($attrname) or die "No attr for $attrname";
 
-	write;
+    my $is;
+    $is = 'rw' if $attr->get_read_method && $attr->get_write_method;
+    $is = 'ro' if $attr->get_read_method && ! $attr->get_write_method;
+    $is = 'wo' if $attr->get_write_method && ! $attr->get_read_method;
+    $is = '--' if ! $attr->get_write_method && ! $attr->get_read_method;
+    $is or die "No \$is for $attrname";
+
+    my $tc = $attr->type_constraint || '';
+    my $from = $attr->associated_class->name || '';
+    my $reqd = $attr->is_required ? 'yes' : 'no';
+    my $lazy = $attr->is_lazy ? 'yes' : 'no';
+    my $has_doc = $attr->has_documentation ? 'yes' : 'no'; # *_api attributes will never have doc, but other attributes might have
+    my $doc = $attr->documentation || '';
+    my $handles = join ', ', sort @{$attr->handles || []};
+    $handles ||= '';
+
+    if ($how eq 'narrow') {
+        $~ = 'ATTR_NARROW';
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'ATTR_POD';
+    }
+    else {
+        $~ = 'ATTR';
+    }
+
+    write;
 
 # ----- format specs -----
-	format ATTRHEAD =
+    format ATTRHEAD =
 
 ATTRIBUTES
 ----------
 Name                is isa                       reqd lazy doc handles
 ==============================================================================================================
-.	
-	format ATTR = 
+.    
+    format ATTR = 
 @<<<<<<<<<<<<<<<<<  @< @<<<<<<<<<<<<<<<<<<<<<<<< @<<< @<<< @<< ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 $attrname,          $is, $tc,                    $reqd, $lazy, $has_doc, $handles
                                                                ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ~~
                                                                $handles
 .
 
-	format ATTR_NARROW = 
+    format ATTR_NARROW = 
 @*
 $attrname
          is: @*
@@ -396,11 +396,11 @@ $attrname
              $handles
 
 .
-	format ATTRHEAD_POD =
+    format ATTRHEAD_POD =
 =head1 ATTRIBUTES
 
 .
-	format ATTR_POD =
+    format ATTR_POD =
 
 =head2 C<@*>
          $attrname
@@ -421,7 +421,7 @@ $attrname
              $handles
 
 .
-	format ATTR_POD_CLOSE = 
+    format ATTR_POD_CLOSE = 
 
 
 .

--- a/modules/openapi-generator/src/main/resources/perl/BaseObject.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/BaseObject.mustache
@@ -13,11 +13,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -25,26 +25,26 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
-	{{#allParents}}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
+    {{#allParents}}
 
-	# initialize parent object {{{.}}}
+    # initialize parent object {{{.}}}
     $self->{{moduleName}}::Object::{{{.}}}::init(%args);
-	{{/allParents}}
+    {{/allParents}}
 }
 
 # return perl hash
 sub to_hash {
     my $self = shift;
     my $_hash = decode_json(JSON->new->convert_blessed->encode($self));
-	{{#allParents}}
+    {{#allParents}}
 
-	# call {{{.}}} to_hash and then combine hash
+    # call {{{.}}} to_hash and then combine hash
     $_hash = { %$_hash, %$self->{{moduleName}}::Object::{{{.}}}::to_hash };
-	{{/allParents}}
+    {{/allParents}}
 
     return $_hash;
 }
@@ -73,7 +73,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -84,7 +84,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
     {{#allParents}}

--- a/modules/openapi-generator/src/main/resources/perl/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/Configuration.mustache
@@ -40,8 +40,8 @@ default: {{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Ge
 Hashref. Keyed on the name of each key (there can be multiple tokens).
 
     api_key => {
-	secretKey => 'aaaabbbbccccdddd',
-	anotherKey => '1111222233334444',
+        secretKey => 'aaaabbbbccccdddd',
+        anotherKey => '1111222233334444',
     };
 
 =item api_key_prefix: (optional)
@@ -50,9 +50,9 @@ Hashref. Keyed on the name of each key (there can be multiple tokens). Note not 
 
     api_key_prefix => {
         secretKey => 'string',
-	anotherKey => 'same or some other string',
+        anotherKey => 'same or some other string',
     };
- 
+
 =item api_key_in: (optional)
 
 =item username: (optional)
@@ -78,80 +78,80 @@ default: {{{basePath}}}
 =cut
 
 sub new {
-	my ($self, %p) = (shift,@_);
+    my ($self, %p) = (shift,@_);
 
-	# class/static variables
-	$p{http_timeout} //= 180;
-	$p{http_user_agent} //= '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{moduleVersion}}}/perl{{/httpUserAgent}}';
+    # class/static variables
+    $p{http_timeout} //= 180;
+    $p{http_user_agent} //= '{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{moduleVersion}}}/perl{{/httpUserAgent}}';
 
-	# authentication setting
-	$p{api_key} //= {};
-	$p{api_key_prefix} //= {};
-	$p{api_key_in} //= {};
+    # authentication setting
+    $p{api_key} //= {};
+    $p{api_key_prefix} //= {};
+    $p{api_key_in} //= {};
 
-	# username and password for HTTP basic authentication
-	$p{username} //= '';
-	$p{password} //= '';
+    # username and password for HTTP basic authentication
+    $p{username} //= '';
+    $p{password} //= '';
 
-	# access token for OAuth
-	$p{access_token} //= '';
+    # access token for OAuth
+    $p{access_token} //= '';
 
-	# base_url
-        $p{base_url} //= '{{{basePath}}}';
+    # base_url
+    $p{base_url} //= '{{{basePath}}}';
 
-	return bless \%p => $self;
+    return bless \%p => $self;
 }
 
 
 sub get_tokens {
-	my $self = shift;
-	
-	my $tokens = {};
-	$tokens->{username} = $self->{username} if $self->{username};
-	$tokens->{password} = $self->{password} if $self->{password};
-	$tokens->{access_token} = $self->{access_token} if $self->{access_token};
-	
-	foreach my $token_name (keys %{ $self->{api_key} }) {
-		$tokens->{$token_name}->{token} = $self->{api_key}{$token_name};
-		$tokens->{$token_name}->{prefix} = $self->{api_key_prefix}{$token_name};
-		$tokens->{$token_name}->{in} = $self->{api_key_in}{$token_name};
-	}
+    my $self = shift;
+   
+    my $tokens = {};
+    $tokens->{username} = $self->{username} if $self->{username};
+    $tokens->{password} = $self->{password} if $self->{password};
+    $tokens->{access_token} = $self->{access_token} if $self->{access_token};
 
-	return $tokens;
+    foreach my $token_name (keys %{ $self->{api_key} }) {
+        $tokens->{$token_name}->{token} = $self->{api_key}{$token_name};
+        $tokens->{$token_name}->{prefix} = $self->{api_key_prefix}{$token_name};
+        $tokens->{$token_name}->{in} = $self->{api_key_in}{$token_name};
+    }
+
+    return $tokens;
 }
 
 sub clear_tokens {
-	my $self = shift;
-	my %tokens = %{$self->get_tokens}; # copy
-	
-	$self->{username} = '';
-	$self->{password} = '';
-	$self->{access_token} = '';
+    my $self = shift;
+    my %tokens = %{$self->get_tokens}; # copy
 
-	$self->{api_key} = {};
-	$self->{api_key_prefix} = {};
-	$self->{api_key_in} = {};
-	
-	return \%tokens;
+    $self->{username} = '';
+    $self->{password} = '';
+    $self->{access_token} = '';
+
+    $self->{api_key} = {};
+    $self->{api_key_prefix} = {};
+    $self->{api_key_in} = {};
+  
+    return \%tokens;
 }
 
 sub accept_tokens {
-	my ($self, $tokens) = @_;
-	
-	foreach my $known_name (qw(username password access_token)) {
-		next unless $tokens->{$known_name};
-		$self->{$known_name} = delete $tokens->{$known_name};
-	}
-	
-	foreach my $token_name (keys %$tokens) {
-		$self->{api_key}{$token_name} = $tokens->{$token_name}{token};
-		if ($tokens->{$token_name}{prefix}) {
-			$self->{api_key_prefix}{$token_name} = $tokens->{$token_name}{prefix};
-		}
-		my $in = $tokens->{$token_name}->{in} || 'head';
-		croak "Tokens can only go in 'head' or 'query' (not in '$in')" unless $in =~ /^(?:head|query)$/;
-		$self->{api_key_in}{$token_name} = $in;
-	}
-}	
+    my ($self, $tokens) = @_;
+  
+    foreach my $known_name (qw(username password access_token)) {
+        next unless $tokens->{$known_name};
+        $self->{$known_name} = delete $tokens->{$known_name};
+    }
+
+    foreach my $token_name (keys %$tokens) {
+        $self->{api_key}{$token_name} = $tokens->{$token_name}{token};
+        if ($tokens->{$token_name}{prefix}) {
+            $self->{api_key_prefix}{$token_name} = $tokens->{$token_name}{prefix};
+        }
+        my $in = $tokens->{$token_name}->{in} || 'head';
+        croak "Tokens can only go in 'head' or 'query' (not in '$in')" unless $in =~ /^(?:head|query)$/;
+        $self->{api_key_in}{$token_name} = $in;
+    }
+}    
 
 1;

--- a/modules/openapi-generator/src/main/resources/perl/Role.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/Role.mustache
@@ -52,29 +52,29 @@ has version_info => ( is => 'ro',
                       );
 
 sub BUILD {
-	my $self = shift;
+    my $self = shift;
 
-	$self->_cfg->accept_tokens( $self->tokens ) if keys %{$self->tokens};
+    $self->_cfg->accept_tokens( $self->tokens ) if keys %{$self->tokens};
 
-	# ignore these symbols imported into API namespaces
-	my %outsiders = map {$_ => 1} qw( croak );
+    # ignore these symbols imported into API namespaces
+    my %outsiders = map {$_ => 1} qw( croak );
 
-	my %delegates;
+    my %delegates;
 
-	# collect the methods callable on each API
-	foreach my $api_name ($self->api_factory->apis_available) {
-		my $api_class = $self->api_factory->classname_for($api_name);
-		my $methods = Class::Inspector->methods($api_class, 'expanded'); # not Moose, so use CI instead
-		my @local_methods = grep {! /^_/} grep {! $outsiders{$_}} map {$_->[2]} grep {$_->[1] eq $api_class} @$methods;
-		push( @{$delegates{$_}}, {api_name => $api_name, api_class => $api_class} ) for @local_methods;
-	}
+    # collect the methods callable on each API
+    foreach my $api_name ($self->api_factory->apis_available) {
+        my $api_class = $self->api_factory->classname_for($api_name);
+        my $methods = Class::Inspector->methods($api_class, 'expanded'); # not Moose, so use CI instead
+        my @local_methods = grep {! /^_/} grep {! $outsiders{$_}} map {$_->[2]} grep {$_->[1] eq $api_class} @$methods;
+        push( @{$delegates{$_}}, {api_name => $api_name, api_class => $api_class} ) for @local_methods;
+    }
 
-	# remove clashes
-	foreach my $method (keys %delegates) {
-		if ( @{$delegates{$method}} > 1 ) {
-			my ($apis) = delete $delegates{$method};
-		}
-	}
+    # remove clashes
+    foreach my $method (keys %delegates) {
+        if ( @{$delegates{$method}} > 1 ) {
+            my ($apis) = delete $delegates{$method};
+        }
+    }
 
     # build the flattened API
     foreach my $api_name ($self->api_factory->apis_available) {
@@ -93,10 +93,10 @@ sub BUILD {
 }
 
 sub _build_af {
-	my $self = shift;
-	my %args;
-	$args{base_url} = $self->base_url if $self->base_url;
-	return {{moduleName}}::ApiFactory->new(%args);
+    my $self = shift;
+    my %args;
+    $args{base_url} = $self->base_url if $self->base_url;
+    return {{moduleName}}::ApiFactory->new(%args);
 }
 
 =head1 NAME
@@ -136,15 +136,15 @@ This module provides an interface to the generated library. All the classes,
 objects, and methods (well, not quite *all*, see below) are flattened into this
 role.
 
-	package MyApp;
-	use Moose;
-	with '{{moduleName}}::Role';
+    package MyApp;
+    use Moose;
+    with '{{moduleName}}::Role';
 
-	package main;
+    package main;
 
-	my $api = MyApp->new({ tokens => $tokens });
+    my $api = MyApp->new({ tokens => $tokens });
 
-	my $pet = $api->get_pet_by_id(pet_id => $pet_id);
+    my $pet = $api->get_pet_by_id(pet_id => $pet_id);
 
 =head2 Structure of the library
 
@@ -213,20 +213,20 @@ String. The password for basic auth.
 
 Hashref. Keyed on the name of each key (there can be multiple tokens).
 
-	$cfg->{api_key} = {
-		secretKey => 'aaaabbbbccccdddd',
-		anotherKey => '1111222233334444',
-		};
+    $cfg->{api_key} = {
+        secretKey => 'aaaabbbbccccdddd',
+        anotherKey => '1111222233334444',
+        };
 
 =item C<$cfg->{api_key_prefix}>
 
 Hashref. Keyed on the name of each key (there can be multiple tokens). Note not
 all api keys require a prefix.
 
-	$cfg->{api_key_prefix} = {
-		secretKey => 'string',
-		anotherKey => 'same or some other string',
-		};
+    $cfg->{api_key_prefix} = {
+        secretKey => 'string',
+        anotherKey => 'same or some other string',
+        };
 
 =item C<$config-\>{access_token}>
 
@@ -260,9 +260,9 @@ In principle, every API is susceptible to the presence of a few, random, undeleg
 method names. In practice, because of the way method names are constructed, it's
 unlikely in general that any methods will be undelegatable, except for:
 
-	new()
-	class_documentation()
-	method_documentation()
+    new()
+    class_documentation()
+    method_documentation()
 
 To call these methods, you need to get a handle on the relevant object, either
 by calling C<$api-E<gt>foo_api> or by retrieving an object, e.g.
@@ -278,14 +278,14 @@ maven 3.0.3 or better already installed.
 
 The config file should specify the project name for the generated library:
 
-	{"moduleName":"WWW::MyProjectName"}
+    {"moduleName":"WWW::MyProjectName"}
 
 Your library files will be built under C<WWW::MyProjectName>.
 
-	$ git clone https://github.com/openapitools/openapi-generator
-	$ cd openapi-generator
-	$ mvn package
-	$ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
+    $ git clone https://github.com/openapitools/openapi-generator
+    $ cd openapi-generator
+    $ mvn package
+    $ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
   -i [URL or file path to JSON OpenAPI API spec] \
   -g perl \
   -c /path/to/config/file.json \
@@ -300,7 +300,7 @@ You can print out a summary of the generated API by running the included
 C<autodoc> script in the C<bin> directory of your generated library. A few
 output formats are supported:
 
-	Usage: autodoc [OPTION]
+    Usage: autodoc [OPTION]
 
   -w           wide format (default)
   -n           narrow format
@@ -320,10 +320,10 @@ spec. If so, this is available via the C<class_documentation()> and
 C<method_documentation()> methods on each generated object class, and the
 C<method_documentation()> method on the endpoint API classes:
 
-	my $cmdoc = $api->pet_api->method_documentation->{$method_name};
+    my $cmdoc = $api->pet_api->method_documentation->{$method_name};
 
-	my $odoc = $api->get_pet_by_id->(pet_id => $pet_id)->class_documentation;
-	my $omdoc = $api->get_pet_by_id->(pet_id => $pet_id)->method_documentation->{method_name};
+    my $odoc = $api->get_pet_by_id->(pet_id => $pet_id)->class_documentation;
+    my $omdoc = $api->get_pet_by_id->(pet_id => $pet_id)->method_documentation->{method_name};
 
 Each of these calls returns a hashref with various useful pieces of information.
 

--- a/modules/openapi-generator/src/main/resources/perl/api.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/api.mustache
@@ -55,7 +55,7 @@ sub new {
 {{/allParams}}
     };
     __PACKAGE__->method_documentation->{ '{{operationId}}' } = { 
-    	summary => '{{summary}}',
+        summary => '{{summary}}',
         params => $params,
         returns => {{#returnType}}'{{{returnType}}}'{{/returnType}}{{^returnType}}undef{{/returnType}},
         };

--- a/modules/openapi-generator/src/main/resources/perl/autodoc.script.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/autodoc.script.mustache
@@ -13,16 +13,16 @@ help if $options{h};
 my $my_app = $options{c} || 'My::App';
 
 if ($options{c}) {
-	eval <<LOAD;
+    eval <<LOAD;
 use $my_app;
 apply_all_roles($my_app, "{{moduleName}}::Role::AutoDoc");
 LOAD
-	die $@ if $@;
+    die $@ if $@;
 }
 else {
-	package My::App;
-	use Moose;
-	with ('{{moduleName}}::Role', '{{moduleName}}::Role::AutoDoc');
+    package My::App;
+    use Moose;
+    with ('{{moduleName}}::Role', '{{moduleName}}::Role::AutoDoc');
 }
 
 package main;
@@ -40,26 +40,26 @@ $opt ||= 'wide';
 my $api = $my_app->new;
 
 if ($options{H}) {
-	my $pod2html = "pod2html --backlink --css http://st.pimg.net/tucs/style.css?3";
-	open STDOUT, "| $pod2html" or die "Can't fork: $!";
-	$api->autodoc($opt);
-	close STDOUT or die "Can't close: $!";
+    my $pod2html = "pod2html --backlink --css http://st.pimg.net/tucs/style.css?3";
+    open STDOUT, "| $pod2html" or die "Can't fork: $!";
+    $api->autodoc($opt);
+    close STDOUT or die "Can't close: $!";
 }
 elsif ($options{m}) {
-	my $pod2markdown = "pod2markdown --html-encode-chars 1";
-	open STDOUT, "| $pod2markdown" or die "Can't fork: $!";
-	$api->autodoc($opt);
-	close STDOUT or die "Can't close: $!";
+    my $pod2markdown = "pod2markdown --html-encode-chars 1";
+    open STDOUT, "| $pod2markdown" or die "Can't fork: $!";
+    $api->autodoc($opt);
+    close STDOUT or die "Can't close: $!";
 }
 else {
-	$api->autodoc($opt);
+    $api->autodoc($opt);
 }
 
 exit(0);
 
 # --------------------
 sub help {
-	print <<HELP;
+    print <<HELP;
 Usage: autodoc [OPTION] [-c My::App::Class]
 
   -w           wide format (default)
@@ -72,6 +72,6 @@ Usage: autodoc [OPTION] [-c My::App::Class]
 
 HELP
 
-	exit(0);
+    exit(0);
 }
 

--- a/modules/openapi-generator/src/main/resources/perl/object.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/object.mustache
@@ -42,12 +42,12 @@ __PACKAGE__->class_documentation({description => '{{description}}',
 __PACKAGE__->method_documentation({
 {{#vars}}
     '{{name}}' => {
-    	datatype => '{{dataType}}',
-    	base_name => '{{baseName}}',
-    	description => '{{description}}',
-    	format => '{{format}}',
-    	read_only => '{{readOnly}}',
-    		},
+        datatype => '{{dataType}}',
+        base_name => '{{baseName}}',
+        description => '{{description}}',
+        format => '{{format}}',
+        read_only => '{{readOnly}}',
+            },
 {{/vars}}
 });
 

--- a/samples/client/petstore/perl/README.md
+++ b/samples/client/petstore/perl/README.md
@@ -327,10 +327,10 @@ use WWW::OpenAPIClient::;
 my $api_instance = WWW::OpenAPIClient::->new(
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval {
-    my $result = $api_instance->call_123_test_special_tags(client => $client);
+    my $result = $api_instance->call_123_test_special_tags(body => $body);
     print Dumper($result);
 };
 if ($@) {

--- a/samples/client/petstore/perl/bin/autodoc
+++ b/samples/client/petstore/perl/bin/autodoc
@@ -13,16 +13,16 @@ help if $options{h};
 my $my_app = $options{c} || 'My::App';
 
 if ($options{c}) {
-	eval <<LOAD;
+    eval <<LOAD;
 use $my_app;
 apply_all_roles($my_app, "WWW::OpenAPIClient::Role::AutoDoc");
 LOAD
-	die $@ if $@;
+    die $@ if $@;
 }
 else {
-	package My::App;
-	use Moose;
-	with ('WWW::OpenAPIClient::Role', 'WWW::OpenAPIClient::Role::AutoDoc');
+    package My::App;
+    use Moose;
+    with ('WWW::OpenAPIClient::Role', 'WWW::OpenAPIClient::Role::AutoDoc');
 }
 
 package main;
@@ -40,26 +40,26 @@ $opt ||= 'wide';
 my $api = $my_app->new;
 
 if ($options{H}) {
-	my $pod2html = "pod2html --backlink --css http://st.pimg.net/tucs/style.css?3";
-	open STDOUT, "| $pod2html" or die "Can't fork: $!";
-	$api->autodoc($opt);
-	close STDOUT or die "Can't close: $!";
+    my $pod2html = "pod2html --backlink --css http://st.pimg.net/tucs/style.css?3";
+    open STDOUT, "| $pod2html" or die "Can't fork: $!";
+    $api->autodoc($opt);
+    close STDOUT or die "Can't close: $!";
 }
 elsif ($options{m}) {
-	my $pod2markdown = "pod2markdown --html-encode-chars 1";
-	open STDOUT, "| $pod2markdown" or die "Can't fork: $!";
-	$api->autodoc($opt);
-	close STDOUT or die "Can't close: $!";
+    my $pod2markdown = "pod2markdown --html-encode-chars 1";
+    open STDOUT, "| $pod2markdown" or die "Can't fork: $!";
+    $api->autodoc($opt);
+    close STDOUT or die "Can't close: $!";
 }
 else {
-	$api->autodoc($opt);
+    $api->autodoc($opt);
 }
 
 exit(0);
 
 # --------------------
 sub help {
-	print <<HELP;
+    print <<HELP;
 Usage: autodoc [OPTION] [-c My::App::Class]
 
   -w           wide format (default)
@@ -72,6 +72,6 @@ Usage: autodoc [OPTION] [-c My::App::Class]
 
 HELP
 
-	exit(0);
+    exit(0);
 }
 

--- a/samples/client/petstore/perl/docs/AnotherfakeApi.md
+++ b/samples/client/petstore/perl/docs/AnotherfakeApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 
 # **call_123_test_special_tags**
-> Client call_123_test_special_tags(client => $client)
+> Client call_123_test_special_tags(body => $body)
 
 To test special tags
 
@@ -26,10 +26,10 @@ use WWW::OpenAPIClient::AnotherFakeApi;
 my $api_instance = WWW::OpenAPIClient::AnotherFakeApi->new(
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval { 
-    my $result = $api_instance->call_123_test_special_tags(client => $client);
+    my $result = $api_instance->call_123_test_special_tags(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -41,7 +41,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -70,7 +70,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **fake_outer_composite_serialize**
-> OuterComposite fake_outer_composite_serialize(outer_composite => $outer_composite)
+> OuterComposite fake_outer_composite_serialize(body => $body)
 
 
 
@@ -83,10 +83,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $outer_composite = WWW::OpenAPIClient::Object::OuterComposite->new(); # OuterComposite | Input composite as post body
+my $body = WWW::OpenAPIClient::Object::OuterComposite->new(); # OuterComposite | Input composite as post body
 
 eval { 
-    my $result = $api_instance->fake_outer_composite_serialize(outer_composite => $outer_composite);
+    my $result = $api_instance->fake_outer_composite_serialize(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -98,7 +98,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **outer_composite** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
+ **body** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
 
 ### Return type
 
@@ -208,7 +208,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_body_with_file_schema**
-> test_body_with_file_schema(file_schema_test_class => $file_schema_test_class)
+> test_body_with_file_schema(body => $body)
 
 
 
@@ -221,10 +221,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $file_schema_test_class = WWW::OpenAPIClient::Object::FileSchemaTestClass->new(); # FileSchemaTestClass | 
+my $body = WWW::OpenAPIClient::Object::FileSchemaTestClass->new(); # FileSchemaTestClass | 
 
 eval { 
-    $api_instance->test_body_with_file_schema(file_schema_test_class => $file_schema_test_class);
+    $api_instance->test_body_with_file_schema(body => $body);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_body_with_file_schema: $@\n";
@@ -235,7 +235,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **file_schema_test_class** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
+ **body** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
 
 ### Return type
 
@@ -253,7 +253,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_body_with_query_params**
-> test_body_with_query_params(query => $query, user => $user)
+> test_body_with_query_params(query => $query, body => $body)
 
 
 
@@ -265,10 +265,10 @@ my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
 my $query = "query_example"; # string | 
-my $user = WWW::OpenAPIClient::Object::User->new(); # User | 
+my $body = WWW::OpenAPIClient::Object::User->new(); # User | 
 
 eval { 
-    $api_instance->test_body_with_query_params(query => $query, user => $user);
+    $api_instance->test_body_with_query_params(query => $query, body => $body);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_body_with_query_params: $@\n";
@@ -280,7 +280,7 @@ if ($@) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **query** | **string**|  | 
- **user** | [**User**](User.md)|  | 
+ **body** | [**User**](User.md)|  | 
 
 ### Return type
 
@@ -298,7 +298,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_client_model**
-> Client test_client_model(client => $client)
+> Client test_client_model(body => $body)
 
 To test \"client\" model
 
@@ -311,10 +311,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval { 
-    my $result = $api_instance->test_client_model(client => $client);
+    my $result = $api_instance->test_client_model(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -326,7 +326,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
 
@@ -533,7 +533,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_inline_additional_properties**
-> test_inline_additional_properties(request_body => $request_body)
+> test_inline_additional_properties(param => $param)
 
 test inline additionalProperties
 
@@ -544,10 +544,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $request_body = WWW::OpenAPIClient::Object::HASH[string,string]->new(); # HASH[string,string] | request body
+my $param = WWW::OpenAPIClient::Object::HASH[string,string]->new(); # HASH[string,string] | request body
 
 eval { 
-    $api_instance->test_inline_additional_properties(request_body => $request_body);
+    $api_instance->test_inline_additional_properties(param => $param);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_inline_additional_properties: $@\n";
@@ -558,7 +558,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **request_body** | [**HASH[string,string]**](string.md)| request body | 
+ **param** | [**HASH[string,string]**](string.md)| request body | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/perl/docs/FakeClassnameTags123Api.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 
 # **test_classname**
-> Client test_classname(client => $client)
+> Client test_classname(body => $body)
 
 To test class name in snake case
 
@@ -31,10 +31,10 @@ my $api_instance = WWW::OpenAPIClient::FakeClassnameTags123Api->new(
     #api_key_prefix => {'api_key_query' => 'Bearer'},
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval { 
-    my $result = $api_instance->test_classname(client => $client);
+    my $result = $api_instance->test_classname(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -46,7 +46,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/PetApi.md
+++ b/samples/client/petstore/perl/docs/PetApi.md
@@ -21,7 +21,7 @@ Method | HTTP request | Description
 
 
 # **add_pet**
-> add_pet(pet => $pet)
+> add_pet(body => $body)
 
 Add a new pet to the store
 
@@ -35,10 +35,10 @@ my $api_instance = WWW::OpenAPIClient::PetApi->new(
     access_token => 'YOUR_ACCESS_TOKEN',
 );
 
-my $pet = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
+my $body = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
 
 eval { 
-    $api_instance->add_pet(pet => $pet);
+    $api_instance->add_pet(body => $body);
 };
 if ($@) {
     warn "Exception when calling PetApi->add_pet: $@\n";
@@ -49,7 +49,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
 
@@ -264,7 +264,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update_pet**
-> update_pet(pet => $pet)
+> update_pet(body => $body)
 
 Update an existing pet
 
@@ -278,10 +278,10 @@ my $api_instance = WWW::OpenAPIClient::PetApi->new(
     access_token => 'YOUR_ACCESS_TOKEN',
 );
 
-my $pet = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
+my $body = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
 
 eval { 
-    $api_instance->update_pet(pet => $pet);
+    $api_instance->update_pet(body => $body);
 };
 if ($@) {
     warn "Exception when calling PetApi->update_pet: $@\n";
@@ -292,7 +292,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/StoreApi.md
+++ b/samples/client/petstore/perl/docs/StoreApi.md
@@ -154,7 +154,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **place_order**
-> Order place_order(order => $order)
+> Order place_order(body => $body)
 
 Place an order for a pet
 
@@ -165,10 +165,10 @@ use WWW::OpenAPIClient::StoreApi;
 my $api_instance = WWW::OpenAPIClient::StoreApi->new(
 );
 
-my $order = WWW::OpenAPIClient::Object::Order->new(); # Order | order placed for purchasing the pet
+my $body = WWW::OpenAPIClient::Object::Order->new(); # Order | order placed for purchasing the pet
 
 eval { 
-    my $result = $api_instance->place_order(order => $order);
+    my $result = $api_instance->place_order(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -180,7 +180,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+ **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/UserApi.md
+++ b/samples/client/petstore/perl/docs/UserApi.md
@@ -20,7 +20,7 @@ Method | HTTP request | Description
 
 
 # **create_user**
-> create_user(user => $user)
+> create_user(body => $body)
 
 Create user
 
@@ -33,10 +33,10 @@ use WWW::OpenAPIClient::UserApi;
 my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
-my $user = WWW::OpenAPIClient::Object::User->new(); # User | Created user object
+my $body = WWW::OpenAPIClient::Object::User->new(); # User | Created user object
 
 eval { 
-    $api_instance->create_user(user => $user);
+    $api_instance->create_user(body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->create_user: $@\n";
@@ -47,7 +47,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**User**](User.md)| Created user object | 
+ **body** | [**User**](User.md)| Created user object | 
 
 ### Return type
 
@@ -65,7 +65,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **create_users_with_array_input**
-> create_users_with_array_input(user => $user)
+> create_users_with_array_input(body => $body)
 
 Creates list of users with given input array
 
@@ -76,10 +76,10 @@ use WWW::OpenAPIClient::UserApi;
 my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
-my $user = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
+my $body = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
 
 eval { 
-    $api_instance->create_users_with_array_input(user => $user);
+    $api_instance->create_users_with_array_input(body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->create_users_with_array_input: $@\n";
@@ -90,7 +90,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
+ **body** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
 
 ### Return type
 
@@ -108,7 +108,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **create_users_with_list_input**
-> create_users_with_list_input(user => $user)
+> create_users_with_list_input(body => $body)
 
 Creates list of users with given input array
 
@@ -119,10 +119,10 @@ use WWW::OpenAPIClient::UserApi;
 my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
-my $user = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
+my $body = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
 
 eval { 
-    $api_instance->create_users_with_list_input(user => $user);
+    $api_instance->create_users_with_list_input(body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->create_users_with_list_input: $@\n";
@@ -133,7 +133,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
+ **body** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
 
 ### Return type
 
@@ -325,7 +325,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update_user**
-> update_user(username => $username, user => $user)
+> update_user(username => $username, body => $body)
 
 Updated user
 
@@ -339,10 +339,10 @@ my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
 my $username = "username_example"; # string | name that need to be deleted
-my $user = WWW::OpenAPIClient::Object::User->new(); # User | Updated user object
+my $body = WWW::OpenAPIClient::Object::User->new(); # User | Updated user object
 
 eval { 
-    $api_instance->update_user(username => $username, user => $user);
+    $api_instance->update_user(username => $username, body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->update_user: $@\n";
@@ -354,7 +354,7 @@ if ($@) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **username** | **string**| name that need to be deleted | 
- **user** | [**User**](User.md)| Updated user object | 
+ **body** | [**User**](User.md)| Updated user object | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/AnotherFakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/AnotherFakeApi.pm
@@ -53,17 +53,17 @@ sub new {
 #
 # To test special tags
 # 
-# @param Client $client client model (required)
+# @param Client $body client model (required)
 {
     my $params = {
-    'client' => {
+    'body' => {
         data_type => 'Client',
         description => 'client model',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'call_123_test_special_tags' } = { 
-    	summary => 'To test special tags',
+        summary => 'To test special tags',
         params => $params,
         returns => 'Client',
         };
@@ -73,9 +73,9 @@ sub new {
 sub call_123_test_special_tags {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'client' is set
-    unless (exists $args{'client'}) {
-      croak("Missing the required parameter 'client' when calling call_123_test_special_tags");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling call_123_test_special_tags");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub call_123_test_special_tags {
 
     my $_body_data;
     # body params
-    if ( exists $args{'client'}) {
-        $_body_data = $args{'client'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiClient.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiClient.pm
@@ -39,7 +39,6 @@ use Module::Runtime qw(use_module);
 
 use WWW::OpenAPIClient::Configuration;
 
-
 sub new {
     my $class = shift;
 
@@ -54,7 +53,7 @@ sub new {
         'ua' => LWP::UserAgent->new,
         'config' => $config,
     );
-  
+
     return bless \%args, $class;
 }
 
@@ -89,23 +88,21 @@ sub set_timeout {
 sub call_api {
     my $self = shift;
     my ($resource_path, $method, $query_params, $post_params, $header_params, $body_data, $auth_settings) = @_;
-  
+
     # update parameters based on authentication settings
     $self->update_params_for_auth($header_params, $query_params, $auth_settings); 
-  
-  
+
     my $_url = $self->{config}{base_url} . $resource_path;
-  
+
     # build query 
     if (%$query_params) {
         $_url = ($_url . '?' . eval { URI::Query->new($query_params)->stringify });
     }
-  
-  
+
     # body data
     $body_data = to_json($body_data->to_hash) if defined $body_data && $body_data->can('to_hash'); # model to json string
     my $_body_data = %$post_params ? $post_params : $body_data;
-  
+
     # Make the HTTP request
     my $_request;
     if ($method eq 'POST') {
@@ -114,15 +111,15 @@ sub call_api {
             'form-data' : $header_params->{'Content-Type'};
         
         $_request = POST($_url, %$header_params, Content => $_body_data);
-  
+
     }
     elsif ($method eq 'PUT') {
         # multipart
         $header_params->{'Content-Type'}  = lc $header_params->{'Content-Type'} eq 'multipart/form' ? 
             'form-data' : $header_params->{'Content-Type'};
-  
+
         $_request = PUT($_url, %$header_params, Content => $_body_data);
-  
+
     }
     elsif ($method eq 'GET') {
         my $headers = HTTP::Headers->new(%$header_params);
@@ -143,17 +140,17 @@ sub call_api {
    
     $self->{ua}->timeout($self->{http_timeout} || $self->{config}{http_timeout});
     $self->{ua}->agent($self->{http_user_agent} || $self->{config}{http_user_agent});
-    
+
     $log->debugf("REQUEST: %s", $_request->as_string);
     my $_response = $self->{ua}->request($_request);
     $log->debugf("RESPONSE: %s", $_response->as_string);
-  
+
     unless ($_response->is_success) {
         croak(sprintf "API Exception(%s): %s\n%s", $_response->code, $_response->message, $_response->content);
     }
        
     return $_response->content;
-  
+
 }
 
 #  Take value and turn it into a string suitable for inclusion in
@@ -173,12 +170,12 @@ sub to_path_value {
 # @param object $object an object to be serialized to a string
 # @return string the serialized object
 sub to_query_value {
-      my ($self, $object) = @_;
-      if (ref($object) eq 'ARRAY') {
-          return join(',', @$object);
-      } else {
-          return $self->to_string($object);
-      }
+    my ($self, $object) = @_;
+    if (ref($object) eq 'ARRAY') {
+        return join(',', @$object);
+    } else {
+        return $self->to_string($object);
+    }
 }
 
 
@@ -226,7 +223,7 @@ sub deserialize
 {
     my ($self, $class, $data) = @_;
     $log->debugf("deserializing %s for %s", $data, $class);
-  
+
     if (not defined $data) {
         return undef;
     } elsif ( (substr($class, 0, 5)) eq 'HASH[') { #hash
@@ -245,10 +242,9 @@ sub deserialize
         } else {
           #TODO log error
         }
-    
     } elsif ( (substr($class, 0, 6)) eq 'ARRAY[' ) { # array of data
         return $data if $data eq '[]'; # return if empty array
-    
+
         my $_sub_class = substr($class, 6, -1);
         my $_json_data = decode_json $data;
         my @_values = ();
@@ -272,7 +268,6 @@ sub deserialize
             return $_instance->from_hash(decode_json $data);
         }
     }
-  
 }
 
 # return 'Accept' based on an array of accept provided
@@ -281,7 +276,7 @@ sub deserialize
 sub select_header_accept
 {
     my ($self, @header) = @_;
-  
+
     if (@header == 0 || (@header == 1 && $header[0] eq '')) {
         return undef;
     } elsif (grep(/^application\/json$/i, @header)) {
@@ -289,7 +284,7 @@ sub select_header_accept
     } else {
         return join(',', @header);
     }
-  
+
 }
 
 # return the content type based on an array of content-type provided
@@ -298,7 +293,7 @@ sub select_header_accept
 sub select_header_content_type
 {
     my ($self, @header) = @_;
-  
+
     if (@header == 0 || (@header == 1 && $header[0] eq '')) {
         return 'application/json'; # default to application/json
     } elsif (grep(/^application\/json$/i, @header)) {
@@ -306,7 +301,7 @@ sub select_header_content_type
     } else {
         return join(',', @header);
     }
-  
+
 }
 
 # Get API key (with prefix if set)
@@ -314,15 +309,15 @@ sub select_header_content_type
 # @return string API key with the prefix
 sub get_api_key_with_prefix
 {
-	my ($self, $key_name) = @_;
+    my ($self, $key_name) = @_;
 
-	my $api_key = $self->{config}{api_key}{$key_name};
-	
-	return unless $api_key;
-	
-	my $prefix = $self->{config}{api_key_prefix}{$key_name};
-	return $prefix ? "$prefix $api_key" : $api_key;
-}	
+    my $api_key = $self->{config}{api_key}{$key_name};
+
+    return unless $api_key;
+
+    my $prefix = $self->{config}{api_key_prefix}{$key_name};
+    return $prefix ? "$prefix $api_key" : $api_key;
+}    
 
 # update header and query param based on authentication setting
 #  
@@ -331,10 +326,10 @@ sub get_api_key_with_prefix
 # @param array $authSettings array of authentication scheme (e.g ['api_key'])
 sub update_params_for_auth {
     my ($self, $header_params, $query_params, $auth_settings) = @_;
-    
+
     return $self->_global_auth_setup($header_params, $query_params) 
-    	unless $auth_settings && @$auth_settings;
-  
+        unless $auth_settings && @$auth_settings;
+
     # one endpoint can have more than 1 auth settings
     foreach my $auth (@$auth_settings) {
         # determine which one to use
@@ -342,33 +337,29 @@ sub update_params_for_auth {
             # TODO show warning about auth setting not defined
         }
         elsif ($auth eq 'api_key') {
-            
             my $api_key = $self->get_api_key_with_prefix('api_key');
             if ($api_key) {
                 $header_params->{'api_key'} = $api_key;
             }
         }
-elsif ($auth eq 'api_key_query') {
-            
+        elsif ($auth eq 'api_key_query') {
             my $api_key = $self->get_api_key_with_prefix('api_key_query');
             if ($api_key) {
                 $query_params->{'api_key_query'} = $api_key;
             }
         }
-elsif ($auth eq 'http_basic_test') {
-            
+        elsif ($auth eq 'http_basic_test') {
             if ($self->{config}{username} || $self->{config}{password}) {
                 $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
             }
         }
-elsif ($auth eq 'petstore_auth') {
-            
+        elsif ($auth eq 'petstore_auth') {
             if ($self->{config}{access_token}) {
                 $header_params->{'Authorization'} = 'Bearer ' . $self->{config}{access_token};
             }
         }
         else {
-       	    # TODO show warning about security definition not found
+           # TODO show warning about security definition not found
         }
     }
 }
@@ -378,37 +369,36 @@ elsif ($auth eq 'petstore_auth') {
 # OpenAPI Spec does not describe the intended authorization. So we check in the config for any 
 # auth tokens and if we find any, we use them for all endpoints; 
 sub _global_auth_setup {
-	my ($self, $header_params, $query_params) = @_; 
-	
-	my $tokens = $self->{config}->get_tokens;
-	return unless keys %$tokens;
-	
-	# basic
-	if (my $uname = delete $tokens->{username}) {
-		my $pword = delete $tokens->{password};
-		$header_params->{'Authorization'} = 'Basic '.encode_base64($uname.":".$pword);
-	}
-	
-	# oauth
-	if (my $access_token = delete $tokens->{access_token}) {
-		$header_params->{'Authorization'} = 'Bearer ' . $access_token;
-	}
-	
-	# other keys
-	foreach my $token_name (keys %$tokens) {
-		my $in = $tokens->{$token_name}->{in};
-		my $token = $self->get_api_key_with_prefix($token_name);
-		if ($in eq 'head') {
-			$header_params->{$token_name} = $token;
-		}
-		elsif ($in eq 'query') {
-			$query_params->{$token_name} = $token;
-		}
-		else {
-			die "Don't know where to put token '$token_name' ('$in' is not 'head' or 'query')";
-		}
-	}
-}
+    my ($self, $header_params, $query_params) = @_; 
 
+    my $tokens = $self->{config}->get_tokens;
+    return unless keys %$tokens;
+
+    # basic
+    if (my $uname = delete $tokens->{username}) {
+        my $pword = delete $tokens->{password};
+        $header_params->{'Authorization'} = 'Basic '.encode_base64($uname.":".$pword);
+    }
+
+    # oauth
+    if (my $access_token = delete $tokens->{access_token}) {
+        $header_params->{'Authorization'} = 'Bearer ' . $access_token;
+    }
+
+    # other keys
+    foreach my $token_name (keys %$tokens) {
+        my $in = $tokens->{$token_name}->{in};
+        my $token = $self->get_api_key_with_prefix($token_name);
+        if ($in eq 'head') {
+            $header_params->{$token_name} = $token;
+        }
+        elsif ($in eq 'query') {
+            $query_params->{$token_name} = $token;
+        }
+        else {
+            die "Don't know where to put token '$token_name' ('$in' is not 'head' or 'query')";
+        }
+    }
+}
 
 1;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiFactory.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiFactory.pm
@@ -32,47 +32,47 @@ use WWW::OpenAPIClient::ApiClient;
 
 =head1 Name
 
-	WWW::OpenAPIClient::ApiFactory - constructs APIs to retrieve WWW::OpenAPIClient objects
+    WWW::OpenAPIClient::ApiFactory - constructs APIs to retrieve WWW::OpenAPIClient objects
 
 =head1 Synopsis
 
-	package My::Petstore::App;
-	
-	use WWW::OpenAPIClient::ApiFactory;
-	
-	my $api_factory = WWW::OpenAPIClient::ApiFactory->new( ... ); # any args for ApiClient constructor
-							  
-	# later...
-	my $pet_api = $api_factory->get_api('Pet');  
-	
-	# $pet_api isa WWW::OpenAPIClient::PetApi
-	
-	my $pet = $pet_api->get_pet_by_id(pet_id => $pet_id);
-	
-	# object attributes have proper accessors:
-	printf "Pet's name is %s", $pet->name;
-	
-	# change the value stored on the object:
-	$pet->name('Dave'); 
+    package My::Petstore::App;
+    
+    use WWW::OpenAPIClient::ApiFactory;
+    
+    my $api_factory = WWW::OpenAPIClient::ApiFactory->new( ... ); # any args for ApiClient constructor
+
+    # later...
+    my $pet_api = $api_factory->get_api('Pet');  
+    
+    # $pet_api isa WWW::OpenAPIClient::PetApi
+    
+    my $pet = $pet_api->get_pet_by_id(pet_id => $pet_id);
+
+    # object attributes have proper accessors:
+    printf "Pet's name is %s", $pet->name;
+
+    # change the value stored on the object:
+    $pet->name('Dave'); 
 
 =cut
 
 # Load all the API classes and construct a lookup table at startup time
 my %_apis = map { $_ =~ /^WWW::OpenAPIClient::(.*)$/; $1 => $_ } 
-			grep {$_ =~ /Api$/} 
-			usesub 'WWW::OpenAPIClient';
+            grep {$_ =~ /Api$/} 
+            usesub 'WWW::OpenAPIClient';
 
 =head1 new($api_client)
-	
-	create a new WWW::OpenAPIClient::ApiFactory instance with the given WWW::OpenAPIClient::ApiClient instance.
+    
+    create a new WWW::OpenAPIClient::ApiFactory instance with the given WWW::OpenAPIClient::ApiClient instance.
 
 =head1 new(%parameters)
 
-	Any parameters are optional, and are passed to and stored on the api_client object.
-	
-	See L<WWW::OpenAPIClient::ApiClient> and L<WWW::OpenAPIClient::Configuration> for valid parameters
+    Any parameters are optional, and are passed to and stored on the api_client object.
+    
+    See L<WWW::OpenAPIClient::ApiClient> and L<WWW::OpenAPIClient::Configuration> for valid parameters
 
-=cut	
+=cut    
 
 sub new {
     my ($class) = shift;
@@ -88,25 +88,25 @@ sub new {
 
 =head1 get_api($which)
 
-	Returns an API object of the requested type. 
-	
-	$which is a nickname for the class: 
-	
-		FooBarClient::BazApi has nickname 'Baz'
-		
+    Returns an API object of the requested type. 
+    
+    $which is a nickname for the class: 
+    
+        FooBarClient::BazApi has nickname 'Baz'
+        
 =cut
 
 sub get_api {
-	my ($self, $which) = @_;
-	croak "API not specified" unless $which;
-	my $api_class = $_apis{"${which}Api"} || croak "No known API for '$which'";
-	return $api_class->new($self->api_client); 
+    my ($self, $which) = @_;
+    croak "API not specified" unless $which;
+    my $api_class = $_apis{"${which}Api"} || croak "No known API for '$which'";
+    return $api_class->new($self->api_client); 
 }
 
 =head1 api_client()
 
-	Returns the api_client object, should you ever need it.
-	
+    Returns the api_client object, should you ever need it.
+    
 =cut
 
 sub api_client { $_[0]->{api_client} }
@@ -120,8 +120,8 @@ sub apis_available { return map { $_ =~ s/Api$//; $_ } sort keys %_apis }
 =cut
 
 sub classname_for {
-	my ($self, $api_name) = @_;
-	return $_apis{"${api_name}Api"};
+    my ($self, $api_name) = @_;
+    return $_apis{"${api_name}Api"};
 }
 
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Configuration.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Configuration.pm
@@ -53,8 +53,8 @@ default: OpenAPI-Generator/1.0.0/perl
 Hashref. Keyed on the name of each key (there can be multiple tokens).
 
     api_key => {
-	secretKey => 'aaaabbbbccccdddd',
-	anotherKey => '1111222233334444',
+        secretKey => 'aaaabbbbccccdddd',
+        anotherKey => '1111222233334444',
     };
 
 =item api_key_prefix: (optional)
@@ -63,7 +63,7 @@ Hashref. Keyed on the name of each key (there can be multiple tokens). Note not 
 
     api_key_prefix => {
         secretKey => 'string',
-	anotherKey => 'same or some other string',
+        anotherKey => 'same or some other string',
     };
  
 =item api_key_in: (optional)
@@ -91,80 +91,80 @@ default: http://petstore.swagger.io:80/v2
 =cut
 
 sub new {
-	my ($self, %p) = (shift,@_);
+    my ($self, %p) = (shift,@_);
 
-	# class/static variables
-	$p{http_timeout} //= 180;
-	$p{http_user_agent} //= 'OpenAPI-Generator/1.0.0/perl';
+    # class/static variables
+    $p{http_timeout} //= 180;
+    $p{http_user_agent} //= 'OpenAPI-Generator/1.0.0/perl';
 
-	# authentication setting
-	$p{api_key} //= {};
-	$p{api_key_prefix} //= {};
-	$p{api_key_in} //= {};
+    # authentication setting
+    $p{api_key} //= {};
+    $p{api_key_prefix} //= {};
+    $p{api_key_in} //= {};
 
-	# username and password for HTTP basic authentication
-	$p{username} //= '';
-	$p{password} //= '';
+    # username and password for HTTP basic authentication
+    $p{username} //= '';
+    $p{password} //= '';
 
-	# access token for OAuth
-	$p{access_token} //= '';
+    # access token for OAuth
+    $p{access_token} //= '';
 
-	# base_url
-        $p{base_url} //= 'http://petstore.swagger.io:80/v2';
+    # base_url
+    $p{base_url} //= 'http://petstore.swagger.io:80/v2';
 
-	return bless \%p => $self;
+    return bless \%p => $self;
 }
 
 
 sub get_tokens {
-	my $self = shift;
-	
-	my $tokens = {};
-	$tokens->{username} = $self->{username} if $self->{username};
-	$tokens->{password} = $self->{password} if $self->{password};
-	$tokens->{access_token} = $self->{access_token} if $self->{access_token};
-	
-	foreach my $token_name (keys %{ $self->{api_key} }) {
-		$tokens->{$token_name}->{token} = $self->{api_key}{$token_name};
-		$tokens->{$token_name}->{prefix} = $self->{api_key_prefix}{$token_name};
-		$tokens->{$token_name}->{in} = $self->{api_key_in}{$token_name};
-	}
+    my $self = shift;
+    
+    my $tokens = {};
+    $tokens->{username} = $self->{username} if $self->{username};
+    $tokens->{password} = $self->{password} if $self->{password};
+    $tokens->{access_token} = $self->{access_token} if $self->{access_token};
+    
+    foreach my $token_name (keys %{ $self->{api_key} }) {
+        $tokens->{$token_name}->{token} = $self->{api_key}{$token_name};
+        $tokens->{$token_name}->{prefix} = $self->{api_key_prefix}{$token_name};
+        $tokens->{$token_name}->{in} = $self->{api_key_in}{$token_name};
+    }
 
-	return $tokens;
+    return $tokens;
 }
 
 sub clear_tokens {
-	my $self = shift;
-	my %tokens = %{$self->get_tokens}; # copy
-	
-	$self->{username} = '';
-	$self->{password} = '';
-	$self->{access_token} = '';
+    my $self = shift;
+    my %tokens = %{$self->get_tokens}; # copy
+    
+    $self->{username} = '';
+    $self->{password} = '';
+    $self->{access_token} = '';
 
-	$self->{api_key} = {};
-	$self->{api_key_prefix} = {};
-	$self->{api_key_in} = {};
-	
-	return \%tokens;
+    $self->{api_key} = {};
+    $self->{api_key_prefix} = {};
+    $self->{api_key_in} = {};
+    
+    return \%tokens;
 }
 
 sub accept_tokens {
-	my ($self, $tokens) = @_;
-	
-	foreach my $known_name (qw(username password access_token)) {
-		next unless $tokens->{$known_name};
-		$self->{$known_name} = delete $tokens->{$known_name};
-	}
-	
-	foreach my $token_name (keys %$tokens) {
-		$self->{api_key}{$token_name} = $tokens->{$token_name}{token};
-		if ($tokens->{$token_name}{prefix}) {
-			$self->{api_key_prefix}{$token_name} = $tokens->{$token_name}{prefix};
-		}
-		my $in = $tokens->{$token_name}->{in} || 'head';
-		croak "Tokens can only go in 'head' or 'query' (not in '$in')" unless $in =~ /^(?:head|query)$/;
-		$self->{api_key_in}{$token_name} = $in;
-	}
-}	
+    my ($self, $tokens) = @_;
+    
+    foreach my $known_name (qw(username password access_token)) {
+        next unless $tokens->{$known_name};
+        $self->{$known_name} = delete $tokens->{$known_name};
+    }
+    
+    foreach my $token_name (keys %$tokens) {
+        $self->{api_key}{$token_name} = $tokens->{$token_name}{token};
+        if ($tokens->{$token_name}{prefix}) {
+            $self->{api_key_prefix}{$token_name} = $tokens->{$token_name}{prefix};
+        }
+        my $in = $tokens->{$token_name}->{in} || 'head';
+        croak "Tokens can only go in 'head' or 'query' (not in '$in')" unless $in =~ /^(?:head|query)$/;
+        $self->{api_key_in}{$token_name} = $in;
+    }
+}    
 
 1;

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
@@ -63,7 +63,7 @@ sub new {
     },
     };
     __PACKAGE__->method_documentation->{ 'fake_outer_boolean_serialize' } = { 
-    	summary => '',
+        summary => '',
         params => $params,
         returns => 'boolean',
         };
@@ -113,17 +113,17 @@ sub fake_outer_boolean_serialize {
 #
 # 
 # 
-# @param OuterComposite $outer_composite Input composite as post body (optional)
+# @param OuterComposite $body Input composite as post body (optional)
 {
     my $params = {
-    'outer_composite' => {
+    'body' => {
         data_type => 'OuterComposite',
         description => 'Input composite as post body',
         required => '0',
     },
     };
     __PACKAGE__->method_documentation->{ 'fake_outer_composite_serialize' } = { 
-    	summary => '',
+        summary => '',
         params => $params,
         returns => 'OuterComposite',
         };
@@ -150,8 +150,8 @@ sub fake_outer_composite_serialize {
 
     my $_body_data;
     # body params
-    if ( exists $args{'outer_composite'}) {
-        $_body_data = $args{'outer_composite'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -183,7 +183,7 @@ sub fake_outer_composite_serialize {
     },
     };
     __PACKAGE__->method_documentation->{ 'fake_outer_number_serialize' } = { 
-    	summary => '',
+        summary => '',
         params => $params,
         returns => 'double',
         };
@@ -243,7 +243,7 @@ sub fake_outer_number_serialize {
     },
     };
     __PACKAGE__->method_documentation->{ 'fake_outer_string_serialize' } = { 
-    	summary => '',
+        summary => '',
         params => $params,
         returns => 'string',
         };
@@ -293,17 +293,17 @@ sub fake_outer_string_serialize {
 #
 # 
 # 
-# @param FileSchemaTestClass $file_schema_test_class  (required)
+# @param FileSchemaTestClass $body  (required)
 {
     my $params = {
-    'file_schema_test_class' => {
+    'body' => {
         data_type => 'FileSchemaTestClass',
         description => '',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'test_body_with_file_schema' } = { 
-    	summary => '',
+        summary => '',
         params => $params,
         returns => undef,
         };
@@ -313,9 +313,9 @@ sub fake_outer_string_serialize {
 sub test_body_with_file_schema {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'file_schema_test_class' is set
-    unless (exists $args{'file_schema_test_class'}) {
-      croak("Missing the required parameter 'file_schema_test_class' when calling test_body_with_file_schema");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_body_with_file_schema");
     }
 
     # parse inputs
@@ -335,8 +335,8 @@ sub test_body_with_file_schema {
 
     my $_body_data;
     # body params
-    if ( exists $args{'file_schema_test_class'}) {
-        $_body_data = $args{'file_schema_test_class'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -355,7 +355,7 @@ sub test_body_with_file_schema {
 # 
 # 
 # @param string $query  (required)
-# @param User $user  (required)
+# @param User $body  (required)
 {
     my $params = {
     'query' => {
@@ -363,14 +363,14 @@ sub test_body_with_file_schema {
         description => '',
         required => '1',
     },
-    'user' => {
+    'body' => {
         data_type => 'User',
         description => '',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'test_body_with_query_params' } = { 
-    	summary => '',
+        summary => '',
         params => $params,
         returns => undef,
         };
@@ -385,9 +385,9 @@ sub test_body_with_query_params {
       croak("Missing the required parameter 'query' when calling test_body_with_query_params");
     }
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling test_body_with_query_params");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_body_with_query_params");
     }
 
     # parse inputs
@@ -412,8 +412,8 @@ sub test_body_with_query_params {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -431,17 +431,17 @@ sub test_body_with_query_params {
 #
 # To test \"client\" model
 # 
-# @param Client $client client model (required)
+# @param Client $body client model (required)
 {
     my $params = {
-    'client' => {
+    'body' => {
         data_type => 'Client',
         description => 'client model',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'test_client_model' } = { 
-    	summary => 'To test \&quot;client\&quot; model',
+        summary => 'To test \&quot;client\&quot; model',
         params => $params,
         returns => 'Client',
         };
@@ -451,9 +451,9 @@ sub test_body_with_query_params {
 sub test_client_model {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'client' is set
-    unless (exists $args{'client'}) {
-      croak("Missing the required parameter 'client' when calling test_client_model");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_client_model");
     }
 
     # parse inputs
@@ -473,8 +473,8 @@ sub test_client_model {
 
     my $_body_data;
     # body params
-    if ( exists $args{'client'}) {
-        $_body_data = $args{'client'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -584,7 +584,7 @@ sub test_client_model {
     },
     };
     __PACKAGE__->method_documentation->{ 'test_endpoint_parameters' } = { 
-    	summary => 'Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ',
+        summary => 'Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ',
         params => $params,
         returns => undef,
         };
@@ -768,7 +768,7 @@ sub test_endpoint_parameters {
     },
     };
     __PACKAGE__->method_documentation->{ 'test_enum_parameters' } = { 
-    	summary => 'To test enum parameters',
+        summary => 'To test enum parameters',
         params => $params,
         returns => undef,
         };
@@ -889,7 +889,7 @@ sub test_enum_parameters {
     },
     };
     __PACKAGE__->method_documentation->{ 'test_group_parameters' } = { 
-    	summary => 'Fake endpoint to test group parameters (optional)',
+        summary => 'Fake endpoint to test group parameters (optional)',
         params => $params,
         returns => undef,
         };
@@ -975,17 +975,17 @@ sub test_group_parameters {
 #
 # test inline additionalProperties
 # 
-# @param HASH[string,string] $request_body request body (required)
+# @param HASH[string,string] $param request body (required)
 {
     my $params = {
-    'request_body' => {
+    'param' => {
         data_type => 'HASH[string,string]',
         description => 'request body',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'test_inline_additional_properties' } = { 
-    	summary => 'test inline additionalProperties',
+        summary => 'test inline additionalProperties',
         params => $params,
         returns => undef,
         };
@@ -995,9 +995,9 @@ sub test_group_parameters {
 sub test_inline_additional_properties {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'request_body' is set
-    unless (exists $args{'request_body'}) {
-      croak("Missing the required parameter 'request_body' when calling test_inline_additional_properties");
+    # verify the required parameter 'param' is set
+    unless (exists $args{'param'}) {
+      croak("Missing the required parameter 'param' when calling test_inline_additional_properties");
     }
 
     # parse inputs
@@ -1017,8 +1017,8 @@ sub test_inline_additional_properties {
 
     my $_body_data;
     # body params
-    if ( exists $args{'request_body'}) {
-        $_body_data = $args{'request_body'};
+    if ( exists $args{'param'}) {
+        $_body_data = $args{'param'};
     }
 
     # authentication setting, if any
@@ -1052,7 +1052,7 @@ sub test_inline_additional_properties {
     },
     };
     __PACKAGE__->method_documentation->{ 'test_json_form_data' } = { 
-    	summary => 'test json serialization of form data',
+        summary => 'test json serialization of form data',
         params => $params,
         returns => undef,
         };

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeClassnameTags123Api.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeClassnameTags123Api.pm
@@ -53,17 +53,17 @@ sub new {
 #
 # To test class name in snake case
 # 
-# @param Client $client client model (required)
+# @param Client $body client model (required)
 {
     my $params = {
-    'client' => {
+    'body' => {
         data_type => 'Client',
         description => 'client model',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'test_classname' } = { 
-    	summary => 'To test class name in snake case',
+        summary => 'To test class name in snake case',
         params => $params,
         returns => 'Client',
         };
@@ -73,9 +73,9 @@ sub new {
 sub test_classname {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'client' is set
-    unless (exists $args{'client'}) {
-      croak("Missing the required parameter 'client' when calling test_classname");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_classname");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub test_classname {
 
     my $_body_data;
     # body params
-    if ( exists $args{'client'}) {
-        $_body_data = $args{'client'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'map_property' => {
-    	datatype => 'HASH[string,string]',
-    	base_name => 'map_property',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,string]',
+        base_name => 'map_property',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'map_of_map_property' => {
-    	datatype => 'HASH[string,HASH[string,string]]',
-    	base_name => 'map_of_map_property',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,HASH[string,string]]',
+        base_name => 'map_of_map_property',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Animal.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Animal.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'class_name' => {
-    	datatype => 'string',
-    	base_name => 'className',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'className',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'color' => {
-    	datatype => 'string',
-    	base_name => 'color',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'color',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ApiResponse.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ApiResponse.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,26 +155,26 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'code' => {
-    	datatype => 'int',
-    	base_name => 'code',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'code',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'type' => {
-    	datatype => 'string',
-    	base_name => 'type',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'type',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'message' => {
-    	datatype => 'string',
-    	base_name => 'message',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'message',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfArrayOfNumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfArrayOfNumberOnly.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'array_array_number' => {
-    	datatype => 'ARRAY[ARRAY[double]]',
-    	base_name => 'ArrayArrayNumber',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[ARRAY[double]]',
+        base_name => 'ArrayArrayNumber',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfNumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayOfNumberOnly.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'array_number' => {
-    	datatype => 'ARRAY[double]',
-    	base_name => 'ArrayNumber',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[double]',
+        base_name => 'ArrayNumber',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ArrayTest.pm
@@ -69,11 +69,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -81,10 +81,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -114,7 +114,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -125,7 +125,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -156,26 +156,26 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'array_of_string' => {
-    	datatype => 'ARRAY[string]',
-    	base_name => 'array_of_string',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[string]',
+        base_name => 'array_of_string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'array_array_of_integer' => {
-    	datatype => 'ARRAY[ARRAY[int]]',
-    	base_name => 'array_array_of_integer',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[ARRAY[int]]',
+        base_name => 'array_array_of_integer',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'array_array_of_model' => {
-    	datatype => 'ARRAY[ARRAY[ReadOnlyFirst]]',
-    	base_name => 'array_array_of_model',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[ARRAY[ReadOnlyFirst]]',
+        base_name => 'array_array_of_model',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Capitalization.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Capitalization.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,47 +155,47 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'small_camel' => {
-    	datatype => 'string',
-    	base_name => 'smallCamel',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'smallCamel',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'capital_camel' => {
-    	datatype => 'string',
-    	base_name => 'CapitalCamel',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'CapitalCamel',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'small_snake' => {
-    	datatype => 'string',
-    	base_name => 'small_Snake',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'small_Snake',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'capital_snake' => {
-    	datatype => 'string',
-    	base_name => 'Capital_Snake',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'Capital_Snake',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'sca_eth_flow_points' => {
-    	datatype => 'string',
-    	base_name => 'SCA_ETH_Flow_Points',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'SCA_ETH_Flow_Points',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'att_name' => {
-    	datatype => 'string',
-    	base_name => 'ATT_NAME',
-    	description => 'Name of the pet ',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'ATT_NAME',
+        description => 'Name of the pet ',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Cat.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Cat.pm
@@ -69,11 +69,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -81,12 +81,12 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 
-	# initialize parent object Animal
+    # initialize parent object Animal
     $self->WWW::OpenAPIClient::Object::Animal::init(%args);
 }
 
@@ -95,7 +95,7 @@ sub to_hash {
     my $self = shift;
     my $_hash = decode_json(JSON->new->convert_blessed->encode($self));
 
-	# call Animal to_hash and then combine hash
+    # call Animal to_hash and then combine hash
     $_hash = { %$_hash, %$self->WWW::OpenAPIClient::Object::Animal::to_hash };
 
     return $_hash;
@@ -123,7 +123,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -134,7 +134,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
 
@@ -168,12 +168,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'declawed' => {
-    	datatype => 'boolean',
-    	base_name => 'declawed',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'boolean',
+        base_name => 'declawed',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Category.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Category.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'id' => {
-    	datatype => 'int',
-    	base_name => 'id',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'id',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'name' => {
-    	datatype => 'string',
-    	base_name => 'name',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'name',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ClassModel.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ClassModel.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => 'Model for testing model with \
 
 __PACKAGE__->method_documentation({
     '_class' => {
-    	datatype => 'string',
-    	base_name => '_class',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => '_class',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Client.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Client.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'client' => {
-    	datatype => 'string',
-    	base_name => 'client',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'client',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Dog.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Dog.pm
@@ -69,11 +69,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -81,12 +81,12 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 
-	# initialize parent object Animal
+    # initialize parent object Animal
     $self->WWW::OpenAPIClient::Object::Animal::init(%args);
 }
 
@@ -95,7 +95,7 @@ sub to_hash {
     my $self = shift;
     my $_hash = decode_json(JSON->new->convert_blessed->encode($self));
 
-	# call Animal to_hash and then combine hash
+    # call Animal to_hash and then combine hash
     $_hash = { %$_hash, %$self->WWW::OpenAPIClient::Object::Animal::to_hash };
 
     return $_hash;
@@ -123,7 +123,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -134,7 +134,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
 
@@ -168,12 +168,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'breed' => {
-    	datatype => 'string',
-    	base_name => 'breed',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'breed',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumArrays.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumArrays.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'just_symbol' => {
-    	datatype => 'string',
-    	base_name => 'just_symbol',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'just_symbol',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'array_enum' => {
-    	datatype => 'ARRAY[string]',
-    	base_name => 'array_enum',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[string]',
+        base_name => 'array_enum',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumClass.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
@@ -69,11 +69,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -81,10 +81,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -114,7 +114,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -125,7 +125,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -156,40 +156,40 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'enum_string' => {
-    	datatype => 'string',
-    	base_name => 'enum_string',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'enum_string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'enum_string_required' => {
-    	datatype => 'string',
-    	base_name => 'enum_string_required',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'enum_string_required',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'enum_integer' => {
-    	datatype => 'int',
-    	base_name => 'enum_integer',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'enum_integer',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'enum_number' => {
-    	datatype => 'double',
-    	base_name => 'enum_number',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'double',
+        base_name => 'enum_number',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'outer_enum' => {
-    	datatype => 'OuterEnum',
-    	base_name => 'outerEnum',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'OuterEnum',
+        base_name => 'outerEnum',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/File.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/File.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => 'Must be named &#x60;File&#x60;
 
 __PACKAGE__->method_documentation({
     'source_uri' => {
-    	datatype => 'string',
-    	base_name => 'sourceURI',
-    	description => 'Test capitalization',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'sourceURI',
+        description => 'Test capitalization',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FileSchemaTestClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FileSchemaTestClass.pm
@@ -69,11 +69,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -81,10 +81,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -114,7 +114,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -125,7 +125,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -156,19 +156,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'file' => {
-    	datatype => 'File',
-    	base_name => 'file',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'File',
+        base_name => 'file',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'files' => {
-    	datatype => 'ARRAY[File]',
-    	base_name => 'files',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[File]',
+        base_name => 'files',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,96 +155,96 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'integer' => {
-    	datatype => 'int',
-    	base_name => 'integer',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'integer',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'int32' => {
-    	datatype => 'int',
-    	base_name => 'int32',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'int32',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'int64' => {
-    	datatype => 'int',
-    	base_name => 'int64',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'int64',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'number' => {
-    	datatype => 'double',
-    	base_name => 'number',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'double',
+        base_name => 'number',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'float' => {
-    	datatype => 'double',
-    	base_name => 'float',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'double',
+        base_name => 'float',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'double' => {
-    	datatype => 'double',
-    	base_name => 'double',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'double',
+        base_name => 'double',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'string' => {
-    	datatype => 'string',
-    	base_name => 'string',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'byte' => {
-    	datatype => 'string',
-    	base_name => 'byte',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'byte',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'binary' => {
-    	datatype => 'string',
-    	base_name => 'binary',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'binary',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'date' => {
-    	datatype => 'DateTime',
-    	base_name => 'date',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'DateTime',
+        base_name => 'date',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'date_time' => {
-    	datatype => 'DateTime',
-    	base_name => 'dateTime',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'DateTime',
+        base_name => 'dateTime',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'uuid' => {
-    	datatype => 'string',
-    	base_name => 'uuid',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'uuid',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'password' => {
-    	datatype => 'string',
-    	base_name => 'password',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'password',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HasOnlyReadOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/HasOnlyReadOnly.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'bar' => {
-    	datatype => 'string',
-    	base_name => 'bar',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'bar',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'foo' => {
-    	datatype => 'string',
-    	base_name => 'foo',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'foo',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/List.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/List.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     '_123_list' => {
-    	datatype => 'string',
-    	base_name => '123-list',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => '123-list',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MapTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MapTest.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,33 +155,33 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'map_map_of_string' => {
-    	datatype => 'HASH[string,HASH[string,string]]',
-    	base_name => 'map_map_of_string',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,HASH[string,string]]',
+        base_name => 'map_map_of_string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'map_of_enum_string' => {
-    	datatype => 'HASH[string,string]',
-    	base_name => 'map_of_enum_string',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,string]',
+        base_name => 'map_of_enum_string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'direct_map' => {
-    	datatype => 'HASH[string,boolean]',
-    	base_name => 'direct_map',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,boolean]',
+        base_name => 'direct_map',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'indirect_map' => {
-    	datatype => 'HASH[string,boolean]',
-    	base_name => 'indirect_map',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,boolean]',
+        base_name => 'indirect_map',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MixedPropertiesAndAdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/MixedPropertiesAndAdditionalPropertiesClass.pm
@@ -69,11 +69,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -81,10 +81,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -114,7 +114,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -125,7 +125,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -156,26 +156,26 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'uuid' => {
-    	datatype => 'string',
-    	base_name => 'uuid',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'uuid',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'date_time' => {
-    	datatype => 'DateTime',
-    	base_name => 'dateTime',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'DateTime',
+        base_name => 'dateTime',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'map' => {
-    	datatype => 'HASH[string,Animal]',
-    	base_name => 'map',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'HASH[string,Animal]',
+        base_name => 'map',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Model200Response.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Model200Response.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => 'Model for testing model name s
 
 __PACKAGE__->method_documentation({
     'name' => {
-    	datatype => 'int',
-    	base_name => 'name',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'name',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'class' => {
-    	datatype => 'string',
-    	base_name => 'class',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'class',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ModelReturn.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ModelReturn.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => 'Model for testing reserved wor
 
 __PACKAGE__->method_documentation({
     'return' => {
-    	datatype => 'int',
-    	base_name => 'return',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'return',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Name.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Name.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,33 +155,33 @@ __PACKAGE__->class_documentation({description => 'Model for testing model name s
 
 __PACKAGE__->method_documentation({
     'name' => {
-    	datatype => 'int',
-    	base_name => 'name',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'name',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'snake_case' => {
-    	datatype => 'int',
-    	base_name => 'snake_case',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'snake_case',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'property' => {
-    	datatype => 'string',
-    	base_name => 'property',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'property',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     '_123_number' => {
-    	datatype => 'int',
-    	base_name => '123Number',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => '123Number',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NumberOnly.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/NumberOnly.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'just_number' => {
-    	datatype => 'double',
-    	base_name => 'JustNumber',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'double',
+        base_name => 'JustNumber',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Order.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Order.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,47 +155,47 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'id' => {
-    	datatype => 'int',
-    	base_name => 'id',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'id',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'pet_id' => {
-    	datatype => 'int',
-    	base_name => 'petId',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'petId',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'quantity' => {
-    	datatype => 'int',
-    	base_name => 'quantity',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'quantity',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'ship_date' => {
-    	datatype => 'DateTime',
-    	base_name => 'shipDate',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'DateTime',
+        base_name => 'shipDate',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'status' => {
-    	datatype => 'string',
-    	base_name => 'status',
-    	description => 'Order Status',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'status',
+        description => 'Order Status',
+        format => '',
+        read_only => '',
+            },
     'complete' => {
-    	datatype => 'boolean',
-    	base_name => 'complete',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'boolean',
+        base_name => 'complete',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterComposite.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterComposite.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,26 +155,26 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'my_number' => {
-    	datatype => 'double',
-    	base_name => 'my_number',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'double',
+        base_name => 'my_number',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'my_string' => {
-    	datatype => 'string',
-    	base_name => 'my_string',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'my_string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'my_boolean' => {
-    	datatype => 'boolean',
-    	base_name => 'my_boolean',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'boolean',
+        base_name => 'my_boolean',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnum.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/OuterEnum.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Pet.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Pet.pm
@@ -70,11 +70,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -82,10 +82,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -115,7 +115,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -126,7 +126,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -157,47 +157,47 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'id' => {
-    	datatype => 'int',
-    	base_name => 'id',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'id',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'category' => {
-    	datatype => 'Category',
-    	base_name => 'category',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'Category',
+        base_name => 'category',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'name' => {
-    	datatype => 'string',
-    	base_name => 'name',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'name',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'photo_urls' => {
-    	datatype => 'ARRAY[string]',
-    	base_name => 'photoUrls',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[string]',
+        base_name => 'photoUrls',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'tags' => {
-    	datatype => 'ARRAY[Tag]',
-    	base_name => 'tags',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'ARRAY[Tag]',
+        base_name => 'tags',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'status' => {
-    	datatype => 'string',
-    	base_name => 'status',
-    	description => 'pet status in the store',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'status',
+        description => 'pet status in the store',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ReadOnlyFirst.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/ReadOnlyFirst.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'bar' => {
-    	datatype => 'string',
-    	base_name => 'bar',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'bar',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'baz' => {
-    	datatype => 'string',
-    	base_name => 'baz',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'baz',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SpecialModelName.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/SpecialModelName.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,12 +155,12 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     '__special[property/name]' => {
-    	datatype => 'int',
-    	base_name => '$special[property.name]',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => '$special[property.name]',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Tag.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/Tag.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,19 +155,19 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'id' => {
-    	datatype => 'int',
-    	base_name => 'id',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'id',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'name' => {
-    	datatype => 'string',
-    	base_name => 'name',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'name',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/User.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/User.pm
@@ -68,11 +68,11 @@ __PACKAGE__->mk_classdata('class_documentation' => {});
 sub new { 
     my ($class, %args) = @_; 
 
-	my $self = bless {}, $class;
+    my $self = bless {}, $class;
 
-	$self->init(%args);
-	
-	return $self;
+    $self->init(%args);
+    
+    return $self;
 }
 
 # initialize the object
@@ -80,10 +80,10 @@ sub init
 {
     my ($self, %args) = @_;
 
-	foreach my $attribute (keys %{$self->attribute_map}) {
-		my $args_key = $self->attribute_map->{$attribute};
-		$self->$attribute( $args{ $args_key } );
-	}
+    foreach my $attribute (keys %{$self->attribute_map}) {
+        my $args_key = $self->attribute_map->{$attribute};
+        $self->$attribute( $args{ $args_key } );
+    }
 }
 
 # return perl hash
@@ -113,7 +113,7 @@ sub from_hash {
 
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
-    	my $_json_attribute = $self->attribute_map->{$_key}; 
+        my $_json_attribute = $self->attribute_map->{$_key}; 
         if ($_type =~ /^array\[/i) { # array
             my $_subclass = substr($_type, 6, -1);
             my @_array = ();
@@ -124,7 +124,7 @@ sub from_hash {
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
-        	$log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
+            $log->debugf("Warning: %s (%s) does not exist in input hash\n", $_key, $_json_attribute);
         }
     }
   
@@ -155,61 +155,61 @@ __PACKAGE__->class_documentation({description => '',
 
 __PACKAGE__->method_documentation({
     'id' => {
-    	datatype => 'int',
-    	base_name => 'id',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'id',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'username' => {
-    	datatype => 'string',
-    	base_name => 'username',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'username',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'first_name' => {
-    	datatype => 'string',
-    	base_name => 'firstName',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'firstName',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'last_name' => {
-    	datatype => 'string',
-    	base_name => 'lastName',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'lastName',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'email' => {
-    	datatype => 'string',
-    	base_name => 'email',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'email',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'password' => {
-    	datatype => 'string',
-    	base_name => 'password',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'password',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'phone' => {
-    	datatype => 'string',
-    	base_name => 'phone',
-    	description => '',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'string',
+        base_name => 'phone',
+        description => '',
+        format => '',
+        read_only => '',
+            },
     'user_status' => {
-    	datatype => 'int',
-    	base_name => 'userStatus',
-    	description => 'User Status',
-    	format => '',
-    	read_only => '',
-    		},
+        datatype => 'int',
+        base_name => 'userStatus',
+        description => 'User Status',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/PetApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/PetApi.pm
@@ -53,17 +53,17 @@ sub new {
 #
 # Add a new pet to the store
 # 
-# @param Pet $pet Pet object that needs to be added to the store (required)
+# @param Pet $body Pet object that needs to be added to the store (required)
 {
     my $params = {
-    'pet' => {
+    'body' => {
         data_type => 'Pet',
         description => 'Pet object that needs to be added to the store',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'add_pet' } = { 
-    	summary => 'Add a new pet to the store',
+        summary => 'Add a new pet to the store',
         params => $params,
         returns => undef,
         };
@@ -73,9 +73,9 @@ sub new {
 sub add_pet {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'pet' is set
-    unless (exists $args{'pet'}) {
-      croak("Missing the required parameter 'pet' when calling add_pet");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling add_pet");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub add_pet {
 
     my $_body_data;
     # body params
-    if ( exists $args{'pet'}) {
-        $_body_data = $args{'pet'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -130,7 +130,7 @@ sub add_pet {
     },
     };
     __PACKAGE__->method_documentation->{ 'delete_pet' } = { 
-    	summary => 'Deletes a pet',
+        summary => 'Deletes a pet',
         params => $params,
         returns => undef,
         };
@@ -198,7 +198,7 @@ sub delete_pet {
     },
     };
     __PACKAGE__->method_documentation->{ 'find_pets_by_status' } = { 
-    	summary => 'Finds Pets by status',
+        summary => 'Finds Pets by status',
         params => $params,
         returns => 'ARRAY[Pet]',
         };
@@ -263,7 +263,7 @@ sub find_pets_by_status {
     },
     };
     __PACKAGE__->method_documentation->{ 'find_pets_by_tags' } = { 
-    	summary => 'Finds Pets by tags',
+        summary => 'Finds Pets by tags',
         params => $params,
         returns => 'ARRAY[Pet]',
         };
@@ -328,7 +328,7 @@ sub find_pets_by_tags {
     },
     };
     __PACKAGE__->method_documentation->{ 'get_pet_by_id' } = { 
-    	summary => 'Find pet by ID',
+        summary => 'Find pet by ID',
         params => $params,
         returns => 'Pet',
         };
@@ -385,17 +385,17 @@ sub get_pet_by_id {
 #
 # Update an existing pet
 # 
-# @param Pet $pet Pet object that needs to be added to the store (required)
+# @param Pet $body Pet object that needs to be added to the store (required)
 {
     my $params = {
-    'pet' => {
+    'body' => {
         data_type => 'Pet',
         description => 'Pet object that needs to be added to the store',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'update_pet' } = { 
-    	summary => 'Update an existing pet',
+        summary => 'Update an existing pet',
         params => $params,
         returns => undef,
         };
@@ -405,9 +405,9 @@ sub get_pet_by_id {
 sub update_pet {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'pet' is set
-    unless (exists $args{'pet'}) {
-      croak("Missing the required parameter 'pet' when calling update_pet");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling update_pet");
     }
 
     # parse inputs
@@ -427,8 +427,8 @@ sub update_pet {
 
     my $_body_data;
     # body params
-    if ( exists $args{'pet'}) {
-        $_body_data = $args{'pet'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -468,7 +468,7 @@ sub update_pet {
     },
     };
     __PACKAGE__->method_documentation->{ 'update_pet_with_form' } = { 
-    	summary => 'Updates a pet in the store with form data',
+        summary => 'Updates a pet in the store with form data',
         params => $params,
         returns => undef,
         };
@@ -553,7 +553,7 @@ sub update_pet_with_form {
     },
     };
     __PACKAGE__->method_documentation->{ 'upload_file' } = { 
-    	summary => 'uploads an image',
+        summary => 'uploads an image',
         params => $params,
         returns => 'ApiResponse',
         };
@@ -643,7 +643,7 @@ sub upload_file {
     },
     };
     __PACKAGE__->method_documentation->{ 'upload_file_with_required_file' } = { 
-    	summary => 'uploads an image (required)',
+        summary => 'uploads an image (required)',
         params => $params,
         returns => 'ApiResponse',
         };

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Role.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Role.pm
@@ -62,29 +62,29 @@ has version_info => ( is => 'ro',
                       );
 
 sub BUILD {
-	my $self = shift;
+    my $self = shift;
 
-	$self->_cfg->accept_tokens( $self->tokens ) if keys %{$self->tokens};
+    $self->_cfg->accept_tokens( $self->tokens ) if keys %{$self->tokens};
 
-	# ignore these symbols imported into API namespaces
-	my %outsiders = map {$_ => 1} qw( croak );
+    # ignore these symbols imported into API namespaces
+    my %outsiders = map {$_ => 1} qw( croak );
 
-	my %delegates;
+    my %delegates;
 
-	# collect the methods callable on each API
-	foreach my $api_name ($self->api_factory->apis_available) {
-		my $api_class = $self->api_factory->classname_for($api_name);
-		my $methods = Class::Inspector->methods($api_class, 'expanded'); # not Moose, so use CI instead
-		my @local_methods = grep {! /^_/} grep {! $outsiders{$_}} map {$_->[2]} grep {$_->[1] eq $api_class} @$methods;
-		push( @{$delegates{$_}}, {api_name => $api_name, api_class => $api_class} ) for @local_methods;
-	}
+    # collect the methods callable on each API
+    foreach my $api_name ($self->api_factory->apis_available) {
+        my $api_class = $self->api_factory->classname_for($api_name);
+        my $methods = Class::Inspector->methods($api_class, 'expanded'); # not Moose, so use CI instead
+        my @local_methods = grep {! /^_/} grep {! $outsiders{$_}} map {$_->[2]} grep {$_->[1] eq $api_class} @$methods;
+        push( @{$delegates{$_}}, {api_name => $api_name, api_class => $api_class} ) for @local_methods;
+    }
 
-	# remove clashes
-	foreach my $method (keys %delegates) {
-		if ( @{$delegates{$method}} > 1 ) {
-			my ($apis) = delete $delegates{$method};
-		}
-	}
+    # remove clashes
+    foreach my $method (keys %delegates) {
+        if ( @{$delegates{$method}} > 1 ) {
+            my ($apis) = delete $delegates{$method};
+        }
+    }
 
     # build the flattened API
     foreach my $api_name ($self->api_factory->apis_available) {
@@ -103,10 +103,10 @@ sub BUILD {
 }
 
 sub _build_af {
-	my $self = shift;
-	my %args;
-	$args{base_url} = $self->base_url if $self->base_url;
-	return WWW::OpenAPIClient::ApiFactory->new(%args);
+    my $self = shift;
+    my %args;
+    $args{base_url} = $self->base_url if $self->base_url;
+    return WWW::OpenAPIClient::ApiFactory->new(%args);
 }
 
 =head1 NAME
@@ -141,15 +141,15 @@ This module provides an interface to the generated library. All the classes,
 objects, and methods (well, not quite *all*, see below) are flattened into this
 role.
 
-	package MyApp;
-	use Moose;
-	with 'WWW::OpenAPIClient::Role';
+    package MyApp;
+    use Moose;
+    with 'WWW::OpenAPIClient::Role';
 
-	package main;
+    package main;
 
-	my $api = MyApp->new({ tokens => $tokens });
+    my $api = MyApp->new({ tokens => $tokens });
 
-	my $pet = $api->get_pet_by_id(pet_id => $pet_id);
+    my $pet = $api->get_pet_by_id(pet_id => $pet_id);
 
 =head2 Structure of the library
 
@@ -218,20 +218,20 @@ String. The password for basic auth.
 
 Hashref. Keyed on the name of each key (there can be multiple tokens).
 
-	$cfg->{api_key} = {
-		secretKey => 'aaaabbbbccccdddd',
-		anotherKey => '1111222233334444',
-		};
+    $cfg->{api_key} = {
+        secretKey => 'aaaabbbbccccdddd',
+        anotherKey => '1111222233334444',
+        };
 
 =item C<$cfg->{api_key_prefix}>
 
 Hashref. Keyed on the name of each key (there can be multiple tokens). Note not
 all api keys require a prefix.
 
-	$cfg->{api_key_prefix} = {
-		secretKey => 'string',
-		anotherKey => 'same or some other string',
-		};
+    $cfg->{api_key_prefix} = {
+        secretKey => 'string',
+        anotherKey => 'same or some other string',
+        };
 
 =item C<$config-\>{access_token}>
 
@@ -265,9 +265,9 @@ In principle, every API is susceptible to the presence of a few, random, undeleg
 method names. In practice, because of the way method names are constructed, it's
 unlikely in general that any methods will be undelegatable, except for:
 
-	new()
-	class_documentation()
-	method_documentation()
+    new()
+    class_documentation()
+    method_documentation()
 
 To call these methods, you need to get a handle on the relevant object, either
 by calling C<$api-E<gt>foo_api> or by retrieving an object, e.g.
@@ -283,14 +283,14 @@ maven 3.0.3 or better already installed.
 
 The config file should specify the project name for the generated library:
 
-	{"moduleName":"WWW::MyProjectName"}
+    {"moduleName":"WWW::MyProjectName"}
 
 Your library files will be built under C<WWW::MyProjectName>.
 
-	$ git clone https://github.com/openapitools/openapi-generator
-	$ cd openapi-generator
-	$ mvn package
-	$ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
+    $ git clone https://github.com/openapitools/openapi-generator
+    $ cd openapi-generator
+    $ mvn package
+    $ java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
   -i [URL or file path to JSON OpenAPI API spec] \
   -g perl \
   -c /path/to/config/file.json \
@@ -305,7 +305,7 @@ You can print out a summary of the generated API by running the included
 C<autodoc> script in the C<bin> directory of your generated library. A few
 output formats are supported:
 
-	Usage: autodoc [OPTION]
+    Usage: autodoc [OPTION]
 
   -w           wide format (default)
   -n           narrow format
@@ -325,10 +325,10 @@ spec. If so, this is available via the C<class_documentation()> and
 C<method_documentation()> methods on each generated object class, and the
 C<method_documentation()> method on the endpoint API classes:
 
-	my $cmdoc = $api->pet_api->method_documentation->{$method_name};
+    my $cmdoc = $api->pet_api->method_documentation->{$method_name};
 
-	my $odoc = $api->get_pet_by_id->(pet_id => $pet_id)->class_documentation;
-	my $omdoc = $api->get_pet_by_id->(pet_id => $pet_id)->method_documentation->{method_name};
+    my $odoc = $api->get_pet_by_id->(pet_id => $pet_id)->class_documentation;
+    my $omdoc = $api->get_pet_by_id->(pet_id => $pet_id)->method_documentation->{method_name};
 
 Each of these calls returns a hashref with various useful pieces of information.
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Role/AutoDoc.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Role/AutoDoc.pm
@@ -23,30 +23,30 @@ use List::MoreUtils qw(uniq);
 use Moose::Role;
 
 sub autodoc {
-	my ($self, $how) = @_;
-	
-	die "Unknown format '$how'" unless $how =~ /^(pod|wide|narrow)$/;
-	
-	$self->_printisa($how);
-	$self->_printmethods($how);
-	$self->_printattrs($how);
-	print "\n";
+    my ($self, $how) = @_;
+
+    die "Unknown format '$how'" unless $how =~ /^(pod|wide|narrow)$/;
+
+    $self->_printisa($how);
+    $self->_printmethods($how);
+    $self->_printattrs($how);
+    print "\n";
 }
 
 sub _printisa {
-	my ($self, $how) = @_;	
-	my $meta = $self->meta;
-	
-	my $myclass = ref $self;
-	
-	my $super = join ', ', $meta->superclasses;
-	my @roles = $meta->calculate_all_roles;
-	#shift(@roles) if @roles > 1; # if > 1, the first is a composite, the rest are the roles
+    my ($self, $how) = @_;
+    my $meta = $self->meta;
 
-	my $isa =   join ', ', grep {$_ ne $myclass} $meta->linearized_isa;
-	my $sub =   join ', ', $meta->subclasses;
-	my $dsub =  join ', ', $meta->direct_subclasses;
-	
+    my $myclass = ref $self;
+
+    my $super = join ', ', $meta->superclasses;
+    my @roles = $meta->calculate_all_roles;
+    #shift(@roles) if @roles > 1; # if > 1, the first is a composite, the rest are the roles
+
+    my $isa =   join ', ', grep {$_ ne $myclass} $meta->linearized_isa;
+    my $sub =   join ', ', $meta->subclasses;
+    my $dsub =  join ', ', $meta->direct_subclasses;
+
     my $app_name = $self->version_info->{app_name};
     my $app_version = $self->version_info->{app_version};
     my $generated_date = $self->version_info->{generated_date};
@@ -54,25 +54,25 @@ sub _printisa {
 
     $~ = $how eq 'pod' ? 'INHERIT_POD' : 'INHERIT';
     write;
-	
-	my ($rolepkg, $role_reqs);
-	
-	foreach my $role (@roles) {
-		$rolepkg = $role->{package} || next; # some are anonymous, or something
-		next if $rolepkg eq 'WWW::OpenAPIClient::Role::AutoDoc';
-		$role_reqs = join ', ', keys %{$role->{required_methods}};
-		$role_reqs ||= '';
-		$~ = $how eq 'pod' ? 'ROLES_POD' : 'ROLES';
-		write;
-	}
-	
-	if ($how eq 'pod') {
-		$~ = 'ROLES_POD_CLOSE';
-		write;
-	}
-	
+
+    my ($rolepkg, $role_reqs);
+
+    foreach my $role (@roles) {
+        $rolepkg = $role->{package} || next; # some are anonymous, or something
+        next if $rolepkg eq 'WWW::OpenAPIClient::Role::AutoDoc';
+        $role_reqs = join ', ', keys %{$role->{required_methods}};
+        $role_reqs ||= '';
+        $~ = $how eq 'pod' ? 'ROLES_POD' : 'ROLES';
+        write;
+    }
+
+    if ($how eq 'pod') {
+        $~ = 'ROLES_POD_CLOSE';
+        write;
+    }
+
 # ----- format specs -----
-	format INHERIT = 
+    format INHERIT = 
 
 @* -
 $myclass
@@ -91,7 +91,7 @@ $myclass
                        $generator_class
                        
 .
-	format ROLES =   
+    format ROLES =   
              Composes: ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ~
                        $rolepkg
                        requires: ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ~
@@ -100,7 +100,7 @@ $myclass
                                  $role_reqs
 .
 
-	format INHERIT_POD =
+    format INHERIT_POD =
 =head1 NAME
 
 @*
@@ -151,7 +151,7 @@ $myclass
 
 
 .
-	format ROLES_POD =
+    format ROLES_POD =
 =head2 C<@*>
        $rolepkg
        
@@ -161,7 +161,7 @@ Requires:
 $role_reqs
 
 .
-	format ROLES_POD_CLOSE =
+    format ROLES_POD_CLOSE =
 
 
 .
@@ -169,96 +169,96 @@ $role_reqs
 }
 
 sub _printmethods {
-	my ($self, $how) = @_;
-	
-	if ($how eq 'narrow') {
-		print <<HEAD;
+    my ($self, $how) = @_;
+
+    if ($how eq 'narrow') {
+        print <<HEAD;
 METHODS
 -------
 HEAD
-	}
-	elsif ($how eq 'wide') {
-		$~ = 'METHODHEAD';
-		write;
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'METHODHEAD_POD';
-		write;
-	}
-	else {
-		die "Don't know how to print '$how'";
-	}
-	
-	$self->_printmethod($_, $how) for uniq sort $self->meta->get_all_method_names; #$self->meta->get_method_list, 
-	
-	if ($how eq 'pod') {
-		$~ = 'METHOD_POD_CLOSE';
-		write;
-	}
+    }
+    elsif ($how eq 'wide') {
+        $~ = 'METHODHEAD';
+        write;
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'METHODHEAD_POD';
+        write;
+    }
+    else {
+        die "Don't know how to print '$how'";
+    }
+
+    $self->_printmethod($_, $how) for uniq sort $self->meta->get_all_method_names; #$self->meta->get_method_list, 
+
+    if ($how eq 'pod') {
+        $~ = 'METHOD_POD_CLOSE';
+        write;
+    }
 
 
 }
 
 sub _printmethod {
-	my ($self, $methodname, $how) = @_;
-	return if $methodname =~ /^_/;
-	return if $self->meta->has_attribute($methodname);
-	my %internal = map {$_ => 1} qw(BUILD BUILDARGS meta can new DEMOLISHALL DESTROY 
-		DOES isa BUILDALL does VERSION dump
-		);
-	return if $internal{$methodname};
-	my $method = $self->meta->get_method($methodname) or return; # symbols imported into namespaces i.e. not known by Moose
-	
-	return if $method->original_package_name eq __PACKAGE__;
-	
-	my $delegate_to = '';
-	my $via = '';
-	my $on = '';
-	my $doc = '';
-	my $original_pkg = $method->original_package_name;
-	if ($method->can('associated_attribute')) {
-		$delegate_to = $method->delegate_to_method;
-		my $aa = $method->associated_attribute;
-		$on = $aa->{isa};
-		$via = $aa->{name};
-		$original_pkg = $on; 
-		$doc = $original_pkg->method_documentation->{$delegate_to}->{summary};
-	}
-	else {
-	    $doc = $method->documentation;
-	}
-	
-	if ($how eq 'narrow') {
-		$~ = 'METHOD_NARROW';
-		write;
-	}
-	elsif ($how eq 'pod' and $delegate_to) {
-		$~ = 'METHOD_POD_DELEGATED';
-		write;
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'METHOD_POD';
-		write;
-	}
-	else {
-		$~ = 'METHOD';
-		write;
-	}
-	
+    my ($self, $methodname, $how) = @_;
+    return if $methodname =~ /^_/;
+    return if $self->meta->has_attribute($methodname);
+    my %internal = map {$_ => 1} qw(BUILD BUILDARGS meta can new DEMOLISHALL DESTROY 
+        DOES isa BUILDALL does VERSION dump
+        );
+    return if $internal{$methodname};
+    my $method = $self->meta->get_method($methodname) or return; # symbols imported into namespaces i.e. not known by Moose
+
+    return if $method->original_package_name eq __PACKAGE__;
+
+    my $delegate_to = '';
+    my $via = '';
+    my $on = '';
+    my $doc = '';
+    my $original_pkg = $method->original_package_name;
+    if ($method->can('associated_attribute')) {
+        $delegate_to = $method->delegate_to_method;
+        my $aa = $method->associated_attribute;
+        $on = $aa->{isa};
+        $via = $aa->{name};
+        $original_pkg = $on; 
+        $doc = $original_pkg->method_documentation->{$delegate_to}->{summary};
+    }
+    else {
+        $doc = $method->documentation;
+    }
+
+    if ($how eq 'narrow') {
+        $~ = 'METHOD_NARROW';
+        write;
+    }
+    elsif ($how eq 'pod' and $delegate_to) {
+        $~ = 'METHOD_POD_DELEGATED';
+        write;
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'METHOD_POD';
+        write;
+    }
+    else {
+        $~ = 'METHOD';
+        write;
+    }
+
 # ----- format specs -----
-	format METHODHEAD =
+    format METHODHEAD =
 
 METHODS
 -------
 Name                                                  delegates to                                             on                                      via
 ===========================================================================================================================================================================
 .
-	format METHOD = 
+    format METHOD = 
 @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<... @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<... @<<<<<<<<<<<<<<<<...
 $methodname,                                          $delegate_to,                                            $on,                                    $via
 .
 
-	format METHOD_NARROW =
+    format METHOD_NARROW =
 @*
 $methodname
     original pkg: @*
@@ -272,14 +272,14 @@ $methodname
 
 .
 
-	format METHODHEAD_POD = 
+    format METHODHEAD_POD = 
 
 =head1 METHODS
 
 .
-	
-	format METHOD_POD = 
-	
+    
+    format METHOD_POD = 
+    
 =head2 C<@*()>
        $methodname
 
@@ -288,13 +288,13 @@ $methodname
 
 
 .
-	format METHOD_POD_DELEGATED = 
+    format METHOD_POD_DELEGATED = 
 
 =head2 C<@*()>
        $methodname
 
        Defined in: @*
-       	           $original_pkg
+                      $original_pkg
      Delegates to: @*()
                    $delegate_to
                On: @* 
@@ -307,90 +307,90 @@ $methodname
                      $via, $delegate_to
 
 .
-	format METHOD_POD_CLOSE =
-	
+    format METHOD_POD_CLOSE =
+    
 .
 # ----- / format specs -----
 }
 
 sub _printattrs {
-	my ($self, $how) = @_;
-	
-	if ($how eq 'narrow') {
-		print <<HEAD;
+    my ($self, $how) = @_;
+
+    if ($how eq 'narrow') {
+        print <<HEAD;
 ATTRIBUTES
 ----------
 HEAD
-	}
-	elsif ($how eq 'wide') {
-		$~ = 'ATTRHEAD';
-		write;
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'ATTRHEAD_POD';
-		write;
-	}
-	else {
-		die "Don't know how to print attributes '$how'";
-	}
-	
-	$self->_printattr($_, $how) for sort $self->meta->get_attribute_list;
-	
-	if ($how eq 'pod') {
-		$~ = 'ATTR_POD_CLOSE';
-		write;
-	}
+    }
+    elsif ($how eq 'wide') {
+        $~ = 'ATTRHEAD';
+        write;
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'ATTRHEAD_POD';
+        write;
+    }
+    else {
+        die "Don't know how to print attributes '$how'";
+    }
+
+    $self->_printattr($_, $how) for sort $self->meta->get_attribute_list;
+
+    if ($how eq 'pod') {
+        $~ = 'ATTR_POD_CLOSE';
+        write;
+    }
 }
 
 sub _printattr {
-	my ($self, $attrname, $how) = @_;
-	return if $attrname =~ /^_/;
-	my $attr = $self->meta->get_attribute($attrname) or die "No attr for $attrname";
-	
-	my $is;
-	$is = 'rw' if $attr->get_read_method && $attr->get_write_method;
-	$is = 'ro' if $attr->get_read_method && ! $attr->get_write_method;
-	$is = 'wo' if $attr->get_write_method && ! $attr->get_read_method;
-	$is = '--' if ! $attr->get_write_method && ! $attr->get_read_method;
-	$is or die "No \$is for $attrname";
-	
-	my $tc = $attr->type_constraint || '';
-	my $from = $attr->associated_class->name || '';
-	my $reqd = $attr->is_required ? 'yes' : 'no';
-	my $lazy = $attr->is_lazy ? 'yes' : 'no';
-	my $has_doc = $attr->has_documentation ? 'yes' : 'no'; # *_api attributes will never have doc, but other attributes might have
-	my $doc = $attr->documentation || '';
-	my $handles = join ', ', sort @{$attr->handles || []};
-	$handles ||= '';
-	
-	if ($how eq 'narrow') {
-		$~ = 'ATTR_NARROW';
-	}
-	elsif ($how eq 'pod') {
-		$~ = 'ATTR_POD';
-	}
-	else {
-		$~ = 'ATTR';
-	}
+    my ($self, $attrname, $how) = @_;
+    return if $attrname =~ /^_/;
+    my $attr = $self->meta->get_attribute($attrname) or die "No attr for $attrname";
 
-	write;
+    my $is;
+    $is = 'rw' if $attr->get_read_method && $attr->get_write_method;
+    $is = 'ro' if $attr->get_read_method && ! $attr->get_write_method;
+    $is = 'wo' if $attr->get_write_method && ! $attr->get_read_method;
+    $is = '--' if ! $attr->get_write_method && ! $attr->get_read_method;
+    $is or die "No \$is for $attrname";
+
+    my $tc = $attr->type_constraint || '';
+    my $from = $attr->associated_class->name || '';
+    my $reqd = $attr->is_required ? 'yes' : 'no';
+    my $lazy = $attr->is_lazy ? 'yes' : 'no';
+    my $has_doc = $attr->has_documentation ? 'yes' : 'no'; # *_api attributes will never have doc, but other attributes might have
+    my $doc = $attr->documentation || '';
+    my $handles = join ', ', sort @{$attr->handles || []};
+    $handles ||= '';
+
+    if ($how eq 'narrow') {
+        $~ = 'ATTR_NARROW';
+    }
+    elsif ($how eq 'pod') {
+        $~ = 'ATTR_POD';
+    }
+    else {
+        $~ = 'ATTR';
+    }
+
+    write;
 
 # ----- format specs -----
-	format ATTRHEAD =
+    format ATTRHEAD =
 
 ATTRIBUTES
 ----------
 Name                is isa                       reqd lazy doc handles
 ==============================================================================================================
-.	
-	format ATTR = 
+.    
+    format ATTR = 
 @<<<<<<<<<<<<<<<<<  @< @<<<<<<<<<<<<<<<<<<<<<<<< @<<< @<<< @<< ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 $attrname,          $is, $tc,                    $reqd, $lazy, $has_doc, $handles
                                                                ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ~~
                                                                $handles
 .
 
-	format ATTR_NARROW = 
+    format ATTR_NARROW = 
 @*
 $attrname
          is: @*
@@ -409,11 +409,11 @@ $attrname
              $handles
 
 .
-	format ATTRHEAD_POD =
+    format ATTRHEAD_POD =
 =head1 ATTRIBUTES
 
 .
-	format ATTR_POD =
+    format ATTR_POD =
 
 =head2 C<@*>
          $attrname
@@ -434,7 +434,7 @@ $attrname
              $handles
 
 .
-	format ATTR_POD_CLOSE = 
+    format ATTR_POD_CLOSE = 
 
 
 .

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/StoreApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/StoreApi.pm
@@ -63,7 +63,7 @@ sub new {
     },
     };
     __PACKAGE__->method_documentation->{ 'delete_order' } = { 
-    	summary => 'Delete purchase order by ID',
+        summary => 'Delete purchase order by ID',
         params => $params,
         returns => undef,
         };
@@ -120,7 +120,7 @@ sub delete_order {
     my $params = {
     };
     __PACKAGE__->method_documentation->{ 'get_inventory' } = { 
-    	summary => 'Returns pet inventories by status',
+        summary => 'Returns pet inventories by status',
         params => $params,
         returns => 'HASH[string,int]',
         };
@@ -175,7 +175,7 @@ sub get_inventory {
     },
     };
     __PACKAGE__->method_documentation->{ 'get_order_by_id' } = { 
-    	summary => 'Find purchase order by ID',
+        summary => 'Find purchase order by ID',
         params => $params,
         returns => 'Order',
         };
@@ -232,17 +232,17 @@ sub get_order_by_id {
 #
 # Place an order for a pet
 # 
-# @param Order $order order placed for purchasing the pet (required)
+# @param Order $body order placed for purchasing the pet (required)
 {
     my $params = {
-    'order' => {
+    'body' => {
         data_type => 'Order',
         description => 'order placed for purchasing the pet',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'place_order' } = { 
-    	summary => 'Place an order for a pet',
+        summary => 'Place an order for a pet',
         params => $params,
         returns => 'Order',
         };
@@ -252,9 +252,9 @@ sub get_order_by_id {
 sub place_order {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'order' is set
-    unless (exists $args{'order'}) {
-      croak("Missing the required parameter 'order' when calling place_order");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling place_order");
     }
 
     # parse inputs
@@ -274,8 +274,8 @@ sub place_order {
 
     my $_body_data;
     # body params
-    if ( exists $args{'order'}) {
-        $_body_data = $args{'order'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/UserApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/UserApi.pm
@@ -53,17 +53,17 @@ sub new {
 #
 # Create user
 # 
-# @param User $user Created user object (required)
+# @param User $body Created user object (required)
 {
     my $params = {
-    'user' => {
+    'body' => {
         data_type => 'User',
         description => 'Created user object',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'create_user' } = { 
-    	summary => 'Create user',
+        summary => 'Create user',
         params => $params,
         returns => undef,
         };
@@ -73,9 +73,9 @@ sub new {
 sub create_user {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling create_user");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling create_user");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub create_user {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -114,17 +114,17 @@ sub create_user {
 #
 # Creates list of users with given input array
 # 
-# @param ARRAY[User] $user List of user object (required)
+# @param ARRAY[User] $body List of user object (required)
 {
     my $params = {
-    'user' => {
+    'body' => {
         data_type => 'ARRAY[User]',
         description => 'List of user object',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'create_users_with_array_input' } = { 
-    	summary => 'Creates list of users with given input array',
+        summary => 'Creates list of users with given input array',
         params => $params,
         returns => undef,
         };
@@ -134,9 +134,9 @@ sub create_user {
 sub create_users_with_array_input {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling create_users_with_array_input");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling create_users_with_array_input");
     }
 
     # parse inputs
@@ -156,8 +156,8 @@ sub create_users_with_array_input {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -175,17 +175,17 @@ sub create_users_with_array_input {
 #
 # Creates list of users with given input array
 # 
-# @param ARRAY[User] $user List of user object (required)
+# @param ARRAY[User] $body List of user object (required)
 {
     my $params = {
-    'user' => {
+    'body' => {
         data_type => 'ARRAY[User]',
         description => 'List of user object',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'create_users_with_list_input' } = { 
-    	summary => 'Creates list of users with given input array',
+        summary => 'Creates list of users with given input array',
         params => $params,
         returns => undef,
         };
@@ -195,9 +195,9 @@ sub create_users_with_array_input {
 sub create_users_with_list_input {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling create_users_with_list_input");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling create_users_with_list_input");
     }
 
     # parse inputs
@@ -217,8 +217,8 @@ sub create_users_with_list_input {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -246,7 +246,7 @@ sub create_users_with_list_input {
     },
     };
     __PACKAGE__->method_documentation->{ 'delete_user' } = { 
-    	summary => 'Delete user',
+        summary => 'Delete user',
         params => $params,
         returns => undef,
         };
@@ -309,7 +309,7 @@ sub delete_user {
     },
     };
     __PACKAGE__->method_documentation->{ 'get_user_by_name' } = { 
-    	summary => 'Get user by user name',
+        summary => 'Get user by user name',
         params => $params,
         returns => 'User',
         };
@@ -382,7 +382,7 @@ sub get_user_by_name {
     },
     };
     __PACKAGE__->method_documentation->{ 'login_user' } = { 
-    	summary => 'Logs user into the system',
+        summary => 'Logs user into the system',
         params => $params,
         returns => 'string',
         };
@@ -451,7 +451,7 @@ sub login_user {
     my $params = {
     };
     __PACKAGE__->method_documentation->{ 'logout_user' } = { 
-    	summary => 'Logs out current logged in user session',
+        summary => 'Logs out current logged in user session',
         params => $params,
         returns => undef,
         };
@@ -493,7 +493,7 @@ sub logout_user {
 # Updated user
 # 
 # @param string $username name that need to be deleted (required)
-# @param User $user Updated user object (required)
+# @param User $body Updated user object (required)
 {
     my $params = {
     'username' => {
@@ -501,14 +501,14 @@ sub logout_user {
         description => 'name that need to be deleted',
         required => '1',
     },
-    'user' => {
+    'body' => {
         data_type => 'User',
         description => 'Updated user object',
         required => '1',
     },
     };
     __PACKAGE__->method_documentation->{ 'update_user' } = { 
-    	summary => 'Updated user',
+        summary => 'Updated user',
         params => $params,
         returns => undef,
         };
@@ -523,9 +523,9 @@ sub update_user {
       croak("Missing the required parameter 'username' when calling update_user");
     }
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling update_user");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling update_user");
     }
 
     # parse inputs
@@ -552,8 +552,8 @@ sub update_user {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use 4-space instead of a tab in Perl templates

To completely control the Perl style, please use the file post-processing hook instead.
