### PR TITLE
[PHP-Symfony] Catch serializer exception

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
@@ -20,6 +20,7 @@
 namespace {{controllerPackage}};
 
 use \Exception;
+use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -137,18 +138,24 @@ class {{controllerName}} extends Controller
         {{/isContainer}}
         {{/required}}
 
+        {{#hasParams}}
         // Deserialize the input values that needs it
-        {{#allParams}}
-        {{^isFile}}
-        {{#isBodyParam}}
-        ${{paramName}} = $this->deserialize(${{paramName}}, '{{#isContainer}}{{#items}}array<{{dataType}}>{{/items}}{{/isContainer}}{{^isContainer}}{{dataType}}{{/isContainer}}', $inputFormat);
-        {{/isBodyParam}}
-        {{^isBodyParam}}
-        ${{paramName}} = $this->deserialize(${{paramName}}, '{{#isContainer}}array<{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}{{^collectionFormat}}csv{{/collectionFormat}},{{dataType}}>{{/isContainer}}{{^isContainer}}{{dataType}}{{/isContainer}}', 'string');
-        {{/isBodyParam}}
-        {{/isFile}}
-        {{/allParams}}
+        try {
+            {{#allParams}}
+            {{^isFile}}
+            {{#isBodyParam}}
+            ${{paramName}} = $this->deserialize(${{paramName}}, '{{#isContainer}}{{#items}}array<{{dataType}}>{{/items}}{{/isContainer}}{{^isContainer}}{{dataType}}{{/isContainer}}', $inputFormat);
+            {{/isBodyParam}}
+            {{^isBodyParam}}
+            ${{paramName}} = $this->deserialize(${{paramName}}, '{{#isContainer}}array<{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}{{^collectionFormat}}csv{{/collectionFormat}},{{dataType}}>{{/isContainer}}{{^isContainer}}{{dataType}}{{/isContainer}}', 'string');
+            {{/isBodyParam}}
+            {{/isFile}}
+            {{/allParams}}
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
+        {{/hasParams}}
         // Validate the input values
 {{>api_input_validation}}
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -30,6 +30,7 @@
 namespace OpenAPI\Server\Controller;
 
 use \Exception;
+use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -87,7 +88,11 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $body = $this->deserialize($body, 'OpenAPI\Server\Model\Pet', $inputFormat);
+        try {
+            $body = $this->deserialize($body, 'OpenAPI\Server\Model\Pet', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -166,8 +171,12 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $petId = $this->deserialize($petId, 'int', 'string');
-        $apiKey = $this->deserialize($apiKey, 'string', 'string');
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+            $apiKey = $this->deserialize($apiKey, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -252,7 +261,11 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $status = $this->deserialize($status, 'array<csv,string>', 'string');
+        try {
+            $status = $this->deserialize($status, 'array<csv,string>', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -339,7 +352,11 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $tags = $this->deserialize($tags, 'array<csv,string>', 'string');
+        try {
+            $tags = $this->deserialize($tags, 'array<csv,string>', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -422,7 +439,11 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $petId = $this->deserialize($petId, 'int', 'string');
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -515,7 +536,11 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $body = $this->deserialize($body, 'OpenAPI\Server\Model\Pet', $inputFormat);
+        try {
+            $body = $this->deserialize($body, 'OpenAPI\Server\Model\Pet', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -601,9 +626,13 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $petId = $this->deserialize($petId, 'int', 'string');
-        $name = $this->deserialize($name, 'string', 'string');
-        $status = $this->deserialize($status, 'string', 'string');
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+            $name = $this->deserialize($name, 'string', 'string');
+            $status = $this->deserialize($status, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -695,8 +724,12 @@ class PetController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $petId = $this->deserialize($petId, 'int', 'string');
-        $additionalMetadata = $this->deserialize($additionalMetadata, 'string', 'string');
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+            $additionalMetadata = $this->deserialize($additionalMetadata, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
@@ -30,6 +30,7 @@
 namespace OpenAPI\Server\Controller;
 
 use \Exception;
+use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -74,7 +75,11 @@ class StoreController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $orderId = $this->deserialize($orderId, 'string', 'string');
+        try {
+            $orderId = $this->deserialize($orderId, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -152,8 +157,6 @@ class StoreController extends Controller
 
         // Use the default value if no value was provided
 
-        // Deserialize the input values that needs it
-
         // Validate the input values
 
 
@@ -220,7 +223,11 @@ class StoreController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $orderId = $this->deserialize($orderId, 'int', 'string');
+        try {
+            $orderId = $this->deserialize($orderId, 'int', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -310,7 +317,11 @@ class StoreController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $body = $this->deserialize($body, 'OpenAPI\Server\Model\Order', $inputFormat);
+        try {
+            $body = $this->deserialize($body, 'OpenAPI\Server\Model\Order', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
@@ -30,6 +30,7 @@
 namespace OpenAPI\Server\Controller;
 
 use \Exception;
+use JMS\Serializer\Exception\RuntimeException as SerializerRuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -83,7 +84,11 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $body = $this->deserialize($body, 'OpenAPI\Server\Model\User', $inputFormat);
+        try {
+            $body = $this->deserialize($body, 'OpenAPI\Server\Model\User', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -165,7 +170,11 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $body = $this->deserialize($body, 'array<OpenAPI\Server\Model\User>', $inputFormat);
+        try {
+            $body = $this->deserialize($body, 'array<OpenAPI\Server\Model\User>', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -249,7 +258,11 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $body = $this->deserialize($body, 'array<OpenAPI\Server\Model\User>', $inputFormat);
+        try {
+            $body = $this->deserialize($body, 'array<OpenAPI\Server\Model\User>', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -324,7 +337,11 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $username = $this->deserialize($username, 'string', 'string');
+        try {
+            $username = $this->deserialize($username, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -400,7 +417,11 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $username = $this->deserialize($username, 'string', 'string');
+        try {
+            $username = $this->deserialize($username, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -481,8 +502,12 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $username = $this->deserialize($username, 'string', 'string');
-        $password = $this->deserialize($password, 'string', 'string');
+        try {
+            $username = $this->deserialize($username, 'string', 'string');
+            $password = $this->deserialize($password, 'string', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];
@@ -564,8 +589,6 @@ class UserController extends Controller
 
         // Use the default value if no value was provided
 
-        // Deserialize the input values that needs it
-
         // Validate the input values
 
 
@@ -639,8 +662,12 @@ class UserController extends Controller
         // Use the default value if no value was provided
 
         // Deserialize the input values that needs it
-        $username = $this->deserialize($username, 'string', 'string');
-        $body = $this->deserialize($body, 'OpenAPI\Server\Model\User', $inputFormat);
+        try {
+            $username = $this->deserialize($username, 'string', 'string');
+            $body = $this->deserialize($body, 'OpenAPI\Server\Model\User', $inputFormat);
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
 
         // Validate the input values
         $asserts = [];


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Since we use `StrictJsonDeserializationVisitor` which can throw an exception on type mismatch we should catch this exception and consider it as validation error and return "Bad request" response.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon