### PR TITLE
Add "servers" support to operation, path in the JS client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -122,18 +122,26 @@
     return param.toString();
   };
 
-{{#emitJSDoc}}  /**
+{{#emitJSDoc}}
+ /**
    * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
    * NOTE: query parameters are not handled here.
    * @param {String} path The path to append to the base URL.
    * @param {Object} pathParams The parameter values to append.
    * @returns {String} The encoded path with parameter values substituted.
    */
-{{/emitJSDoc}}  exports.prototype.buildUrl = function(path, pathParams) {
+{{/emitJSDoc}}
+  exports.prototype.buildUrl = function(path, pathParams, apiBasePath) {
     if (!path.match(/^\//)) {
       path = '/' + path;
     }
     var url = this.basePath + path;
+
+    // use API (operation, path) base path if defined
+    if (apiBasePath !== undefined) {
+        url = apiBasePath + path;
+    }
+
     var _this = this;
     url = url.replace(/\{([\w-]+)\}/g, function(fullMatch, key) {
       var value;
@@ -390,10 +398,10 @@
    */
 {{/emitJSDoc}}  exports.prototype.callApi = function callApi(path, httpMethod, pathParams,
       queryParams, collectionQueryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-      returnType{{^usePromises}}, callback{{/usePromises}}) {
+      returnType, apiBasePath{{^usePromises}}, callback{{/usePromises}}) {
 
     var _this = this;
-    var url = this.buildUrl(path, pathParams);
+    var url = this.buildUrl(path, pathParams, apiBasePath);
     var request = superagent(httpMethod, url);
 
     if (this.plugins !== null) {

--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -138,7 +138,7 @@
     var url = this.basePath + path;
 
     // use API (operation, path) base path if defined
-    if (apiBasePath !== undefined) {
+    if (apiBasePath !== null && apiBasePath !== undefined) {
         url = apiBasePath + path;
     }
 

--- a/modules/openapi-generator/src/main/resources/Javascript/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/api.mustache
@@ -85,11 +85,21 @@
       var contentTypes = [<#consumes>'<& mediaType>'<#hasMore>, </hasMore></consumes>];
       var accepts = [<#produces>'<& mediaType>'<#hasMore>, </hasMore></produces>];
       var returnType = <#vendorExtensions.x-return-type><&vendorExtensions.x-return-type></vendorExtensions.x-return-type><^vendorExtensions.x-return-type>null</vendorExtensions.x-return-type>;
+      <#servers.0>
+      let basePaths = [<#servers>'<url>'<^-last>, </-last></servers>];
+      let basePath = basePaths[0]; // by default use the first one in "servers" defined in OpenAPI
+      if (typeof opts['_base_path_index'] !== 'undefined') {
+        if (opts['_base_path_index'] < 0 || opts['_base_path_index'] >= basePaths.length) {
+          throw new Error("Invalid index " + opts['_base_path_index'] + " when selecting the host settings. Must be less than " + basePaths.length);
+        }
+        basePath = basePaths[opts['_base_path_index']];
+      }
 
+      </servers.0>
       return this.apiClient.callApi(
         '<&path>', '<httpMethod>',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType<^usePromises>, callback</usePromises>
+        authNames, contentTypes, accepts, returnType, <#servers.0>basePath</servers.0><^servers.0>null</servers.0><^usePromises>, callback</usePromises>
       );
     }
 <#usePromises>

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -130,7 +130,7 @@ class ApiClient {
         var url = this.basePath + path;
 
         // use API (operation, path) base path if defined
-        if (apiBasePath !== undefined) {
+        if (apiBasePath !== null && apiBasePath !== undefined) {
             url = apiBasePath + path;
         }
 

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -112,19 +112,28 @@ class ApiClient {
         return param.toString();
     }
 
-    {{#emitJSDoc}}/**
+    {{#emitJSDoc}}
+   /**
     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
     * NOTE: query parameters are not handled here.
     * @param {String} path The path to append to the base URL.
     * @param {Object} pathParams The parameter values to append.
+    * @param {String} apiBasePath Base path defined in the path, operation level to override the default one
     * @returns {String} The encoded path with parameter values substituted.
-    */{{/emitJSDoc}}
-    buildUrl(path, pathParams) {
+    */
+    {{/emitJSDoc}}
+    buildUrl(path, pathParams, apiBasePath) {
         if (!path.match(/^\//)) {
             path = '/' + path;
         }
 
         var url = this.basePath + path;
+
+        // use API (operation, path) base path if defined
+        if (apiBasePath !== undefined) {
+            url = apiBasePath + path;
+        }
+
         url = url.replace(/\{([\w-]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
@@ -309,7 +318,8 @@ class ApiClient {
         });
     }
 
-    {{#emitJSDoc}}/**
+    {{#emitJSDoc}}
+   /**
     * Deserializes an HTTP response body into a value of the specified type.
     * @param {Object} response A SuperAgent response object.
     * @param {(String|Array.<String>|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
@@ -335,15 +345,20 @@ class ApiClient {
         return ApiClient.convertToType(data, returnType);
     }
 
-    {{#emitJSDoc}}{{^usePromises}}/**
+    {{#emitJSDoc}}
+    {{^usePromises}}
+   /**
     * Callback function to receive the result of the operation.
     * @callback module:{{#invokerPackage}}{{invokerPackage}}/{{/invokerPackage}}ApiClient~callApiCallback
     * @param {String} error Error message, if any.
     * @param data The data returned by the service call.
     * @param {String} response The complete HTTP response.
-    */{{/usePromises}}{{/emitJSDoc}}
+    */
+    {{/usePromises}}
+    {{/emitJSDoc}}
 
-    {{#emitJSDoc}}/**
+    {{#emitJSDoc}}
+   /**
     * Invokes the REST service using the supplied settings and parameters.
     * @param {String} path The base URL to invoke.
     * @param {String} httpMethod The HTTP method to use.
@@ -356,16 +371,19 @@ class ApiClient {
     * @param {Array.<String>} contentTypes An array of request MIME types.
     * @param {Array.<String>} accepts An array of acceptable response MIME types.
     * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
-    * constructor for a complex type.{{^usePromises}}
-    * @param {module:{{#invokerPackage}}{{invokerPackage}}/{{/invokerPackage}}ApiClient~callApiCallback} callback The callback function.{{/usePromises}}
+    * constructor for a complex type.
+    * @param {String} apiBasePath base path defined in the operation/path level to override the default one 
+    {{^usePromises}}
+    * @param {module:{{#invokerPackage}}{{invokerPackage}}/{{/invokerPackage}}ApiClient~callApiCallback} callback The callback function.
+    {{/usePromises}}
     * @returns {{#usePromises}}{Promise} A {@link https://www.promisejs.org/|Promise} object{{/usePromises}}{{^usePromises}}{Object} The SuperAgent request object{{/usePromises}}.
     */
     {{/emitJSDoc}}
     callApi(path, httpMethod, pathParams,
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-        returnType{{^usePromises}}, callback{{/usePromises}}) {
+        returnType, apiBasePath{{^usePromises}}, callback{{/usePromises}}) {
 
-        var url = this.buildUrl(path, pathParams);
+        var url = this.buildUrl(path, pathParams, apiBasePath);
         var request = superagent(httpMethod, url);
 
         if (this.plugins !== null) {
@@ -446,7 +464,8 @@ class ApiClient {
             }
         }
 
-        {{#usePromises}}return new Promise((resolve, reject) => {
+        {{#usePromises}}
+        return new Promise((resolve, reject) => {
             request.end((error, response) => {
                 if (error) {
                     var err = {};
@@ -470,9 +489,11 @@ class ApiClient {
                     }
                 }
             });
-        });{{/usePromises}}
+        });
 
-        {{^usePromises}}request.end((error, response) => {
+        {{/usePromises}}
+        {{^usePromises}}
+        request.end((error, response) => {
             if (callback) {
                 var data = null;
                 if (!error) {
@@ -490,7 +511,8 @@ class ApiClient {
             }
         });
 
-        return request;{{/usePromises}}
+        return request;
+        {{/usePromises}}
     }
 
     {{#emitJSDoc}}/**

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/api.mustache
@@ -46,12 +46,14 @@ export default class <classname> {
 </emitJSDoc>    <operationId><#usePromises>WithHttpInfo</usePromises>(<vendorExtensions.x-codegen-argList>) {<#hasOptionalParams>
       opts = opts || {};</hasOptionalParams>
       let postBody = <#bodyParam><#required><paramName></required><^required>opts['<paramName>']</required></bodyParam><^bodyParam>null</bodyParam>;
-<#allParams><#required>
+<#allParams>
+<#required>
       // verify the required parameter '<paramName>' is set
       if (<paramName> === undefined || <paramName> === null) {
         throw new Error("Missing the required parameter '<paramName>' when calling <operationId>");
       }
-</required></allParams>
+</required>
+</allParams>
 
       let pathParams = {<#pathParams>
         '<baseName>': <#required><paramName></required><^required>opts['<paramName>']</required><#hasMore>,</hasMore></pathParams>
@@ -70,15 +72,25 @@ export default class <classname> {
       let contentTypes = [<#consumes>'<& mediaType>'<#hasMore>, </hasMore></consumes>];
       let accepts = [<#produces>'<& mediaType>'<#hasMore>, </hasMore></produces>];
       let returnType = <#vendorExtensions.x-return-type><&vendorExtensions.x-return-type></vendorExtensions.x-return-type><^vendorExtensions.x-return-type>null</vendorExtensions.x-return-type>;
+      <#servers.0>
+      let basePaths = [<#servers>'<url>'<^-last>, </-last></servers>];
+      let basePath = basePaths[0]; // by default use the first one in "servers" defined in OpenAPI
+      if (typeof opts['_base_path_index'] !== 'undefined') {
+        if (opts['_base_path_index'] < 0 || opts['_base_path_index'] >= basePaths.length) {
+          throw new Error("Invalid index " + opts['_base_path_index'] + " when selecting the host settings. Must be less than " + basePaths.length);
+        }
+        basePath = basePaths[opts['_base_path_index']];
+      }
 
+      </servers.0>
       return this.apiClient.callApi(
         '<&path>', '<httpMethod>',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType<^usePromises>, callback</usePromises>
+        authNames, contentTypes, accepts, returnType, <#servers.0>basePath</servers.0><^servers.0>null</servers.0><^usePromises>, callback</usePromises>
       );
     }
 <#usePromises>
-    <#emitJSDoc>
+<#emitJSDoc>
 
     /**<#summary>
      * <summary></summary><#notes>
@@ -90,7 +102,8 @@ export default class <classname> {
      * data is of type: {@link <&vendorExtensions.x-jsdoc-type>}</returnType></usePromises><#usePromises>
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}<#returnType>, with data of type {@link <&vendorExtensions.x-jsdoc-type>}</returnType></usePromises>
      */
-</emitJSDoc>    <operationId>(<vendorExtensions.x-codegen-argList>) {
+</emitJSDoc>
+    <operationId>(<vendorExtensions.x-codegen-argList>) {
       return this.<operationId>WithHttpInfo(<vendorExtensions.x-codegen-argList>)
         .then(function(response_and_data) {
           return response_and_data.data;

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -112,19 +112,26 @@ class ApiClient {
         return param.toString();
     }
 
-    /**
+   /**
     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
     * NOTE: query parameters are not handled here.
     * @param {String} path The path to append to the base URL.
     * @param {Object} pathParams The parameter values to append.
+    * @param {String} apiBasePath Base path defined in the path, operation level to override the default one
     * @returns {String} The encoded path with parameter values substituted.
     */
-    buildUrl(path, pathParams) {
+    buildUrl(path, pathParams, apiBasePath) {
         if (!path.match(/^\//)) {
             path = '/' + path;
         }
 
         var url = this.basePath + path;
+
+        // use API (operation, path) base path if defined
+        if (apiBasePath !== undefined) {
+            url = apiBasePath + path;
+        }
+
         url = url.replace(/\{([\w-]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
@@ -308,7 +315,7 @@ class ApiClient {
         });
     }
 
-    /**
+   /**
     * Deserializes an HTTP response body into a value of the specified type.
     * @param {Object} response A SuperAgent response object.
     * @param {(String|Array.<String>|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
@@ -333,7 +340,7 @@ class ApiClient {
         return ApiClient.convertToType(data, returnType);
     }
 
-    /**
+   /**
     * Callback function to receive the result of the operation.
     * @callback module:ApiClient~callApiCallback
     * @param {String} error Error message, if any.
@@ -341,7 +348,7 @@ class ApiClient {
     * @param {String} response The complete HTTP response.
     */
 
-    /**
+   /**
     * Invokes the REST service using the supplied settings and parameters.
     * @param {String} path The base URL to invoke.
     * @param {String} httpMethod The HTTP method to use.
@@ -355,14 +362,15 @@ class ApiClient {
     * @param {Array.<String>} accepts An array of acceptable response MIME types.
     * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
     * constructor for a complex type.
+    * @param {String} apiBasePath base path defined in the operation/path level to override the default one 
     * @param {module:ApiClient~callApiCallback} callback The callback function.
     * @returns {Object} The SuperAgent request object.
     */
     callApi(path, httpMethod, pathParams,
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-        returnType, callback) {
+        returnType, apiBasePath, callback) {
 
-        var url = this.buildUrl(path, pathParams);
+        var url = this.buildUrl(path, pathParams, apiBasePath);
         var request = superagent(httpMethod, url);
 
         if (this.plugins !== null) {
@@ -442,8 +450,6 @@ class ApiClient {
                 request.withCredentials();
             }
         }
-
-        
 
         request.end((error, response) => {
             if (callback) {

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -128,7 +128,7 @@ class ApiClient {
         var url = this.basePath + path;
 
         // use API (operation, path) base path if defined
-        if (apiBasePath !== undefined) {
+        if (apiBasePath !== null && apiBasePath !== undefined) {
             url = apiBasePath + path;
         }
 

--- a/samples/client/petstore/javascript-es6/src/api/AnotherFakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/AnotherFakeApi.js
@@ -51,12 +51,10 @@ export default class AnotherFakeApi {
      */
     call123testSpecialTags(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling call123testSpecialTags");
       }
-
 
       let pathParams = {
       };
@@ -71,11 +69,10 @@ export default class AnotherFakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/another-fake/dummy', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -54,12 +54,10 @@ export default class FakeApi {
      */
     createXmlItem(xmlItem, callback) {
       let postBody = xmlItem;
-
       // verify the required parameter 'xmlItem' is set
       if (xmlItem === undefined || xmlItem === null) {
         throw new Error("Missing the required parameter 'xmlItem' when calling createXmlItem");
       }
-
 
       let pathParams = {
       };
@@ -74,11 +72,10 @@ export default class FakeApi {
       let contentTypes = ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/create_xml_item', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -101,7 +98,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -115,11 +111,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = 'Boolean';
-
       return this.apiClient.callApi(
         '/fake/outer/boolean', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -142,7 +137,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -156,11 +150,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = OuterComposite;
-
       return this.apiClient.callApi(
         '/fake/outer/composite', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -183,7 +176,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -197,11 +189,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = 'Number';
-
       return this.apiClient.callApi(
         '/fake/outer/number', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -224,7 +215,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -238,11 +228,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = 'String';
-
       return this.apiClient.callApi(
         '/fake/outer/string', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -261,12 +250,10 @@ export default class FakeApi {
      */
     testBodyWithFileSchema(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testBodyWithFileSchema");
       }
-
 
       let pathParams = {
       };
@@ -281,11 +268,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-file-schema', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -304,17 +290,14 @@ export default class FakeApi {
      */
     testBodyWithQueryParams(query, body, callback) {
       let postBody = body;
-
       // verify the required parameter 'query' is set
       if (query === undefined || query === null) {
         throw new Error("Missing the required parameter 'query' when calling testBodyWithQueryParams");
       }
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testBodyWithQueryParams");
       }
-
 
       let pathParams = {
       };
@@ -330,11 +313,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-query-params', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -355,12 +337,10 @@ export default class FakeApi {
      */
     testClientModel(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testClientModel");
       }
-
 
       let pathParams = {
       };
@@ -375,11 +355,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/fake', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -414,27 +393,22 @@ export default class FakeApi {
     testEndpointParameters(_number, _double, patternWithoutDelimiter, _byte, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter '_number' is set
       if (_number === undefined || _number === null) {
         throw new Error("Missing the required parameter '_number' when calling testEndpointParameters");
       }
-
       // verify the required parameter '_double' is set
       if (_double === undefined || _double === null) {
         throw new Error("Missing the required parameter '_double' when calling testEndpointParameters");
       }
-
       // verify the required parameter 'patternWithoutDelimiter' is set
       if (patternWithoutDelimiter === undefined || patternWithoutDelimiter === null) {
         throw new Error("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
       }
-
       // verify the required parameter '_byte' is set
       if (_byte === undefined || _byte === null) {
         throw new Error("Missing the required parameter '_byte' when calling testEndpointParameters");
       }
-
 
       let pathParams = {
       };
@@ -463,11 +437,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -497,7 +470,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -519,11 +491,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -550,22 +521,18 @@ export default class FakeApi {
     testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'requiredStringGroup' is set
       if (requiredStringGroup === undefined || requiredStringGroup === null) {
         throw new Error("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
       }
-
       // verify the required parameter 'requiredBooleanGroup' is set
       if (requiredBooleanGroup === undefined || requiredBooleanGroup === null) {
         throw new Error("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
       }
-
       // verify the required parameter 'requiredInt64Group' is set
       if (requiredInt64Group === undefined || requiredInt64Group === null) {
         throw new Error("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
       }
-
 
       let pathParams = {
       };
@@ -586,11 +553,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -609,12 +575,10 @@ export default class FakeApi {
      */
     testInlineAdditionalProperties(param, callback) {
       let postBody = param;
-
       // verify the required parameter 'param' is set
       if (param === undefined || param === null) {
         throw new Error("Missing the required parameter 'param' when calling testInlineAdditionalProperties");
       }
-
 
       let pathParams = {
       };
@@ -629,11 +593,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/inline-additionalProperties', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -653,17 +616,14 @@ export default class FakeApi {
      */
     testJsonFormData(param, param2, callback) {
       let postBody = null;
-
       // verify the required parameter 'param' is set
       if (param === undefined || param === null) {
         throw new Error("Missing the required parameter 'param' when calling testJsonFormData");
       }
-
       // verify the required parameter 'param2' is set
       if (param2 === undefined || param2 === null) {
         throw new Error("Missing the required parameter 'param2' when calling testJsonFormData");
       }
-
 
       let pathParams = {
       };
@@ -680,11 +640,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/jsonFormData', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/client/petstore/javascript-es6/src/api/FakeClassnameTags123Api.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeClassnameTags123Api.js
@@ -51,12 +51,10 @@ export default class FakeClassnameTags123Api {
      */
     testClassname(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testClassname");
       }
-
 
       let pathParams = {
       };
@@ -71,11 +69,10 @@ export default class FakeClassnameTags123Api {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/fake_classname_test', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/client/petstore/javascript-es6/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/PetApi.js
@@ -50,12 +50,10 @@ export default class PetApi {
      */
     addPet(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling addPet");
       }
-
 
       let pathParams = {
       };
@@ -70,11 +68,10 @@ export default class PetApi {
       let contentTypes = ['application/json', 'application/xml'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -96,12 +93,10 @@ export default class PetApi {
     deletePet(petId, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling deletePet");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -118,11 +113,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -143,12 +137,10 @@ export default class PetApi {
      */
     findPetsByStatus(status, callback) {
       let postBody = null;
-
       // verify the required parameter 'status' is set
       if (status === undefined || status === null) {
         throw new Error("Missing the required parameter 'status' when calling findPetsByStatus");
       }
-
 
       let pathParams = {
       };
@@ -164,11 +156,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -189,12 +180,10 @@ export default class PetApi {
      */
     findPetsByTags(tags, callback) {
       let postBody = null;
-
       // verify the required parameter 'tags' is set
       if (tags === undefined || tags === null) {
         throw new Error("Missing the required parameter 'tags' when calling findPetsByTags");
       }
-
 
       let pathParams = {
       };
@@ -210,11 +199,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -235,12 +223,10 @@ export default class PetApi {
      */
     getPetById(petId, callback) {
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling getPetById");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -256,11 +242,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Pet;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -279,12 +264,10 @@ export default class PetApi {
      */
     updatePet(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling updatePet");
       }
-
 
       let pathParams = {
       };
@@ -299,11 +282,10 @@ export default class PetApi {
       let contentTypes = ['application/json', 'application/xml'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -326,12 +308,10 @@ export default class PetApi {
     updatePetWithForm(petId, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling updatePetWithForm");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -349,11 +329,10 @@ export default class PetApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -377,12 +356,10 @@ export default class PetApi {
     uploadFile(petId, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling uploadFile");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -400,11 +377,10 @@ export default class PetApi {
       let contentTypes = ['multipart/form-data'];
       let accepts = ['application/json'];
       let returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -428,17 +404,14 @@ export default class PetApi {
     uploadFileWithRequiredFile(petId, requiredFile, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
       }
-
       // verify the required parameter 'requiredFile' is set
       if (requiredFile === undefined || requiredFile === null) {
         throw new Error("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -456,11 +429,10 @@ export default class PetApi {
       let contentTypes = ['multipart/form-data'];
       let accepts = ['application/json'];
       let returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/fake/{petId}/uploadImageWithRequiredFile', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/client/petstore/javascript-es6/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/StoreApi.js
@@ -50,12 +50,10 @@ export default class StoreApi {
      */
     deleteOrder(orderId, callback) {
       let postBody = null;
-
       // verify the required parameter 'orderId' is set
       if (orderId === undefined || orderId === null) {
         throw new Error("Missing the required parameter 'orderId' when calling deleteOrder");
       }
-
 
       let pathParams = {
         'order_id': orderId
@@ -71,11 +69,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -96,7 +93,6 @@ export default class StoreApi {
     getInventory(callback) {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -110,11 +106,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = {'String': 'Number'};
-
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -135,12 +130,10 @@ export default class StoreApi {
      */
     getOrderById(orderId, callback) {
       let postBody = null;
-
       // verify the required parameter 'orderId' is set
       if (orderId === undefined || orderId === null) {
         throw new Error("Missing the required parameter 'orderId' when calling getOrderById");
       }
-
 
       let pathParams = {
         'order_id': orderId
@@ -156,11 +149,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -180,12 +172,10 @@ export default class StoreApi {
      */
     placeOrder(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling placeOrder");
       }
-
 
       let pathParams = {
       };
@@ -200,11 +190,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/client/petstore/javascript-es6/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/UserApi.js
@@ -50,12 +50,10 @@ export default class UserApi {
      */
     createUser(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling createUser");
       }
-
 
       let pathParams = {
       };
@@ -70,11 +68,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -93,12 +90,10 @@ export default class UserApi {
      */
     createUsersWithArrayInput(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling createUsersWithArrayInput");
       }
-
 
       let pathParams = {
       };
@@ -113,11 +108,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -136,12 +130,10 @@ export default class UserApi {
      */
     createUsersWithListInput(body, callback) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling createUsersWithListInput");
       }
-
 
       let pathParams = {
       };
@@ -156,11 +148,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -180,12 +171,10 @@ export default class UserApi {
      */
     deleteUser(username, callback) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling deleteUser");
       }
-
 
       let pathParams = {
         'username': username
@@ -201,11 +190,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -225,12 +213,10 @@ export default class UserApi {
      */
     getUserByName(username, callback) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling getUserByName");
       }
-
 
       let pathParams = {
         'username': username
@@ -246,11 +232,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = User;
-
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -271,17 +256,14 @@ export default class UserApi {
      */
     loginUser(username, password, callback) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling loginUser");
       }
-
       // verify the required parameter 'password' is set
       if (password === undefined || password === null) {
         throw new Error("Missing the required parameter 'password' when calling loginUser");
       }
-
 
       let pathParams = {
       };
@@ -298,11 +280,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = 'String';
-
       return this.apiClient.callApi(
         '/user/login', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -321,7 +302,6 @@ export default class UserApi {
     logoutUser(callback) {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -335,11 +315,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/logout', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -360,17 +339,14 @@ export default class UserApi {
      */
     updateUser(username, body, callback) {
       let postBody = body;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling updateUser");
       }
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling updateUser");
       }
-
 
       let pathParams = {
         'username': username
@@ -386,11 +362,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -128,7 +128,7 @@ class ApiClient {
         var url = this.basePath + path;
 
         // use API (operation, path) base path if defined
-        if (apiBasePath !== undefined) {
+        if (apiBasePath !== null && apiBasePath !== undefined) {
             url = apiBasePath + path;
         }
 

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -112,19 +112,26 @@ class ApiClient {
         return param.toString();
     }
 
-    /**
+   /**
     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
     * NOTE: query parameters are not handled here.
     * @param {String} path The path to append to the base URL.
     * @param {Object} pathParams The parameter values to append.
+    * @param {String} apiBasePath Base path defined in the path, operation level to override the default one
     * @returns {String} The encoded path with parameter values substituted.
     */
-    buildUrl(path, pathParams) {
+    buildUrl(path, pathParams, apiBasePath) {
         if (!path.match(/^\//)) {
             path = '/' + path;
         }
 
         var url = this.basePath + path;
+
+        // use API (operation, path) base path if defined
+        if (apiBasePath !== undefined) {
+            url = apiBasePath + path;
+        }
+
         url = url.replace(/\{([\w-]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
@@ -308,7 +315,7 @@ class ApiClient {
         });
     }
 
-    /**
+   /**
     * Deserializes an HTTP response body into a value of the specified type.
     * @param {Object} response A SuperAgent response object.
     * @param {(String|Array.<String>|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
@@ -333,9 +340,8 @@ class ApiClient {
         return ApiClient.convertToType(data, returnType);
     }
 
-    
 
-    /**
+   /**
     * Invokes the REST service using the supplied settings and parameters.
     * @param {String} path The base URL to invoke.
     * @param {String} httpMethod The HTTP method to use.
@@ -349,13 +355,14 @@ class ApiClient {
     * @param {Array.<String>} accepts An array of acceptable response MIME types.
     * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
     * constructor for a complex type.
+    * @param {String} apiBasePath base path defined in the operation/path level to override the default one 
     * @returns {Promise} A {@link https://www.promisejs.org/|Promise} object.
     */
     callApi(path, httpMethod, pathParams,
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-        returnType) {
+        returnType, apiBasePath) {
 
-        var url = this.buildUrl(path, pathParams);
+        var url = this.buildUrl(path, pathParams, apiBasePath);
         var request = superagent(httpMethod, url);
 
         if (this.plugins !== null) {
@@ -462,7 +469,6 @@ class ApiClient {
             });
         });
 
-        
     }
 
     /**

--- a/samples/client/petstore/javascript-promise-es6/src/api/AnotherFakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/AnotherFakeApi.js
@@ -43,12 +43,10 @@ export default class AnotherFakeApi {
      */
     call123testSpecialTagsWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling call123testSpecialTags");
       }
-
 
       let pathParams = {
       };
@@ -63,11 +61,10 @@ export default class AnotherFakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/another-fake/dummy', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
@@ -47,12 +47,10 @@ export default class FakeApi {
      */
     createXmlItemWithHttpInfo(xmlItem) {
       let postBody = xmlItem;
-
       // verify the required parameter 'xmlItem' is set
       if (xmlItem === undefined || xmlItem === null) {
         throw new Error("Missing the required parameter 'xmlItem' when calling createXmlItem");
       }
-
 
       let pathParams = {
       };
@@ -67,11 +65,10 @@ export default class FakeApi {
       let contentTypes = ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/create_xml_item', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -99,7 +96,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -113,11 +109,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = 'Boolean';
-
       return this.apiClient.callApi(
         '/fake/outer/boolean', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -145,7 +140,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -159,11 +153,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = OuterComposite;
-
       return this.apiClient.callApi(
         '/fake/outer/composite', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -191,7 +184,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -205,11 +197,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = 'Number';
-
       return this.apiClient.callApi(
         '/fake/outer/number', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -237,7 +228,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -251,11 +241,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = ['*/*'];
       let returnType = 'String';
-
       return this.apiClient.callApi(
         '/fake/outer/string', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -280,12 +269,10 @@ export default class FakeApi {
      */
     testBodyWithFileSchemaWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testBodyWithFileSchema");
       }
-
 
       let pathParams = {
       };
@@ -300,11 +287,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-file-schema', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -328,17 +314,14 @@ export default class FakeApi {
      */
     testBodyWithQueryParamsWithHttpInfo(query, body) {
       let postBody = body;
-
       // verify the required parameter 'query' is set
       if (query === undefined || query === null) {
         throw new Error("Missing the required parameter 'query' when calling testBodyWithQueryParams");
       }
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testBodyWithQueryParams");
       }
-
 
       let pathParams = {
       };
@@ -354,11 +337,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-query-params', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -383,12 +365,10 @@ export default class FakeApi {
      */
     testClientModelWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testClientModel");
       }
-
 
       let pathParams = {
       };
@@ -403,11 +383,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/fake', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -448,27 +427,22 @@ export default class FakeApi {
     testEndpointParametersWithHttpInfo(_number, _double, patternWithoutDelimiter, _byte, opts) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter '_number' is set
       if (_number === undefined || _number === null) {
         throw new Error("Missing the required parameter '_number' when calling testEndpointParameters");
       }
-
       // verify the required parameter '_double' is set
       if (_double === undefined || _double === null) {
         throw new Error("Missing the required parameter '_double' when calling testEndpointParameters");
       }
-
       // verify the required parameter 'patternWithoutDelimiter' is set
       if (patternWithoutDelimiter === undefined || patternWithoutDelimiter === null) {
         throw new Error("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
       }
-
       // verify the required parameter '_byte' is set
       if (_byte === undefined || _byte === null) {
         throw new Error("Missing the required parameter '_byte' when calling testEndpointParameters");
       }
-
 
       let pathParams = {
       };
@@ -497,11 +471,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -551,7 +524,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -573,11 +545,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -618,22 +589,18 @@ export default class FakeApi {
     testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, opts) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'requiredStringGroup' is set
       if (requiredStringGroup === undefined || requiredStringGroup === null) {
         throw new Error("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
       }
-
       // verify the required parameter 'requiredBooleanGroup' is set
       if (requiredBooleanGroup === undefined || requiredBooleanGroup === null) {
         throw new Error("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
       }
-
       // verify the required parameter 'requiredInt64Group' is set
       if (requiredInt64Group === undefined || requiredInt64Group === null) {
         throw new Error("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
       }
-
 
       let pathParams = {
       };
@@ -654,11 +621,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -689,12 +655,10 @@ export default class FakeApi {
      */
     testInlineAdditionalPropertiesWithHttpInfo(param) {
       let postBody = param;
-
       // verify the required parameter 'param' is set
       if (param === undefined || param === null) {
         throw new Error("Missing the required parameter 'param' when calling testInlineAdditionalProperties");
       }
-
 
       let pathParams = {
       };
@@ -709,11 +673,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/inline-additionalProperties', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -738,17 +701,14 @@ export default class FakeApi {
      */
     testJsonFormDataWithHttpInfo(param, param2) {
       let postBody = null;
-
       // verify the required parameter 'param' is set
       if (param === undefined || param === null) {
         throw new Error("Missing the required parameter 'param' when calling testJsonFormData");
       }
-
       // verify the required parameter 'param2' is set
       if (param2 === undefined || param2 === null) {
         throw new Error("Missing the required parameter 'param2' when calling testJsonFormData");
       }
-
 
       let pathParams = {
       };
@@ -765,11 +725,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/jsonFormData', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeClassnameTags123Api.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeClassnameTags123Api.js
@@ -43,12 +43,10 @@ export default class FakeClassnameTags123Api {
      */
     testClassnameWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling testClassname");
       }
-
 
       let pathParams = {
       };
@@ -63,11 +61,10 @@ export default class FakeClassnameTags123Api {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/fake_classname_test', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/PetApi.js
@@ -43,12 +43,10 @@ export default class PetApi {
      */
     addPetWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling addPet");
       }
-
 
       let pathParams = {
       };
@@ -63,11 +61,10 @@ export default class PetApi {
       let contentTypes = ['application/json', 'application/xml'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -94,12 +91,10 @@ export default class PetApi {
     deletePetWithHttpInfo(petId, opts) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling deletePet");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -116,11 +111,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -147,12 +141,10 @@ export default class PetApi {
      */
     findPetsByStatusWithHttpInfo(status) {
       let postBody = null;
-
       // verify the required parameter 'status' is set
       if (status === undefined || status === null) {
         throw new Error("Missing the required parameter 'status' when calling findPetsByStatus");
       }
-
 
       let pathParams = {
       };
@@ -168,11 +160,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -198,12 +189,10 @@ export default class PetApi {
      */
     findPetsByTagsWithHttpInfo(tags) {
       let postBody = null;
-
       // verify the required parameter 'tags' is set
       if (tags === undefined || tags === null) {
         throw new Error("Missing the required parameter 'tags' when calling findPetsByTags");
       }
-
 
       let pathParams = {
       };
@@ -219,11 +208,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -249,12 +237,10 @@ export default class PetApi {
      */
     getPetByIdWithHttpInfo(petId) {
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling getPetById");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -270,11 +256,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Pet;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -299,12 +284,10 @@ export default class PetApi {
      */
     updatePetWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling updatePet");
       }
-
 
       let pathParams = {
       };
@@ -319,11 +302,10 @@ export default class PetApi {
       let contentTypes = ['application/json', 'application/xml'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -351,12 +333,10 @@ export default class PetApi {
     updatePetWithFormWithHttpInfo(petId, opts) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling updatePetWithForm");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -374,11 +354,10 @@ export default class PetApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -409,12 +388,10 @@ export default class PetApi {
     uploadFileWithHttpInfo(petId, opts) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling uploadFile");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -432,11 +409,10 @@ export default class PetApi {
       let contentTypes = ['multipart/form-data'];
       let accepts = ['application/json'];
       let returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -467,17 +443,14 @@ export default class PetApi {
     uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, opts) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
       }
-
       // verify the required parameter 'requiredFile' is set
       if (requiredFile === undefined || requiredFile === null) {
         throw new Error("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -495,11 +468,10 @@ export default class PetApi {
       let contentTypes = ['multipart/form-data'];
       let accepts = ['application/json'];
       let returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/fake/{petId}/uploadImageWithRequiredFile', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/StoreApi.js
@@ -43,12 +43,10 @@ export default class StoreApi {
      */
     deleteOrderWithHttpInfo(orderId) {
       let postBody = null;
-
       // verify the required parameter 'orderId' is set
       if (orderId === undefined || orderId === null) {
         throw new Error("Missing the required parameter 'orderId' when calling deleteOrder");
       }
-
 
       let pathParams = {
         'order_id': orderId
@@ -64,11 +62,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -94,7 +91,6 @@ export default class StoreApi {
     getInventoryWithHttpInfo() {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -108,11 +104,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = {'String': 'Number'};
-
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -137,12 +132,10 @@ export default class StoreApi {
      */
     getOrderByIdWithHttpInfo(orderId) {
       let postBody = null;
-
       // verify the required parameter 'orderId' is set
       if (orderId === undefined || orderId === null) {
         throw new Error("Missing the required parameter 'orderId' when calling getOrderById");
       }
-
 
       let pathParams = {
         'order_id': orderId
@@ -158,11 +151,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -187,12 +179,10 @@ export default class StoreApi {
      */
     placeOrderWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling placeOrder");
       }
-
 
       let pathParams = {
       };
@@ -207,11 +197,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/UserApi.js
@@ -43,12 +43,10 @@ export default class UserApi {
      */
     createUserWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling createUser");
       }
-
 
       let pathParams = {
       };
@@ -63,11 +61,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -92,12 +89,10 @@ export default class UserApi {
      */
     createUsersWithArrayInputWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling createUsersWithArrayInput");
       }
-
 
       let pathParams = {
       };
@@ -112,11 +107,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -140,12 +134,10 @@ export default class UserApi {
      */
     createUsersWithListInputWithHttpInfo(body) {
       let postBody = body;
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling createUsersWithListInput");
       }
-
 
       let pathParams = {
       };
@@ -160,11 +152,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -189,12 +180,10 @@ export default class UserApi {
      */
     deleteUserWithHttpInfo(username) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling deleteUser");
       }
-
 
       let pathParams = {
         'username': username
@@ -210,11 +199,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -239,12 +227,10 @@ export default class UserApi {
      */
     getUserByNameWithHttpInfo(username) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling getUserByName");
       }
-
 
       let pathParams = {
         'username': username
@@ -260,11 +246,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = User;
-
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -289,17 +274,14 @@ export default class UserApi {
      */
     loginUserWithHttpInfo(username, password) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling loginUser");
       }
-
       // verify the required parameter 'password' is set
       if (password === undefined || password === null) {
         throw new Error("Missing the required parameter 'password' when calling loginUser");
       }
-
 
       let pathParams = {
       };
@@ -316,11 +298,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = 'String';
-
       return this.apiClient.callApi(
         '/user/login', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -345,7 +326,6 @@ export default class UserApi {
     logoutUserWithHttpInfo() {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -359,11 +339,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/logout', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -388,17 +367,14 @@ export default class UserApi {
      */
     updateUserWithHttpInfo(username, body) {
       let postBody = body;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling updateUser");
       }
-
       // verify the required parameter 'body' is set
       if (body === undefined || body === null) {
         throw new Error("Missing the required parameter 'body' when calling updateUser");
       }
-
 
       let pathParams = {
         'username': username
@@ -414,11 +390,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -137,7 +137,7 @@
     var url = this.basePath + path;
 
     // use API (operation, path) base path if defined
-    if (apiBasePath !== undefined) {
+    if (apiBasePath !== null && apiBasePath !== undefined) {
         url = apiBasePath + path;
     }
 

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -123,18 +123,24 @@
     return param.toString();
   };
 
-  /**
+ /**
    * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
    * NOTE: query parameters are not handled here.
    * @param {String} path The path to append to the base URL.
    * @param {Object} pathParams The parameter values to append.
    * @returns {String} The encoded path with parameter values substituted.
    */
-  exports.prototype.buildUrl = function(path, pathParams) {
+  exports.prototype.buildUrl = function(path, pathParams, apiBasePath) {
     if (!path.match(/^\//)) {
       path = '/' + path;
     }
     var url = this.basePath + path;
+
+    // use API (operation, path) base path if defined
+    if (apiBasePath !== undefined) {
+        url = apiBasePath + path;
+    }
+
     var _this = this;
     url = url.replace(/\{([\w-]+)\}/g, function(fullMatch, key) {
       var value;
@@ -382,10 +388,10 @@
    */
   exports.prototype.callApi = function callApi(path, httpMethod, pathParams,
       queryParams, collectionQueryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-      returnType) {
+      returnType, apiBasePath) {
 
     var _this = this;
-    var url = this.buildUrl(path, pathParams);
+    var url = this.buildUrl(path, pathParams, apiBasePath);
     var request = superagent(httpMethod, url);
 
     if (this.plugins !== null) {

--- a/samples/client/petstore/javascript-promise/src/api/AnotherFakeApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/AnotherFakeApi.js
@@ -78,11 +78,10 @@
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
       var returnType = Client;
-
       return this.apiClient.callApi(
         '/another-fake/dummy', 'PATCH',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/FakeApi.js
@@ -78,11 +78,10 @@
       var contentTypes = ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/create_xml_item', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -126,11 +125,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = 'Boolean';
-
       return this.apiClient.callApi(
         '/fake/outer/boolean', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -174,11 +172,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = OuterComposite;
-
       return this.apiClient.callApi(
         '/fake/outer/composite', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -222,11 +219,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = 'Number';
-
       return this.apiClient.callApi(
         '/fake/outer/number', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -270,11 +266,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = 'String';
-
       return this.apiClient.callApi(
         '/fake/outer/string', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -321,11 +316,10 @@
       var contentTypes = ['application/json'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-file-schema', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -377,11 +371,10 @@
       var contentTypes = ['application/json'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-query-params', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -428,11 +421,10 @@
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
       var returnType = Client;
-
       return this.apiClient.callApi(
         '/fake', 'PATCH',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -524,11 +516,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -605,11 +596,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -688,11 +678,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -745,11 +734,10 @@
       var contentTypes = ['application/json'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/inline-additionalProperties', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -803,11 +791,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/jsonFormData', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise/src/api/FakeClassnameTags123Api.js
+++ b/samples/client/petstore/javascript-promise/src/api/FakeClassnameTags123Api.js
@@ -78,11 +78,10 @@
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
       var returnType = Client;
-
       return this.apiClient.callApi(
         '/fake_classname_test', 'PATCH',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise/src/api/PetApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/PetApi.js
@@ -77,11 +77,10 @@
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -132,11 +131,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -189,11 +187,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -245,11 +242,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -298,11 +294,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = Pet;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -349,11 +344,10 @@
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -406,11 +400,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -466,11 +459,10 @@
       var contentTypes = ['multipart/form-data'];
       var accepts = ['application/json'];
       var returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -531,11 +523,10 @@
       var contentTypes = ['multipart/form-data'];
       var accepts = ['application/json'];
       var returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/fake/{petId}/uploadImageWithRequiredFile', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/StoreApi.js
@@ -79,11 +79,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -125,11 +124,10 @@
       var contentTypes = [];
       var accepts = ['application/json'];
       var returnType = {'String': 'Number'};
-
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -177,11 +175,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -228,11 +225,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript-promise/src/api/UserApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/UserApi.js
@@ -78,11 +78,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -129,11 +128,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -179,11 +177,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -231,11 +228,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -283,11 +279,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = User;
-
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -341,11 +336,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = 'String';
-
       return this.apiClient.callApi(
         '/user/login', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -386,11 +380,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/logout', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 
@@ -443,11 +436,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, null
       );
     }
 

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -137,7 +137,7 @@
     var url = this.basePath + path;
 
     // use API (operation, path) base path if defined
-    if (apiBasePath !== undefined) {
+    if (apiBasePath !== null && apiBasePath !== undefined) {
         url = apiBasePath + path;
     }
 

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -123,18 +123,24 @@
     return param.toString();
   };
 
-  /**
+ /**
    * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
    * NOTE: query parameters are not handled here.
    * @param {String} path The path to append to the base URL.
    * @param {Object} pathParams The parameter values to append.
    * @returns {String} The encoded path with parameter values substituted.
    */
-  exports.prototype.buildUrl = function(path, pathParams) {
+  exports.prototype.buildUrl = function(path, pathParams, apiBasePath) {
     if (!path.match(/^\//)) {
       path = '/' + path;
     }
     var url = this.basePath + path;
+
+    // use API (operation, path) base path if defined
+    if (apiBasePath !== undefined) {
+        url = apiBasePath + path;
+    }
+
     var _this = this;
     url = url.replace(/\{([\w-]+)\}/g, function(fullMatch, key) {
       var value;
@@ -391,10 +397,10 @@
    */
   exports.prototype.callApi = function callApi(path, httpMethod, pathParams,
       queryParams, collectionQueryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-      returnType, callback) {
+      returnType, apiBasePath, callback) {
 
     var _this = this;
-    var url = this.buildUrl(path, pathParams);
+    var url = this.buildUrl(path, pathParams, apiBasePath);
     var request = superagent(httpMethod, url);
 
     if (this.plugins !== null) {

--- a/samples/client/petstore/javascript/src/api/AnotherFakeApi.js
+++ b/samples/client/petstore/javascript/src/api/AnotherFakeApi.js
@@ -86,11 +86,10 @@
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
       var returnType = Client;
-
       return this.apiClient.callApi(
         '/another-fake/dummy', 'PATCH',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
   };

--- a/samples/client/petstore/javascript/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript/src/api/FakeApi.js
@@ -85,11 +85,10 @@
       var contentTypes = ['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/create_xml_item', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -128,11 +127,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = 'Boolean';
-
       return this.apiClient.callApi(
         '/fake/outer/boolean', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -171,11 +169,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = OuterComposite;
-
       return this.apiClient.callApi(
         '/fake/outer/composite', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -214,11 +211,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = 'Number';
-
       return this.apiClient.callApi(
         '/fake/outer/number', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -257,11 +253,10 @@
       var contentTypes = [];
       var accepts = ['*/*'];
       var returnType = 'String';
-
       return this.apiClient.callApi(
         '/fake/outer/string', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -302,11 +297,10 @@
       var contentTypes = ['application/json'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-file-schema', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -353,11 +347,10 @@
       var contentTypes = ['application/json'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-query-params', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -400,11 +393,10 @@
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
       var returnType = Client;
-
       return this.apiClient.callApi(
         '/fake', 'PATCH',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -490,11 +482,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -551,11 +542,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -620,11 +610,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -665,11 +654,10 @@
       var contentTypes = ['application/json'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/inline-additionalProperties', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -718,11 +706,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/fake/jsonFormData', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
   };

--- a/samples/client/petstore/javascript/src/api/FakeClassnameTags123Api.js
+++ b/samples/client/petstore/javascript/src/api/FakeClassnameTags123Api.js
@@ -86,11 +86,10 @@
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
       var returnType = Client;
-
       return this.apiClient.callApi(
         '/fake_classname_test', 'PATCH',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
   };

--- a/samples/client/petstore/javascript/src/api/PetApi.js
+++ b/samples/client/petstore/javascript/src/api/PetApi.js
@@ -84,11 +84,10 @@
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -134,11 +133,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -185,11 +183,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -236,11 +233,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -284,11 +280,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = Pet;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -329,11 +324,10 @@
       var contentTypes = ['application/json', 'application/xml'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -381,11 +375,10 @@
       var contentTypes = ['application/x-www-form-urlencoded'];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -434,11 +427,10 @@
       var contentTypes = ['multipart/form-data'];
       var accepts = ['application/json'];
       var returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -492,11 +484,10 @@
       var contentTypes = ['multipart/form-data'];
       var accepts = ['application/json'];
       var returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/fake/{petId}/uploadImageWithRequiredFile', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
   };

--- a/samples/client/petstore/javascript/src/api/StoreApi.js
+++ b/samples/client/petstore/javascript/src/api/StoreApi.js
@@ -86,11 +86,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -127,11 +126,10 @@
       var contentTypes = [];
       var accepts = ['application/json'];
       var returnType = {'String': 'Number'};
-
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -175,11 +173,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -221,11 +218,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
   };

--- a/samples/client/petstore/javascript/src/api/UserApi.js
+++ b/samples/client/petstore/javascript/src/api/UserApi.js
@@ -85,11 +85,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -130,11 +129,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -175,11 +173,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -222,11 +219,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -269,11 +265,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = User;
-
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -323,11 +318,10 @@
       var contentTypes = [];
       var accepts = ['application/xml', 'application/json'];
       var returnType = 'String';
-
       return this.apiClient.callApi(
         '/user/login', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -362,11 +356,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/logout', 'GET',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -415,11 +408,10 @@
       var contentTypes = [];
       var accepts = [];
       var returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
         pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
   };

--- a/samples/openapi3/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/ApiClient.js
@@ -129,7 +129,7 @@ class ApiClient {
         var url = this.basePath + path;
 
         // use API (operation, path) base path if defined
-        if (apiBasePath !== undefined) {
+        if (apiBasePath !== null && apiBasePath !== undefined) {
             url = apiBasePath + path;
         }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/ApiClient.js
@@ -113,19 +113,26 @@ class ApiClient {
         return param.toString();
     }
 
-    /**
+   /**
     * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
     * NOTE: query parameters are not handled here.
     * @param {String} path The path to append to the base URL.
     * @param {Object} pathParams The parameter values to append.
+    * @param {String} apiBasePath Base path defined in the path, operation level to override the default one
     * @returns {String} The encoded path with parameter values substituted.
     */
-    buildUrl(path, pathParams) {
+    buildUrl(path, pathParams, apiBasePath) {
         if (!path.match(/^\//)) {
             path = '/' + path;
         }
 
         var url = this.basePath + path;
+
+        // use API (operation, path) base path if defined
+        if (apiBasePath !== undefined) {
+            url = apiBasePath + path;
+        }
+
         url = url.replace(/\{([\w-]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
@@ -309,7 +316,7 @@ class ApiClient {
         });
     }
 
-    /**
+   /**
     * Deserializes an HTTP response body into a value of the specified type.
     * @param {Object} response A SuperAgent response object.
     * @param {(String|Array.<String>|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
@@ -334,7 +341,7 @@ class ApiClient {
         return ApiClient.convertToType(data, returnType);
     }
 
-    /**
+   /**
     * Callback function to receive the result of the operation.
     * @callback module:ApiClient~callApiCallback
     * @param {String} error Error message, if any.
@@ -342,7 +349,7 @@ class ApiClient {
     * @param {String} response The complete HTTP response.
     */
 
-    /**
+   /**
     * Invokes the REST service using the supplied settings and parameters.
     * @param {String} path The base URL to invoke.
     * @param {String} httpMethod The HTTP method to use.
@@ -356,14 +363,15 @@ class ApiClient {
     * @param {Array.<String>} accepts An array of acceptable response MIME types.
     * @param {(String|Array|ObjectFunction)} returnType The required type to return; can be a string for simple types or the
     * constructor for a complex type.
+    * @param {String} apiBasePath base path defined in the operation/path level to override the default one 
     * @param {module:ApiClient~callApiCallback} callback The callback function.
     * @returns {Object} The SuperAgent request object.
     */
     callApi(path, httpMethod, pathParams,
         queryParams, headerParams, formParams, bodyParam, authNames, contentTypes, accepts,
-        returnType, callback) {
+        returnType, apiBasePath, callback) {
 
-        var url = this.buildUrl(path, pathParams);
+        var url = this.buildUrl(path, pathParams, apiBasePath);
         var request = superagent(httpMethod, url);
 
         if (this.plugins !== null) {
@@ -443,8 +451,6 @@ class ApiClient {
                 request.withCredentials();
             }
         }
-
-        
 
         request.end((error, response) => {
             if (callback) {

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/AnotherFakeApi.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/AnotherFakeApi.js
@@ -51,12 +51,10 @@ export default class AnotherFakeApi {
      */
     call123testSpecialTags(client, callback) {
       let postBody = client;
-
       // verify the required parameter 'client' is set
       if (client === undefined || client === null) {
         throw new Error("Missing the required parameter 'client' when calling call123testSpecialTags");
       }
-
 
       let pathParams = {
       };
@@ -71,11 +69,10 @@ export default class AnotherFakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/another-fake/dummy', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/DefaultApi.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/DefaultApi.js
@@ -49,7 +49,6 @@ export default class DefaultApi {
     fooGet(callback) {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -63,11 +62,10 @@ export default class DefaultApi {
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = InlineResponseDefault;
-
       return this.apiClient.callApi(
         '/foo', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -56,7 +56,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -70,11 +69,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['*/*'];
       let returnType = 'Boolean';
-
       return this.apiClient.callApi(
         '/fake/outer/boolean', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -97,7 +95,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['outerComposite'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -111,11 +108,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['*/*'];
       let returnType = OuterComposite;
-
       return this.apiClient.callApi(
         '/fake/outer/composite', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -138,7 +134,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -152,11 +147,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['*/*'];
       let returnType = 'Number';
-
       return this.apiClient.callApi(
         '/fake/outer/number', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -179,7 +173,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = opts['body'];
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -193,11 +186,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['*/*'];
       let returnType = 'String';
-
       return this.apiClient.callApi(
         '/fake/outer/string', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -216,12 +208,10 @@ export default class FakeApi {
      */
     testBodyWithFileSchema(fileSchemaTestClass, callback) {
       let postBody = fileSchemaTestClass;
-
       // verify the required parameter 'fileSchemaTestClass' is set
       if (fileSchemaTestClass === undefined || fileSchemaTestClass === null) {
         throw new Error("Missing the required parameter 'fileSchemaTestClass' when calling testBodyWithFileSchema");
       }
-
 
       let pathParams = {
       };
@@ -236,11 +226,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-file-schema', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -259,17 +248,14 @@ export default class FakeApi {
      */
     testBodyWithQueryParams(query, user, callback) {
       let postBody = user;
-
       // verify the required parameter 'query' is set
       if (query === undefined || query === null) {
         throw new Error("Missing the required parameter 'query' when calling testBodyWithQueryParams");
       }
-
       // verify the required parameter 'user' is set
       if (user === undefined || user === null) {
         throw new Error("Missing the required parameter 'user' when calling testBodyWithQueryParams");
       }
-
 
       let pathParams = {
       };
@@ -285,11 +271,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/body-with-query-params', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -310,12 +295,10 @@ export default class FakeApi {
      */
     testClientModel(client, callback) {
       let postBody = client;
-
       // verify the required parameter 'client' is set
       if (client === undefined || client === null) {
         throw new Error("Missing the required parameter 'client' when calling testClientModel");
       }
-
 
       let pathParams = {
       };
@@ -330,11 +313,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/fake', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -369,27 +351,22 @@ export default class FakeApi {
     testEndpointParameters(_number, _double, patternWithoutDelimiter, _byte, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter '_number' is set
       if (_number === undefined || _number === null) {
         throw new Error("Missing the required parameter '_number' when calling testEndpointParameters");
       }
-
       // verify the required parameter '_double' is set
       if (_double === undefined || _double === null) {
         throw new Error("Missing the required parameter '_double' when calling testEndpointParameters");
       }
-
       // verify the required parameter 'patternWithoutDelimiter' is set
       if (patternWithoutDelimiter === undefined || patternWithoutDelimiter === null) {
         throw new Error("Missing the required parameter 'patternWithoutDelimiter' when calling testEndpointParameters");
       }
-
       // verify the required parameter '_byte' is set
       if (_byte === undefined || _byte === null) {
         throw new Error("Missing the required parameter '_byte' when calling testEndpointParameters");
       }
-
 
       let pathParams = {
       };
@@ -418,11 +395,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -452,7 +428,6 @@ export default class FakeApi {
       opts = opts || {};
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -474,11 +449,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -505,22 +479,18 @@ export default class FakeApi {
     testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'requiredStringGroup' is set
       if (requiredStringGroup === undefined || requiredStringGroup === null) {
         throw new Error("Missing the required parameter 'requiredStringGroup' when calling testGroupParameters");
       }
-
       // verify the required parameter 'requiredBooleanGroup' is set
       if (requiredBooleanGroup === undefined || requiredBooleanGroup === null) {
         throw new Error("Missing the required parameter 'requiredBooleanGroup' when calling testGroupParameters");
       }
-
       // verify the required parameter 'requiredInt64Group' is set
       if (requiredInt64Group === undefined || requiredInt64Group === null) {
         throw new Error("Missing the required parameter 'requiredInt64Group' when calling testGroupParameters");
       }
-
 
       let pathParams = {
       };
@@ -541,11 +511,10 @@ export default class FakeApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -564,12 +533,10 @@ export default class FakeApi {
      */
     testInlineAdditionalProperties(requestBody, callback) {
       let postBody = requestBody;
-
       // verify the required parameter 'requestBody' is set
       if (requestBody === undefined || requestBody === null) {
         throw new Error("Missing the required parameter 'requestBody' when calling testInlineAdditionalProperties");
       }
-
 
       let pathParams = {
       };
@@ -584,11 +551,10 @@ export default class FakeApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/inline-additionalProperties', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -608,17 +574,14 @@ export default class FakeApi {
      */
     testJsonFormData(param, param2, callback) {
       let postBody = null;
-
       // verify the required parameter 'param' is set
       if (param === undefined || param === null) {
         throw new Error("Missing the required parameter 'param' when calling testJsonFormData");
       }
-
       // verify the required parameter 'param2' is set
       if (param2 === undefined || param2 === null) {
         throw new Error("Missing the required parameter 'param2' when calling testJsonFormData");
       }
-
 
       let pathParams = {
       };
@@ -635,11 +598,10 @@ export default class FakeApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/fake/jsonFormData', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/FakeClassnameTags123Api.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/FakeClassnameTags123Api.js
@@ -51,12 +51,10 @@ export default class FakeClassnameTags123Api {
      */
     testClassname(client, callback) {
       let postBody = client;
-
       // verify the required parameter 'client' is set
       if (client === undefined || client === null) {
         throw new Error("Missing the required parameter 'client' when calling testClassname");
       }
-
 
       let pathParams = {
       };
@@ -71,11 +69,10 @@ export default class FakeClassnameTags123Api {
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Client;
-
       return this.apiClient.callApi(
         '/fake_classname_test', 'PATCH',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/PetApi.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/PetApi.js
@@ -50,12 +50,10 @@ export default class PetApi {
      */
     addPet(pet, callback) {
       let postBody = pet;
-
       // verify the required parameter 'pet' is set
       if (pet === undefined || pet === null) {
         throw new Error("Missing the required parameter 'pet' when calling addPet");
       }
-
 
       let pathParams = {
       };
@@ -70,11 +68,10 @@ export default class PetApi {
       let contentTypes = ['application/json', 'application/xml'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -96,12 +93,10 @@ export default class PetApi {
     deletePet(petId, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling deletePet");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -118,11 +113,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -143,12 +137,10 @@ export default class PetApi {
      */
     findPetsByStatus(status, callback) {
       let postBody = null;
-
       // verify the required parameter 'status' is set
       if (status === undefined || status === null) {
         throw new Error("Missing the required parameter 'status' when calling findPetsByStatus");
       }
-
 
       let pathParams = {
       };
@@ -164,11 +156,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByStatus', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -189,12 +180,10 @@ export default class PetApi {
      */
     findPetsByTags(tags, callback) {
       let postBody = null;
-
       // verify the required parameter 'tags' is set
       if (tags === undefined || tags === null) {
         throw new Error("Missing the required parameter 'tags' when calling findPetsByTags");
       }
-
 
       let pathParams = {
       };
@@ -210,11 +199,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = [Pet];
-
       return this.apiClient.callApi(
         '/pet/findByTags', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -235,12 +223,10 @@ export default class PetApi {
      */
     getPetById(petId, callback) {
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling getPetById");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -256,11 +242,10 @@ export default class PetApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Pet;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -279,12 +264,10 @@ export default class PetApi {
      */
     updatePet(pet, callback) {
       let postBody = pet;
-
       // verify the required parameter 'pet' is set
       if (pet === undefined || pet === null) {
         throw new Error("Missing the required parameter 'pet' when calling updatePet");
       }
-
 
       let pathParams = {
       };
@@ -299,11 +282,10 @@ export default class PetApi {
       let contentTypes = ['application/json', 'application/xml'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -326,12 +308,10 @@ export default class PetApi {
     updatePetWithForm(petId, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling updatePetWithForm");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -349,11 +329,10 @@ export default class PetApi {
       let contentTypes = ['application/x-www-form-urlencoded'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/pet/{petId}', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -377,12 +356,10 @@ export default class PetApi {
     uploadFile(petId, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling uploadFile");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -400,11 +377,10 @@ export default class PetApi {
       let contentTypes = ['multipart/form-data'];
       let accepts = ['application/json'];
       let returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/pet/{petId}/uploadImage', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -428,17 +404,14 @@ export default class PetApi {
     uploadFileWithRequiredFile(petId, requiredFile, opts, callback) {
       opts = opts || {};
       let postBody = null;
-
       // verify the required parameter 'petId' is set
       if (petId === undefined || petId === null) {
         throw new Error("Missing the required parameter 'petId' when calling uploadFileWithRequiredFile");
       }
-
       // verify the required parameter 'requiredFile' is set
       if (requiredFile === undefined || requiredFile === null) {
         throw new Error("Missing the required parameter 'requiredFile' when calling uploadFileWithRequiredFile");
       }
-
 
       let pathParams = {
         'petId': petId
@@ -456,11 +429,10 @@ export default class PetApi {
       let contentTypes = ['multipart/form-data'];
       let accepts = ['application/json'];
       let returnType = ApiResponse;
-
       return this.apiClient.callApi(
         '/fake/{petId}/uploadImageWithRequiredFile', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/StoreApi.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/StoreApi.js
@@ -50,12 +50,10 @@ export default class StoreApi {
      */
     deleteOrder(orderId, callback) {
       let postBody = null;
-
       // verify the required parameter 'orderId' is set
       if (orderId === undefined || orderId === null) {
         throw new Error("Missing the required parameter 'orderId' when calling deleteOrder");
       }
-
 
       let pathParams = {
         'order_id': orderId
@@ -71,11 +69,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -96,7 +93,6 @@ export default class StoreApi {
     getInventory(callback) {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -110,11 +106,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = {'String': 'Number'};
-
       return this.apiClient.callApi(
         '/store/inventory', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -135,12 +130,10 @@ export default class StoreApi {
      */
     getOrderById(orderId, callback) {
       let postBody = null;
-
       // verify the required parameter 'orderId' is set
       if (orderId === undefined || orderId === null) {
         throw new Error("Missing the required parameter 'orderId' when calling getOrderById");
       }
-
 
       let pathParams = {
         'order_id': orderId
@@ -156,11 +149,10 @@ export default class StoreApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order/{order_id}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -180,12 +172,10 @@ export default class StoreApi {
      */
     placeOrder(order, callback) {
       let postBody = order;
-
       // verify the required parameter 'order' is set
       if (order === undefined || order === null) {
         throw new Error("Missing the required parameter 'order' when calling placeOrder");
       }
-
 
       let pathParams = {
       };
@@ -200,11 +190,10 @@ export default class StoreApi {
       let contentTypes = ['application/json'];
       let accepts = ['application/xml', 'application/json'];
       let returnType = Order;
-
       return this.apiClient.callApi(
         '/store/order', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 

--- a/samples/openapi3/client/petstore/javascript-es6/src/api/UserApi.js
+++ b/samples/openapi3/client/petstore/javascript-es6/src/api/UserApi.js
@@ -50,12 +50,10 @@ export default class UserApi {
      */
     createUser(user, callback) {
       let postBody = user;
-
       // verify the required parameter 'user' is set
       if (user === undefined || user === null) {
         throw new Error("Missing the required parameter 'user' when calling createUser");
       }
-
 
       let pathParams = {
       };
@@ -70,11 +68,10 @@ export default class UserApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -93,12 +90,10 @@ export default class UserApi {
      */
     createUsersWithArrayInput(user, callback) {
       let postBody = user;
-
       // verify the required parameter 'user' is set
       if (user === undefined || user === null) {
         throw new Error("Missing the required parameter 'user' when calling createUsersWithArrayInput");
       }
-
 
       let pathParams = {
       };
@@ -113,11 +108,10 @@ export default class UserApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithArray', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -136,12 +130,10 @@ export default class UserApi {
      */
     createUsersWithListInput(user, callback) {
       let postBody = user;
-
       // verify the required parameter 'user' is set
       if (user === undefined || user === null) {
         throw new Error("Missing the required parameter 'user' when calling createUsersWithListInput");
       }
-
 
       let pathParams = {
       };
@@ -156,11 +148,10 @@ export default class UserApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/createWithList', 'POST',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -180,12 +171,10 @@ export default class UserApi {
      */
     deleteUser(username, callback) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling deleteUser");
       }
-
 
       let pathParams = {
         'username': username
@@ -201,11 +190,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'DELETE',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -225,12 +213,10 @@ export default class UserApi {
      */
     getUserByName(username, callback) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling getUserByName");
       }
-
 
       let pathParams = {
         'username': username
@@ -246,11 +232,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = User;
-
       return this.apiClient.callApi(
         '/user/{username}', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -271,17 +256,14 @@ export default class UserApi {
      */
     loginUser(username, password, callback) {
       let postBody = null;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling loginUser");
       }
-
       // verify the required parameter 'password' is set
       if (password === undefined || password === null) {
         throw new Error("Missing the required parameter 'password' when calling loginUser");
       }
-
 
       let pathParams = {
       };
@@ -298,11 +280,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = ['application/xml', 'application/json'];
       let returnType = 'String';
-
       return this.apiClient.callApi(
         '/user/login', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -321,7 +302,6 @@ export default class UserApi {
     logoutUser(callback) {
       let postBody = null;
 
-
       let pathParams = {
       };
       let queryParams = {
@@ -335,11 +315,10 @@ export default class UserApi {
       let contentTypes = [];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/logout', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 
@@ -360,17 +339,14 @@ export default class UserApi {
      */
     updateUser(username, user, callback) {
       let postBody = user;
-
       // verify the required parameter 'username' is set
       if (username === undefined || username === null) {
         throw new Error("Missing the required parameter 'username' when calling updateUser");
       }
-
       // verify the required parameter 'user' is set
       if (user === undefined || user === null) {
         throw new Error("Missing the required parameter 'user' when calling updateUser");
       }
-
 
       let pathParams = {
         'username': username
@@ -386,11 +362,10 @@ export default class UserApi {
       let contentTypes = ['application/json'];
       let accepts = [];
       let returnType = null;
-
       return this.apiClient.callApi(
         '/user/{username}', 'PUT',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType, callback
+        authNames, contentTypes, accepts, returnType, null, callback
       );
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add "servers" support to operation, path in the JS client. Similar PRs:
- Python: https://github.com/OpenAPITools/openapi-generator/pull/2052
- PHP: https://github.com/OpenAPITools/openapi-generator/pull/2072

cc @CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)


