### PR TITLE
[Ruby] Fix regualr expression in error message (#2069)

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -102,8 +102,9 @@ module {{moduleName}}
 
       {{/minimum}}
       {{#pattern}}
-      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} !~ Regexp.new({{{pattern}}})
-        fail ArgumentError, "invalid value for '{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:\"{{{paramName}}}\"]{{/required}}' when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}."
+      pattern = Regexp.new({{{pattern}}})
+      if @api_client.config.client_side_validation && {{^required}}!opts[:'{{{paramName}}}'].nil? && {{/required}}{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}} !~ pattern
+        fail ArgumentError, "invalid value for '{{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:\"{{{paramName}}}\"]{{/required}}' when calling {{classname}}.{{operationId}}, must conform to the pattern #{pattern}."
       end
 
       {{/pattern}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -174,8 +174,9 @@
 
       {{/minimum}}
       {{#pattern}}
-      if {{^required}}!@{{{name}}}.nil? && {{/required}}@{{{name}}} !~ Regexp.new({{{pattern}}})
-        invalid_properties.push('invalid value for "{{{name}}}", must conform to the pattern {{{pattern}}}.')
+      pattern = Regexp.new({{{pattern}}})
+      if {{^required}}!@{{{name}}}.nil? && {{/required}}@{{{name}}} !~ pattern
+        invalid_properties.push("invalid value for \"{{{name}}}\", must conform to the pattern #{pattern}.")
       end
 
       {{/pattern}}
@@ -327,8 +328,9 @@
 
       {{/minimum}}
       {{#pattern}}
-      if {{^required}}!{{{name}}}.nil? && {{/required}}{{{name}}} !~ Regexp.new({{{pattern}}})
-        fail ArgumentError, 'invalid value for "{{{name}}}", must conform to the pattern {{{pattern}}}.'
+      pattern = Regexp.new({{{pattern}}})
+      if {{^required}}!{{{name}}}.nil? && {{/required}}{{{name}}} !~ pattern
+        fail ArgumentError, "invalid value for \"{{{name}}}\", must conform to the pattern #{pattern}."
       end
 
       {{/pattern}}

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -492,8 +492,9 @@ module Petstore
       if @api_client.config.client_side_validation && pattern_without_delimiter.nil?
         fail ArgumentError, "Missing the required parameter 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters"
       end
-      if @api_client.config.client_side_validation && pattern_without_delimiter !~ Regexp.new(/^[A-Z].*/)
-        fail ArgumentError, "invalid value for 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters, must conform to the pattern /^[A-Z].*/."
+      pattern = Regexp.new(/^[A-Z].*/)
+      if @api_client.config.client_side_validation && pattern_without_delimiter !~ pattern
+        fail ArgumentError, "invalid value for 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters, must conform to the pattern #{pattern}."
       end
 
       # verify the required parameter 'byte' is set
@@ -520,8 +521,9 @@ module Petstore
         fail ArgumentError, 'invalid value for "opts[:"float"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 987.6.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'string'].nil? && opts[:'string'] !~ Regexp.new(/[a-z]/i)
-        fail ArgumentError, "invalid value for 'opts[:\"string\"]' when calling FakeApi.test_endpoint_parameters, must conform to the pattern /[a-z]/i."
+      pattern = Regexp.new(/[a-z]/i)
+      if @api_client.config.client_side_validation && !opts[:'string'].nil? && opts[:'string'] !~ pattern
+        fail ArgumentError, "invalid value for 'opts[:\"string\"]' when calling FakeApi.test_endpoint_parameters, must conform to the pattern #{pattern}."
       end
 
       if @api_client.config.client_side_validation && !opts[:'password'].nil? && opts[:'password'].to_s.length > 64

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -187,16 +187,18 @@ module Petstore
         invalid_properties.push('invalid value for "double", must be greater than or equal to 67.8.')
       end
 
-      if !@string.nil? && @string !~ Regexp.new(/[a-z]/i)
-        invalid_properties.push('invalid value for "string", must conform to the pattern /[a-z]/i.')
+      pattern = Regexp.new(/[a-z]/i)
+      if !@string.nil? && @string !~ pattern
+        invalid_properties.push("invalid value for \"string\", must conform to the pattern #{pattern}.")
       end
 
       if @byte.nil?
         invalid_properties.push('invalid value for "byte", byte cannot be nil.')
       end
 
-      if @byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
-        invalid_properties.push('invalid value for "byte", must conform to the pattern /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/.')
+      pattern = Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
+      if @byte !~ pattern
+        invalid_properties.push("invalid value for \"byte\", must conform to the pattern #{pattern}.")
       end
 
       if @date.nil?
@@ -319,8 +321,9 @@ module Petstore
     # Custom attribute writer method with validation
     # @param [Object] string Value to be assigned
     def string=(string)
-      if !string.nil? && string !~ Regexp.new(/[a-z]/i)
-        fail ArgumentError, 'invalid value for "string", must conform to the pattern /[a-z]/i.'
+      pattern = Regexp.new(/[a-z]/i)
+      if !string.nil? && string !~ pattern
+        fail ArgumentError, "invalid value for \"string\", must conform to the pattern #{pattern}."
       end
 
       @string = string
@@ -333,8 +336,9 @@ module Petstore
         fail ArgumentError, 'byte cannot be nil'
       end
 
-      if byte !~ Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
-        fail ArgumentError, 'invalid value for "byte", must conform to the pattern /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/.'
+      pattern = Regexp.new(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/)
+      if byte !~ pattern
+        fail ArgumentError, "invalid value for \"byte\", must conform to the pattern #{pattern}."
       end
 
       @byte = byte

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -448,8 +448,9 @@ module Petstore
       if @api_client.config.client_side_validation && pattern_without_delimiter.nil?
         fail ArgumentError, "Missing the required parameter 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters"
       end
-      if @api_client.config.client_side_validation && pattern_without_delimiter !~ Regexp.new(/^[A-Z].*/)
-        fail ArgumentError, "invalid value for 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters, must conform to the pattern /^[A-Z].*/."
+      pattern = Regexp.new(/^[A-Z].*/)
+      if @api_client.config.client_side_validation && pattern_without_delimiter !~ pattern
+        fail ArgumentError, "invalid value for 'pattern_without_delimiter' when calling FakeApi.test_endpoint_parameters, must conform to the pattern #{pattern}."
       end
 
       # verify the required parameter 'byte' is set
@@ -476,8 +477,9 @@ module Petstore
         fail ArgumentError, 'invalid value for "opts[:"float"]" when calling FakeApi.test_endpoint_parameters, must be smaller than or equal to 987.6.'
       end
 
-      if @api_client.config.client_side_validation && !opts[:'string'].nil? && opts[:'string'] !~ Regexp.new(/[a-z]/i)
-        fail ArgumentError, "invalid value for 'opts[:\"string\"]' when calling FakeApi.test_endpoint_parameters, must conform to the pattern /[a-z]/i."
+      pattern = Regexp.new(/[a-z]/i)
+      if @api_client.config.client_side_validation && !opts[:'string'].nil? && opts[:'string'] !~ pattern
+        fail ArgumentError, "invalid value for 'opts[:\"string\"]' when calling FakeApi.test_endpoint_parameters, must conform to the pattern #{pattern}."
       end
 
       if @api_client.config.client_side_validation && !opts[:'password'].nil? && opts[:'password'].to_s.length > 64

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -205,8 +205,9 @@ module Petstore
         invalid_properties.push('invalid value for "double", must be greater than or equal to 67.8.')
       end
 
-      if !@string.nil? && @string !~ Regexp.new(/[a-z]/i)
-        invalid_properties.push('invalid value for "string", must conform to the pattern /[a-z]/i.')
+      pattern = Regexp.new(/[a-z]/i)
+      if !@string.nil? && @string !~ pattern
+        invalid_properties.push("invalid value for \"string\", must conform to the pattern #{pattern}.")
       end
 
       if @byte.nil?
@@ -229,12 +230,14 @@ module Petstore
         invalid_properties.push('invalid value for "password", the character length must be great than or equal to 10.')
       end
 
-      if !@pattern_with_digits.nil? && @pattern_with_digits !~ Regexp.new(/^\d{10}$/)
-        invalid_properties.push('invalid value for "pattern_with_digits", must conform to the pattern /^\d{10}$/.')
+      pattern = Regexp.new(/^\d{10}$/)
+      if !@pattern_with_digits.nil? && @pattern_with_digits !~ pattern
+        invalid_properties.push("invalid value for \"pattern_with_digits\", must conform to the pattern #{pattern}.")
       end
 
-      if !@pattern_with_digits_and_delimiter.nil? && @pattern_with_digits_and_delimiter !~ Regexp.new(/^image_\d{1,3}$/i)
-        invalid_properties.push('invalid value for "pattern_with_digits_and_delimiter", must conform to the pattern /^image_\d{1,3}$/i.')
+      pattern = Regexp.new(/^image_\d{1,3}$/i)
+      if !@pattern_with_digits_and_delimiter.nil? && @pattern_with_digits_and_delimiter !~ pattern
+        invalid_properties.push("invalid value for \"pattern_with_digits_and_delimiter\", must conform to the pattern #{pattern}.")
       end
 
       invalid_properties
@@ -342,8 +345,9 @@ module Petstore
     # Custom attribute writer method with validation
     # @param [Object] string Value to be assigned
     def string=(string)
-      if !string.nil? && string !~ Regexp.new(/[a-z]/i)
-        fail ArgumentError, 'invalid value for "string", must conform to the pattern /[a-z]/i.'
+      pattern = Regexp.new(/[a-z]/i)
+      if !string.nil? && string !~ pattern
+        fail ArgumentError, "invalid value for \"string\", must conform to the pattern #{pattern}."
       end
 
       @string = string
@@ -370,8 +374,9 @@ module Petstore
     # Custom attribute writer method with validation
     # @param [Object] pattern_with_digits Value to be assigned
     def pattern_with_digits=(pattern_with_digits)
-      if !pattern_with_digits.nil? && pattern_with_digits !~ Regexp.new(/^\d{10}$/)
-        fail ArgumentError, 'invalid value for "pattern_with_digits", must conform to the pattern /^\d{10}$/.'
+      pattern = Regexp.new(/^\d{10}$/)
+      if !pattern_with_digits.nil? && pattern_with_digits !~ pattern
+        fail ArgumentError, "invalid value for \"pattern_with_digits\", must conform to the pattern #{pattern}."
       end
 
       @pattern_with_digits = pattern_with_digits
@@ -380,8 +385,9 @@ module Petstore
     # Custom attribute writer method with validation
     # @param [Object] pattern_with_digits_and_delimiter Value to be assigned
     def pattern_with_digits_and_delimiter=(pattern_with_digits_and_delimiter)
-      if !pattern_with_digits_and_delimiter.nil? && pattern_with_digits_and_delimiter !~ Regexp.new(/^image_\d{1,3}$/i)
-        fail ArgumentError, 'invalid value for "pattern_with_digits_and_delimiter", must conform to the pattern /^image_\d{1,3}$/i.'
+      pattern = Regexp.new(/^image_\d{1,3}$/i)
+      if !pattern_with_digits_and_delimiter.nil? && pattern_with_digits_and_delimiter !~ pattern
+        fail ArgumentError, "invalid value for \"pattern_with_digits_and_delimiter\", must conform to the pattern #{pattern}."
       end
 
       @pattern_with_digits_and_delimiter = pattern_with_digits_and_delimiter


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


Fix #2069.

- To correctly embedding the regualr expression into error message, it's changed to string interpolation.
- Unnecessary invocation of `Regexp.new` is deleted. (`Regexp.new(/.../)` -> `/.../`)