### PR TITLE
[C++][Client][C++ Rest SDK] Fix path parameters with format

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/apiclient-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/apiclient-header.mustache
@@ -49,6 +49,8 @@ public:
     static utility::string_t parameterToString(const utility::datetime &value);
     template<class T>
     static utility::string_t parameterToString(const std::vector<T>& value);
+    template<class T>
+    static utility::string_t parameterToString(const std::shared_ptr<T>& value);
 
     pplx::task<web::http::http_response> callApi(
         const utility::string_t& path,
@@ -80,6 +82,13 @@ utility::string_t ApiClient::parameterToString(const std::vector<T>& value)
 
     return ss.str();
 }
+
+template<class T>
+utility::string_t ApiClient::parameterToString(const std::shared_ptr<T>& value)
+{
+    return parameterToString(*value.get());
+}
+
 
 {{#apiNamespaceDeclarations}}
 }

--- a/samples/client/petstore/cpp-restsdk/ApiClient.h
+++ b/samples/client/petstore/cpp-restsdk/ApiClient.h
@@ -60,6 +60,8 @@ public:
     static utility::string_t parameterToString(const utility::datetime &value);
     template<class T>
     static utility::string_t parameterToString(const std::vector<T>& value);
+    template<class T>
+    static utility::string_t parameterToString(const std::shared_ptr<T>& value);
 
     pplx::task<web::http::http_response> callApi(
         const utility::string_t& path,
@@ -91,6 +93,13 @@ utility::string_t ApiClient::parameterToString(const std::vector<T>& value)
 
     return ss.str();
 }
+
+template<class T>
+utility::string_t ApiClient::parameterToString(const std::shared_ptr<T>& value)
+{
+    return parameterToString(*value.get());
+}
+
 
 }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #561

Before this change, the following OpenAPI path would cause a compilation failure in the generated C++ code. Specifically, the `format: "uuid"` was problematic, as it cause the underlying implementation to wrap the string in a `std::shared_ptr<>`.
```yaml
paths:
  "/foo/{id}":
    get:
      summary: "Get a specific Fooby ID"
      operationId: "getFoo"
      parameters:
        - name: "id"
          in: "path"
          description: "The UUID of the referenced object"
          required: true
          type: "string"
          format: "uuid"
```
Yields:
```cpp
FooApi.cpp: In member function 'virtual pplx::task<std::shared_ptr<Foo> > FooApi::getFoo(std::shared_ptr<std::basic_string<char> >)':
FooApi.cpp:330:184: error: no matching function for call to 'ApiClient::parameterToString(std::shared_ptr<std::basic_string<char> >&)'
     boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("id") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(id));
                                                                                                                                                                                        ^
In file included from FooApi.h:23:0,
                 from FooApi.cpp:14:
ApiClient.h:48:30: note: candidate: static utility::string_t ApiClient::parameterToString(utility::string_t)
     static utility::string_t parameterToString(utility::string_t value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:48:30: note:   no known conversion for argument 1 from 'std::shared_ptr<std::basic_string<char> >' to 'utility::string_t {aka std::basic_string<char>}'
ApiClient.h:49:30: note: candidate: static utility::string_t ApiClient::parameterToString(int32_t)
     static utility::string_t parameterToString(int32_t value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:49:30: note:   no known conversion for argument 1 from 'std::shared_ptr<std::basic_string<char> >' to 'int32_t {aka int}'
ApiClient.h:50:30: note: candidate: static utility::string_t ApiClient::parameterToString(int64_t)
     static utility::string_t parameterToString(int64_t value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:50:30: note:   no known conversion for argument 1 from 'std::shared_ptr<std::basic_string<char> >' to 'int64_t {aka long int}'
ApiClient.h:51:30: note: candidate: static utility::string_t ApiClient::parameterToString(float)
     static utility::string_t parameterToString(float value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:51:30: note:   no known conversion for argument 1 from 'std::shared_ptr<std::basic_string<char> >' to 'float'
ApiClient.h:52:30: note: candidate: static utility::string_t ApiClient::parameterToString(double)
     static utility::string_t parameterToString(double value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:52:30: note:   no known conversion for argument 1 from 'std::shared_ptr<std::basic_string<char> >' to 'double'
ApiClient.h:53:30: note: candidate: static utility::string_t ApiClient::parameterToString(const utility::datetime&)
     static utility::string_t parameterToString(const utility::datetime &value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:53:30: note:   no known conversion for argument 1 from 'std::shared_ptr<std::basic_string<char> >' to 'const utility::datetime&'
ApiClient.h:55:30: note: candidate: template<class T> static utility::string_t ApiClient::parameterToString(const std::vector<_Type>&)
     static utility::string_t parameterToString(const std::vector<T>& value);
                              ^~~~~~~~~~~~~~~~~
ApiClient.h:55:30: note:   template argument deduction/substitution failed:
Api.cpp:330:184: note:   'std::shared_ptr<std::basic_string<char> >' is not derived from 'const std::vector<_Type>'
     boost::replace_all(path, utility::conversions::to_string_t("{") + utility::conversions::to_string_t("id") + utility::conversions::to_string_t("}"), ApiClient::parameterToString(id));


```

This PR adds a templated `parameterToString(std::shared_ptr<T>)` function, which simply dereferences the shared pointer, and calls the appropriate `parameterToString` for the templated type `T`. 
