### PR TITLE
Something in the dependencies changed. This switch is no longer needed.

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-servant/Types.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/Types.mustache
@@ -70,7 +70,7 @@ uncapitalize [] = []
 -- Remove a field label prefix during JSON parsing.
 -- Also perform any replacements for special characters.
 removeFieldLabelPrefix :: Bool -> String -> Options
-removeFieldLabelPrefix forParsing prefix =
+removeFieldLabelPrefix _ prefix =
   defaultOptions
     { omitNothingFields  = True
     , fieldLabelModifier = uncapitalize . fromMaybe (error ("did not find prefix " ++ prefix)) . stripPrefix prefix . replaceSpecialChars
@@ -81,8 +81,4 @@ removeFieldLabelPrefix forParsing prefix =
       [ {{#specialCharReplacements}}("{{&char}}", "{{&replacement}}"){{#hasMore}}
       , {{/hasMore}}{{/specialCharReplacements}}
       ]
-    mkCharReplacement (replaceStr, searchStr) = T.unpack . replacer (T.pack searchStr) (T.pack replaceStr) . T.pack
-    replacer =
-      if forParsing
-        then flip T.replace
-        else T.replace
+    mkCharReplacement (replaceStr, searchStr) = T.unpack . T.replace (T.tail $ T.pack searchStr) (T.pack replaceStr) . T.pack

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/Types.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/Types.hs
@@ -147,7 +147,7 @@ uncapitalize [] = []
 -- Remove a field label prefix during JSON parsing.
 -- Also perform any replacements for special characters.
 removeFieldLabelPrefix :: Bool -> String -> Options
-removeFieldLabelPrefix forParsing prefix =
+removeFieldLabelPrefix _ prefix =
   defaultOptions
     { omitNothingFields  = True
     , fieldLabelModifier = uncapitalize . fromMaybe (error ("did not find prefix " ++ prefix)) . stripPrefix prefix . replaceSpecialChars
@@ -190,8 +190,4 @@ removeFieldLabelPrefix forParsing prefix =
       , ("?", "'Question_Mark")
       , (">=", "'Greater_Than_Or_Equal_To")
       ]
-    mkCharReplacement (replaceStr, searchStr) = T.unpack . replacer (T.pack searchStr) (T.pack replaceStr) . T.pack
-    replacer =
-      if forParsing
-        then flip T.replace
-        else T.replace
+    mkCharReplacement (replaceStr, searchStr) = T.unpack . T.replace (T.tail $ T.pack searchStr) (T.pack replaceStr) . T.pack


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Implemented fix for https://github.com/OpenAPITools/openapi-generator/issues/1849