### PR TITLE
Fix index check in Ruby client

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -261,8 +261,8 @@ module {{moduleName}}
       servers = server_settings
 
       # check array index out of bound
-      if (index < 0 || index > servers.size)
-        fail ArgumentError "Invalid index #{index} when selecting the server. Must be less than #{servers.size}"
+      if (index < 0 || index >= servers.size)
+        fail ArgumentError, "Invalid index #{index} when selecting the server. Must be less than #{servers.size}"
       end
 
       server = servers[index]

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -245,8 +245,8 @@ module Petstore
       servers = server_settings
 
       # check array index out of bound
-      if (index < 0 || index > servers.size)
-        fail ArgumentError "Invalid index #{index} when selecting the server. Must be less than #{servers.size}"
+      if (index < 0 || index >= servers.size)
+        fail ArgumentError, "Invalid index #{index} when selecting the server. Must be less than #{servers.size}"
       end
 
       server = servers[index]

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/configuration.rb
@@ -278,8 +278,8 @@ module Petstore
       servers = server_settings
 
       # check array index out of bound
-      if (index < 0 || index > servers.size)
-        fail ArgumentError "Invalid index #{index} when selecting the server. Must be less than #{servers.size}"
+      if (index < 0 || index >= servers.size)
+        fail ArgumentError, "Invalid index #{index} when selecting the server. Must be less than #{servers.size}"
       end
 
       server = servers[index]

--- a/samples/openapi3/client/petstore/ruby/spec/configuration_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/configuration_spec.rb
@@ -51,5 +51,9 @@ describe Petstore::Configuration do
     it 'should raise error due to invalid enum value' do
       expect{config.server_url(1, version: "v6")}.to raise_error(ArgumentError)
     end
+
+    it 'should raise error due to invalid index' do
+      expect{config.server_url(2)}.to raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- fixed index check for multiple server settings in Ruby client
- added a test case to cover the issue moving forward

cc @cliffano (2017/07) @zlx (2017/09)

