### PR TITLE
Don't escape [ and ] in query param keys

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
@@ -14,7 +14,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);
@@ -31,7 +33,9 @@ export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v2/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
@@ -8,7 +8,9 @@
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return k.replace(/\+/gi, '%2B')
+            .replace(/%5B/, "[").replace(/%5D/, "]")
+            ;
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);


### PR DESCRIPTION
rails' default naming for arrays in query parameters is name[]=...&name[]=...
It doesn't recognize the escaped forms %5B + %5D but fails silently

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adapting the solution [here](https://stackoverflow.com/a/48307962) to prevent HttpParameterCodec from encoding '[' and ']' in query param keys.

This is important for using Rails as a backend as the square brackets are added to the parameter names as per default.

I suppose this change doesn't interfere with most people's APIs as square brackets are not common suffixes other to arrays. Encoding them on the other hand is not necessary for URIs and users could still do this if required for their specific project.

However, if this still considered to be a breaking change, I suppose introducing an additional parameter such as 'rails-compat-query-array-params'.

