### PR TITLE
[PHP] remove deprecated options

### DIFF
--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -20,6 +20,4 @@ sidebar_label: php
 |gitUserId|Git user ID, e.g. openapitools.| |null|
 |gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
-|composerVendorName|The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets. IMPORTANT NOTE (2016/03): composerVendorName will be deprecated and replaced by gitUserId in the next openapi-generator release| |null|
-|composerProjectName|The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client. IMPORTANT NOTE (2016/03): composerProjectName will be deprecated and replaced by gitRepoId in the next openapi-generator release| |null|
 |hideGenerationTimestamp|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -40,11 +40,6 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     public static final String VARIABLE_NAMING_CONVENTION = "variableNamingConvention";
     public static final String PACKAGE_NAME = "packageName";
     public static final String SRC_BASE_PATH = "srcBasePath";
-    // composerVendorName/composerProjectName has be replaced by gitUserId/gitRepoId. prepare to remove these.
-    // public static final String COMPOSER_VENDOR_NAME = "composerVendorName";
-    // public static final String COMPOSER_PROJECT_NAME = "composerProjectName";
-    // protected String composerVendorName = null;
-    // protected String composerProjectName = null;
     protected String invokerPackage = "php";
     protected String packageName = "php-base";
     protected String artifactVersion = null;
@@ -137,9 +132,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, "The main namespace to use for all classes. e.g. Yay\\Pets"));
         cliOptions.add(new CliOption(PACKAGE_NAME, "The main package name for classes. e.g. GeneratedPetstore"));
         cliOptions.add(new CliOption(SRC_BASE_PATH, "The directory to serve as source root."));
-        // cliOptions.add(new CliOption(COMPOSER_VENDOR_NAME, "The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets. IMPORTANT NOTE (2016/03): composerVendorName will be deprecated and replaced by gitUserId in the next openapi-generator release"));
         cliOptions.add(new CliOption(CodegenConstants.GIT_USER_ID, CodegenConstants.GIT_USER_ID_DESC));
-        // cliOptions.add(new CliOption(COMPOSER_PROJECT_NAME, "The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client. IMPORTANT NOTE (2016/03): composerProjectName will be deprecated and replaced by gitRepoId in the next openapi-generator release"));
         cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_ID, CodegenConstants.GIT_REPO_ID_DESC));
         cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, "The version to use in the composer package version field. e.g. 1.2.3"));
     }
@@ -187,23 +180,11 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         }
         additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
 
-        // if (additionalProperties.containsKey(COMPOSER_PROJECT_NAME)) {
-        //     this.setComposerProjectName((String) additionalProperties.get(COMPOSER_PROJECT_NAME));
-        // } else {
-        //     additionalProperties.put(COMPOSER_PROJECT_NAME, composerProjectName);
-        // }
-
         if (additionalProperties.containsKey(CodegenConstants.GIT_USER_ID)) {
             this.setGitUserId((String) additionalProperties.get(CodegenConstants.GIT_USER_ID));
         } else {
             additionalProperties.put(CodegenConstants.GIT_USER_ID, gitUserId);
         }
