### PR TITLE
[java-jaxrs] Add Javadoc to enum (x-enum-descriptions)

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/enumClass.mustache
@@ -5,6 +5,11 @@
     {{#gson}}
         {{#allowableValues}}
             {{#enumVars}}
+               {{#enumDescription}}
+    /**
+     * {{enumDescription}}
+     */
+               {{/enumDescription}}
     @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}
@@ -14,6 +19,11 @@
     {{^gson}}
         {{#allowableValues}}
             {{#enumVars}}
+               {{#enumDescription}}
+    /**
+     * {{enumDescription}}
+     */
+               {{/enumDescription}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{#-last}};{{/-last}}
             {{/enumVars}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/enumOuterClass.mustache
@@ -8,12 +8,22 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
   {{#gson}}
   {{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+  /**
+   * {{enumDescription}}
+   */
+    {{/enumDescription}}
   @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
   {{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
   {{/gson}}
   {{^gson}}
   {{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+  /**
+   * {{enumDescription}}
+   */
+    {{/enumDescription}}
   {{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
   {{/gson}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

Generate javadoc for enum (based on `x-enum-descriptions`) for JaxRS, see #1693 for more details.

Tested with:

```yaml
  weather:
    type: object
    properties:
      type:
        type: integer
        format: int32
        enum:
          - 1
          - 2
          - 3
        x-enum-descriptions:
          - 'Blue sky'
          - 'Slightly overcast'
          - 'Take an umbrella with you'
        x-enum-varnames:
          - Sunny
          - Cloudy
          - Rainy
```

Produces:

```diff
--- a/Weather.java
+++ b/Weather.java
@@ -31,10 +31,19 @@
    * Gets or Sets type
    */
   public enum TypeEnum {
+    /**
+     * Blue sky
+     */
     Sunny(1),
     
+    /**
+     * Slightly overcast
+     */
     Cloudy(2),
     
+    /**
+     * Take an umbrella with you
+     */
     Rainy(3);
 
     private Integer value;
```

