### PR TITLE
[Java] Generate OAuth related files only if OAuth security schema is used

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -496,7 +496,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         }
 
         // google-api-client doesn't use the OpenAPI auth, because it uses Google Credential directly (HttpRequestInitializer)
-        if ((!(GOOGLE_API_CLIENT.equals(getLibrary()) || REST_ASSURED.equals(getLibrary()))) && ProcessUtils.hasOAuthMethods(objs)) {
+        if ((!(GOOGLE_API_CLIENT.equals(getLibrary()) || REST_ASSURED.equals(getLibrary()) || usePlayWS)) && ProcessUtils.hasOAuthMethods(objs)) {
             supportingFiles.add(new SupportingFile("auth/OAuth.mustache", authFolder, "OAuth.java"));
             supportingFiles.add(new SupportingFile("auth/OAuthFlow.mustache", authFolder, "OAuthFlow.java"));
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -31,6 +31,7 @@ import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.GzipFeatures;
 import org.openapitools.codegen.languages.features.PerformBeanValidationFeatures;
 import org.openapitools.codegen.mustache.CaseFormatLambda;
+import org.openapitools.codegen.utils.ProcessUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,6 +102,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     protected boolean useGzipFeature = false;
     protected boolean useRuntimeException = false;
     protected boolean useReflectionEqualsHashCode = false;
+    protected String authFolder;
 
     public JavaClientCodegen() {
         super();
@@ -236,8 +238,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         }
 
         final String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
-        final String authFolder = (sourceFolder + '/' + invokerPackage + ".auth").replace(".", "/");
         final String apiFolder = (sourceFolder + '/' + apiPackage).replace(".", "/");
+        authFolder = (sourceFolder + '/' + invokerPackage + ".auth").replace(".", "/");
 
         //Common files
         writeOptional(outputFolder, new SupportingFile("pom.mustache", "", "pom.xml"));
@@ -253,12 +255,13 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             supportingFiles.add(new SupportingFile("StringUtil.mustache", invokerFolder, "StringUtil.java"));
         }
 
-        // google-api-client doesn't use the Swagger auth, because it uses Google Credential directly (HttpRequestInitializer)
+        // google-api-client doesn't use the OpenAPI auth, because it uses Google Credential directly (HttpRequestInitializer)
         if (!(GOOGLE_API_CLIENT.equals(getLibrary()) || REST_ASSURED.equals(getLibrary()))) {
             supportingFiles.add(new SupportingFile("auth/HttpBasicAuth.mustache", authFolder, "HttpBasicAuth.java"));
             supportingFiles.add(new SupportingFile("auth/ApiKeyAuth.mustache", authFolder, "ApiKeyAuth.java"));
-            supportingFiles.add(new SupportingFile("auth/OAuth.mustache", authFolder, "OAuth.java"));
-            supportingFiles.add(new SupportingFile("auth/OAuthFlow.mustache", authFolder, "OAuthFlow.java"));
+            // NOTE: below moved to postProcessOperationsWithModels
+            //supportingFiles.add(new SupportingFile("auth/OAuth.mustache", authFolder, "OAuth.java"));
+            //supportingFiles.add(new SupportingFile("auth/OAuthFlow.mustache", authFolder, "OAuthFlow.java"));
         }
         supportingFiles.add(new SupportingFile("gradlew.mustache", "", "gradlew"));
         supportingFiles.add(new SupportingFile("gradlew.bat.mustache", "", "gradlew.bat"));
@@ -302,8 +305,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             supportingFiles.add(new SupportingFile("ProgressRequestBody.mustache", invokerFolder, "ProgressRequestBody.java"));
             supportingFiles.add(new SupportingFile("ProgressResponseBody.mustache", invokerFolder, "ProgressResponseBody.java"));
             supportingFiles.add(new SupportingFile("GzipRequestInterceptor.mustache", invokerFolder, "GzipRequestInterceptor.java"));
-            supportingFiles.add(new SupportingFile("auth/OAuthOkHttpClient.mustache", authFolder, "OAuthOkHttpClient.java"));
-            supportingFiles.add(new SupportingFile("auth/RetryingOAuth.mustache", authFolder, "RetryingOAuth.java"));
+
+            // NOTE: below moved to postProcessOpoerationsWithModels
+            //supportingFiles.add(new SupportingFile("auth/OAuthOkHttpClient.mustache", authFolder, "OAuthOkHttpClient.java"));
+            //supportingFiles.add(new SupportingFile("auth/RetryingOAuth.mustache", authFolder, "RetryingOAuth.java"));
             additionalProperties.put("gson", "true");
         } else if (usesAnyRetrofitLibrary()) {
             supportingFiles.add(new SupportingFile("auth/OAuthOkHttpClient.mustache", authFolder, "OAuthOkHttpClient.java"));
@@ -482,6 +487,18 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                 }
                 op.path = StringUtils.join(items, "/");
             }
