### PR TITLE
[Java] Getter/Setter naming convention not followed in generated models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1551,7 +1551,7 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
-     * Output the Getter name, e.g. getSize
+     * Output the Setter name, e.g. setSize
      *
      * @param name the name of the property
      * @return setter name based on naming convention

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1349,10 +1349,12 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         this.supportJava6 = value;
     }
 
+    @Override
     public String toRegularExpression(String pattern) {
         return escapeText(pattern);
     }
 
+    @Override
     public boolean convertPropertyToBoolean(String propertyKey) {
         boolean booleanValue = false;
         if (additionalProperties.containsKey(propertyKey)) {
@@ -1362,6 +1364,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         return booleanValue;
     }
 
+    @Override
     public void writePropertyBack(String propertyKey, boolean value) {
         additionalProperties.put(propertyKey, value);
     }
@@ -1386,6 +1389,33 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
         return tag;
     }
+
+    /**
+     * Camelize the method name of the getter and setter
+     *
+     * @param name string to be camelized
+     * @return Camelized string
+     */
+    @Override
+    public String getterAndSetterCapitalize(String name) {
+        boolean lowercaseFirstLetter = false;
+        if (name == null || name.length() == 0) {
+            return name;
+        }
+        name = toVarName(name);
+        //
+        // Let the property name capitalized
+        // except when the first letter of the property name is lowercase and the second letter is uppercase
+        // Refer to section 8.8: Capitalization of inferred names of the JavaBeans API specification
+        // http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf)
+        //
+        if (name.length() > 1 && Character.isLowerCase(name.charAt(0)) && Character.isUpperCase(name.charAt(1))) {
+            lowercaseFirstLetter = true;
+        }
+        return camelize(name, lowercaseFirstLetter);
+    }
+
+
 
     @Override
     public void postProcessFile(File file, String fileType) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -227,7 +227,7 @@ public class JavaModelTest {
         Assert.assertTrue(property.isContainer);
     }
 
-    @Test(description = "convert a model with restriced characters")
+    @Test(description = "convert a model with restricted characters")
     public void restrictedCharactersPropertiesTest() {
         final Schema schema = new Schema()
                 .description("a sample model")
@@ -468,8 +468,8 @@ public class JavaModelTest {
 
         final CodegenProperty property = cm.vars.get(0);
         Assert.assertEquals(property.baseName, "pId");
-        Assert.assertEquals(property.getter, "getPId");
-        Assert.assertEquals(property.setter, "setPId");
+        Assert.assertEquals(property.getter, "getpId");
+        Assert.assertEquals(property.setter, "setpId");
         Assert.assertEquals(property.dataType, "String");
         Assert.assertEquals(property.name, "pId");
         Assert.assertEquals(property.defaultValue, null);
@@ -500,6 +500,34 @@ public class JavaModelTest {
         Assert.assertEquals(property.setter, "setAtTName");
         Assert.assertEquals(property.dataType, "String");
         Assert.assertEquals(property.name, "atTName");
+        Assert.assertEquals(property.defaultValue, null);
+        Assert.assertEquals(property.baseType, "String");
+        Assert.assertFalse(property.hasMore);
+        Assert.assertTrue(property.required);
+        Assert.assertFalse(property.isContainer);
+    }
+
+    @Test(description = "convert a model with an all upper-case letter and one non letter property names")
+    public void allUpperCaseOneNonLetterNamesTest() {
+        final Schema schema = new Schema()
+                .description("a model with a property name starting with two upper-case letters")
+                .addProperties("ATT_NAME", new StringSchema())
+                .addRequiredItem("ATT_NAME");
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", schema);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.baseName, "ATT_NAME");
+        Assert.assertEquals(property.getter, "getATTNAME");
+        Assert.assertEquals(property.setter, "setATTNAME");
+        Assert.assertEquals(property.dataType, "String");
+        Assert.assertEquals(property.name, "ATT_NAME");
         Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "String");
         Assert.assertFalse(property.hasMore);


### PR DESCRIPTION
fix the getter/setter when the second letter of the field name is already uppercase (following the JavaBeans API specification)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
cc @bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

[Java] Getter/Setter naming convention not followed in generated models #2085

fix the getter/setter when the second letter of the field name is already uppercase (following the JavaBeans API specification)

Details : 
Override `getterAndSetterCapitalize` class in the `AbstractJavaCodeGen` class
Change Java test `convert a model with a 2nd char upper-case property names` (getter and setter expected results)

useful links : 
- https://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf?AuthParam=1548672501_cd9f95cc049ee0220b70f6c448b2a095 (chapter 8)
- https://dertompson.com/2013/04/29/java-bean-getterssetters/

