### PR TITLE
[PHP-Symfony] Fix JMSSerializerBundle version

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "symfony/validator": "*",
-        "jms/serializer-bundle": "*",
+        "jms/serializer-bundle": "^2.0",
         "symfony/framework-bundle": "^2.3|^3.0|^4.1"
     },
     "require-dev": {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "symfony/validator": "*",
-        "jms/serializer-bundle": "*",
+        "jms/serializer-bundle": "^2.0",
         "symfony/framework-bundle": "^2.3|^3.0|^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #1996
Current version of code is not compatible with JSMSerializerBundle:>=3.0