### PR TITLE
[java-client][okhttp-gson] no oauth2 usage when hasOAuthMethods is false

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1508,7 +1508,7 @@ public class DefaultCodegen implements CodegenConfig {
      *
      * @param name string to be capitalized
      * @return capitalized string
-     * @deprecated
+     * @deprecated use {@link org.openapitools.codegen.utils.StringUtils#camelize(String)} instead
      */
     @SuppressWarnings("static-method")
     public String initialCaps(String name) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -53,9 +53,11 @@ import java.util.regex.Pattern;
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
 import {{invokerPackage}}.auth.RetryingOAuth;
 import {{invokerPackage}}.auth.OAuthFlow;
+{{/hasOAuthMethods}}
 
 public class ApiClient {
 
@@ -117,12 +119,14 @@ public class ApiClient {
     public ApiClient(String clientId, String clientSecret, Map<String, String> parameters) {
         init();
 
+{{#hasOAuthMethods}}
         RetryingOAuth retryingOAuth = new RetryingOAuth("{{tokenUrl}}", clientId, OAuthFlow.{{flow}}, clientSecret, parameters);
         authentications.put(
                 "{{name}}",
                 retryingOAuth
         );
         httpClient.interceptors().add(retryingOAuth);
+{{/hasOAuthMethods}}
 
         // Prevent the authentications from being modified.
         authentications = Collections.unmodifiableMap(authentications);
@@ -399,12 +403,14 @@ public class ApiClient {
      * @param accessToken Access token
      */
     public void setAccessToken(String accessToken) {
+        {{#hasOAuthMethods}}
         for (Authentication auth : authentications.values()) {
             if (auth instanceof OAuth) {
                 ((OAuth) auth).setAccessToken(accessToken);
                 return;
             }
         }
+        {{/hasOAuthMethods}}
         throw new RuntimeException("No OAuth2 authentication configured!");
     }
 
@@ -550,6 +556,7 @@ public class ApiClient {
         return this;
     }
 
+    {{#hasOAuthMethods}}
     /**
      * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
      * @return Token request builder
@@ -563,6 +570,7 @@ public class ApiClient {
         }
         return null;
     }
+    {{/hasOAuthMethods}}
 
     /**
      * Format the given parameter object into string.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/OAuthOkHttpClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/OAuthOkHttpClient.mustache
@@ -1,3 +1,4 @@
+{{#hasOAuthMethods}}
 package {{invokerPackage}}.auth;
 
 import com.squareup.okhttp.OkHttpClient;
@@ -66,3 +67,4 @@ public class OAuthOkHttpClient implements HttpClient {
         // Nothing to do here
     }
 }
+{{/hasOAuthMethods}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/RetryingOAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/auth/RetryingOAuth.mustache
@@ -1,3 +1,4 @@
+{{#hasOAuthMethods}}
 package {{invokerPackage}}.auth;
 
 import {{invokerPackage}}.Pair;
@@ -172,3 +173,4 @@ public class RetryingOAuth extends OAuth implements Interceptor {
         // No implementation necessary
     }
 }
+{{/hasOAuthMethods}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. 

@wing328 (author of #1838).
Java tech committee @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

Follow up from of PR #1838:

The `org.apache.oltu.oauth2:org.apache.oltu.oauth2.client` is now only included if `hasOAuthMethods` is true. See:

This means that when a spec do not use OAuth, the generated code should not use any of the classes provided by the dependency. Otherwise maven build for the generated lib looks like this:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[10,37] package org.apache.oltu.oauth2.client does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[11,45] package org.apache.oltu.oauth2.client.request does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[12,45] package org.apache.oltu.oauth2.client.request does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[13,64] package org.apache.oltu.oauth2.client.request.OAuthClientRequest does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[14,46] package org.apache.oltu.oauth2.client.response does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[15,47] package org.apache.oltu.oauth2.common.exception does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[16,47] package org.apache.oltu.oauth2.common.exception does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[17,51] package org.apache.oltu.oauth2.common.message.types does not exist
[ERROR] <java-okhttp-gson project>/src/main/java/...../okhttpgson/auth/RetryingOAuth.java:[25,13] cannot find symbol
  symbol:   class OAuthClient
  location: class xxxxx.okhttpgson.auth.RetryingOAuth
...
```

This PR add more `{#hasOAuthMethods}..{/hasOAuthMethods}` to the templates.

