### PR TITLE
Fix customized source folder in Java client

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -349,6 +349,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if (additionalProperties.containsKey(CodegenConstants.SOURCE_FOLDER)) {
             this.setSourceFolder((String) additionalProperties.get(CodegenConstants.SOURCE_FOLDER));
         }
+        additionalProperties.put(CodegenConstants.SOURCE_FOLDER, sourceFolder);
 
         if (additionalProperties.containsKey(CodegenConstants.LOCAL_VARIABLE_PREFIX)) {
             this.setLocalVariablePrefix((String) additionalProperties.get(CodegenConstants.LOCAL_VARIABLE_PREFIX));

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -1,5 +1,8 @@
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+{{#sourceFolder}}
+apply plugin: 'java'
+{{/sourceFolder}}
 
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
@@ -18,8 +21,12 @@ buildscript {
 repositories {
     jcenter()
 }
+{{#sourceFolder}}
+sourceSets {
+    main.java.srcDirs = ['{{sourceFolder}}']
+}
 
-
+{{/sourceFolder}}
 if(hasProperty('target') && target == 'android') {
 
     apply plugin: 'com.android.library'

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -121,8 +121,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/main/java</source>
+                                <source>{{{sourceFolder}}}</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -134,8 +133,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/test/java</source>
+                                <source>src/test/java</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+apply plugin: 'java'
 
 group = 'org.openapitools'
 version = '1.0.0'
@@ -18,7 +19,9 @@ buildscript {
 repositories {
     jcenter()
 }
-
+sourceSets {
+    main.java.srcDirs = ['src/main/java']
+}
 
 if(hasProperty('target') && target == 'android') {
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -114,8 +114,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/main/java</source>
+                                <source>src/main/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -127,8 +126,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/test/java</source>
+                                <source>src/test/java</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+apply plugin: 'java'
 
 group = 'org.openapitools'
 version = '1.0.0'
@@ -18,7 +19,9 @@ buildscript {
 repositories {
     jcenter()
 }
-
+sourceSets {
+    main.java.srcDirs = ['src/main/java']
+}
 
 if(hasProperty('target') && target == 'android') {
 

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -114,8 +114,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/main/java</source>
+                                <source>src/main/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -127,8 +126,7 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/test/java</source>
+                                <source>src/test/java</source>
                             </sources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use customized source folder in build config when provided.

cc @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)


