### PR TITLE
[WIP] Fix allOf in inline model resolver

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4667,8 +4667,6 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (codegenModel != null) {
                 codegenParameter.isModel = true;
-            } else {
-                throw new RuntimeException("model is null " + schema);
             }
 
             if (codegenModel != null && !codegenModel.emptyVars) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4667,6 +4667,8 @@ public class DefaultCodegen implements CodegenConfig {
             }
             if (codegenModel != null) {
                 codegenParameter.isModel = true;
+            } else {
+                throw new RuntimeException("model is null " + schema);
             }
 
             if (codegenModel != null && !codegenModel.emptyVars) {


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Found this bug while working on better allOf, anyOf, oneOf support: `model instanceof Schema` should be the last check, otherwise all other checks (eg.. ArraySchema) will be skipped.

Also deprecating `fixStringModel` as we shouldn't need it to remove double quote in enum example value

cc @OpenAPITools/generator-core-team 


