### PR TITLE
[Python] Add "servers" support in path, operation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -111,7 +111,7 @@ public interface CodegenConfig {
 
     CodegenModel fromModel(String name, Schema schema);
 
-    CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation);
+    CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, List<Server> servers);
 
     List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> schemas);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -34,6 +34,7 @@ public class CodegenOperation {
             returnContainer, summary, unescapedNotes, notes, baseName, defaultResponse; 
     public CodegenDiscriminator discriminator;
     public List<Map<String, String>> consumes, produces, prioritizedContentTypes;
+    public List<CodegenServer> servers = new ArrayList<CodegenServer>();
     public CodegenParameter bodyParam;
     public List<CodegenParameter> allParams = new ArrayList<CodegenParameter>();
     public List<CodegenParameter> bodyParams = new ArrayList<CodegenParameter>();
@@ -317,6 +318,8 @@ public class CodegenOperation {
             return false;
         if (produces != null ? !produces.equals(that.produces) : that.produces != null)
             return false;
+        if (servers != null ? !servers.equals(that.servers) : that.servers != null)
+            return false;
         if (bodyParam != null ? !bodyParam.equals(that.bodyParam) : that.bodyParam != null)
             return false;
         if (allParams != null ? !allParams.equals(that.allParams) : that.allParams != null)
@@ -399,6 +402,7 @@ public class CodegenOperation {
         result = 31 * result + (discriminator != null ? discriminator.hashCode() : 0);
         result = 31 * result + (consumes != null ? consumes.hashCode() : 0);
         result = 31 * result + (produces != null ? produces.hashCode() : 0);
+        result = 31 * result + (servers != null ? servers.hashCode() : 0);
         result = 31 * result + (bodyParam != null ? bodyParam.hashCode() : 0);
         result = 31 * result + (allParams != null ? allParams.hashCode() : 0);
         result = 31 * result + (bodyParams != null ? bodyParams.hashCode() : 0);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1017,7 +1017,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         final List<SecurityRequirement> globalSecurities = openAPI.getSecurity();
         for (Tag tag : tags) {
             try {
-                CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, operation);
+                CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, operation, path.getServers());
                 codegenOperation.tags = new ArrayList<>(tags);
                 config.addOperationToGroup(config.sanitizeTag(tag.getName()), resourcePath, operation, codegenOperation, operations);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -389,8 +390,8 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse methodResponse = findMethodResponse(operation.getResponses());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.MapSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -561,10 +562,10 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
 
         CodegenOperation op = super.fromOperation(
-                path, httpMethod, operation);
+                path, httpMethod, operation, null);
 
         if (op.getHasExamples()) {
             // prepare examples for Apex test classes

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -1130,8 +1131,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
         op.path = sanitizePath(op.path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
@@ -566,9 +567,9 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public CodegenOperation fromOperation(String path, String httpMethod,
-                                          Operation operation) {
+                                          Operation operation, List<Server> servers) {
         Map<String, Schema> definitions = ModelUtils.getSchemas(this.openAPI);
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         /**
          * Check if the operation has a Bash codegen specific description

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -172,8 +173,8 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse apiResponse = findMethodResponse(operation.getResponses());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -227,8 +228,8 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse methodResponse = findMethodResponse(operation.getResponses());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
@@ -458,8 +459,8 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
 
     @Override
-    public CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation) {
-        CodegenOperation op = super.fromOperation(resourcePath, httpMethod, operation);
+    public CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(resourcePath, httpMethod, operation, servers);
 
         List<String> path = pathToServantRoute(op.path, op.pathParams);
         List<String> type = pathToClientType(op.path, op.pathParams);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.servers.Server;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.URLPathUtils;
 
@@ -193,9 +194,9 @@ public class JavaVertXServerCodegen extends AbstractJavaCodegen {
 
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
         CodegenOperation codegenOperation =
-                super.fromOperation(path, httpMethod, operation);
+                super.fromOperation(path, httpMethod, operation, servers);
         codegenOperation.imports.add("MainApiException");
         return codegenOperation;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -19,6 +19,7 @@ package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.openapitools.codegen.*;
 import org.slf4j.Logger;
@@ -242,8 +243,9 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
-                                          Operation operation) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+                                          Operation operation,
+                                          List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
         op.path = encodePath(path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.media.FileSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.XML;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -466,9 +467,9 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
         Map<String, Schema> definitions = ModelUtils.getSchemas(this.openAPI);
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         // The Rust code will need to contain a series of regular expressions.
         // For performance, we'll construct these at start-of-day and re-use

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.Markdown;
@@ -186,8 +187,8 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation);
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
         if (op.returnType != null) {
             op.returnType = normalizeType(op.returnType);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SwiftClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SwiftClientCodegen.java
@@ -20,6 +20,7 @@ package org.openapitools.codegen.languages;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
@@ -509,10 +510,10 @@ public class SwiftClientCodegen extends DefaultCodegen implements CodegenConfig 
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
         path = normalizePath(path); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         // issue 3914 - removed logic designed to remove any parameter of type HeaderParameter
-        return super.fromOperation(path, httpMethod, operation);
+        return super.fromOperation(path, httpMethod, operation, servers);
     }
 
     private static String normalizePath(String path) {

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -86,9 +86,9 @@ class {{classname}}(object):
         local_var_hosts = [{{#servers}}'{{{url}}}'{{^-last}}, {{/-last}}{{/servers}}]  # noqa: E501
         local_var_host = local_var_hosts[0]
         if kwargs.get('_host_index'):
-            if kwags.get('_host_index') < 0 or kawgs.get('_host_index') >= len(local_var_hosts):
+            if int(kwags.get('_host_index')) < 0 or int(kawgs.get('_host_index')) >= len(local_var_hosts):
                 raise ValueError("Invalid host index. Must be 0 <= index < %s" % len(local_var_host))
-            local_var_host = local_var_hosts[kwargs.get('_host_index')]
+            local_var_host = local_var_hosts[int(kwargs.get('_host_index'))]
         {{/servers.0}}
         local_var_params = locals()
 

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -82,6 +82,14 @@ class {{classname}}(object):
                  returns the request thread.
         """
 
+        {{#servers.0}}
+        local_var_hosts = [{{#servers}}'{{{url}}}'{{^-last}}, {{/-last}}{{/servers}}]  # noqa: E501
+        local_var_host = local_var_hosts[0]
+        if kwargs.get('_host_index'):
+            if kwags.get('_host_index') < 0 or kawgs.get('_host_index') >= len(local_var_hosts):
+                raise ValueError("Invalid host index. Must be 0 <= index < %s" % len(local_var_host))
+            local_var_host = local_var_hosts[kwargs.get('_host_index')]
+        {{/servers.0}}
         local_var_params = locals()
 
         all_params = [{{#allParams}}'{{paramName}}'{{#hasMore}}, {{/hasMore}}{{/allParams}}]  # noqa: E501
@@ -91,7 +99,7 @@ class {{classname}}(object):
         all_params.append('_request_timeout')
 
         for key, val in six.iteritems(local_var_params['kwargs']):
-            if key not in all_params:
+            if key not in all_params{{#servers.0}} and key != "_host_index"{{/servers.0}}:
                 raise TypeError(
                     "Got an unexpected keyword argument '%s'"
                     " to method {{operationId}}" % key
@@ -212,6 +220,9 @@ class {{classname}}(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
+            {{#servers.0}}
+            _host=local_var_host,
+            {{/servers.0}}
             collection_formats=collection_formats)
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -107,7 +107,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -154,7 +154,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = {{#asyncio}}await {{/asyncio}}{{#tornado}}yield {{/tornado}}self.request(
@@ -296,7 +300,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -339,7 +343,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -348,7 +352,7 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content, _request_timeout, _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -352,7 +352,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout, _host))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -93,7 +93,7 @@ public class DefaultCodegenTest {
         Assert.assertEquals(createProducesInfo.size(), 0);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
-        CodegenOperation coCreate = codegen.fromOperation("somepath", "post", createOperation);
+        CodegenOperation coCreate = codegen.fromOperation("somepath", "post", createOperation, null);
         Assert.assertTrue(coCreate.hasConsumes);
         Assert.assertEquals(coCreate.consumes.size(), 2);
         Assert.assertFalse(coCreate.hasProduces);
@@ -108,7 +108,7 @@ public class DefaultCodegenTest {
         Assert.assertEquals(updateProducesInfo.size(), 1);
         Assert.assertTrue(updateProducesInfo.contains("application/xml"), "contains 'application/xml'");
 
-        CodegenOperation coUpdate = codegen.fromOperation("somepath", "post", updateOperationWithRef);
+        CodegenOperation coUpdate = codegen.fromOperation("somepath", "post", updateOperationWithRef, null);
         Assert.assertTrue(coUpdate.hasConsumes);
         Assert.assertEquals(coUpdate.consumes.size(), 1);
         Assert.assertEquals(coUpdate.consumes.get(0).get("mediaType"), "application/json");
@@ -124,19 +124,19 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation textOperation = openAPI.getPaths().get("/ping/text").getGet();
-        CodegenOperation coText = codegen.fromOperation("/ping/text", "get", textOperation);
+        CodegenOperation coText = codegen.fromOperation("/ping/text", "get", textOperation, null);
         Assert.assertTrue(coText.hasProduces);
         Assert.assertEquals(coText.produces.size(), 1);
         Assert.assertEquals(coText.produces.get(0).get("mediaType"), "text/plain");
 
         Operation jsonOperation = openAPI.getPaths().get("/ping/json").getGet();
-        CodegenOperation coJson = codegen.fromOperation("/ping/json", "get", jsonOperation);
+        CodegenOperation coJson = codegen.fromOperation("/ping/json", "get", jsonOperation, null);
         Assert.assertTrue(coJson.hasProduces);
         Assert.assertEquals(coJson.produces.size(), 1);
         Assert.assertEquals(coJson.produces.get(0).get("mediaType"), "application/json");
 
         Operation issue443Operation = openAPI.getPaths().get("/other/issue443").getGet();
-        CodegenOperation coIssue443 = codegen.fromOperation("/other/issue443", "get", issue443Operation);
+        CodegenOperation coIssue443 = codegen.fromOperation("/other/issue443", "get", issue443Operation, null);
         Assert.assertTrue(coIssue443.hasProduces);
         Assert.assertEquals(coIssue443.produces.size(), 2);
         Assert.assertEquals(coIssue443.produces.get(0).get("mediaType"), "application/json");
@@ -207,7 +207,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation operation = openAPI.getPaths().get("/test").getGet();
-        CodegenOperation co = codegen.fromOperation("/test", "get", operation);
+        CodegenOperation co = codegen.fromOperation("/test", "get", operation, null);
 
         Assert.assertEquals(co.produces.size(), 1);
         Assert.assertEquals(co.produces.get(0).get("mediaType"), "application/json");
@@ -224,7 +224,7 @@ public class DefaultCodegenTest {
 
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
-        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation);
+        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
         Assert.assertEquals(co.path, "/some/path");
         Assert.assertEquals(co.allParams.size(), 2);
         List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
@@ -443,7 +443,7 @@ public class DefaultCodegenTest {
 
         String path = "/person/display/{personId}";
         Operation operation = openAPI.getPaths().get(path).getGet();
-        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation);
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
         verifyPersonDiscriminator(codegenOperation.discriminator);
 
         Schema person = openAPI.getComponents().getSchemas().get("Person");
@@ -471,7 +471,7 @@ public class DefaultCodegenTest {
 
         final String path = "/streams";
         Operation subscriptionOperation = openAPI.getPaths().get("/streams").getPost();
-        CodegenOperation op = codegen.fromOperation(path, "post", subscriptionOperation);
+        CodegenOperation op = codegen.fromOperation(path, "post", subscriptionOperation, null);
 
         Assert.assertFalse(op.isCallbackRequest);
         Assert.assertNotNull(op.operationId);
@@ -528,9 +528,9 @@ public class DefaultCodegenTest {
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
-        CodegenOperation co1 = codegen.fromOperation("/here", "get", operation2);
+        CodegenOperation co1 = codegen.fromOperation("/here", "get", operation2, null);
         Assert.assertEquals(co1.path, "/here");
-        CodegenOperation co2 = codegen.fromOperation("some/path", "get", operation2);
+        CodegenOperation co2 = codegen.fromOperation("some/path", "get", operation2, null);
         Assert.assertEquals(co2.path, "/some/path");
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
@@ -46,7 +46,8 @@ public class BashTest {
             = codegen.fromOperation(
                 "/pet/findByStatus",
                 "GET",
-                findPetsByStatusOperation);
+                findPetsByStatusOperation,
+                null);
 
         Assert.assertTrue(
             op.vendorExtensions.containsKey("x-code-samples"));
@@ -75,7 +76,8 @@ public class BashTest {
             = codegen.fromOperation(
                 "/pet",
                 "POST",
-                addPetOperation);
+                addPetOperation,
+                null);
 
         Assert.assertEquals(op.bodyParams.size(), 1);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -318,7 +318,7 @@ public class DartModelTest {
 
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.returnType, "DateTime");
         Assert.assertEquals(op.bodyParam.dataType, "DateTime");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -66,7 +66,7 @@ public class GoClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/fake";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
         Assert.assertEquals(op.formParams.size(), 2);
         CodegenParameter bp = op.formParams.get(0);
         Assert.assertFalse(bp.isPrimitiveType);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaCXFClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaCXFClientCodegenTest.java
@@ -48,7 +48,7 @@ public class JavaCXFClientCodegenTest {
                         .addApiResponse("400", new ApiResponse().description("Error")));
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema());
         final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
-        final CodegenOperation co = codegen.fromOperation("getAllPets", "GET", operation);
+        final CodegenOperation co = codegen.fromOperation("getAllPets", "GET", operation, null);
 
         Map<String, Object> objs = new HashMap<>();
         objs.put("operations", Collections.singletonMap("operation", Collections.singletonList(co)));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -199,7 +199,7 @@ public class JavaClientCodegenTest {
         final JavaClientCodegen codegen = new JavaClientCodegen();
 
         Operation operation = openAPI.getPaths().get("/ping").getPost();
-        CodegenOperation co = codegen.fromOperation("/ping", "POST", operation);
+        CodegenOperation co = codegen.fromOperation("/ping", "POST", operation, null);
         Assert.assertEquals(co.allParams.size(), 1);
         Assert.assertEquals(co.allParams.get(0).baseType, "MessageEventCoreWithTimeListEntries");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -1059,7 +1059,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
 
         Assert.assertEquals(co.bodyParams.size(), 1);
         CodegenParameter cp1 = co.bodyParams.get(0);
@@ -1090,7 +1090,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
 
         Assert.assertEquals(co.responses.size(), 1);
         CodegenResponse cr = co.responses.get(0);
@@ -1139,7 +1139,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
 
         Assert.assertEquals(co.bodyParams.size(), 1);
         CodegenParameter cp1 = co.bodyParams.get(0);
@@ -1174,7 +1174,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
 
         Assert.assertEquals(co.responses.size(), 1);
         CodegenResponse cr = co.responses.get(0);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
@@ -349,7 +349,7 @@ public class ObjcModelTest {
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertTrue(op.bodyParam.isBinary);
         Assert.assertTrue(op.responses.get(0).isBinary);
@@ -368,7 +368,7 @@ public class ObjcModelTest {
         final PathItem animalOps = animalPaths.get("/animals");
         Assert.assertNotNull(animalOps.getPost());
 
-        final CodegenOperation animalCo = codegen.fromOperation("/animals", "POST", animalOps.getPost());
+        final CodegenOperation animalCo = codegen.fromOperation("/animals", "POST", animalOps.getPost(), null);
         Assert.assertEquals(animalCo.imports.size(), 1);
         Assert.assertTrue(animalCo.imports.contains("OAIAnimal"));
 
@@ -376,7 +376,7 @@ public class ObjcModelTest {
         final PathItem insectOps = insectPaths.get("/insects");
         Assert.assertNotNull(insectOps.getPost());
 
-        final CodegenOperation insectCo = codegen.fromOperation("/insects", "POST", insectOps.getPost());
+        final CodegenOperation insectCo = codegen.fromOperation("/insects", "POST", insectOps.getPost(), null);
         Assert.assertEquals(insectCo.imports.size(), 1);
         Assert.assertTrue(insectCo.imports.contains("OAIInsect"));
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
@@ -65,7 +65,7 @@ public class PerlClientCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation operation = openAPI.getPaths().get("/issue677").getPost();
-        CodegenOperation co = codegen.fromOperation("/issue677", "POST", operation);
+        CodegenOperation co = codegen.fromOperation("/issue677", "POST", operation, null);
         Assert.assertNotNull(co);
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -385,7 +385,7 @@ public class PhpModelTest {
 
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.returnType, "\\DateTime");
         Assert.assertEquals(op.bodyParam.dataType, "\\DateTime");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -66,7 +66,7 @@ public class PythonClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p);
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
         // pattern_no_forward_slashes '^pattern$'
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/'

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonTest.java
@@ -52,7 +52,7 @@ public class PythonTest {
 
         final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
         final Operation operation = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation);
+        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
         Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
         Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -152,7 +152,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/fake";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p);
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
         Assert.assertEquals(op.formParams.size(), 2);
         CodegenParameter fp = op.formParams.get(0);
         Assert.assertEquals(fp.dataType, "Array<String>");
@@ -168,7 +168,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/pet";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
         Assert.assertEquals(op.bodyParams.size(), 1);
         CodegenParameter bp = op.bodyParams.get(0);
         Assert.assertEquals(bp.example, "OnlinePetstore::Pet.new");
@@ -299,7 +299,7 @@ public class RubyClientCodegenTest {
         final String path = "/pet/{petId}";
 
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.pathParams.size(), 1);
         CodegenParameter pp = op.pathParams.get(0);
@@ -321,7 +321,7 @@ public class RubyClientCodegenTest {
         final String path = "/pet/{petId}";
 
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         // path parameter x-nullable test
         Assert.assertEquals(op.pathParams.size(), 1);
@@ -541,7 +541,7 @@ public class RubyClientCodegenTest {
         final String path = "/store/order/{orderId}";
 
         final Operation p = openAPI.getPaths().get(path).getDelete();
-        final CodegenOperation op = codegen.fromOperation(path, "delete", p);
+        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
 
         CodegenParameter pp = op.pathParams.get(0);
         Assert.assertEquals(pp.example, "'orderid123'");
@@ -557,7 +557,7 @@ public class RubyClientCodegenTest {
         final String path = "/store/order/{orderId}";
 
         final Operation p = openAPI.getPaths().get(path).getDelete();
-        final CodegenOperation op = codegen.fromOperation(path, "delete", p);
+        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
 
         CodegenParameter pp = op.pathParams.get(0);
         Assert.assertEquals(pp.example, "'orderid123'");
@@ -577,7 +577,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p);
+        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
         // pattern_no_forward_slashes '^pattern$'
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/i'

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift3/Swift3CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift3/Swift3CodegenTest.java
@@ -95,7 +95,7 @@ public class Swift3CodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.returnType, "Data");
         Assert.assertEquals(op.bodyParam.dataType, "Data");
@@ -110,7 +110,7 @@ public class Swift3CodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.returnType, "ISOFullDate");
         Assert.assertEquals(op.bodyParam.dataType, "ISOFullDate");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4CodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift4/Swift4CodegenTest.java
@@ -98,7 +98,7 @@ public class Swift4CodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.returnType, "URL");
         Assert.assertEquals(op.bodyParam.dataType, "URL");
@@ -113,7 +113,7 @@ public class Swift4CodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p);
+        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
 
         Assert.assertEquals(op.returnType, "Date");
         Assert.assertEquals(op.bodyParam.dataType, "Date");

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -30,6 +30,9 @@ paths:
                   string:
                     $ref: '#/components/schemas/Foo'
   /pet:
+    servers:
+    - url: 'http://petstore.swagger.io/v2'
+    - url: 'http://path-server-test.petstore.local/v2'
     post:
       tags:
         - pet

--- a/samples/client/petstore/python-asyncio/README.md
+++ b/samples/client/petstore/python-asyncio/README.md
@@ -51,6 +51,7 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
+
 # create an instance of the API class
 api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
 body = petstore_api.Client() # Client | client model
@@ -158,15 +159,18 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+
 ## api_key_query
 
 - **Type**: API key
 - **API key parameter name**: api_key_query
 - **Location**: URL query string
 
+
 ## http_basic_test
 
 - **Type**: HTTP basic authentication
+
 
 ## petstore_auth
 

--- a/samples/client/petstore/python-asyncio/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/AnotherFakeApi.md
@@ -15,6 +15,7 @@ To test special tags
 To test special tags and operation ID starting with number
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/FakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeApi.md
@@ -27,6 +27,7 @@ creates an XmlItem
 this route creates an XmlItem
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -74,6 +75,7 @@ No authorization required
 Test serialization of outer boolean types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -121,6 +123,7 @@ No authorization required
 Test serialization of object with outer number type
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -168,6 +171,7 @@ No authorization required
 Test serialization of outer number types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -215,6 +219,7 @@ No authorization required
 Test serialization of outer string types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -262,6 +267,7 @@ No authorization required
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -306,6 +312,7 @@ No authorization required
 
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -354,6 +361,7 @@ To test \"client\" model
 To test \"client\" model
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -403,7 +411,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ### Example
 
-* Basic Authentication (http_basic_test): 
+* Basic Authentication (http_basic_test):
 ```python
 from __future__ import print_function
 import time
@@ -481,6 +489,7 @@ To test enum parameters
 To test enum parameters
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -542,6 +551,7 @@ Fake endpoint to test group parameters (optional)
 Fake endpoint to test group parameters (optional)
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -597,6 +607,7 @@ No authorization required
 test inline additionalProperties
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -642,6 +653,7 @@ No authorization required
 test json serialization of form data
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeClassnameTags123Api.md
@@ -16,7 +16,7 @@ To test class name in snake case
 
 ### Example
 
-* Api Key Authentication (api_key_query): 
+* Api Key Authentication (api_key_query):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/PetApi.md
+++ b/samples/client/petstore/python-asyncio/docs/PetApi.md
@@ -22,7 +22,7 @@ Add a new pet to the store
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -72,7 +72,7 @@ Deletes a pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -126,7 +126,7 @@ Multiple status values can be provided with comma separated strings
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -179,7 +179,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -232,7 +232,7 @@ Returns a single pet
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -285,7 +285,7 @@ Update an existing pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -335,7 +335,7 @@ Updates a pet in the store with form data
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -389,7 +389,7 @@ uploads an image
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -444,7 +444,7 @@ uploads an image (required)
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/StoreApi.md
+++ b/samples/client/petstore/python-asyncio/docs/StoreApi.md
@@ -18,6 +18,7 @@ Delete purchase order by ID
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -66,7 +67,7 @@ Returns a map of status codes to quantities
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -116,6 +117,7 @@ Find purchase order by ID
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -162,6 +164,7 @@ No authorization required
 Place an order for a pet
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/docs/UserApi.md
+++ b/samples/client/petstore/python-asyncio/docs/UserApi.md
@@ -22,6 +22,7 @@ Create user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -67,6 +68,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -112,6 +114,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -159,6 +162,7 @@ Delete user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -204,6 +208,7 @@ No authorization required
 Get user by user name
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -250,6 +255,7 @@ No authorization required
 Logs user into the system
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -298,6 +304,7 @@ No authorization required
 Logs out current logged in user session
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -341,6 +348,7 @@ Updated user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -109,7 +109,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -156,7 +156,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = await self.request(
@@ -289,7 +293,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -332,7 +336,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -341,7 +345,7 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content, _request_timeout, _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -345,7 +345,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout, _host))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -59,10 +59,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.username = ""
         # Password for HTTP basic authentication
         self.password = ""
-
-        # access token for OAuth
+        # access token for OAuth/Bearer
         self.access_token = ""
-
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("petstore_api")
@@ -236,7 +234,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': self.get_basic_auth_token()
                 },
-
             'petstore_auth':
                 {
                     'type': 'oauth2',
@@ -244,7 +241,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': 'Bearer ' + self.access_token
                 },
-
         }
 
     def to_debug_report(self):
@@ -281,7 +277,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         servers = self.get_host_settings()
 
         # check array index out of bound
-        if index < 0 or index > len(servers):
+        if index < 0 or index >= len(servers):
             raise ValueError(
                 "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
                 .format(index, len(servers)))

--- a/samples/client/petstore/python-tornado/README.md
+++ b/samples/client/petstore/python-tornado/README.md
@@ -51,6 +51,7 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
+
 # create an instance of the API class
 api_instance = petstore_api.AnotherFakeApi(petstore_api.ApiClient(configuration))
 body = petstore_api.Client() # Client | client model
@@ -158,15 +159,18 @@ Class | Method | HTTP request | Description
 - **API key parameter name**: api_key
 - **Location**: HTTP header
 
+
 ## api_key_query
 
 - **Type**: API key
 - **API key parameter name**: api_key_query
 - **Location**: URL query string
 
+
 ## http_basic_test
 
 - **Type**: HTTP basic authentication
+
 
 ## petstore_auth
 

--- a/samples/client/petstore/python-tornado/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/AnotherFakeApi.md
@@ -15,6 +15,7 @@ To test special tags
 To test special tags and operation ID starting with number
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/FakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/FakeApi.md
@@ -27,6 +27,7 @@ creates an XmlItem
 this route creates an XmlItem
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -74,6 +75,7 @@ No authorization required
 Test serialization of outer boolean types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -121,6 +123,7 @@ No authorization required
 Test serialization of object with outer number type
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -168,6 +171,7 @@ No authorization required
 Test serialization of outer number types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -215,6 +219,7 @@ No authorization required
 Test serialization of outer string types
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -262,6 +267,7 @@ No authorization required
 For this test, the body for this request much reference a schema named `File`.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -306,6 +312,7 @@ No authorization required
 
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -354,6 +361,7 @@ To test \"client\" model
 To test \"client\" model
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -403,7 +411,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ### Example
 
-* Basic Authentication (http_basic_test): 
+* Basic Authentication (http_basic_test):
 ```python
 from __future__ import print_function
 import time
@@ -481,6 +489,7 @@ To test enum parameters
 To test enum parameters
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -542,6 +551,7 @@ Fake endpoint to test group parameters (optional)
 Fake endpoint to test group parameters (optional)
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -597,6 +607,7 @@ No authorization required
 test inline additionalProperties
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -642,6 +653,7 @@ No authorization required
 test json serialization of form data
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/python-tornado/docs/FakeClassnameTags123Api.md
@@ -16,7 +16,7 @@ To test class name in snake case
 
 ### Example
 
-* Api Key Authentication (api_key_query): 
+* Api Key Authentication (api_key_query):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/PetApi.md
+++ b/samples/client/petstore/python-tornado/docs/PetApi.md
@@ -22,7 +22,7 @@ Add a new pet to the store
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -72,7 +72,7 @@ Deletes a pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -126,7 +126,7 @@ Multiple status values can be provided with comma separated strings
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -179,7 +179,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -232,7 +232,7 @@ Returns a single pet
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -285,7 +285,7 @@ Update an existing pet
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -335,7 +335,7 @@ Updates a pet in the store with form data
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -389,7 +389,7 @@ uploads an image
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time
@@ -444,7 +444,7 @@ uploads an image (required)
 
 ### Example
 
-* OAuth Authentication (petstore_auth): 
+* OAuth Authentication (petstore_auth):
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/StoreApi.md
+++ b/samples/client/petstore/python-tornado/docs/StoreApi.md
@@ -18,6 +18,7 @@ Delete purchase order by ID
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -66,7 +67,7 @@ Returns a map of status codes to quantities
 
 ### Example
 
-* Api Key Authentication (api_key): 
+* Api Key Authentication (api_key):
 ```python
 from __future__ import print_function
 import time
@@ -116,6 +117,7 @@ Find purchase order by ID
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -162,6 +164,7 @@ No authorization required
 Place an order for a pet
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/docs/UserApi.md
+++ b/samples/client/petstore/python-tornado/docs/UserApi.md
@@ -22,6 +22,7 @@ Create user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -67,6 +68,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -112,6 +114,7 @@ No authorization required
 Creates list of users with given input array
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -159,6 +162,7 @@ Delete user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -204,6 +208,7 @@ No authorization required
 Get user by user name
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -250,6 +255,7 @@ No authorization required
 Logs user into the system
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -298,6 +304,7 @@ No authorization required
 Logs out current logged in user session
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time
@@ -341,6 +348,7 @@ Updated user
 This can only be done by the logged in user.
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -111,7 +111,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -158,7 +158,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = yield self.request(
@@ -291,7 +295,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -334,7 +338,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -343,7 +347,7 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content, _request_timeout, _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -347,7 +347,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout, _host))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -59,10 +59,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.username = ""
         # Password for HTTP basic authentication
         self.password = ""
-
-        # access token for OAuth
+        # access token for OAuth/Bearer
         self.access_token = ""
-
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("petstore_api")
@@ -236,7 +234,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': self.get_basic_auth_token()
                 },
-
             'petstore_auth':
                 {
                     'type': 'oauth2',
@@ -244,7 +241,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': 'Bearer ' + self.access_token
                 },
-
         }
 
     def to_debug_report(self):
@@ -281,7 +277,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         servers = self.get_host_settings()
 
         # check array index out of bound
-        if index < 0 or index > len(servers):
+        if index < 0 or index >= len(servers):
             raise ValueError(
                 "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
                 .format(index, len(servers)))

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -345,7 +345,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout, _host))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -109,7 +109,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -156,7 +156,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = self.request(
@@ -289,7 +293,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -332,7 +336,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -341,7 +345,7 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content, _request_timeout, _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -68,6 +68,12 @@ class PetApi(object):
                  returns the request thread.
         """
 
+        local_var_hosts = ['http://operation-server-test.petstore.swagger.io/v2']  # noqa: E501
+        local_var_host = local_var_hosts[0]
+        if kwargs.get('_host_index'):
+            if kwags.get('_host_index') < 0 or kawgs.get('_host_index') >= len(local_var_hosts):
+                raise ValueError("Invalid host index. Must be 0 <= index < %s" % len(local_var_host))
+            local_var_host = local_var_hosts[kwargs.get('_host_index')]
         local_var_params = locals()
 
         all_params = ['pet']  # noqa: E501
@@ -77,7 +83,7 @@ class PetApi(object):
         all_params.append('_request_timeout')
 
         for key, val in six.iteritems(local_var_params['kwargs']):
-            if key not in all_params:
+            if key not in all_params and key != "_host_index":
                 raise TypeError(
                     "Got an unexpected keyword argument '%s'"
                     " to method add_pet" % key
@@ -124,6 +130,7 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
+            _host=local_var_host,
             collection_formats=collection_formats)
 
     def delete_pet(self, pet_id, **kwargs):  # noqa: E501
@@ -546,6 +553,12 @@ class PetApi(object):
                  returns the request thread.
         """
 
+        local_var_hosts = ['http://petstore.swagger.io/v2', 'http://path-server-test.petstore.local/v2']  # noqa: E501
+        local_var_host = local_var_hosts[0]
+        if kwargs.get('_host_index'):
+            if kwags.get('_host_index') < 0 or kawgs.get('_host_index') >= len(local_var_hosts):
+                raise ValueError("Invalid host index. Must be 0 <= index < %s" % len(local_var_host))
+            local_var_host = local_var_hosts[kwargs.get('_host_index')]
         local_var_params = locals()
 
         all_params = ['pet']  # noqa: E501
@@ -555,7 +568,7 @@ class PetApi(object):
         all_params.append('_request_timeout')
 
         for key, val in six.iteritems(local_var_params['kwargs']):
-            if key not in all_params:
+            if key not in all_params and key != "_host_index":
                 raise TypeError(
                     "Got an unexpected keyword argument '%s'"
                     " to method update_pet" % key
@@ -602,6 +615,7 @@ class PetApi(object):
             _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
+            _host=local_var_host,
             collection_formats=collection_formats)
 
     def update_pet_with_form(self, pet_id, **kwargs):  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -68,12 +68,12 @@ class PetApi(object):
                  returns the request thread.
         """
 
-        local_var_hosts = ['http://operation-server-test.petstore.swagger.io/v2']  # noqa: E501
+        local_var_hosts = ['http://petstore.swagger.io/v2', 'http://path-server-test.petstore.local/v2']  # noqa: E501
         local_var_host = local_var_hosts[0]
         if kwargs.get('_host_index'):
-            if kwags.get('_host_index') < 0 or kawgs.get('_host_index') >= len(local_var_hosts):
+            if int(kwags.get('_host_index')) < 0 or int(kawgs.get('_host_index')) >= len(local_var_hosts):
                 raise ValueError("Invalid host index. Must be 0 <= index < %s" % len(local_var_host))
-            local_var_host = local_var_hosts[kwargs.get('_host_index')]
+            local_var_host = local_var_hosts[int(kwargs.get('_host_index'))]
         local_var_params = locals()
 
         all_params = ['pet']  # noqa: E501
@@ -556,9 +556,9 @@ class PetApi(object):
         local_var_hosts = ['http://petstore.swagger.io/v2', 'http://path-server-test.petstore.local/v2']  # noqa: E501
         local_var_host = local_var_hosts[0]
         if kwargs.get('_host_index'):
-            if kwags.get('_host_index') < 0 or kawgs.get('_host_index') >= len(local_var_hosts):
+            if int(kwags.get('_host_index')) < 0 or int(kawgs.get('_host_index')) >= len(local_var_hosts):
                 raise ValueError("Invalid host index. Must be 0 <= index < %s" % len(local_var_host))
-            local_var_host = local_var_hosts[kwargs.get('_host_index')]
+            local_var_host = local_var_hosts[int(kwargs.get('_host_index'))]
         local_var_params = locals()
 
         all_params = ['pet']  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -345,7 +345,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout, _host))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -109,7 +109,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -156,7 +156,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = self.request(
@@ -289,7 +293,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -332,7 +336,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -341,7 +345,7 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content, _request_timeout, _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Added "servers" support in path, operation
- Tested locally to ensure the servers defined in operation override those defined in path

Dependency: https://github.com/OpenAPITools/openapi-generator/pull/2048

cc @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01)



