### PR TITLE
[typescript-angular] Incorrect OperationId Generated (starting with number)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -407,9 +407,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
             throw new RuntimeException("Empty method name (operationId) not allowed");
         }
 
-        // method name cannot use reserved keyword, e.g. return
-        // append _ at the beginning, e.g. _return
-        if (isReservedWord(operationId)) {
+        // method name cannot use reserved keyword or word starting with number, e.g. return or 123return
+        // append _ at the beginning, e.g. _return or _123return
+        if (isReservedWord(operationId) || operationId.matches("^\\d.*")) {
             return escapeReservedWord(camelize(sanitizeName(operationId), true));
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -3,6 +3,13 @@ package org.openapitools.codegen.typescript.typescriptangular;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openapitools.codegen.languages.TypeScriptAngularClientCodegen;
+import org.openapitools.codegen.TestUtils;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import org.openapitools.codegen.CodegenOperation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 
 public class TypeScriptAngularClientCodegenTest {
     @Test
@@ -14,4 +21,18 @@ public class TypeScriptAngularClientCodegenTest {
 
         Assert.assertEquals(codegen.toModelFilename("testName"), "testNameMySuffix");
     }
+
+    @Test
+    public void testOperationIdParser() {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        Operation operation1 = new Operation().operationId("123_test_@#$%_special_tags").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")));
+        openAPI.path("another-fake/dummy/", new PathItem().get(operation1));
+        final TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        CodegenOperation co1 = codegen.fromOperation("/another-fake/dummy/", "get", operation1, null);
+        org.testng.Assert.assertEquals(co1.operationId, "_123testSpecialTags");
+
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularModelTest.java
@@ -214,4 +214,31 @@ public class TypeScriptAngularModelTest {
         Assert.assertEquals(cm.additionalPropertiesType, "Children");
         Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
     }
+
+    @Test(description = "convert a model with a name starting with decimal")
+    public void beginDecimalNameTest() {
+        final Schema schema = new Schema()
+                .description("a model with a name starting with decimal")
+                .addProperties("1list", new StringSchema())
+                .addRequiredItem("1list");
+        final DefaultCodegen codegen = new TypeScriptAngularClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", schema);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.baseName, "1list");
+        Assert.assertEquals(property.dataType, "string");
+        Assert.assertEquals(property.name, "_1list");
+        Assert.assertEquals(property.defaultValue, "undefined");
+        Assert.assertEquals(property.baseType, "string");
+        Assert.assertFalse(property.hasMore);
+        Assert.assertTrue(property.required);
+        Assert.assertFalse(property.isContainer);
+    }
+
 }


### PR DESCRIPTION

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### Description of the PR

fix #2120
append _ at the beginning, as reserved keyword
add 2 tests case to check codegen parser for operationId and property starting with decimal

