### PR TITLE
[Java] Bean Validation for decimalmin/max incorrect when exclusive set

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/beanValidationCore.mustache
@@ -17,4 +17,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}} @Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/beanValidationCore.mustache
@@ -17,4 +17,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}} @Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/beanValidationCore.mustache
@@ -17,4 +17,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}} @Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/beanValidationCore.mustache
@@ -17,4 +17,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}} @Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/beanValidationCore.mustache
@@ -17,4 +17,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}} @Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidationCore.mustache
@@ -17,4 +17,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}} @Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}"){{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}} @DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/beanValidationCore.mustache
@@ -19,4 +19,4 @@ isInteger set
 isLong set
 }}{{#isLong}}{{#minimum}}@Min({{minimum}}L){{/minimum}}{{#maximum}} @Max({{maximum}}L) {{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
-}}{{^isInteger}}{{^isLong}}{{#minimum}}@DecimalMin("{{minimum}}"){{/minimum}}{{#maximum}} @DecimalMax("{{maximum}}") {{/maximum}}{{/isLong}}{{/isInteger}}
+}}{{^isInteger}}{{^isLong}}{{#minimum}}@DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @DecimalMax({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{maximum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}) {{/maximum}}{{/isLong}}{{/isInteger}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)

### Description of the PR

the exclusiveMinimum openApi properties is not mapped in bean validation annotation template
#2082

