### PR TITLE
[Python] handle nullable parameters with None added to allowed_values

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -107,7 +107,7 @@ class {{classname}}(object):
 {{/isNullable}}
 {{#isEnum}}
 {{#isContainer}}
-        allowed_values = [{{#allowableValues}}{{#values}}{{#items.isString}}"{{/items.isString}}{{{this}}}{{#items.isString}}"{{/items.isString}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]  # noqa: E501
+        allowed_values = [{{#isNullable}}None,{{/isNullable}}{{#allowableValues}}{{#values}}{{#items.isString}}"{{/items.isString}}{{{this}}}{{#items.isString}}"{{/items.isString}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]  # noqa: E501
 {{#isListContainer}}
         if not set({{{name}}}).issubset(set(allowed_values)):
             raise ValueError(
@@ -126,7 +126,7 @@ class {{classname}}(object):
 {{/isMapContainer}}
 {{/isContainer}}
 {{^isContainer}}
-        allowed_values = [{{#allowableValues}}{{#values}}{{#isString}}"{{/isString}}{{{this}}}{{#isString}}"{{/isString}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]  # noqa: E501
+        allowed_values = [{{#isNullable}}None,{{/isNullable}}{{#allowableValues}}{{#values}}{{#isString}}"{{/isString}}{{{this}}}{{#isString}}"{{/isString}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}]  # noqa: E501
         if {{{name}}} not in allowed_values:
             raise ValueError(
                 "Invalid value for `{{{name}}}` ({0}), must be one of {1}"  # noqa: E501

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -20,12 +20,17 @@ package org.openapitools.codegen.python;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.languages.PythonClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class PythonClientCodegenTest {
 
@@ -56,6 +61,18 @@ public class PythonClientCodegenTest {
 
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.FALSE);
         Assert.assertEquals(codegen.isHideGenerationTimestamp(), false);
+    }
+
+    @Test(description = "test enum null/nullable patterns")
+    public void testEnumNull() {
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_1997.yaml", null, new ParseOptions()).getOpenAPI();
+
+
+        StringSchema prop = (StringSchema) openAPI.getComponents().getSchemas().get("Type").getProperties().get("prop");
+        ArrayList<Object> expected = new ArrayList<>(Arrays.asList("A", "B", "C"));
+        assert prop.getNullable();
+        assert prop.getEnum().equals(expected);
     }
 
     @Test(description = "test regex patterns")

--- a/modules/openapi-generator/src/test/resources/3_0/issue_1997.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_1997.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.1
+paths:
+  /test:
+    summary: test
+info:
+  description: test
+  version: 1.0.0
+  title: test
+components:
+  schemas:
+    Type:
+      properties:
+        prop:
+          nullable: true
+          enum: [A, B, C]
+          type: string
+        prop2:
+          enum: [A, B, C, null]
+          type: string
+        prop3:
+          nullable: true
+          enum: []
+          type: string

--- a/samples/client/petstore/python-asyncio/README.md
+++ b/samples/client/petstore/python-asyncio/README.md
@@ -51,6 +51,7 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
+
 # create an instance of the API class
 api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
 body = petstore_api.Client() # Client | client model
@@ -158,15 +159,18 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+
 ## api_key_query
 
 - **Type**: API key
 - **API key parameter name**: api_key_query
 - **Location**: URL query string
 
+
 ## http_basic_test
 
 - **Type**: HTTP basic authentication
+
 
 ## petstore_auth
 

--- a/samples/client/petstore/python-asyncio/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/AnotherFakeApi.md
@@ -15,6 +15,7 @@ To test special tags
 To test special tags and operation ID starting with number
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/FakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeApi.md
@@ -27,6 +27,7 @@ creates an XmlItem
 this route creates an XmlItem
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -74,6 +75,7 @@ No authorization required
 Test serialization of outer boolean types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -121,6 +123,7 @@ No authorization required
 Test serialization of object with outer number type
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -168,6 +171,7 @@ No authorization required
 Test serialization of outer number types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -215,6 +219,7 @@ No authorization required
 Test serialization of outer string types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -262,6 +267,7 @@ No authorization required
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -306,6 +312,7 @@ No authorization required
 
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -354,6 +361,7 @@ To test \"client\" model
 To test \"client\" model
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -403,7 +411,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ### Example
 
-* Basic Authentication (http_basic_test): 
+* Basic Authentication (http_basic_test):
 ```python
 from __future__ import print_function
 import time
@@ -481,6 +489,7 @@ To test enum parameters
 To test enum parameters
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -542,6 +551,7 @@ Fake endpoint to test group parameters (optional)
 Fake endpoint to test group parameters (optional)
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -597,6 +607,7 @@ No authorization required
 test inline additionalProperties
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -642,6 +653,7 @@ No authorization required
 test json serialization of form data
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeClassnameTags123Api.md
@@ -16,7 +16,7 @@ To test class name in snake case
 
 ### Example
 
-* Api Key Authentication (api_key_query): 
+* Api Key Authentication (api_key_query):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/PetApi.md
+++ b/samples/client/petstore/python-asyncio/docs/PetApi.md
@@ -22,7 +22,7 @@ Add a new pet to the store
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -72,7 +72,7 @@ Deletes a pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -126,7 +126,7 @@ Multiple status values can be provided with comma separated strings
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -179,7 +179,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -232,7 +232,7 @@ Returns a single pet
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -285,7 +285,7 @@ Update an existing pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -335,7 +335,7 @@ Updates a pet in the store with form data
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -389,7 +389,7 @@ uploads an image
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -444,7 +444,7 @@ uploads an image (required)
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/StoreApi.md
+++ b/samples/client/petstore/python-asyncio/docs/StoreApi.md
@@ -18,6 +18,7 @@ Delete purchase order by ID
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -66,7 +67,7 @@ Returns a map of status codes to quantities
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -116,6 +117,7 @@ Find purchase order by ID
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -162,6 +164,7 @@ No authorization required
 Place an order for a pet
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/UserApi.md
+++ b/samples/client/petstore/python-asyncio/docs/UserApi.md
@@ -22,6 +22,7 @@ Create user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -67,6 +68,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -112,6 +114,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -159,6 +162,7 @@ Delete user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -204,6 +208,7 @@ No authorization required
 Get user by user name
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -250,6 +255,7 @@ No authorization required
 Logs user into the system
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -298,6 +304,7 @@ No authorization required
 Logs out current logged in user session
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -341,6 +348,7 @@ Updated user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -59,10 +59,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.username = ""
         # Password for HTTP basic authentication
         self.password = ""
-
-        # access token for OAuth
+        # access token for OAuth/Bearer
         self.access_token = ""
-
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("petstore_api")
@@ -236,7 +234,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': self.get_basic_auth_token()
                 },
-
             'petstore_auth':
                 {
                     'type': 'oauth2',
@@ -244,7 +241,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': 'Bearer ' + self.access_token
                 },
-
         }
 
     def to_debug_report(self):
@@ -281,7 +277,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         servers = self.get_host_settings()
 
         # check array index out of bound
-        if index < 0 or index > len(servers):
+        if index < 0 or index >= len(servers):
             raise ValueError(
                 "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
                 .format(index, len(servers)))

--- a/samples/client/petstore/python-tornado/README.md
+++ b/samples/client/petstore/python-tornado/README.md
@@ -51,6 +51,7 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
+
 # create an instance of the API class
 api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
 body = petstore_api.Client() # Client | client model
@@ -158,15 +159,18 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+
 ## api_key_query
 
 - **Type**: API key
 - **API key parameter name**: api_key_query
 - **Location**: URL query string
 
+
 ## http_basic_test
 
 - **Type**: HTTP basic authentication
+
 
 ## petstore_auth
 

--- a/samples/client/petstore/python-tornado/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/AnotherFakeApi.md
@@ -15,6 +15,7 @@ To test special tags
 To test special tags and operation ID starting with number
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/FakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/FakeApi.md
@@ -27,6 +27,7 @@ creates an XmlItem
 this route creates an XmlItem
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -74,6 +75,7 @@ No authorization required
 Test serialization of outer boolean types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -121,6 +123,7 @@ No authorization required
 Test serialization of object with outer number type
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -168,6 +171,7 @@ No authorization required
 Test serialization of outer number types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -215,6 +219,7 @@ No authorization required
 Test serialization of outer string types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -262,6 +267,7 @@ No authorization required
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -306,6 +312,7 @@ No authorization required
 
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -354,6 +361,7 @@ To test \"client\" model
 To test \"client\" model
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -403,7 +411,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ### Example
 
-* Basic Authentication (http_basic_test): 
+* Basic Authentication (http_basic_test):
 ```python
 from __future__ import print_function
 import time
@@ -481,6 +489,7 @@ To test enum parameters
 To test enum parameters
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -542,6 +551,7 @@ Fake endpoint to test group parameters (optional)
 Fake endpoint to test group parameters (optional)
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -597,6 +607,7 @@ No authorization required
 test inline additionalProperties
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -642,6 +653,7 @@ No authorization required
 test json serialization of form data
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-tornado/docs/FakeClassnameTags123Api.md
@@ -16,7 +16,7 @@ To test class name in snake case
 
 ### Example
 
-* Api Key Authentication (api_key_query): 
+* Api Key Authentication (api_key_query):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/PetApi.md
+++ b/samples/client/petstore/python-tornado/docs/PetApi.md
@@ -22,7 +22,7 @@ Add a new pet to the store
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -72,7 +72,7 @@ Deletes a pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -126,7 +126,7 @@ Multiple status values can be provided with comma separated strings
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -179,7 +179,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -232,7 +232,7 @@ Returns a single pet
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -285,7 +285,7 @@ Update an existing pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -335,7 +335,7 @@ Updates a pet in the store with form data
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -389,7 +389,7 @@ uploads an image
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -444,7 +444,7 @@ uploads an image (required)
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/StoreApi.md
+++ b/samples/client/petstore/python-tornado/docs/StoreApi.md
@@ -18,6 +18,7 @@ Delete purchase order by ID
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -66,7 +67,7 @@ Returns a map of status codes to quantities
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -116,6 +117,7 @@ Find purchase order by ID
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -162,6 +164,7 @@ No authorization required
 Place an order for a pet
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/UserApi.md
+++ b/samples/client/petstore/python-tornado/docs/UserApi.md
@@ -22,6 +22,7 @@ Create user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -67,6 +68,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -112,6 +114,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -159,6 +162,7 @@ Delete user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -204,6 +208,7 @@ No authorization required
 Get user by user name
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -250,6 +255,7 @@ No authorization required
 Logs user into the system
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -298,6 +304,7 @@ No authorization required
 Logs out current logged in user session
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -341,6 +348,7 @@ Updated user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -59,10 +59,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.username = ""
         # Password for HTTP basic authentication
         self.password = ""
-
-        # access token for OAuth
+        # access token for OAuth/Bearer
         self.access_token = ""
-
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("petstore_api")
@@ -236,7 +234,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': self.get_basic_auth_token()
                 },
-
             'petstore_auth':
                 {
                     'type': 'oauth2',
@@ -244,7 +241,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': 'Bearer ' + self.access_token
                 },
-
         }
 
     def to_debug_report(self):
@@ -281,7 +277,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         servers = self.get_host_settings()
 
         # check array index out of bound
-        if index < 0 or index > len(servers):
+        if index < 0 or index >= len(servers):
             raise ValueError(
                 "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
                 .format(index, len(servers)))


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@wing328 @taxpon @frol @mbohlool @cbornet @kenjones-cisco

### Description of the PR

I think this fixes #1997, if a parameter is nullable, then `None` should be an allowed value.

I ran `./bin/saples/python-petstore-all.sh' it created a bunch of changes that don't seem related, not sure why.

