### PR TITLE
[TypeScript-Node] support setting the content-type header per-call

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -127,7 +127,7 @@ export class {{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: any = {}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         const localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
         let localVarQueryParameters: any = {};

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -127,7 +127,7 @@ export class {{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: any = {}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         const localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
         let localVarQueryParameters: any = {};
@@ -152,6 +152,7 @@ export class {{classname}} {
 {{#headerParams}}
         localVarHeaderParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
 {{/headerParams}}
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -152,7 +152,7 @@ export class {{classname}} {
 {{#headerParams}}
         localVarHeaderParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
 {{/headerParams}}
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -127,7 +127,7 @@ export class {{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         const localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
         let localVarQueryParameters: any = {};
@@ -152,7 +152,7 @@ export class {{classname}} {
 {{#headerParams}}
         localVarHeaderParams['{{baseName}}'] = ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}");
 {{/headerParams}}
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -127,7 +127,7 @@ export class {{classname}} {
      * @param {{paramName}} {{description}}
      {{/allParams}}
      */
-    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
+    public {{nickname}} ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}; {{#returnType}}body: {{{returnType}}}; {{/returnType}}{{^returnType}}body?: any; {{/returnType}} }> {
         const localVarPath = this.basePath + '{{{path}}}'{{#pathParams}}
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
         let localVarQueryParameters: any = {};

--- a/samples/client/petstore-security-test/typescript-node/api/fakeApi.ts
+++ b/samples/client/petstore-security-test/typescript-node/api/fakeApi.ts
@@ -74,13 +74,13 @@ export class FakeApi {
      * @summary To test code injection *_/ ' \" =end -- \\r\\n \\n \\r
      * @param testCodeInjectEndRnNR To test code injection *_/ &#39; \\\&quot; &#x3D;end -- \\\\r\\\\n \\\\n \\\\r
      */
-    public testCodeInjectEndRnNR (testCodeInjectEndRnNR?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public testCodeInjectEndRnNR (testCodeInjectEndRnNR?: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/fake';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore-security-test/typescript-node/api/fakeApi.ts
+++ b/samples/client/petstore-security-test/typescript-node/api/fakeApi.ts
@@ -74,12 +74,13 @@ export class FakeApi {
      * @summary To test code injection *_/ ' \" =end -- \\r\\n \\n \\r
      * @param testCodeInjectEndRnNR To test code injection *_/ &#39; \\\&quot; &#x3D;end -- \\\\r\\\\n \\\\n \\\\r
      */
-    public testCodeInjectEndRnNR (testCodeInjectEndRnNR?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public testCodeInjectEndRnNR (testCodeInjectEndRnNR?: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/fake';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore-security-test/typescript-node/api/fakeApi.ts
+++ b/samples/client/petstore-security-test/typescript-node/api/fakeApi.ts
@@ -74,7 +74,7 @@ export class FakeApi {
      * @summary To test code injection *_/ ' \" =end -- \\r\\n \\n \\r
      * @param testCodeInjectEndRnNR To test code injection *_/ &#39; \\\&quot; &#x3D;end -- \\\\r\\\\n \\\\n \\\\r
      */
-    public testCodeInjectEndRnNR (testCodeInjectEndRnNR?: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public testCodeInjectEndRnNR (testCodeInjectEndRnNR?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/fake';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -139,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -195,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -254,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -313,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -369,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -426,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -491,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -94,7 +94,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -139,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -152,7 +152,7 @@ export class PetApi {
         }
 
         localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -195,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -210,7 +210,7 @@ export class PetApi {
             localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<'available' | 'pending' | 'sold'>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -254,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -269,7 +269,7 @@ export class PetApi {
             localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -313,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -325,7 +325,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -369,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -380,7 +380,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -426,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -438,7 +438,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -491,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -503,7 +503,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -94,6 +94,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -138,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -151,6 +152,7 @@ export class PetApi {
         }
 
         localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -193,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -208,6 +210,7 @@ export class PetApi {
             localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<'available' | 'pending' | 'sold'>");
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -251,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -266,6 +269,7 @@ export class PetApi {
             localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -309,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -321,6 +325,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -364,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -375,6 +380,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -420,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -432,6 +438,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -484,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: any = {}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -496,6 +503,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -94,7 +94,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -139,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -152,7 +152,7 @@ export class PetApi {
         }
 
         localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -195,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -210,7 +210,7 @@ export class PetApi {
             localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<'available' | 'pending' | 'sold'>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -254,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -269,7 +269,7 @@ export class PetApi {
             localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -313,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -325,7 +325,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -369,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -380,7 +380,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -426,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -438,7 +438,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -491,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: any = {}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -503,7 +503,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -89,7 +89,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -129,13 +129,13 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory (options: any = {}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -179,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -191,7 +191,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -233,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -244,7 +244,7 @@ export class StoreApi {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -89,6 +89,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -128,12 +129,13 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: any = {}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -177,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -189,6 +191,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -230,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -241,6 +244,7 @@ export class StoreApi {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -129,7 +129,7 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory (options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -179,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -233,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -89,7 +89,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -129,13 +129,13 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -179,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -191,7 +191,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -233,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -244,7 +244,7 @@ export class StoreApi {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -86,7 +86,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -128,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -139,7 +139,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -181,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -192,7 +192,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -234,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -246,7 +246,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -287,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -299,7 +299,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -342,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -366,7 +366,7 @@ export class UserApi {
             localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -407,13 +407,13 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -455,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -472,7 +472,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling updateUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -86,6 +86,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -127,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -138,6 +139,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -179,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -190,6 +192,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -231,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -243,6 +246,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -283,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -295,6 +299,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -337,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -361,6 +366,7 @@ export class UserApi {
             localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -401,12 +407,13 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser () : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -448,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -465,6 +472,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling updateUser.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -86,7 +86,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -128,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -139,7 +139,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -181,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -192,7 +192,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -234,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -246,7 +246,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -287,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -299,7 +299,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -342,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -366,7 +366,7 @@ export class UserApi {
             localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -407,13 +407,13 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser (options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -455,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -472,7 +472,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling updateUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -128,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -181,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -234,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -287,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -342,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -407,7 +407,7 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser (options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -455,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User, options: {headerParams: {[name: string]: value}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -94,7 +94,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -139,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -152,7 +152,7 @@ export class PetApi {
         }
 
         localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -195,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -210,7 +210,7 @@ export class PetApi {
             localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<'available' | 'pending' | 'sold'>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -254,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -269,7 +269,7 @@ export class PetApi {
             localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -313,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -325,7 +325,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -369,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -380,7 +380,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -426,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -438,7 +438,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -491,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -503,7 +503,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -94,7 +94,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -139,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -152,7 +152,7 @@ export class PetApi {
         }
 
         localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -195,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -210,7 +210,7 @@ export class PetApi {
             localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<'available' | 'pending' | 'sold'>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -254,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -269,7 +269,7 @@ export class PetApi {
             localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -313,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -325,7 +325,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -369,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -380,7 +380,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -426,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -438,7 +438,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -491,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: any = {}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -503,7 +503,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -83,7 +83,7 @@ export class PetApi {
      * @summary Add a new pet to the store
      * @param body Pet object that needs to be added to the store
      */
-    public addPet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public addPet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -94,6 +94,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling addPet.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -138,7 +139,7 @@ export class PetApi {
      * @param petId Pet id to delete
      * @param apiKey 
      */
-    public deletePet (petId: number, apiKey?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deletePet (petId: number, apiKey?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -151,6 +152,7 @@ export class PetApi {
         }
 
         localVarHeaderParams['api_key'] = ObjectSerializer.serialize(apiKey, "string");
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -193,7 +195,7 @@ export class PetApi {
      * @summary Finds Pets by status
      * @param status Status values that need to be considered for filter
      */
-    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByStatus (status: Array<'available' | 'pending' | 'sold'>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -208,6 +210,7 @@ export class PetApi {
             localVarQueryParameters['status'] = ObjectSerializer.serialize(status, "Array<'available' | 'pending' | 'sold'>");
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -251,7 +254,7 @@ export class PetApi {
      * @summary Finds Pets by tags
      * @param tags Tags to filter by
      */
-    public findPetsByTags (tags: Array<string>) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
+    public findPetsByTags (tags: Array<string>, options: any = {}) : Promise<{ response: http.ClientResponse; body: Array<Pet>;  }> {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -266,6 +269,7 @@ export class PetApi {
             localVarQueryParameters['tags'] = ObjectSerializer.serialize(tags, "Array<string>");
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -309,7 +313,7 @@ export class PetApi {
      * @summary Find pet by ID
      * @param petId ID of pet to return
      */
-    public getPetById (petId: number) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
+    public getPetById (petId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Pet;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -321,6 +325,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -364,7 +369,7 @@ export class PetApi {
      * @summary Update an existing pet
      * @param body Pet object that needs to be added to the store
      */
-    public updatePet (body: Pet) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePet (body: Pet, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -375,6 +380,7 @@ export class PetApi {
             throw new Error('Required parameter body was null or undefined when calling updatePet.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -420,7 +426,7 @@ export class PetApi {
      * @param name Updated name of the pet
      * @param status Updated status of the pet
      */
-    public updatePetWithForm (petId: number, name?: string, status?: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updatePetWithForm (petId: number, name?: string, status?: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/pet/{petId}'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -432,6 +438,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -484,7 +491,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: any = {}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
@@ -496,6 +503,7 @@ export class PetApi {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -89,6 +89,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -128,12 +129,13 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory () : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: any = {}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -177,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -189,6 +191,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -230,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -241,6 +244,7 @@ export class StoreApi {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -89,7 +89,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -129,13 +129,13 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -179,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -191,7 +191,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -233,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -244,7 +244,7 @@ export class StoreApi {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/storeApi.ts
@@ -77,7 +77,7 @@ export class StoreApi {
      * @summary Delete purchase order by ID
      * @param orderId ID of the order that needs to be deleted
      */
-    public deleteOrder (orderId: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteOrder (orderId: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -89,7 +89,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -129,13 +129,13 @@ export class StoreApi {
      * Returns a map of status codes to quantities
      * @summary Returns pet inventories by status
      */
-    public getInventory (options: any = {}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
+    public getInventory (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: { [key: string]: number; };  }> {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -179,7 +179,7 @@ export class StoreApi {
      * @summary Find purchase order by ID
      * @param orderId ID of pet that needs to be fetched
      */
-    public getOrderById (orderId: number, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public getOrderById (orderId: number, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order/{orderId}'
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
@@ -191,7 +191,7 @@ export class StoreApi {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -233,7 +233,7 @@ export class StoreApi {
      * @summary Place an order for a pet
      * @param body order placed for purchasing the pet
      */
-    public placeOrder (body: Order, options: any = {}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
+    public placeOrder (body: Order, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: Order;  }> {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -244,7 +244,7 @@ export class StoreApi {
             throw new Error('Required parameter body was null or undefined when calling placeOrder.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -86,7 +86,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -128,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -139,7 +139,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -181,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -192,7 +192,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -234,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -246,7 +246,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -287,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -299,7 +299,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -342,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -366,7 +366,7 @@ export class UserApi {
             localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -407,13 +407,13 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser (options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 
@@ -455,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -472,7 +472,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling updateUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headers);
+        (<any>Object).assign(localVarHeaderParams, options.headerParams);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -86,7 +86,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -128,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -139,7 +139,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -181,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -192,7 +192,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -234,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -246,7 +246,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -287,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -299,7 +299,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -342,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -366,7 +366,7 @@ export class UserApi {
             localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -407,13 +407,13 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser (options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -455,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User, options: {headerParams: {[name: string]: string}} = {headerParams: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -472,7 +472,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling updateUser.');
         }
 
-        (<any>Object).assign(localVarHeaderParams, options.headerParams);
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 

--- a/samples/client/petstore/typescript-node/npm/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/userApi.ts
@@ -75,7 +75,7 @@ export class UserApi {
      * @summary Create user
      * @param body Created user object
      */
-    public createUser (body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUser (body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -86,6 +86,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUser.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -127,7 +128,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithArrayInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithArrayInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithArray';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -138,6 +139,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithArrayInput.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -179,7 +181,7 @@ export class UserApi {
      * @summary Creates list of users with given input array
      * @param body List of user object
      */
-    public createUsersWithListInput (body: Array<User>) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public createUsersWithListInput (body: Array<User>, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/createWithList';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -190,6 +192,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling createUsersWithListInput.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -231,7 +234,7 @@ export class UserApi {
      * @summary Delete user
      * @param username The name that needs to be deleted
      */
-    public deleteUser (username: string) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public deleteUser (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -243,6 +246,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -283,7 +287,7 @@ export class UserApi {
      * @summary Get user by user name
      * @param username The name that needs to be fetched. Use user1 for testing.
      */
-    public getUserByName (username: string) : Promise<{ response: http.ClientResponse; body: User;  }> {
+    public getUserByName (username: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: User;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -295,6 +299,7 @@ export class UserApi {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -337,7 +342,7 @@ export class UserApi {
      * @param username The user name for login
      * @param password The password for login in clear text
      */
-    public loginUser (username: string, password: string) : Promise<{ response: http.ClientResponse; body: string;  }> {
+    public loginUser (username: string, password: string, options: any = {}) : Promise<{ response: http.ClientResponse; body: string;  }> {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -361,6 +366,7 @@ export class UserApi {
             localVarQueryParameters['password'] = ObjectSerializer.serialize(password, "string");
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -401,12 +407,13 @@ export class UserApi {
      * 
      * @summary Logs out current logged in user session
      */
-    public logoutUser () : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public logoutUser (options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/logout';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
         let localVarFormParams: any = {};
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 
@@ -448,7 +455,7 @@ export class UserApi {
      * @param username name that need to be deleted
      * @param body Updated user object
      */
-    public updateUser (username: string, body: User) : Promise<{ response: http.ClientResponse; body?: any;  }> {
+    public updateUser (username: string, body: User, options: any = {}) : Promise<{ response: http.ClientResponse; body?: any;  }> {
         const localVarPath = this.basePath + '/user/{username}'
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
@@ -465,6 +472,7 @@ export class UserApi {
             throw new Error('Required parameter body was null or undefined when calling updateUser.');
         }
 
+        (<any>Object).assign(localVarHeaderParams, options.headers);
 
         let localVarUseFormData = false;
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This approach is inspired by the typescript-fetch implementation in swagger-codegen.

Fixes #1867
