### PR TITLE
SCM and license parameters are now also for resteasy clients available.

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -7,9 +7,9 @@
     <name>{{artifactId}}</name>
     <version>{{artifactVersion}}</version>
     <scm>
-        <connection>scm:git:git@github.com:openapitools/openapi-generator.git</connection>
-        <developerConnection>scm:git:git@github.com:openapitools/openapi-generator.git</developerConnection>
-        <url>https://openapi-generator.tech</url>
+        <connection>{{scmConnection}}</connection>
+        <developerConnection>{{scmDeveloperConnection}}</developerConnection>
+        <url>{{scmUrl}}</url>
     </scm>
 {{#parentOverridden}}
     <parent>
@@ -18,6 +18,23 @@
         <version>{{{parentVersion}}}</version>
     </parent>
 {{/parentOverridden}}
+
+    <licenses>
+        <license>
+            <name>{{licenseName}}</name>
+            <url>{{licenseUrl}}</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>{{developerName}}</name>
+            <email>{{developerEmail}}</email>
+            <organization>{{developerOrganization}}</organization>
+            <organizationUrl>{{developerOrganizationUrl}}</organizationUrl>
+        </developer>
+    </developers>
 
     <build>
         <plugins>

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -9,8 +9,25 @@
     <scm>
         <connection>scm:git:git@github.com:openapitools/openapi-generator.git</connection>
         <developerConnection>scm:git:git@github.com:openapitools/openapi-generator.git</developerConnection>
-        <url>https://openapi-generator.tech</url>
+        <url>https://github.com/openapitools/openapi-generator</url>
     </scm>
+
+    <licenses>
+        <license>
+            <name>Unlicense</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>OpenAPI</name>
+            <email>team@openapitools.org</email>
+            <organization>OpenAPI</organization>
+            <organizationUrl>http://openapitools.org</organizationUrl>
+        </developer>
+    </developers>
 
     <build>
         <plugins>


### PR DESCRIPTION
### PR checklist

- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.

### Description of the PR
Now the sections scm, license and developer are not ignored when using the generator java and the library restesy.