### PR TITLE
[gradle] Add 4 boolean properties supported by codegenConfigurator

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -268,6 +268,26 @@ The gradle plugin is not currently published to https://plugins.gradle.org/m2/.
 |None
 |A map of options specific to a generator.
 
+|logToStderr
+|Boolean
+|false
+|To write all log messages (not just errors) to STDOUT
+
+|enablePostProcessFile
+|Boolean
+|false
+|To enable the file post-processing hook. This enables executing an external post-processor (usually a linter program). This only enables the post-processor. To define the post-processing command, define an environment variable such as LANG_POST_PROCESS_FILE (e.g. GO_POST_PROCESS_FILE, SCALA_POST_PROCESS_FILE). Please open an issue if your target generator does not support this functionality.
+
+|skipValidateSpec
+|Boolean
+|false
+|To skip spec validation. When true, we will skip the default behavior of validating a spec before generation.
+
+|generateAliasAsModel
+|Boolean
+|false
+|To generate alias (array, list, map) as model. When false, top-level objects defined as array, list, or map will result in those definitions generated as top-level Array-of-items, List-of-items, Map-of-items definitions. When true, A model representation either containing or extending the array,list,map (depending on specific generator implementation) will be generated.
+
 |===
 
 [NOTE]

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -577,3 +577,35 @@ you need a task reference or instance. One way to do this is to access it as `ta
 
 You can run `gradle tasks --debug` to see this registration.
 ====
+
+== Troubleshooting
+
+=== Android Studio
+
+Android Studio may experience a Windows-specific Guava dependency conflict with openapig-enerator-gradle-plugin versions greater than 3.0.0.
+
+As a workaround, you may force exclude conflicting Guava dependencies.
+
+```gradle
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath('org.openapitools:openapi-generator-gradle-plugin:3.3.4') {
+            exclude group: 'com.google.guava'
+        }
+    }
+}
+// …
+
+configurations {
+    compile.exclude module: 'guava-jdk5'
+}
+// …
+apply plugin: 'org.openapi.generator'
+```
+
+See https://github.com/OpenAPITools/openapi-generator/issues/1818[OpenAPITools/openapi-generator#1818] for more details.

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -44,6 +44,13 @@ openApiGenerate {
     systemProperties = [
             modelDocs: "false"
     ]
+    skipValidateSpec = true
+    logToStderr = true
+    generateAliasAsModel = false
+    // set to true and set environment variable {LANG}_POST_PROCESS_FILE
+    // (e.g. SCALA_POST_PROCESS_FILE) to the linter/formatter to be processed.
+    // This command will be passed one file at a time for most supported post processors.
+    enablePostProcessFile = false
 }
 
 task buildGoSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask){

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -121,6 +121,10 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
                     generateApiDocumentation.set(generate.generateApiDocumentation)
                     withXml.set(generate.withXml)
                     configOptions.set(generate.configOptions)
+                    logToStderr.set(generate.logToStderr)
+                    enablePostProcessFile.set(generate.enablePostProcessFile)
+                    skipValidateSpec.set(generate.skipValidateSpec)
+                    generateAliasAsModel.set(generate.generateAliasAsModel)
                 }
             }
         }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -262,6 +262,31 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     val withXml = project.objects.property<Boolean>()
 
     /**
+     * To write all log messages (not just errors) to STDOUT
+     */
+    val logToStderr = project.objects.property<Boolean>()
+
+    /**
+     * To enable the file post-processing hook. This enables executing an external post-processor (usually a linter program).
+     * This only enables the post-processor. To define the post-processing command, define an environment variable such as
+     * LANG_POST_PROCESS_FILE (e.g. GO_POST_PROCESS_FILE, SCALA_POST_PROCESS_FILE). Please open an issue if your target
+     * generator does not support this functionality.
+     */
+    val enablePostProcessFile = project.objects.property<Boolean>()
+
+    /**
+     * To skip spec validation. When true, we will skip the default behavior of validating a spec before generation.
+     */
+    val skipValidateSpec = project.objects.property<Boolean>()
+
+    /**
+     * To generate alias (array, list, map) as model. When false, top-level objects defined as array, list, or map will result in those
+     * definitions generated as top-level Array-of-items, List-of-items, Map-of-items definitions.
+     * When true, A model representation either containing or extending the array,list,map (depending on specific generator implementation) will be generated.
+     */
+    val generateAliasAsModel = project.objects.property<Boolean>()
+
+    /**
      * A map of options specific to a generator.
      */
     val configOptions = project.objects.property<Map<String, String>>()
@@ -282,5 +307,9 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
         withXml.set(false)
         configOptions.set(mapOf())
         validateSpec.set(true)
+        logToStderr.set(false)
+        enablePostProcessFile.set(false)
+        skipValidateSpec.set(false)
+        generateAliasAsModel.set(false)
     }
 }

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -318,6 +318,36 @@ open class GenerateTask : DefaultTask() {
     @get:Internal
     val withXml = project.objects.property<Boolean>()
 
+
+    /**
+     * To write all log messages (not just errors) to STDOUT
+     */
+    @get:Internal
+    val logToStderr = project.objects.property<Boolean>()
+
+    /**
+     * To enable the file post-processing hook. This enables executing an external post-processor (usually a linter program).
+     * This only enables the post-processor. To define the post-processing command, define an environment variable such as
+     * LANG_POST_PROCESS_FILE (e.g. GO_POST_PROCESS_FILE, SCALA_POST_PROCESS_FILE). Please open an issue if your target
+     * generator does not support this functionality.
+     */
+    @get:Internal
+    val enablePostProcessFile = project.objects.property<Boolean>()
+
+    /**
+     * To skip spec validation. When true, we will skip the default behavior of validating a spec before generation.
+     */
+    @get:Internal
+    val skipValidateSpec = project.objects.property<Boolean>()
+
+    /**
+     * To generate alias (array, list, map) as model. When false, top-level objects defined as array, list, or map will result in those
+     * definitions generated as top-level Array-of-items, List-of-items, Map-of-items definitions.
+     * When true, A model representation either containing or extending the array,list,map (depending on specific generator implementation) will be generated.
+     */
+    @get:Internal
+    val generateAliasAsModel = project.objects.property<Boolean>()
+
     /**
      * A dynamic map of options specific to a generator.
      */
@@ -470,6 +500,22 @@ open class GenerateTask : DefaultTask() {
 
             removeOperationIdPrefix.ifNotEmpty { value ->
                 configurator.removeOperationIdPrefix = value!!
+            }
+
+            logToStderr.ifNotEmpty { value ->
+                configurator.logToStderr = value
+            }
+
+            enablePostProcessFile.ifNotEmpty { value ->
+                configurator.enablePostProcessFile = value
+            }
+
+            skipValidateSpec.ifNotEmpty { value ->
+                configurator.setValidateSpec(value)
+            }
+
+            generateAliasAsModel.ifNotEmpty { value ->
+                configurator.setGenerateAliasAsModel(value)
             }
 
             if (systemProperties.isPresent) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adds missing options supported by codegenConfigurator for consistency with maven plugin (see #1845)

Also includes documentation for a workaround found to address #1818.

