### PR TITLE
Add `controller.service_arguments` tag to controllers to make them public

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
@@ -28,6 +28,7 @@ services:
          - [setSerializer, ['@{{bundleAlias}}.service.serializer']]
          - [setValidator,  ['@{{bundleAlias}}.service.validator']]
          - [setApiServer,  ['@{{bundleAlias}}.api.api_server']]
+        tags: ['controller.service_arguments']
 
 {{/operations}}
 {{/apis}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
@@ -25,6 +25,7 @@ services:
          - [setSerializer, ['@open_apiserver.service.serializer']]
          - [setValidator,  ['@open_apiserver.service.validator']]
          - [setApiServer,  ['@open_apiserver.api.api_server']]
+        tags: ['controller.service_arguments']
 
     open_apiserver.controller.store:
         class: OpenAPI\Server\Controller\StoreController
@@ -32,6 +33,7 @@ services:
          - [setSerializer, ['@open_apiserver.service.serializer']]
          - [setValidator,  ['@open_apiserver.service.validator']]
          - [setApiServer,  ['@open_apiserver.api.api_server']]
+        tags: ['controller.service_arguments']
 
     open_apiserver.controller.user:
         class: OpenAPI\Server\Controller\UserController
@@ -39,4 +41,5 @@ services:
          - [setSerializer, ['@open_apiserver.service.serializer']]
          - [setValidator,  ['@open_apiserver.service.validator']]
          - [setApiServer,  ['@open_apiserver.api.api_server']]
+        tags: ['controller.service_arguments']
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #1002 
Continues #1003

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon