### PR TITLE
Making completion work with openapi-generator-cli or openapi-generator

### DIFF
--- a/scripts/openapi-generator-cli-completion.bash
+++ b/scripts/openapi-generator-cli-completion.bash
@@ -43,4 +43,6 @@ _openapi_generator_cli_completions() {
   fi
 }
 
-complete -F _openapi_generator_cli_completions openapi-generator-cli
+for i in openapi-generator-cli openapi-generator; do
+  type $i > /dev/null 2>&1 && complete -F _openapi_generator_cli_completions $i
+done


### PR DESCRIPTION
Homebrew installs openapi-generator-cli as openapi-generator.  This will make bash completion work with either.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- (n/a) Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- (n/a) Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Making the bash completion script work with Homebrew.
