### PR TITLE
Add "servers" support to the operation, path in PHP API client

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -55,7 +55,7 @@ use {{invokerPackage}}\ObjectSerializer;
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -63,7 +63,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -121,6 +121,15 @@ use {{invokerPackage}}\ObjectSerializer;
      * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
 {{/vendorExtensions.x-group-parameters}}
+{{#servers}}
+{{#-first}}
+     * This oepration contains host(s) defined in the OpenAP spec. Use 'hostIndex' to select the host.
+{{/-first}}
+     * URL: {{{url}}}
+{{#-last}}
+     *
+{{/-last}}
+{{/servers}}
 {{#allParams}}
      * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
@@ -147,9 +156,18 @@ use {{invokerPackage}}\ObjectSerializer;
      *
 {{/description}}
 {{#vendorExtensions.x-group-parameters}}
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
 {{/vendorExtensions.x-group-parameters}}
+{{#servers}}
+{{#-first}}
+     * This oepration contains host(s) defined in the OpenAP spec. Use 'hostIndex' to select the host.
+{{/-first}}
+     * URL: {{{url}}}
+{{#-last}}
+     *
+{{/-last}}
+{{/servers}}
 {{#allParams}}
      * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
@@ -263,9 +281,18 @@ use {{invokerPackage}}\ObjectSerializer;
      *
 {{/description}}
 {{#vendorExtensions.x-group-parameters}}
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
 {{/vendorExtensions.x-group-parameters}}
+{{#servers}}
+{{#-first}}
+     * This oepration contains host(s) defined in the OpenAP spec. Use 'hostIndex' to select the host.
+{{/-first}}
+     * URL: {{{url}}}
+{{#-last}}
+     *
+{{/-last}}
+{{/servers}}
 {{#allParams}}
      * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
@@ -293,9 +320,18 @@ use {{invokerPackage}}\ObjectSerializer;
      *
 {{/description}}
 {{#vendorExtensions.x-group-parameters}}
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
 {{/vendorExtensions.x-group-parameters}}
+{{#servers}}
+{{#-first}}
+     * This oepration contains host(s) defined in the OpenAP spec. Use 'hostIndex' to select the host.
+{{/-first}}
+     * URL: {{{url}}}
+{{#-last}}
+     *
+{{/-last}}
+{{/servers}}
 {{#allParams}}
      * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}
@@ -354,6 +390,15 @@ use {{invokerPackage}}\ObjectSerializer;
      * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
 {{/vendorExtensions.x-group-parameters}}
+{{#servers}}
+{{#-first}}
+     * This oepration contains host(s) defined in the OpenAP spec. Use 'hostIndex' to select the host.
+{{/-first}}
+     * URL: {{{url}}}
+{{#-last}}
+     *
+{{/-last}}
+{{/servers}}
 {{#allParams}}
      * @param  {{dataType}} ${{paramName}}{{#description}} {{description}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -55,18 +55,46 @@ use {{invokerPackage}}\ObjectSerializer;
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**
@@ -538,10 +566,18 @@ use {{invokerPackage}}\ObjectSerializer;
             $headers
         );
 
+        {{#servers.0}}
+        $operationHosts = [{{#servers}}"{{{url}}}"{{^-last}}, {{/-last}}{{/servers}}];
+        if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
+            throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
+        }
+        $operationHost = $operationHosts[$this->hostIndex];
+
+        {{/servers.0}}
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             '{{httpMethod}}',
-            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            {{^servers.0}}$this->config->getHost(){{/servers.0}}{{#servers.0}}$operationHost{{/servers.0}} . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody
         );

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -30,9 +30,6 @@ paths:
                   string:
                     $ref: '#/components/schemas/Foo'
   /pet:
-    servers:
-    - url: 'http://petstore.swagger.io/v2'
-    - url: 'http://localhost:8080/v2'
     post:
       tags:
         - pet

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -30,6 +30,9 @@ paths:
                   string:
                     $ref: '#/components/schemas/Foo'
   /pet:
+    servers:
+    - url: 'http://petstore.swagger.io/v2'
+    - url: 'http://localhost:8080/v2'
     post:
       tags:
         - pet

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -65,7 +65,7 @@ class AnotherFakeApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class AnotherFakeApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -65,18 +65,46 @@ class AnotherFakeApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -65,18 +65,46 @@ class FakeApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -65,7 +65,7 @@ class FakeApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class FakeApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -2792,7 +2792,7 @@ class FakeApi
      *
      * Fake endpoint to test group parameters (optional)
      *
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
@@ -2851,7 +2851,7 @@ class FakeApi
      *
      * Fake endpoint to test group parameters (optional)
      *
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
@@ -2878,7 +2878,7 @@ class FakeApi
      *
      * Fake endpoint to test group parameters (optional)
      *
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -65,18 +65,46 @@ class FakeClassnameTags123Api
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -65,7 +65,7 @@ class FakeClassnameTags123Api
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class FakeClassnameTags123Api
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -65,18 +65,46 @@ class PetApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -65,7 +65,7 @@ class PetApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class PetApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -65,7 +65,7 @@ class StoreApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class StoreApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -65,18 +65,46 @@ class StoreApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -65,7 +65,7 @@ class UserApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class UserApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -65,18 +65,46 @@ class UserApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -65,7 +65,7 @@ class AnotherFakeApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class AnotherFakeApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -65,18 +65,46 @@ class AnotherFakeApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -65,7 +65,7 @@ class DefaultApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class DefaultApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -65,18 +65,46 @@ class DefaultApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -65,18 +65,46 @@ class FakeApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -65,7 +65,7 @@ class FakeApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class FakeApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -2573,7 +2573,7 @@ class FakeApi
      *
      * Fake endpoint to test group parameters (optional)
      *
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
@@ -2632,7 +2632,7 @@ class FakeApi
      *
      * Fake endpoint to test group parameters (optional)
      *
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
@@ -2659,7 +2659,7 @@ class FakeApi
      *
      * Fake endpoint to test group parameters (optional)
      *
-     * Note: the inpput parameter is an associative array with the keys listed as the parameter name below
+     * Note: the input parameter is an associative array with the keys listed as the parameter name below
      *
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -65,18 +65,46 @@ class FakeClassnameTags123Api
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -65,7 +65,7 @@ class FakeClassnameTags123Api
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class FakeClassnameTags123Api
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -65,18 +65,46 @@ class PetApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**
@@ -301,10 +329,16 @@ class PetApi
             $headers
         );
 
+        $operationHosts = ["http://petstore.swagger.io/v2", "http://localhost:8080/v2"];
+        if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
+            throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
+        }
+        $operationHost = $operationHosts[$this->hostIndex];
+
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'POST',
-            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody
         );
@@ -1588,10 +1622,16 @@ class PetApi
             $headers
         );
 
+        $operationHosts = ["http://petstore.swagger.io/v2", "http://localhost:8080/v2"];
+        if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
+            throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
+        }
+        $operationHost = $operationHosts[$this->hostIndex];
+
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'PUT',
-            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody
         );

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -65,7 +65,7 @@ class PetApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class PetApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -329,16 +329,10 @@ class PetApi
             $headers
         );
 
-        $operationHosts = ["http://petstore.swagger.io/v2", "http://localhost:8080/v2"];
-        if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
-            throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
-        }
-        $operationHost = $operationHosts[$this->hostIndex];
-
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'POST',
-            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody
         );
@@ -1622,16 +1616,10 @@ class PetApi
             $headers
         );
 
-        $operationHosts = ["http://petstore.swagger.io/v2", "http://localhost:8080/v2"];
-        if ($this->hostIndex < 0 || $this->hostIndex >= sizeof($operationHosts)) {
-            throw new \InvalidArgumentException("Invalid index {$this->hostIndex} when selecting the host. Must be less than ".sizeof($operationHosts));
-        }
-        $operationHost = $operationHosts[$this->hostIndex];
-
         $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'PUT',
-            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
             $headers,
             $httpBody
         );

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -65,7 +65,7 @@ class StoreApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class StoreApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -65,18 +65,46 @@ class StoreApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -65,7 +65,7 @@ class UserApi
     protected $headerSelector;
 
     /**
-     * @var Host index
+     * @var int Host index
      */
     protected $hostIndex;
 
@@ -73,7 +73,7 @@ class UserApi
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
-     * @param int             $host_index
+     * @param int             $host_index (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -65,18 +65,46 @@ class UserApi
     protected $headerSelector;
 
     /**
+     * @var Host index
+     */
+    protected $hostIndex;
+
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
+     * @param int             $host_index
      */
     public function __construct(
         ClientInterface $client = null,
         Configuration $config = null,
-        HeaderSelector $selector = null
+        HeaderSelector $selector = null,
+        $host_index = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
         $this->headerSelector = $selector ?: new HeaderSelector();
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Set the host index
+     *
+     * @param  int Host index (required)
+     */
+    public function setHostIndex($host_index)
+    {
+        $this->hostIndex = $host_index;
+    }
+
+    /**
+     * Get the host index
+     *
+     * @return Host index
+     */
+    public function getHostIndex()
+    {
+        return $this->hostIndex;
     }
 
     /**


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

An example of the change can be found in https://github.com/OpenAPITools/openapi-generator/pull/2072/commits/64bf0d48c0b51de9e4e5a2efde49332d8f8bb60e#diff-15582b49a62d7a5ecac56414cfe6407fR332

cc @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09), @ybelenko (2018/07), @renepardon (2018/12)


