### PR TITLE
[angular-typescript] Wrong Typescript Version for Angular 6 with Npm

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -225,7 +225,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             // Angular v7 requires typescript ">=3.1.1 <3.2.0"
             additionalProperties.put("tsVersion", ">=3.1.1 <3.2.0");
         } else if (ngVersion.atLeast("6.0.0")) {
-            additionalProperties.put("tsVersion", ">=2.1.5 <2.7.0");
+            additionalProperties.put("tsVersion", ">=2.7.2 and <2.10.0");
         } else if (ngVersion.atLeast("5.0.0")) {
             additionalProperties.put("tsVersion", ">=2.1.5 <2.7.0");
         } else {
@@ -268,8 +268,8 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             additionalProperties.put("tsickleVersion", "0.34.0");
         } else if (ngVersion.atLeast("6.0.0")) {
             // compatible versions with typescript version
-            additionalProperties.put("ngPackagrVersion", "2.4.5");
-            additionalProperties.put("tsickleVersion", "0.27.5");
+            additionalProperties.put("ngPackagrVersion", "3.0.6");
+            additionalProperties.put("tsickleVersion", "0.32.1");
         } else if (ngVersion.atLeast("5.0.0")) {
             // compatible versions with typescript version
             additionalProperties.put("ngPackagrVersion", "2.4.5");

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
@@ -27,12 +27,12 @@
     "@angular/common": "^6.0.0",
     "@angular/compiler": "^6.0.0",
     "@angular/platform-browser": "^6.0.0",
-    "ng-packagr": "^2.4.5",
-    "tsickle": "^0.27.5",
+    "ng-packagr": "^3.0.6",
+    "tsickle": "^0.32.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
     "zone.js": "^0.8.26",
-    "typescript": ">=2.1.5 <2.7.0"
+    "typescript": ">=2.7.2 and <2.10.0"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
@@ -27,12 +27,12 @@
     "@angular/common": "^6.0.0",
     "@angular/compiler": "^6.0.0",
     "@angular/platform-browser": "^6.0.0",
-    "ng-packagr": "^2.4.5",
-    "tsickle": "^0.27.5",
+    "ng-packagr": "^3.0.6",
+    "tsickle": "^0.32.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
     "zone.js": "^0.8.26",
-    "typescript": ">=2.1.5 <2.7.0"
+    "typescript": ">=2.7.2 and <2.10.0"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"


### PR DESCRIPTION
The Angular Compiler 6 requires TypeScript >=2.7.2 and <2.10.0  #2096

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### Description of the PR

changed the TypeScript  version for Angular 6
also changed tsickle and ngPackagr version for compatibility with this new TS Version

