### PR TITLE
[TypescriptAngular] gets package npm version from API specification

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -206,6 +206,8 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
 
         if (additionalProperties.containsKey(NPM_VERSION)) {
             this.setNpmVersion(additionalProperties.get(NPM_VERSION).toString());
+        } else if (this.getVersionFromApi() != null) {
+            this.setNpmVersion(this.getVersionFromApi());
         }
 
         if (additionalProperties.containsKey(SNAPSHOT)
@@ -649,5 +651,18 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             name = camelize(name, true);
         }
         return name;
+    }
+
+    /**
+     * Returns version from OpenAPI info.
+     *
+     * @return
+     */
+    private String getVersionFromApi() {
+        if (this.openAPI != null && this.openAPI.getInfo() != null) {
+            return this.openAPI.getInfo().getVersion();
+        } else {
+            return null;
+        }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypescriptAngularApiVersionTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypescriptAngularApiVersionTest.java
@@ -1,0 +1,54 @@
+package org.openapitools.codegen.typescript.typescriptangular;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openapitools.codegen.*;
+import org.openapitools.codegen.languages.TypeScriptAngularClientCodegen;
+
+public class TypescriptAngularApiVersionTest {
+
+    @Test
+    public void testWithApiVersion() {
+        final TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+
+        codegen.additionalProperties().put("npmName", "just-a-test");
+
+        OpenAPI api = TestUtils.createOpenAPI();
+        codegen.setOpenAPI(api);
+
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.getNpmVersion(), "1.0.7");
+    }
+
+    @Test
+    public void testWithoutNpmName() {
+        final TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+
+        OpenAPI api = TestUtils.createOpenAPI();
+
+        codegen.setOpenAPI(api);
+
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.getNpmVersion(), "1.0.0");
+    }
+
+    @Test
+    public void testWithNpmVersion() {
+        final TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+
+        codegen.additionalProperties().put("npmName", "just-a-test");
+        codegen.additionalProperties().put("npmVersion", "2.0.0");
+
+        OpenAPI api = TestUtils.createOpenAPI();
+        codegen.setOpenAPI(api);
+
+        codegen.processOpts();
+
+        Assert.assertEquals(codegen.getNpmVersion(), "2.0.0");
+    }
+
+
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

 @topce 
@macjohnny  
@nicokoenig 
### Description of the PR

Uses, if specified in OpenAPI file and not received as additional property, version from OpenAPI specification instead of using "1.0.0" as default one.

