### PR TITLE
Update openapi-generator-cli.sh

### DIFF
--- a/bin/utils/openapi-generator-cli.sh
+++ b/bin/utils/openapi-generator-cli.sh
@@ -20,7 +20,7 @@
 ####
 set -o pipefail
 
-for cmd in {mvn,python,curl}; do
+for cmd in {mvn,jq,curl}; do
   if ! command -v ${cmd} > /dev/null; then
   >&2 echo "This script requires '${cmd}' to be installed."
     exit 1
@@ -28,8 +28,8 @@ for cmd in {mvn,python,curl}; do
 done
 
 function latest.tag {
-  local uri="https://api.github.com/repos/${1}/tags"
-  curl -s ${uri} | python -c "import sys, json; print json.load(sys.stdin)[0]['name'][1:]"
+  local uri="https://api.github.com/repos/${1}/releases"
+  curl -s ${uri} | jq -r 'first(.[]|select(.prerelease==false)).tag_name
 }
 
 ghrepo=openapitools/openapi-generator


### PR DESCRIPTION
* `jq` executable is a much cleaner way to get version number
* Using `jq` and getting `releases` instead of `tags` allows us to get latest stable release

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Very simple change, simpler way to get latest release (not pre-relase) in the bash script.