### PR TITLE
Python: Update api_doc_example for multiple auth

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_doc_example.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc_example.mustache
@@ -4,18 +4,16 @@ import time
 import {{{packageName}}}
 from {{{packageName}}}.rest import ApiException
 from pprint import pprint
-{{#hasAuthMethods}}{{#isBasic}}
+{{#hasAuthMethods}}
+configuration = {{{packageName}}}.Configuration(){{#isBasic}}
 # Configure HTTP basic authorization: {{{name}}}
-configuration = {{{packageName}}}.Configuration()
 configuration.username = 'YOUR_USERNAME'
 configuration.password = 'YOUR_PASSWORD'{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
-configuration = {{{packageName}}}.Configuration()
 configuration.api_key['{{{keyParamName}}}'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
-configuration = {{{packageName}}}.Configuration()
 configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}
 
 # create an instance of the API class

--- a/modules/openapi-generator/src/main/resources/python/common_README.mustache
+++ b/modules/openapi-generator/src/main/resources/python/common_README.mustache
@@ -4,18 +4,16 @@ import time
 import {{{packageName}}}
 from {{{packageName}}}.rest import ApiException
 from pprint import pprint
-{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
+{{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}{{#hasAuthMethods}}{{#authMethods}}
+configuration = {{{packageName}}}.Configuration(){{#isBasic}}
 # Configure HTTP basic authorization: {{{name}}}
-configuration = {{{packageName}}}.Configuration()
 configuration.username = 'YOUR_USERNAME'
 configuration.password = 'YOUR_PASSWORD'{{/isBasic}}{{#isApiKey}}
 # Configure API key authorization: {{{name}}}
-configuration = {{{packageName}}}.Configuration()
 configuration.api_key['{{{keyParamName}}}'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['{{{keyParamName}}}'] = 'Bearer'{{/isApiKey}}{{#isOAuth}}
 # Configure OAuth2 access token for authorization: {{{name}}}
-configuration = {{{packageName}}}.Configuration()
 configuration.access_token = 'YOUR_ACCESS_TOKEN'{{/isOAuth}}{{/authMethods}}
 {{/hasAuthMethods}}
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [-] Ran the shell script under `./bin/` to update Petstore sample ... _only a doc change_
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Python technical committee: @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10)

### Description of the PR

APIs may have more than one auth method (for example both an app key and basic auth).
This changes the example to only initialize the config option once instead of once per auth method.
