### PR TITLE
[core] consider schema in headers when computing unused schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -192,10 +192,20 @@ public class ModelUtils {
                 if (operation.getResponses() != null) {
                     for (ApiResponse r : operation.getResponses().values()) {
                         ApiResponse apiResponse = getReferencedApiResponse(openAPI, r);
-                        if (apiResponse != null && apiResponse.getContent() != null) {
-                            for (Entry<String, MediaType> e : apiResponse.getContent().entrySet()) {
-                                if (e.getValue().getSchema() != null) {
-                                    visitSchema(openAPI, e.getValue().getSchema(), e.getKey(), visitedSchemas, visitor);
+                        if (apiResponse != null) {
+                            if (apiResponse.getContent() != null) {
+                                for (Entry<String, MediaType> e : apiResponse.getContent().entrySet()) {
+                                    if (e.getValue().getSchema() != null) {
+                                        visitSchema(openAPI, e.getValue().getSchema(), e.getKey(), visitedSchemas, visitor);
+                                    }
+                                }
+                            }
+                            if (apiResponse.getHeaders() != null) {
+                                for (Entry<String, Header> e : apiResponse.getHeaders().entrySet()) {
+                                    Header header = getReferencedHeader(openAPI, e.getValue());
+                                    if (header.getSchema() != null) {
+                                        visitSchema(openAPI, header.getSchema(), e.getKey(), visitedSchemas, visitor);
+                                    }
                                 }
                             }
                         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -37,7 +37,7 @@ public class ModelUtilsTest {
     public void testGetAllUsedSchemas() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
-        Assert.assertEquals(allUsedSchemas.size(), 32);
+        Assert.assertEquals(allUsedSchemas.size(), 34);
 
         Assert.assertTrue(allUsedSchemas.contains("SomeObjShared"), "contains 'SomeObjShared'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj1"), "contains 'UnusedObj1'");
@@ -71,6 +71,8 @@ public class ModelUtilsTest {
         Assert.assertTrue(allUsedSchemas.contains("PingDataOutput21"), "contains 'PingDataOutput21'");
         Assert.assertTrue(allUsedSchemas.contains("SInput22"), "contains 'SInput22'");
         Assert.assertTrue(allUsedSchemas.contains("SOutput22"), "contains 'SInput22'");
+        Assert.assertTrue(allUsedSchemas.contains("SomeHeader23"), "contains 'SomeHeader23'");
+        Assert.assertTrue(allUsedSchemas.contains("SomeHeader24"), "contains 'SomeHeader24'");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
@@ -280,6 +280,27 @@ paths:
       callbacks:
         sharedCallback:
           $ref: "#/components/callbacks/sharedCallback22"
+  /some/p23:
+    post:
+      operationId: op23
+      responses:
+        '2XX':
+          description: OK
+          headers:
+            x-app-info:
+              description: basic app info
+              style: simple
+              schema:
+                $ref: "#/components/schemas/SomeHeader23"
+  /some/p24:
+    post:
+      operationId: op24
+      responses:
+        '2XX':
+          description: OK
+          headers:
+            x-app-info:
+              $ref: "#/components/headers/sharedHeader24"
 components:
   schemas:
     UnusedObj1:
@@ -538,6 +559,11 @@ components:
           type: String
         response:
           type: String
+    SomeHeader23:
+      type: string
+    SomeHeader24:
+      type: integer
+      format: int64
     SomeObjShared:
       type: object
       properties:
@@ -607,4 +633,9 @@ components:
                 application/json:
                   schema:
                     $ref: '#/components/schemas/SOutput22'
-  
+  headers:
+    sharedHeader24:
+      description: basic header
+      style: simple
+      schema:
+        $ref: "#/components/schemas/SomeHeader24"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @OpenAPITools/generator-core-team 

### Description of the PR

Introduced with #74 and updated with #1232, the `ModelUtils.getUnusedSchemas(OpenAPI)` returns all schemas that are not used in an OpenAPI specification.

This PR fixes the case where a Schema is referenced in an Header.

Original issue: #50 