+        }
+
+        // for okhttp-gson (default), check to see if OAuth is defined and included OAuth-related files accordingly
+        if ((OKHTTP_GSON.equals(getLibrary()) || StringUtils.isEmpty(getLibrary())) && ProcessUtils.hasOAuthMethods(objs)) {
+            supportingFiles.add(new SupportingFile("auth/OAuthOkHttpClient.mustache", authFolder, "OAuthOkHttpClient.java"));
+            supportingFiles.add(new SupportingFile("auth/RetryingOAuth.mustache", authFolder, "RetryingOAuth.java"));
+        }
+
+        // google-api-client doesn't use the OpenAPI auth, because it uses Google Credential directly (HttpRequestInitializer)
+        if ((!(GOOGLE_API_CLIENT.equals(getLibrary()) || REST_ASSURED.equals(getLibrary()))) && ProcessUtils.hasOAuthMethods(objs)) {
+            supportingFiles.add(new SupportingFile("auth/OAuth.mustache", authFolder, "OAuth.java"));
+            supportingFiles.add(new SupportingFile("auth/OAuthFlow.mustache", authFolder, "OAuthFlow.java"));
         }
 
         return objs;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
@@ -38,6 +38,9 @@ public class ProcessUtils {
 
     /**
      * Returns true if at least one operation has OAuth security schema defined
+     *
+     * @param objs Map of operations
+     * @return True if at least one operation has OAuth security schema defined
      */
     public static boolean hasOAuthMethods(Map<String, Object> objs) {
         Map<String, Object> operations = (Map<String, Object>) objs.get("operations");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
@@ -1,7 +1,9 @@
 package org.openapitools.codegen.utils;
 
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.CodegenSecurity;
 
 import java.util.List;
 import java.util.Map;
@@ -11,7 +13,7 @@ public class ProcessUtils {
     /**
      * Add x-index extension to the model's properties
      *
-     * @param models  List of models
+     * @param models List of models
      */
     public static void addIndexToProperties(List<Object> models) {
         for (Object _mo : models) {
@@ -32,6 +34,27 @@ public class ProcessUtils {
 
         }
 
+    }
+
+    /**
+     * Returns true if at least one operation has OAuth security schema defined
+     */
+    public static boolean hasOAuthMethods(Map<String, Object> objs) {
+        Map<String, Object> operations = (Map<String, Object>) objs.get("operations");
+        if (operations != null) {
+            List<CodegenOperation> ops = (List<CodegenOperation>) operations.get("operation");
+            for (CodegenOperation operation : ops) {
+                if (operation.authMethods != null && !operation.authMethods.isEmpty()) {
+                    for (CodegenSecurity cs : operation.authMethods) {
+                        if (cs.isOAuth) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
 }

--- a/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
@@ -52,7 +52,9 @@ import java.text.DateFormat;
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
 
 {{>generatedAnnotation}}
 public class ApiClient {
@@ -261,6 +263,7 @@ public class ApiClient {
     throw new RuntimeException("No API key authentication configured!");
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper method to set access token for the first OAuth2 authentication.
    * @param accessToken Access token
@@ -275,6 +278,7 @@ public class ApiClient {
     throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
+  {{/hasOAuthMethods}}
   /**
    * Set the User-Agent header's value (by adding to the default header map).
    * @param userAgent User agent

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -29,7 +29,9 @@ import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.slf4j.Slf4jLogger;
 import {{invokerPackage}}.auth.*;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth.AccessTokenListener;
+{{/hasOAuthMethods}}
 
 {{>generatedAnnotation}}
 public class ApiClient {
@@ -104,6 +106,7 @@ public class ApiClient {
     this.setCredentials(username,  password);
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper constructor for single password oauth2
    * @param authName
@@ -112,15 +115,16 @@ public class ApiClient {
    * @param username
    * @param password
    */
-   public ApiClient(String authName, String clientId, String secret, String username, String password) {
-     this(authName);
-     this.getTokenEndPoint()
-            .setClientId(clientId)
-            .setClientSecret(secret)
-            .setUsername(username)
-            .setPassword(password);
-   }
+  public ApiClient(String authName, String clientId, String secret, String username, String password) {
+    this(authName);
+    this.getTokenEndPoint()
+           .setClientId(clientId)
+           .setClientSecret(secret)
+           .setUsername(username)
+           .setPassword(password);
+  }
 
+  {{/hasOAuthMethods}}
   public String getBasePath() {
     return basePath;
   }
@@ -248,15 +252,18 @@ public class ApiClient {
         basicAuth.setCredentials(username, password);
         return;
       }
+      {{#hasOAuthMethods}}
       if (apiAuthorization instanceof OAuth) {
         OAuth oauth = (OAuth) apiAuthorization;
         oauth.getTokenRequestBuilder().setUsername(username).setPassword(password);
         return;
       }
+      {{/hasOAuthMethods}}
     }
     throw new RuntimeException("No Basic authentication or OAuth configured!");
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
    * @return Token request builder
@@ -336,6 +343,7 @@ public class ApiClient {
     }
   }
 
+  {{/hasOAuthMethods}}
   /**
    * Gets request interceptor based on authentication name
    * @param authName Authentiation name

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -54,7 +54,9 @@ import java.util.regex.Pattern;
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
 
 {{>generatedAnnotation}}
 public class ApiClient {
@@ -190,6 +192,7 @@ public class ApiClient {
     throw new RuntimeException("No API key authentication configured!");
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper method to set access token for the first OAuth2 authentication.
    * @param accessToken Access token
@@ -204,6 +207,7 @@ public class ApiClient {
     throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
+  {{/hasOAuthMethods}}
   /**
    * Set the User-Agent header's value (by adding to the default header map).
    * @param userAgent Http user agent

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -42,7 +42,9 @@ import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
 
 {{>generatedAnnotation}}
 public class ApiClient {
@@ -200,6 +202,7 @@ public class ApiClient {
     throw new RuntimeException("No API key authentication configured!");
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper method to set access token for the first OAuth2 authentication.
    * @param accessToken the access token
@@ -214,6 +217,7 @@ public class ApiClient {
     throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
+  {{/hasOAuthMethods}}
   /**
    * Set the User-Agent header's value (by adding to the default header map).
    * @param userAgent the User-Agent header value

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -67,7 +67,9 @@ import java.util.TimeZone;
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
 
 {{>generatedAnnotation}}
 @Component("{{invokerPackage}}.ApiClient")
@@ -239,6 +241,7 @@ public class ApiClient {
         throw new RuntimeException("No API key authentication configured!");
     }
 
+    {{#hasOAuthMethods}}
     /**
      * Helper method to set access token for the first OAuth2 authentication.
      * @param accessToken the access token
@@ -253,6 +256,7 @@ public class ApiClient {
         throw new RuntimeException("No OAuth2 authentication configured!");
     }
 
+    {{/hasOAuthMethods}}
     /**
      * Set the User-Agent header's value (by adding to the default header map).
      * @param userAgent the user agent string

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
@@ -34,10 +34,11 @@ import com.squareup.okhttp.OkHttpClient;
 
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
 import {{invokerPackage}}.auth.OAuth.AccessTokenListener;
 import {{invokerPackage}}.auth.OAuthFlow;
-
+{{/hasOAuthMethods}}
 
 public class ApiClient {
 
@@ -104,6 +105,7 @@ public class ApiClient {
         this.setCredentials(username,  password);
     }
 
+    {{#hasOAuthMethods}}
     /**
      * Helper constructor for single password oauth2
      * @param authName Authentication name
@@ -120,21 +122,22 @@ public class ApiClient {
                 .setUsername(username)
                 .setPassword(password);
     }
-    
-   public void createDefaultAdapter() {
-        Gson gson = new GsonBuilder()
-                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-                .registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
-                .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter())
-                .create();
 
-        okClient = new OkHttpClient();
+    {{/hasOAuthMethods}}
+    public void createDefaultAdapter() {
+         Gson gson = new GsonBuilder()
+                 .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                 .registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
+                 .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter())
+                 .create();
 
-        adapterBuilder = new RestAdapter
-                .Builder()
-                .setEndpoint("{{{basePath}}}")
-                .setClient(new OkClient(okClient))
-                .setConverter(new GsonConverterWrapper(gson));
+         okClient = new OkHttpClient();
+
+         adapterBuilder = new RestAdapter
+                 .Builder()
+                 .setEndpoint("{{{basePath}}}")
+                 .setClient(new OkClient(okClient))
+                 .setConverter(new GsonConverterWrapper(gson));
     }
 
     public <S> S createService(Class<S> serviceClass) {
@@ -168,14 +171,17 @@ public class ApiClient {
                 basicAuth.setCredentials(username, password);
                 return;
             }
+            {{#hasOAuthMethods}}
             if (apiAuthorization instanceof OAuth) {
                 OAuth oauth = (OAuth) apiAuthorization;
                 oauth.getTokenRequestBuilder().setUsername(username).setPassword(password);
                 return;
             }
+            {{/hasOAuthMethods}}
         }
     }
 
+    {{#hasOAuthMethods}}
     /**
      * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
      * @return Token request builder
@@ -253,6 +259,7 @@ public class ApiClient {
             }
         }
     }
+    {{/hasOAuthMethods}}
 
     /**
      * Adds an authorization to be used by the client

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -27,9 +27,11 @@ import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
 import {{invokerPackage}}.auth.OAuth.AccessTokenListener;
 import {{invokerPackage}}.auth.OAuthFlow;
+{{/hasOAuthMethods}}
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -110,6 +112,7 @@ public class ApiClient {
     this.setCredentials(username,  password);
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper constructor for single password oauth2
    * @param authName Authentication name
@@ -127,6 +130,7 @@ public class ApiClient {
       .setPassword(password);
   }
 
+  {{/hasOAuthMethods}}
   public void createDefaultAdapter() {
     json = new JSON();
     okBuilder = new OkHttpClient.Builder();
@@ -218,15 +222,18 @@ public class ApiClient {
         basicAuth.setCredentials(username, password);
         return this;
       }
+      {{#hasOAuthMethods}}
       if (apiAuthorization instanceof OAuth) {
         OAuth oauth = (OAuth) apiAuthorization;
         oauth.getTokenRequestBuilder().setUsername(username).setPassword(password);
         return this;
       }
+      {{/hasOAuthMethods}}
     }
     return this;
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper method to configure the token endpoint of the first oauth found in the apiAuthorizations (there should be only one)
    * @return Token request builder
@@ -310,6 +317,7 @@ public class ApiClient {
     }
     return this;
   }
+  {{/hasOAuthMethods}}
 
   /**
    * Adds an authorization to be used by the client

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -3,7 +3,9 @@ package {{invokerPackage}};
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -219,6 +221,7 @@ public class ApiClient {
         throw new RuntimeException("No API key authentication configured!");
     }
 
+    {{#hasOAuthMethods}}
     /**
      * Helper method to set access token for the first OAuth2 authentication.
      *
@@ -234,6 +237,7 @@ public class ApiClient {
         throw new RuntimeException("No OAuth2 authentication configured!");
     }
 
+    {{/hasOAuthMethods}}
     /**
      * Format the given Date object into string.
      *

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -60,7 +60,9 @@ import java.util.TimeZone;
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
+{{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
+{{/hasOAuthMethods}}
 
 {{>generatedAnnotation}}
 public class ApiClient {
@@ -236,6 +238,7 @@ public class ApiClient {
         throw new RuntimeException("No API key authentication configured!");
     }
 
+    {{#hasOAuthMethods}}
     /**
      * Helper method to set access token for the first OAuth2 authentication.
      * @param accessToken the access token
@@ -250,6 +253,7 @@ public class ApiClient {
         throw new RuntimeException("No OAuth2 authentication configured!");
     }
 
+    {{/hasOAuthMethods}}
     /**
      * Set the User-Agent header's value (by adding to the default header map).
      * @param userAgent the user agent string

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -268,7 +268,7 @@ public class JavaClientCodegenTest {
         generator.opts(clientOptInput).generate();
 
         Map<String, String> generatedFiles = generator.getFiles();
-        Assert.assertEquals(generatedFiles.size(), 37);
+        Assert.assertEquals(generatedFiles.size(), 33);
         ensureContainsFile(generatedFiles, output, ".gitignore");
         ensureContainsFile(generatedFiles, output, ".openapi-generator-ignore");
         ensureContainsFile(generatedFiles, output, ".openapi-generator/VERSION");
@@ -294,8 +294,8 @@ public class JavaClientCodegenTest {
         ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/ApiKeyAuth.java");
         ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/Authentication.java");
         ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/HttpBasicAuth.java");
-        ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/OAuth.java");
-        ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/OAuthFlow.java");
+        //ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/OAuth.java");
+        //ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/auth/OAuthFlow.java");
         ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/Configuration.java");
         ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/GzipRequestInterceptor.java");
         ensureContainsFile(generatedFiles, output, "src/main/java/xyz/abcdef/JSON.java");

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
@@ -95,14 +95,14 @@ public class ApiClient {
    * @param username
    * @param password
    */
-   public ApiClient(String authName, String clientId, String secret, String username, String password) {
-     this(authName);
-     this.getTokenEndPoint()
-            .setClientId(clientId)
-            .setClientSecret(secret)
-            .setUsername(username)
-            .setPassword(password);
-   }
+  public ApiClient(String authName, String clientId, String secret, String username, String password) {
+    this(authName);
+    this.getTokenEndPoint()
+           .setClientId(clientId)
+           .setClientSecret(secret)
+           .setUsername(username)
+           .setPassword(password);
+  }
 
   public String getBasePath() {
     return basePath;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
@@ -95,14 +95,14 @@ public class ApiClient {
    * @param username
    * @param password
    */
-   public ApiClient(String authName, String clientId, String secret, String username, String password) {
-     this(authName);
-     this.getTokenEndPoint()
-            .setClientId(clientId)
-            .setClientSecret(secret)
-            .setUsername(username)
-            .setPassword(password);
-   }
+  public ApiClient(String authName, String clientId, String secret, String username, String password) {
+    this(authName);
+    this.getTokenEndPoint()
+           .setClientId(clientId)
+           .setClientSecret(secret)
+           .setUsername(username)
+           .setPassword(password);
+  }
 
   public String getBasePath() {
     return basePath;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/ApiClient.java
@@ -38,7 +38,6 @@ import org.openapitools.client.auth.OAuth;
 import org.openapitools.client.auth.OAuth.AccessTokenListener;
 import org.openapitools.client.auth.OAuthFlow;
 
-
 public class ApiClient {
 
     private Map<String, Interceptor> apiAuthorizations;
@@ -116,21 +115,21 @@ public class ApiClient {
                 .setUsername(username)
                 .setPassword(password);
     }
-    
-   public void createDefaultAdapter() {
-        Gson gson = new GsonBuilder()
-                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-                .registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
-                .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter())
-                .create();
 
-        okClient = new OkHttpClient();
+    public void createDefaultAdapter() {
+         Gson gson = new GsonBuilder()
+                 .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                 .registerTypeAdapter(DateTime.class, new DateTimeTypeAdapter())
+                 .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter())
+                 .create();
 
-        adapterBuilder = new RestAdapter
-                .Builder()
-                .setEndpoint("http://petstore.swagger.io:80/v2")
-                .setClient(new OkClient(okClient))
-                .setConverter(new GsonConverterWrapper(gson));
+         okClient = new OkHttpClient();
+
+         adapterBuilder = new RestAdapter
+                 .Builder()
+                 .setEndpoint("http://petstore.swagger.io:80/v2")
+                 .setClient(new OkClient(okClient))
+                 .setConverter(new GsonConverterWrapper(gson));
     }
 
     public <S> S createService(Class<S> serviceClass) {


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Generate OAuth related files only if OAuth security schema is used

cc @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)