-
-        // if (additionalProperties.containsKey(COMPOSER_VENDOR_NAME)) {
-        //     this.setComposerVendorName((String) additionalProperties.get(COMPOSER_VENDOR_NAME));
-        // } else {
-        //     additionalProperties.put(COMPOSER_VENDOR_NAME, composerVendorName);
-        // }
 
         if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_ID)) {
             this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
@@ -408,14 +389,6 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     public void setParameterNamingConvention(String variableNamingConvention) {
         this.variableNamingConvention = variableNamingConvention;
     }
-
-    // public void setComposerVendorName(String composerVendorName) {
-    //     this.composerVendorName = composerVendorName;
-    // }
-
-    // public void setComposerProjectName(String composerProjectName) {
-    //     this.composerProjectName = composerProjectName;
-    // }
 
     @Override
     public String toVarName(String name) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpClientCodegen.java
@@ -34,11 +34,6 @@ public class PhpClientCodegen extends AbstractPhpCodegen {
     @SuppressWarnings("hiding")
     private static final Logger LOGGER = LoggerFactory.getLogger(PhpClientCodegen.class);
 
-    public static final String COMPOSER_VENDOR_NAME = "composerVendorName";
-    public static final String COMPOSER_PROJECT_NAME = "composerProjectName";
-    protected String composerVendorName = null;
-    protected String composerProjectName = null;
-
     public PhpClientCodegen() {
         super();
 
@@ -64,8 +59,6 @@ public class PhpClientCodegen extends AbstractPhpCodegen {
         String primitives = "'" + StringUtils.join(sortedLanguageSpecificPrimitives, "', '") + "'";
         additionalProperties.put("primitives", primitives);
 
-        cliOptions.add(new CliOption(COMPOSER_VENDOR_NAME, "The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets. IMPORTANT NOTE (2016/03): composerVendorName will be deprecated and replaced by gitUserId in the next openapi-generator release"));
-        cliOptions.add(new CliOption(COMPOSER_PROJECT_NAME, "The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client. IMPORTANT NOTE (2016/03): composerProjectName will be deprecated and replaced by gitRepoId in the next openapi-generator release"));
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.ALLOW_UNICODE_IDENTIFIERS_DESC)
                 .defaultValue(Boolean.TRUE.toString()));
     }
@@ -89,18 +82,6 @@ public class PhpClientCodegen extends AbstractPhpCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey(COMPOSER_PROJECT_NAME)) {
-            this.setComposerProjectName((String) additionalProperties.get(COMPOSER_PROJECT_NAME));
-        } else {
-            additionalProperties.put(COMPOSER_PROJECT_NAME, composerProjectName);
-        }
-
-        if (additionalProperties.containsKey(COMPOSER_VENDOR_NAME)) {
-            this.setComposerVendorName((String) additionalProperties.get(COMPOSER_VENDOR_NAME));
-        } else {
-            additionalProperties.put(COMPOSER_VENDOR_NAME, composerVendorName);
-        }
-
         supportingFiles.add(new SupportingFile("ApiException.mustache", toSrcPath(invokerPackage, srcBasePath), "ApiException.php"));
         supportingFiles.add(new SupportingFile("Configuration.mustache", toSrcPath(invokerPackage, srcBasePath), "Configuration.php"));
         supportingFiles.add(new SupportingFile("ObjectSerializer.mustache", toSrcPath(invokerPackage, srcBasePath), "ObjectSerializer.php"));
