### PR TITLE
[PHP] Provide oneOf types in php code generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -37,7 +37,6 @@ public class CodegenModel {
     // anyOf, oneOf, allOf
     public Set<String> anyOf = new TreeSet<String>();
     public Set<String> oneOf = new TreeSet<String>();
-    public Set<String> oneOfTypes = new TreeSet<String>();
     public Set<String> allOf = new TreeSet<String>();
 
     public String name, classname, title, description, classVarName, modelJson, dataType, xmlPrefix, xmlNamespace, xmlName;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -37,6 +37,7 @@ public class CodegenModel {
     // anyOf, oneOf, allOf
     public Set<String> anyOf = new TreeSet<String>();
     public Set<String> oneOf = new TreeSet<String>();
+    public Set<String> oneOfTypes = new TreeSet<String>();
     public Set<String> allOf = new TreeSet<String>();
 
     public String name, classname, title, description, classVarName, modelJson, dataType, xmlPrefix, xmlNamespace, xmlName;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1648,6 +1648,11 @@ public class DefaultCodegen implements CodegenConfig {
         return m;
     }
 
+    protected String getOneOfType(Schema option) {
+        String ref = ModelUtils.getSimpleRef(option.get$ref());
+        return toModelName(ref);
+    }
+
     protected void getComposite(String name, ComposedSchema composed, Map<String, Schema> allDefinitions, CodegenModel m) {
         Map<String, Schema> properties = new LinkedHashMap<String, Schema>();
         List<String> required = new ArrayList<String>();
@@ -1720,7 +1725,7 @@ public class DefaultCodegen implements CodegenConfig {
                 if (composed.getAnyOf() != null) {
                     m.anyOf.add(modelName);
                 } else if (composed.getOneOf() != null) {
-                    m.oneOf.add(modelName);
+                    m.oneOf.add(getOneOfType(interfaceSchema));
                 } else if (composed.getAllOf() != null) {
                     m.allOf.add(modelName);
                 } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -334,17 +334,11 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
-    protected void getComposite(String name, ComposedSchema composed, Map<String, Schema> allDefinitions, CodegenModel m) {
-        super.getComposite(name, composed, allDefinitions, m);
-        if (composed.getOneOf() != null) {
-            for (Schema option: composed.getOneOf()) {
-                if (ModelUtils.isArraySchema(ModelUtils.unaliasSchema(this.openAPI, option))) {
-                    m.oneOfTypes.add(getTypeDeclaration(ModelUtils.unaliasSchema(this.openAPI, option)));
-                } else {
-                    m.oneOfTypes.add(getTypeDeclaration(option));
-                }
-            }
+    protected String getOneOfType(Schema option) {
+        if (ModelUtils.isArraySchema(ModelUtils.unaliasSchema(this.openAPI, option))) {
+            return getTypeDeclaration(ModelUtils.unaliasSchema(this.openAPI, option));
         }
+        return getTypeDeclaration(option);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -244,10 +244,34 @@ class ObjectSerializer
             $data = is_string($data) ? json_decode($data) : $data;
             $subClass = substr($class, 0, -2);
             $values = [];
+            if (!is_array($data)) {
+                throw new \InvalidArgumentException('expected array');
+            }
             foreach ($data as $key => $value) {
                 $values[] = self::deserialize($value, $subClass, null);
             }
             return $values;
+        } elseif (substr($class, 0, strlen('oneOf[')) === 'oneOf[') {
+          $inner = substr($class, strlen('oneOf['), -1);
+          $options = explode(',', $inner);
+          $deserialized = [];
+          $errors = [];
+          foreach ($options as $option) {
+            try {
+              $deserialized[] = ['option' => trim($option), 'value' => self::deserialize($data, trim($option), $httpHeaders)];
+            } catch (\InvalidArgumentException $e) {
+              $errors[] = $e->getMessage();
+            }
+          }
+          if (count($deserialized) > 1) {
+            throw new \InvalidArgumentException(
+              'too many matching options for oneOf: '. implode(', ', array_map(function($option) { return $option['option']; }, $deserialized))
+            );
+          }
+          if (count($deserialized) < 1) {
+            throw new \InvalidArgumentException('no values matched oneOf:\n    '. implode('\n    ', $errors));
+          }
+          return $deserialized[0]['value'];
         } elseif ($class === 'object') {
             settype($data, 'array');
             return $data;
@@ -301,17 +325,26 @@ class ObjectSerializer
                 }
             }
             $instance = new $class();
-            foreach ($instance::openAPITypes() as $property => $type) {
-                $propertySetter = $instance::setters()[$property];
-
-                if (!isset($propertySetter) || !isset($data->{$instance::attributeMap()[$property]})) {
-                    continue;
+            $reverseAttributes = array_flip($instance::attributeMap());
+            if (!is_object($data)) {
+                return null;
+            }
+            if (!empty($instance::oneOf())) {
+                return self::deserialize($data, "oneOf[". implode(', ', $instance->onefOf())  ."]", $httpHeaders);
+            }
+            foreach(get_object_vars($data) as $key => $propertyValue) {
+              $modelField = $reverseAttributes[$key];
+              $propertySetter = $instance::setters()[$modelField];
+              if (!isset($propertySetter)) {
+                if ($instance->additionalPropertiesType()) {
+                  $instance->additionalPropertySetter($key, self::deserialize($propertyValue, $instance->additionalPropertiesType(), $httpHeaders));
+                } else {
+                  throw new \InvalidArgumentException("No additional properties allowed: " . $key);
                 }
+              }
 
-                $propertyValue = $data->{$instance::attributeMap()[$property]};
-                if (isset($propertyValue)) {
-                    $instance->$propertySetter(self::deserialize($propertyValue, $type, null));
-                }
+              $type = $instance::openAPITypes()[$modelField];
+              $instance->$propertySetter(self::deserialize($propertyValue, $type, $httpHeaders));
             }
             return $instance;
         }

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -183,7 +183,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     }
 
     public static function oneOf() {
-        return [{{#oneOfTypes}}'{{.}}'{{^-last}}, {{/-last}}{{/oneOfTypes}}];
+        return [{{#oneOf}}'{{.}}'{{^-last}}, {{/-last}}{{/oneOf}}];
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -170,6 +170,22 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         {{/discriminator}}
     }
 
+    public static additionalPropertiesType() {
+        return {{#additionalPropertiesType}}{{additionalPropertiesType}}{{/additionalPropertiesType}}{{^additionalPropertiesType}}null{{/additionalPropertiesType}};
+    }
+
+    public function additionalPropertiesSetter($key, $value) {
+        $this->container[$key] = $value;
+    }
+
+    public function additionalPropertiesGetter($key) {
+        return $this->container[$key];
+    }
+
+    public static function oneOf() {
+        return [{{#oneOfTypes}}'{{.}}'{{^-last}}, {{/-last}}{{/oneOfTypes}}];
+    }
+
     /**
      * Show all the invalid properties with reasons.
      *


### PR DESCRIPTION
(this is fairly work in progress but I would like to get feedback if this is at all sensible approach to this before going much further) 

Fixes https://github.com/OpenAPITools/openapi-generator/issues/2011

For Models openAPITypes map the idea is to encode oneOf values as string
`oneOf[type1, .., typeN]` in the property dataType template variable

For Models that consist of a oneOf block like

```
model:
  oneOf:
    - $ref: modelA
    - type: array
      items: string

```

We generate a new template variable oneOfTypes containing the list of
options which in turn get used to generate a new method `Model::oneOf`
which return a list

```
['\fully\qualified\name\modelA', 'string[]']
```

@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon @wing328 
