### PR TITLE
Add multiple servers support to PHP client

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php/Configuration.mustache
@@ -419,4 +419,82 @@ class Configuration
 
         return $keyWithPrefix;
     }
+
+    /**
+     * Returns an array of host setting
+     *
+     * @return an array of host setting
+     */
+    public function getHostSettings()
+    {
+        return array(
+        {{#servers}}
+          array(
+            "url" => "{{{url}}}",
+            "description" => "{{{description}}}{{^description}}No description provided{{/description}}",
+            {{#variables}}
+            {{#-first}}
+            "variables" => array(
+            {{/-first}}
+              "{{{name}}}" => array(
+                  "description" => "{{{description}}}{{^description}}No description provided{{/description}}",
+                  "default_value" => "{{{defaultValue}}}",
+                  {{#enumValues}}
+                  {{#-first}}
+                  "enum_values" => array(
+                  {{/-first}}
+                    "{{{.}}}"{{^-last}},{{/-last}}
+                  {{#-last}}
+                  )
+                  {{/-last}}
+                  {{/enumValues}}
+                ){{^-last}},{{/-last}}
+              {{#-last}}
+              )
+              {{/-last}}
+            {{/variables}}
+          ){{^-last}},{{/-last}}
+        {{/servers}}
+        );
+    }
+
+    /**
+     * Returns URL based on index and variables
+     *
+     * @param index array index of the host settings
+     * @param variables hash of variable and the corresponding value
+     * @return URL based on host settings
+     */
+    public function getHostFromSettings($index, $variables)
+    {
+        if (null === $variables) {
+            $variables = array();
+        }
+
+        $hosts = $this->getHostSettings();
+
+        // check array index out of bound
+        if ($index < 0 || $index > sizeof($hosts)) {
+            throw new \InvalidArgumentException("Invalid index $index when selecting the server. Must be less than ".sizeof(servers));
+        }
+
+        $host = $hosts[$index];
+        $url = $host["url"];
+
+        // go through variable and assign a value
+        foreach ($host["variables"] as $name => $variable) {
+            if (array_key_exists($name, $variables)) { // check to see if it's in the variables provided by the user
+                if (in_array($variables[$name], $variable["enum_values"])) { // check to see if the value is in the enum
+                    $url = str_replace("{".$name."}", $variables[$name], $url);
+                } else {
+                    throw new \InvalidArgumentException("The variable `$name` in the server URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                }
+            } else {
+                // use default value
+                $url = str_replace("{".$name."}", $variable["default_value"], $url);
+            }
+        }
+
+        return $url;
+    }
 }

--- a/modules/openapi-generator/src/main/resources/php/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php/Configuration.mustache
@@ -462,10 +462,10 @@ class Configuration
      * Returns URL based on the index and variables
      *
      * @param index array index of the host settings
-     * @param variables hash of variable and the corresponding value
+     * @param variables hash of variable and the corresponding value (optional)
      * @return URL based on host settings
      */
-    public function getHostFromSettings($index, $variables)
+    public function getHostFromSettings($index, $variables = null)
     {
         if (null === $variables) {
             $variables = array();

--- a/modules/openapi-generator/src/main/resources/php/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php/Configuration.mustache
@@ -421,9 +421,9 @@ class Configuration
     }
 
     /**
-     * Returns an array of host setting
+     * Returns an array of host settings
      *
-     * @return an array of host setting
+     * @return an array of host settings
      */
     public function getHostSettings()
     {
@@ -459,7 +459,7 @@ class Configuration
     }
 
     /**
-     * Returns URL based on index and variables
+     * Returns URL based on the index and variables
      *
      * @param index array index of the host settings
      * @param variables hash of variable and the corresponding value
@@ -475,7 +475,7 @@ class Configuration
 
         // check array index out of bound
         if ($index < 0 || $index > sizeof($hosts)) {
-            throw new \InvalidArgumentException("Invalid index $index when selecting the server. Must be less than ".sizeof(servers));
+            throw new \InvalidArgumentException("Invalid index $index when selecting the host. Must be less than ".sizeof($hosts));
         }
 
         $host = $hosts[$index];
@@ -487,7 +487,7 @@ class Configuration
                 if (in_array($variables[$name], $variable["enum_values"])) { // check to see if the value is in the enum
                     $url = str_replace("{".$name."}", $variables[$name], $url);
                 } else {
-                    throw new \InvalidArgumentException("The variable `$name` in the server URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                    throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
                 }
             } else {
                 // use default value

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -446,10 +446,10 @@ class Configuration
      * Returns URL based on the index and variables
      *
      * @param index array index of the host settings
-     * @param variables hash of variable and the corresponding value
+     * @param variables hash of variable and the corresponding value (optional)
      * @return URL based on host settings
      */
-    public function getHostFromSettings($index, $variables)
+    public function getHostFromSettings($index, $variables = null)
     {
         if (null === $variables) {
             $variables = array();

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -426,4 +426,59 @@ class Configuration
 
         return $keyWithPrefix;
     }
+
+    /**
+     * Returns an array of host setting
+     *
+     * @return an array of host setting
+     */
+    public function getHostSettings()
+    {
+        return array(
+          array(
+            "url" => "http://petstore.swagger.io:80/v2",
+            "description" => "No description provided",
+          )
+        );
+    }
+
+    /**
+     * Returns URL based on index and variables
+     *
+     * @param index array index of the host settings
+     * @param variables hash of variable and the corresponding value
+     * @return URL based on host settings
+     */
+    public function getHostFromSettings($index, $variables)
+    {
+        if (null === $variables) {
+            $variables = array();
+        }
+
+        $hosts = $this->getHostSettings();
+
+        // check array index out of bound
+        if ($index < 0 || $index > sizeof($hosts)) {
+            throw new \InvalidArgumentException("Invalid index $index when selecting the server. Must be less than ".sizeof(servers));
+        }
+
+        $host = $hosts[$index];
+        $url = $host["url"];
+
+        // go through variable and assign a value
+        foreach ($host["variables"] as $name => $variable) {
+            if (array_key_exists($name, $variables)) { // check to see if it's in the variables provided by the user
+                if (in_array($variables[$name], $variable["enum_values"])) { // check to see if the value is in the enum
+                    $url = str_replace("{".$name."}", $variables[$name], $url);
+                } else {
+                    throw new \InvalidArgumentException("The variable `$name` in the server URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                }
+            } else {
+                // use default value
+                $url = str_replace("{".$name."}", $variable["default_value"], $url);
+            }
+        }
+
+        return $url;
+    }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -428,9 +428,9 @@ class Configuration
     }
 
     /**
-     * Returns an array of host setting
+     * Returns an array of host settings
      *
-     * @return an array of host setting
+     * @return an array of host settings
      */
     public function getHostSettings()
     {
@@ -443,7 +443,7 @@ class Configuration
     }
 
     /**
-     * Returns URL based on index and variables
+     * Returns URL based on the index and variables
      *
      * @param index array index of the host settings
      * @param variables hash of variable and the corresponding value
@@ -459,7 +459,7 @@ class Configuration
 
         // check array index out of bound
         if ($index < 0 || $index > sizeof($hosts)) {
-            throw new \InvalidArgumentException("Invalid index $index when selecting the server. Must be less than ".sizeof(servers));
+            throw new \InvalidArgumentException("Invalid index $index when selecting the host. Must be less than ".sizeof($hosts));
         }
 
         $host = $hosts[$index];
@@ -471,7 +471,7 @@ class Configuration
                 if (in_array($variables[$name], $variable["enum_values"])) { // check to see if the value is in the enum
                     $url = str_replace("{".$name."}", $variables[$name], $url);
                 } else {
-                    throw new \InvalidArgumentException("The variable `$name` in the server URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                    throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
                 }
             } else {
                 // use default value

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -479,10 +479,10 @@ class Configuration
      * Returns URL based on the index and variables
      *
      * @param index array index of the host settings
-     * @param variables hash of variable and the corresponding value
+     * @param variables hash of variable and the corresponding value (optional)
      * @return URL based on host settings
      */
-    public function getHostFromSettings($index, $variables)
+    public function getHostFromSettings($index, $variables = null)
     {
         if (null === $variables) {
             $variables = array();

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -426,4 +426,92 @@ class Configuration
 
         return $keyWithPrefix;
     }
+
+    /**
+     * Returns an array of host setting
+     *
+     * @return an array of host setting
+     */
+    public function getHostSettings()
+    {
+        return array(
+          array(
+            "url" => "http://{server}.swagger.io:{port}/v2",
+            "description" => "petstore server",
+            "variables" => array(
+              "server" => array(
+                  "description" => "No description provided",
+                  "default_value" => "petstore",
+                  "enum_values" => array(
+                    "petstore",
+                    "qa-petstore",
+                    "dev-petstore"
+                  )
+                ),
+              "port" => array(
+                  "description" => "No description provided",
+                  "default_value" => "80",
+                  "enum_values" => array(
+                    "80",
+                    "8080"
+                  )
+                )
+              )
+          ),
+          array(
+            "url" => "https://localhost:8080/{version}",
+            "description" => "The local server",
+            "variables" => array(
+              "version" => array(
+                  "description" => "No description provided",
+                  "default_value" => "v2",
+                  "enum_values" => array(
+                    "v1",
+                    "v2"
+                  )
+                )
+              )
+          )
+        );
+    }
+
+    /**
+     * Returns URL based on index and variables
+     *
+     * @param index array index of the host settings
+     * @param variables hash of variable and the corresponding value
+     * @return URL based on host settings
+     */
+    public function getHostFromSettings($index, $variables)
+    {
+        if (null === $variables) {
+            $variables = array();
+        }
+
+        $hosts = $this->getHostSettings();
+
+        // check array index out of bound
+        if ($index < 0 || $index > sizeof($hosts)) {
+            throw new \InvalidArgumentException("Invalid index $index when selecting the server. Must be less than ".sizeof(servers));
+        }
+
+        $host = $hosts[$index];
+        $url = $host["url"];
+
+        // go through variable and assign a value
+        foreach ($host["variables"] as $name => $variable) {
+            if (array_key_exists($name, $variables)) { // check to see if it's in the variables provided by the user
+                if (in_array($variables[$name], $variable["enum_values"])) { // check to see if the value is in the enum
+                    $url = str_replace("{".$name."}", $variables[$name], $url);
+                } else {
+                    throw new \InvalidArgumentException("The variable `$name` in the server URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                }
+            } else {
+                // use default value
+                $url = str_replace("{".$name."}", $variable["default_value"], $url);
+            }
+        }
+
+        return $url;
+    }
 }

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Configuration.php
@@ -428,9 +428,9 @@ class Configuration
     }
 
     /**
-     * Returns an array of host setting
+     * Returns an array of host settings
      *
-     * @return an array of host setting
+     * @return an array of host settings
      */
     public function getHostSettings()
     {
@@ -476,7 +476,7 @@ class Configuration
     }
 
     /**
-     * Returns URL based on index and variables
+     * Returns URL based on the index and variables
      *
      * @param index array index of the host settings
      * @param variables hash of variable and the corresponding value
@@ -492,7 +492,7 @@ class Configuration
 
         // check array index out of bound
         if ($index < 0 || $index > sizeof($hosts)) {
-            throw new \InvalidArgumentException("Invalid index $index when selecting the server. Must be less than ".sizeof(servers));
+            throw new \InvalidArgumentException("Invalid index $index when selecting the host. Must be less than ".sizeof($hosts));
         }
 
         $host = $hosts[$index];
@@ -504,7 +504,7 @@ class Configuration
                 if (in_array($variables[$name], $variable["enum_values"])) { // check to see if the value is in the enum
                     $url = str_replace("{".$name."}", $variables[$name], $url);
                 } else {
-                    throw new \InvalidArgumentException("The variable `$name` in the server URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                    throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
                 }
             } else {
                 // use default value

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OpenAPI\Client;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    /**
+     * Test server settings
+     */
+    public function testMultipleServers()
+    {
+        $config = new Configuration();
+        $servers = $config->getHostSettings();
+
+        $this->assertCount(2, $servers);
+        $this->assertSame("http://{server}.swagger.io:{port}/v2", $servers[0]["url"]);
+        $this->assertSame("petstore", $servers[0]["variables"]["server"]["default_value"]);
+        $this->assertSame("80", $servers[0]["variables"]["port"]["default_value"]);
+        $this->assertSame(array("80", "8080"), $servers[0]["variables"]["port"]["enum_values"]);
+    }
+
+    /**
+     * Test server settings
+     */
+    public function testServerUrl()
+    {
+        $config = new Configuration();
+        // default value
+        $url = $config->getHostFromSettings(0, null);
+        $this->assertSame("http://petstore.swagger.io:80/v2", $url);
+
+        // using a variable
+        $url = $config->getHostFromSettings(0, array("server" => "dev-petstore"));
+        $this->assertSame("http://dev-petstore.swagger.io:80/v2", $url);
+
+        // using 2 variables
+        $url = $config->getHostFromSettings(0, array("server" => "dev-petstore", "port" => "8080"));
+        $this->assertSame("http://dev-petstore.swagger.io:8080/v2", $url);
+    }
+
+    /**
+     * Test server settings with invalid vaues
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The variable `port` in the server URL has invalid value 8. Must be 80,8080
+     */
+    public function testServerUrlWithInvalidValues()
+    {
+        // using 2 variables with invalid values
+        $config = new Configuration();
+        $url = $config->getHostFromSettings(0, array("server" => "dev-petstore", "port" => "8"));
+        $this->assertSame("http://dev-petstore.swagger.io:8080/v2", $url);
+    }
+}

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -42,11 +42,11 @@ class ConfigurationTest extends TestCase
     }
 
     /**
-     * Test server settings with invalid vaues
+     * Test host settings with invalid vaues
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The variable `port` in the server URL has invalid value 8. Must be 80,8080
+     * @expectedExceptionMessage The variable `port` in the host URL has invalid value 8. Must be 80,8080
      */
-    public function testServerUrlWithInvalidValues()
+    public function testHostUrlWithInvalidValues()
     {
         // using 2 variables with invalid values
         $config = new Configuration();

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/tests/ConfigurationTest.php
@@ -29,7 +29,7 @@ class ConfigurationTest extends TestCase
     {
         $config = new Configuration();
         // default value
-        $url = $config->getHostFromSettings(0, null);
+        $url = $config->getHostFromSettings(0);
         $this->assertSame("http://petstore.swagger.io:80/v2", $url);
 
         // using a variable


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- allows the PHP API client to retrieve all server URLs defined in the spec

Ref: https://github.com/OpenAPITools/openapi-generator/pull/1280 for Ruby client

cc @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) , @ybelenko (2018/07), @renepardon (2018/12)