@@ -112,13 +93,5 @@ public class PhpClientCodegen extends AbstractPhpCodegen {
         supportingFiles.add(new SupportingFile(".travis.yml", "", ".travis.yml"));
         supportingFiles.add(new SupportingFile(".php_cs", "", ".php_cs"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-    }
-
-    public void setComposerVendorName(String composerVendorName) {
-        this.composerVendorName = composerVendorName;
-    }
-
-    public void setComposerProjectName(String composerProjectName) {
-        this.composerProjectName = composerProjectName;
     }
 }

--- a/modules/openapi-generator/src/main/resources/lumen/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/lumen/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}",
+    "name": "{{gitUserId}}/{{gitRepoId}}",
     {{#artifactVersion}}
     "version": "{{artifactVersion}}",
     {{/artifactVersion}}

--- a/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/composer.mustache
@@ -1,5 +1,5 @@
 {
-  "name": "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}",
+  "name": "{{gitUserId}}/{{gitRepoId}}",
   "description": "{{description}}.",
   "keywords": ["framework", "laravel"],
   {{#artifactVersion}}

--- a/modules/openapi-generator/src/main/resources/php-symfony/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/README.mustache
@@ -37,7 +37,7 @@ To install the dependencies via [Composer](http://getcomposer.org/), add the fol
 Then run:
 
 ```
-composer require {{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}:dev-master
+composer require {{gitUserId}}/{{gitRepoId}}:dev-master
 ```
 
 to add the generated openapi bundle as a dependency.

--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}",
+    "name": "{{gitUserId}}/{{gitRepoId}}",
     {{#artifactVersion}}
     "version": "{{artifactVersion}}",
     {{/artifactVersion}}

--- a/modules/openapi-generator/src/main/resources/php/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php/README.mustache
@@ -31,11 +31,11 @@ To install the bindings via [Composer](http://getcomposer.org/), add the followi
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}.git"
+      "url": "https://github.com/{{gitUserId}}/{{gitRepoId}}.git"
     }
   ],
   "require": {
-    "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}": "*@dev"
+    "{{gitUserId}}/{{gitRepoId}}": "*@dev"
   }
 }
 ```

--- a/modules/openapi-generator/src/main/resources/php/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/composer.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "{{#composerVendorName}}{{.}}{{/composerVendorName}}{{^composerVendorName}}{{gitUserId}}{{/composerVendorName}}/{{#composerProjectName}}{{.}}{{/composerProjectName}}{{^composerProjectName}}{{gitRepoId}}{{/composerProjectName}}",
+    "name": "{{gitUserId}}/{{gitRepoId}}",
     {{#artifactVersion}}
     "version": "{{artifactVersion}}",
     {{/artifactVersion}}
@@ -7,12 +7,13 @@
     "keywords": [
         "openapitools",
         "openapi-generator",
+        "openapi",
         "php",
         "sdk",
         "rest",
         "api"
     ],
-    "homepage": "http://openapi-generator.tech",
+    "homepage": "https://openapi-generator.tech",
     "license": "proprietary",
     "authors": [
         {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
@@ -32,8 +32,6 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String INVOKER_PACKAGE_VALUE = "OpenAPITools\\Client\\Php";
     public static final String PACKAGE_NAME_VALUE = "OpenAPIToolsClient-php";
     public static final String SRC_BASE_PATH_VALUE = "libPhp";
-    public static final String COMPOSER_VENDOR_NAME_VALUE = "openAPIToolsPhp";
-    public static final String COMPOSER_PROJECT_NAME_VALUE = "openapi-tools-client-php";
     public static final String GIT_USER_ID_VALUE = "gitOpenAPIToolsPhp";
     public static final String GIT_REPO_ID_VALUE = "git-openapi-tools-client-php";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0-SNAPSHOT";
@@ -56,9 +54,7 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
                 .put(PhpClientCodegen.PACKAGE_NAME, PACKAGE_NAME_VALUE)
                 .put(PhpClientCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)
-                .put(PhpClientCodegen.COMPOSER_VENDOR_NAME, COMPOSER_VENDOR_NAME_VALUE)
                 .put(CodegenConstants.GIT_USER_ID, GIT_USER_ID_VALUE)
-                .put(PhpClientCodegen.COMPOSER_PROJECT_NAME, COMPOSER_PROJECT_NAME_VALUE)
                 .put(CodegenConstants.GIT_REPO_ID, GIT_REPO_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
@@ -56,11 +56,7 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSrcBasePath(PhpClientOptionsProvider.SRC_BASE_PATH_VALUE);
             times = 1;
-            clientCodegen.setComposerVendorName(PhpClientOptionsProvider.COMPOSER_VENDOR_NAME_VALUE);
-            times = 1;
             clientCodegen.setGitUserId(PhpClientOptionsProvider.GIT_USER_ID_VALUE);
-            times = 1;
-            clientCodegen.setComposerProjectName(PhpClientOptionsProvider.COMPOSER_PROJECT_NAME_VALUE);
             times = 1;
             clientCodegen.setGitRepoId(PhpClientOptionsProvider.GIT_REPO_ID_VALUE);
             times = 1;

--- a/samples/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/client/petstore/php/OpenAPIClient-php/composer.json
@@ -4,12 +4,13 @@
     "keywords": [
         "openapitools",
         "openapi-generator",
+        "openapi",
         "php",
         "sdk",
         "rest",
         "api"
     ],
-    "homepage": "http://openapi-generator.tech",
+    "homepage": "https://openapi-generator.tech",
     "license": "proprietary",
     "authors": [
         {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/composer.json
@@ -4,12 +4,13 @@
     "keywords": [
         "openapitools",
         "openapi-generator",
+        "openapi",
         "php",
         "sdk",
         "rest",
         "api"
     ],
-    "homepage": "http://openapi-generator.tech",
+    "homepage": "https://openapi-generator.tech",
     "license": "proprietary",
     "authors": [
         {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
@@ -26,7 +26,7 @@ To install the dependencies via [Composer](http://getcomposer.org/), add the fol
 Then run:
 
 ```
-composer require openapi/server-bundle:dev-master
+composer require GIT_USER_ID/GIT_REPO_ID:dev-master
 ```
 
 to add the generated openapi bundle as a dependency.

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "openapi/server-bundle",
+    "name": "GIT_USER_ID/GIT_REPO_ID",
     "description": "",
     "keywords": [
         "openapi",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

[PHP] remove deprecated options: composerVendorName, composerProjectName

cc @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09), @ybelenko (2018/07), @renepardon (2018/12)


