### PR TITLE
[Ruby] Fix enum expansion in Ruby client (#2081)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -401,7 +401,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         if ("Integer".equals(datatype) || "Float".equals(datatype)) {
             return value;
         } else {
-            return "'" + escapeText(value) + "'";
+            return "\"" + escapeText(value) + "\"";
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -52,8 +52,9 @@ module {{moduleName}}
       {{#isEnum}}
       {{^isContainer}}
       # verify enum value
-      if @api_client.config.client_side_validation && ![{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?({{{paramName}}})
-        fail ArgumentError, "invalid value for '{{{paramName}}}', must be one of {{#allowableValues}}{{#values}}{{{this}}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}"
+      allowable_values = [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]
+      if @api_client.config.client_side_validation && !allowable_values.include?({{{paramName}}})
+        fail ArgumentError, "invalid value for \"{{{paramName}}}\", must be one of #{allowable_values}"
       end
       {{/isContainer}}
       {{/isEnum}}
@@ -62,13 +63,15 @@ module {{moduleName}}
       {{^required}}
       {{#isEnum}}
       {{#collectionFormat}}
-      if @api_client.config.client_side_validation && opts[:'{{{paramName}}}'] && !opts[:'{{{paramName}}}'].all? { |item| [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?(item) }
-        fail ArgumentError, 'invalid value for "{{{paramName}}}", must include one of {{#allowableValues}}{{#values}}{{{this}}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}'
+      allowable_values = [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]
+      if @api_client.config.client_side_validation && opts[:'{{{paramName}}}'] && !opts[:'{{{paramName}}}'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"{{{paramName}}}\", must include one of #{allowable_values}"
       end
       {{/collectionFormat}}
       {{^collectionFormat}}
-      if @api_client.config.client_side_validation && opts[:'{{{paramName}}}'] && ![{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}].include?(opts[:'{{{paramName}}}'])
-        fail ArgumentError, 'invalid value for "{{{paramName}}}", must be one of {{#allowableValues}}{{#values}}{{{this}}}{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}'
+      allowable_values = [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]
+      if @api_client.config.client_side_validation && opts[:'{{{paramName}}}'] && !allowable_values.include?(opts[:'{{{paramName}}}'])
+        fail ArgumentError, "invalid value for \"{{{paramName}}}\", must be one of #{allowable_values}"
       end
       {{/collectionFormat}}
       {{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/model_test.mustache
@@ -31,7 +31,7 @@ describe '{{classname}}' do
     it 'should work' do
       {{#isEnum}}
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#values}}"{{{this}}}"{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}])
       # validator.allowable_values.each do |value|
       #   expect { @instance.{{name}} = value }.not_to raise_error
       # end

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_enum_class.mustache
@@ -1,7 +1,7 @@
-  class {{classname}}
-    {{#allowableValues}}{{#enumVars}}
-    {{{name}}} = {{{value}}}.freeze{{/enumVars}}{{/allowableValues}}
+  class {{classname}}{{#allowableValues}}{{#enumVars}}
+    {{{name}}} = {{{value}}}.freeze{{/enumVars}}
 
+{{/allowableValues}}
     # Builds the enum from string
     # @param [String] The enum value in the form of the string
     # @return [String] The enum value

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -207,7 +207,7 @@
       {{/isNullable}}
       {{#isEnum}}
       {{^isContainer}}
-      {{{name}}}_validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}])
+      {{{name}}}_validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}])
       return false unless {{{name}}}_validator.valid?(@{{{name}}})
       {{/isContainer}}
       {{/isEnum}}
@@ -280,7 +280,7 @@
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] {{{name}}} Object to be assigned
     def {{{name}}}=({{{name}}})
-      validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#values}}'{{{this}}}'{{^-last}}, {{/-last}}{{/values}}{{/allowableValues}}])
+      validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}])
       unless validator.valid?({{{name}}})
         fail ArgumentError, "invalid value for \"{{{name}}}\", must be one of #{validator.allowable_values}."
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -608,29 +608,37 @@ module Petstore
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_enum_parameters ...'
       end
-      if @api_client.config.client_side_validation && opts[:'enum_header_string_array'] && !opts[:'enum_header_string_array'].all? { |item| ['>', '$'].include?(item) }
-        fail ArgumentError, 'invalid value for "enum_header_string_array", must include one of >, $'
+      allowable_values = [">", "$"]
+      if @api_client.config.client_side_validation && opts[:'enum_header_string_array'] && !opts[:'enum_header_string_array'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"enum_header_string_array\", must include one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_header_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_header_string'])
-        fail ArgumentError, 'invalid value for "enum_header_string", must be one of _abc, -efg, (xyz)'
+      allowable_values = ["_abc", "-efg", "(xyz)"]
+      if @api_client.config.client_side_validation && opts[:'enum_header_string'] && !allowable_values.include?(opts[:'enum_header_string'])
+        fail ArgumentError, "invalid value for \"enum_header_string\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_string_array'] && !opts[:'enum_query_string_array'].all? { |item| ['>', '$'].include?(item) }
-        fail ArgumentError, 'invalid value for "enum_query_string_array", must include one of >, $'
+      allowable_values = [">", "$"]
+      if @api_client.config.client_side_validation && opts[:'enum_query_string_array'] && !opts[:'enum_query_string_array'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"enum_query_string_array\", must include one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_query_string'])
-        fail ArgumentError, 'invalid value for "enum_query_string", must be one of _abc, -efg, (xyz)'
+      allowable_values = ["_abc", "-efg", "(xyz)"]
+      if @api_client.config.client_side_validation && opts[:'enum_query_string'] && !allowable_values.include?(opts[:'enum_query_string'])
+        fail ArgumentError, "invalid value for \"enum_query_string\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_integer'] && !['1', '-2'].include?(opts[:'enum_query_integer'])
-        fail ArgumentError, 'invalid value for "enum_query_integer", must be one of 1, -2'
+      allowable_values = [1, -2]
+      if @api_client.config.client_side_validation && opts[:'enum_query_integer'] && !allowable_values.include?(opts[:'enum_query_integer'])
+        fail ArgumentError, "invalid value for \"enum_query_integer\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_double'] && !['1.1', '-1.2'].include?(opts[:'enum_query_double'])
-        fail ArgumentError, 'invalid value for "enum_query_double", must be one of 1.1, -1.2'
+      allowable_values = [1.1, -1.2]
+      if @api_client.config.client_side_validation && opts[:'enum_query_double'] && !allowable_values.include?(opts[:'enum_query_double'])
+        fail ArgumentError, "invalid value for \"enum_query_double\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_form_string_array'] && !opts[:'enum_form_string_array'].all? { |item| ['>', '$'].include?(item) }
-        fail ArgumentError, 'invalid value for "enum_form_string_array", must include one of >, $'
+      allowable_values = [">", "$"]
+      if @api_client.config.client_side_validation && opts[:'enum_form_string_array'] && !opts[:'enum_form_string_array'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"enum_form_string_array\", must include one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_form_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_form_string'])
-        fail ArgumentError, 'invalid value for "enum_form_string", must be one of _abc, -efg, (xyz)'
+      allowable_values = ["_abc", "-efg", "(xyz)"]
+      if @api_client.config.client_side_validation && opts[:'enum_form_string'] && !allowable_values.include?(opts[:'enum_form_string'])
+        fail ArgumentError, "invalid value for \"enum_form_string\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = '/fake'

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -85,7 +85,7 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      just_symbol_validator = EnumAttributeValidator.new('String', ['>=', '$'])
+      just_symbol_validator = EnumAttributeValidator.new('String', [">=", "$"])
       return false unless just_symbol_validator.valid?(@just_symbol)
       true
     end
@@ -93,7 +93,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] just_symbol Object to be assigned
     def just_symbol=(just_symbol)
-      validator = EnumAttributeValidator.new('String', ['>=', '$'])
+      validator = EnumAttributeValidator.new('String', [">=", "$"])
       unless validator.valid?(just_symbol)
         fail ArgumentError, "invalid value for \"just_symbol\", must be one of #{validator.allowable_values}."
       end

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_class.rb
@@ -14,10 +14,9 @@ require 'date'
 
 module Petstore
   class EnumClass
-    
-    ABC = '_abc'.freeze
-    EFG = '-efg'.freeze
-    XYZ = '(xyz)'.freeze
+    ABC = "_abc".freeze
+    EFG = "-efg".freeze
+    XYZ = "(xyz)".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -111,14 +111,14 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      enum_string_validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      enum_string_validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       return false unless enum_string_validator.valid?(@enum_string)
       return false if @enum_string_required.nil?
-      enum_string_required_validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      enum_string_required_validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       return false unless enum_string_required_validator.valid?(@enum_string_required)
-      enum_integer_validator = EnumAttributeValidator.new('Integer', ['1', '-1'])
+      enum_integer_validator = EnumAttributeValidator.new('Integer', [1, -1])
       return false unless enum_integer_validator.valid?(@enum_integer)
-      enum_number_validator = EnumAttributeValidator.new('Float', ['1.1', '-1.2'])
+      enum_number_validator = EnumAttributeValidator.new('Float', [1.1, -1.2])
       return false unless enum_number_validator.valid?(@enum_number)
       true
     end
@@ -126,7 +126,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_string Object to be assigned
     def enum_string=(enum_string)
-      validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       unless validator.valid?(enum_string)
         fail ArgumentError, "invalid value for \"enum_string\", must be one of #{validator.allowable_values}."
       end
@@ -136,7 +136,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_string_required Object to be assigned
     def enum_string_required=(enum_string_required)
-      validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       unless validator.valid?(enum_string_required)
         fail ArgumentError, "invalid value for \"enum_string_required\", must be one of #{validator.allowable_values}."
       end
@@ -146,7 +146,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_integer Object to be assigned
     def enum_integer=(enum_integer)
-      validator = EnumAttributeValidator.new('Integer', ['1', '-1'])
+      validator = EnumAttributeValidator.new('Integer', [1, -1])
       unless validator.valid?(enum_integer)
         fail ArgumentError, "invalid value for \"enum_integer\", must be one of #{validator.allowable_values}."
       end
@@ -156,7 +156,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_number Object to be assigned
     def enum_number=(enum_number)
-      validator = EnumAttributeValidator.new('Float', ['1.1', '-1.2'])
+      validator = EnumAttributeValidator.new('Float', [1.1, -1.2])
       unless validator.valid?(enum_number)
         fail ArgumentError, "invalid value for \"enum_number\", must be one of #{validator.allowable_values}."
       end

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -118,7 +118,7 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      status_validator = EnumAttributeValidator.new('String', ['placed', 'approved', 'delivered'])
+      status_validator = EnumAttributeValidator.new('String', ["placed", "approved", "delivered"])
       return false unless status_validator.valid?(@status)
       true
     end
@@ -126,7 +126,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] status Object to be assigned
     def status=(status)
-      validator = EnumAttributeValidator.new('String', ['placed', 'approved', 'delivered'])
+      validator = EnumAttributeValidator.new('String', ["placed", "approved", "delivered"])
       unless validator.valid?(status)
         fail ArgumentError, "invalid value for \"status\", must be one of #{validator.allowable_values}."
       end

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_enum.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_enum.rb
@@ -14,10 +14,9 @@ require 'date'
 
 module Petstore
   class OuterEnum
-    
-    PLACED = 'placed'.freeze
-    APPROVED = 'approved'.freeze
-    DELIVERED = 'delivered'.freeze
+    PLACED = "placed".freeze
+    APPROVED = "approved".freeze
+    DELIVERED = "delivered".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -130,7 +130,7 @@ module Petstore
     def valid?
       return false if @name.nil?
       return false if @photo_urls.nil?
-      status_validator = EnumAttributeValidator.new('String', ['available', 'pending', 'sold'])
+      status_validator = EnumAttributeValidator.new('String', ["available", "pending", "sold"])
       return false unless status_validator.valid?(@status)
       true
     end
@@ -138,7 +138,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] status Object to be assigned
     def status=(status)
-      validator = EnumAttributeValidator.new('String', ['available', 'pending', 'sold'])
+      validator = EnumAttributeValidator.new('String', ["available", "pending", "sold"])
       unless validator.valid?(status)
         fail ArgumentError, "invalid value for \"status\", must be one of #{validator.allowable_values}."
       end

--- a/samples/client/petstore/ruby/spec/models/enum_test_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/enum_test_spec.rb
@@ -55,7 +55,7 @@ describe 'EnumTest' do
   describe 'test attribute "enum_integer"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Integer', ["1", "-1"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Integer', [1, -1])
       # validator.allowable_values.each do |value|
       #   expect { @instance.enum_integer = value }.not_to raise_error
       # end
@@ -65,7 +65,7 @@ describe 'EnumTest' do
   describe 'test attribute "enum_number"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Float', ["1.1", "-1.2"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Float', [1.1, -1.2])
       # validator.allowable_values.each do |value|
       #   expect { @instance.enum_number = value }.not_to raise_error
       # end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -564,29 +564,37 @@ module Petstore
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_enum_parameters ...'
       end
-      if @api_client.config.client_side_validation && opts[:'enum_header_string_array'] && !opts[:'enum_header_string_array'].all? { |item| ['>', '$'].include?(item) }
-        fail ArgumentError, 'invalid value for "enum_header_string_array", must include one of >, $'
+      allowable_values = [">", "$"]
+      if @api_client.config.client_side_validation && opts[:'enum_header_string_array'] && !opts[:'enum_header_string_array'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"enum_header_string_array\", must include one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_header_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_header_string'])
-        fail ArgumentError, 'invalid value for "enum_header_string", must be one of _abc, -efg, (xyz)'
+      allowable_values = ["_abc", "-efg", "(xyz)"]
+      if @api_client.config.client_side_validation && opts[:'enum_header_string'] && !allowable_values.include?(opts[:'enum_header_string'])
+        fail ArgumentError, "invalid value for \"enum_header_string\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_string_array'] && !opts[:'enum_query_string_array'].all? { |item| ['>', '$'].include?(item) }
-        fail ArgumentError, 'invalid value for "enum_query_string_array", must include one of >, $'
+      allowable_values = [">", "$"]
+      if @api_client.config.client_side_validation && opts[:'enum_query_string_array'] && !opts[:'enum_query_string_array'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"enum_query_string_array\", must include one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_query_string'])
-        fail ArgumentError, 'invalid value for "enum_query_string", must be one of _abc, -efg, (xyz)'
+      allowable_values = ["_abc", "-efg", "(xyz)"]
+      if @api_client.config.client_side_validation && opts[:'enum_query_string'] && !allowable_values.include?(opts[:'enum_query_string'])
+        fail ArgumentError, "invalid value for \"enum_query_string\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_integer'] && !['1', '-2'].include?(opts[:'enum_query_integer'])
-        fail ArgumentError, 'invalid value for "enum_query_integer", must be one of 1, -2'
+      allowable_values = [1, -2]
+      if @api_client.config.client_side_validation && opts[:'enum_query_integer'] && !allowable_values.include?(opts[:'enum_query_integer'])
+        fail ArgumentError, "invalid value for \"enum_query_integer\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_query_double'] && !['1.1', '-1.2'].include?(opts[:'enum_query_double'])
-        fail ArgumentError, 'invalid value for "enum_query_double", must be one of 1.1, -1.2'
+      allowable_values = [1.1, -1.2]
+      if @api_client.config.client_side_validation && opts[:'enum_query_double'] && !allowable_values.include?(opts[:'enum_query_double'])
+        fail ArgumentError, "invalid value for \"enum_query_double\", must be one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_form_string_array'] && !opts[:'enum_form_string_array'].all? { |item| ['>', '$'].include?(item) }
-        fail ArgumentError, 'invalid value for "enum_form_string_array", must include one of >, $'
+      allowable_values = [">", "$"]
+      if @api_client.config.client_side_validation && opts[:'enum_form_string_array'] && !opts[:'enum_form_string_array'].all? { |item| allowable_values.include?(item) }
+        fail ArgumentError, "invalid value for \"enum_form_string_array\", must include one of #{allowable_values}"
       end
-      if @api_client.config.client_side_validation && opts[:'enum_form_string'] && !['_abc', '-efg', '(xyz)'].include?(opts[:'enum_form_string'])
-        fail ArgumentError, 'invalid value for "enum_form_string", must be one of _abc, -efg, (xyz)'
+      allowable_values = ["_abc", "-efg", "(xyz)"]
+      if @api_client.config.client_side_validation && opts[:'enum_form_string'] && !allowable_values.include?(opts[:'enum_form_string'])
+        fail ArgumentError, "invalid value for \"enum_form_string\", must be one of #{allowable_values}"
       end
       # resource path
       local_var_path = '/fake'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -85,7 +85,7 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      just_symbol_validator = EnumAttributeValidator.new('String', ['>=', '$'])
+      just_symbol_validator = EnumAttributeValidator.new('String', [">=", "$"])
       return false unless just_symbol_validator.valid?(@just_symbol)
       true
     end
@@ -93,7 +93,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] just_symbol Object to be assigned
     def just_symbol=(just_symbol)
-      validator = EnumAttributeValidator.new('String', ['>=', '$'])
+      validator = EnumAttributeValidator.new('String', [">=", "$"])
       unless validator.valid?(just_symbol)
         fail ArgumentError, "invalid value for \"just_symbol\", must be one of #{validator.allowable_values}."
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_class.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_class.rb
@@ -14,10 +14,9 @@ require 'date'
 
 module Petstore
   class EnumClass
-    
-    ABC = '_abc'.freeze
-    EFG = '-efg'.freeze
-    XYZ = '(xyz)'.freeze
+    ABC = "_abc".freeze
+    EFG = "-efg".freeze
+    XYZ = "(xyz)".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -111,14 +111,14 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      enum_string_validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      enum_string_validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       return false unless enum_string_validator.valid?(@enum_string)
       return false if @enum_string_required.nil?
-      enum_string_required_validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      enum_string_required_validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       return false unless enum_string_required_validator.valid?(@enum_string_required)
-      enum_integer_validator = EnumAttributeValidator.new('Integer', ['1', '-1'])
+      enum_integer_validator = EnumAttributeValidator.new('Integer', [1, -1])
       return false unless enum_integer_validator.valid?(@enum_integer)
-      enum_number_validator = EnumAttributeValidator.new('Float', ['1.1', '-1.2'])
+      enum_number_validator = EnumAttributeValidator.new('Float', [1.1, -1.2])
       return false unless enum_number_validator.valid?(@enum_number)
       true
     end
@@ -126,7 +126,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_string Object to be assigned
     def enum_string=(enum_string)
-      validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       unless validator.valid?(enum_string)
         fail ArgumentError, "invalid value for \"enum_string\", must be one of #{validator.allowable_values}."
       end
@@ -136,7 +136,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_string_required Object to be assigned
     def enum_string_required=(enum_string_required)
-      validator = EnumAttributeValidator.new('String', ['UPPER', 'lower', ''])
+      validator = EnumAttributeValidator.new('String', ["UPPER", "lower", ""])
       unless validator.valid?(enum_string_required)
         fail ArgumentError, "invalid value for \"enum_string_required\", must be one of #{validator.allowable_values}."
       end
@@ -146,7 +146,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_integer Object to be assigned
     def enum_integer=(enum_integer)
-      validator = EnumAttributeValidator.new('Integer', ['1', '-1'])
+      validator = EnumAttributeValidator.new('Integer', [1, -1])
       unless validator.valid?(enum_integer)
         fail ArgumentError, "invalid value for \"enum_integer\", must be one of #{validator.allowable_values}."
       end
@@ -156,7 +156,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] enum_number Object to be assigned
     def enum_number=(enum_number)
-      validator = EnumAttributeValidator.new('Float', ['1.1', '-1.2'])
+      validator = EnumAttributeValidator.new('Float', [1.1, -1.2])
       unless validator.valid?(enum_number)
         fail ArgumentError, "invalid value for \"enum_number\", must be one of #{validator.allowable_values}."
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/order.rb
@@ -118,7 +118,7 @@ module Petstore
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
-      status_validator = EnumAttributeValidator.new('String', ['placed', 'approved', 'delivered'])
+      status_validator = EnumAttributeValidator.new('String', ["placed", "approved", "delivered"])
       return false unless status_validator.valid?(@status)
       true
     end
@@ -126,7 +126,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] status Object to be assigned
     def status=(status)
-      validator = EnumAttributeValidator.new('String', ['placed', 'approved', 'delivered'])
+      validator = EnumAttributeValidator.new('String', ["placed", "approved", "delivered"])
       unless validator.valid?(status)
         fail ArgumentError, "invalid value for \"status\", must be one of #{validator.allowable_values}."
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/outer_enum.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/outer_enum.rb
@@ -14,10 +14,9 @@ require 'date'
 
 module Petstore
   class OuterEnum
-    
-    PLACED = 'placed'.freeze
-    APPROVED = 'approved'.freeze
-    DELIVERED = 'delivered'.freeze
+    PLACED = "placed".freeze
+    APPROVED = "approved".freeze
+    DELIVERED = "delivered".freeze
 
     # Builds the enum from string
     # @param [String] The enum value in the form of the string

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -130,7 +130,7 @@ module Petstore
     def valid?
       return false if @name.nil?
       return false if @photo_urls.nil?
-      status_validator = EnumAttributeValidator.new('String', ['available', 'pending', 'sold'])
+      status_validator = EnumAttributeValidator.new('String', ["available", "pending", "sold"])
       return false unless status_validator.valid?(@status)
       true
     end
@@ -138,7 +138,7 @@ module Petstore
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] status Object to be assigned
     def status=(status)
-      validator = EnumAttributeValidator.new('String', ['available', 'pending', 'sold'])
+      validator = EnumAttributeValidator.new('String', ["available", "pending", "sold"])
       unless validator.valid?(status)
         fail ArgumentError, "invalid value for \"status\", must be one of #{validator.allowable_values}."
       end

--- a/samples/openapi3/client/petstore/ruby/spec/models/enum_test_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/models/enum_test_spec.rb
@@ -55,7 +55,7 @@ describe 'EnumTest' do
   describe 'test attribute "enum_integer"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Integer', ["1", "-1"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Integer', [1, -1])
       # validator.allowable_values.each do |value|
       #   expect { @instance.enum_integer = value }.not_to raise_error
       # end
@@ -65,7 +65,7 @@ describe 'EnumTest' do
   describe 'test attribute "enum_number"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Float', ["1.1", "-1.2"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('Float', [1.1, -1.2])
       # validator.allowable_values.each do |value|
       #   expect { @instance.enum_number = value }.not_to raise_error
       # end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

### Description of the PR

Fix #2081.

- To correctly escape, `toEnumValue` now returns double-quote string.
- To correctly expand allowable values, `{{#values}}` in `{{#allowableValues}}` changed to `{{#enumVars}}`.
