### PR TITLE
[python-flask] [python-aiohttp] [bug] Fixed handling of dotted module names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
@@ -199,13 +199,13 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
             additionalProperties.put(SUPPORT_PYTHON2, Boolean.TRUE);
             typeMapping.put("long", "long");
         }
-        supportingFiles.add(new SupportingFile("__main__.mustache", packageName, "__main__.py"));
-        supportingFiles.add(new SupportingFile("util.mustache", packageName, "util.py"));
-        supportingFiles.add(new SupportingFile("__init__.mustache", packageName + File.separatorChar + controllerPackage, "__init__.py"));
-        supportingFiles.add(new SupportingFile("security_controller_.mustache", packageName + File.separatorChar + controllerPackage, "security_controller_.py"));
-        supportingFiles.add(new SupportingFile("__init__model.mustache", packageName + File.separatorChar + modelPackage, "__init__.py"));
-        supportingFiles.add(new SupportingFile("base_model_.mustache", packageName + File.separatorChar + modelPackage, "base_model_.py"));
-        supportingFiles.add(new SupportingFile("openapi.mustache", packageName + File.separatorChar + "openapi", "openapi.yaml"));
+        supportingFiles.add(new SupportingFile("__main__.mustache", packagePath(), "__main__.py"));
+        supportingFiles.add(new SupportingFile("util.mustache", packagePath(), "util.py"));
+        supportingFiles.add(new SupportingFile("__init__.mustache", packagePath() + File.separatorChar + controllerPackage, "__init__.py"));
+        supportingFiles.add(new SupportingFile("security_controller_.mustache", packagePath() + File.separatorChar + controllerPackage, "security_controller_.py"));
+        supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + modelPackage, "__init__.py"));
+        supportingFiles.add(new SupportingFile("base_model_.mustache", packagePath() + File.separatorChar + modelPackage, "base_model_.py"));
+        supportingFiles.add(new SupportingFile("openapi.mustache", packagePath() + File.separatorChar + "openapi", "openapi.yaml"));
         addSupportingFiles();
 
         modelPackage = packageName + "." + modelPackage;
@@ -714,6 +714,9 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
         this.packageVersion = packageVersion;
     }
 
+    public String packagePath() {
+        return packageName.replace('.', File.separatorChar);
+    }
 
     @Override
     public String escapeQuotationMark(String input) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAiohttpConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAiohttpConnexionServerCodegen.java
@@ -43,6 +43,6 @@ public class PythonAiohttpConnexionServerCodegen extends PythonAbstractConnexion
     protected void addSupportingFiles() {
         supportingFiles.add(new SupportingFile("conftest.mustache", testPackage, "conftest.py"));
         supportingFiles.add(new SupportingFile("__init__test.mustache", testPackage, "__init__.py"));
-        supportingFiles.add(new SupportingFile("__init__main.mustache", packageName, "__init__.py"));
+        supportingFiles.add(new SupportingFile("__init__main.mustache", packagePath(), "__init__.py"));
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
@@ -49,9 +49,9 @@ public class PythonFlaskConnexionServerCodegen extends PythonAbstractConnexionSe
         supportingFiles.add(new SupportingFile("tox.mustache", "", "tox.ini"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("travis.mustache", "", ".travis.yml"));
-        supportingFiles.add(new SupportingFile("encoder.mustache", packageName, "encoder.py"));
-        supportingFiles.add(new SupportingFile("__init__test.mustache", packageName + File.separatorChar + testPackage, "__init__.py"));
-        supportingFiles.add(new SupportingFile("__init__.mustache", packageName, "__init__.py"));
+        supportingFiles.add(new SupportingFile("encoder.mustache", packagePath(), "encoder.py"));
+        supportingFiles.add(new SupportingFile("__init__test.mustache", packagePath() + File.separatorChar + testPackage, "__init__.py"));
+        supportingFiles.add(new SupportingFile("__init__.mustache", packagePath(), "__init__.py"));
         testPackage = packageName + "." + testPackage;
     }
 }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Previously, if you used a packageName of the form "foo.bar.baz", half of the
generated files of the python generator went into a subdirectory
"foo/bar/baz" (correct), the other half went into a subdirectory
"foo.bar.baz" (incorrect).

@taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess