### PR TITLE
[R] Fix return type

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -96,12 +96,10 @@
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         {{#returnType}}
         {{#isPrimitiveType}}
-        Response$new(httr::content(resp, "text", encoding = "UTF-8"), resp)
+        httr::content(resp, "text", encoding = "UTF-8"
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        returnObject <- {{returnType}}$new()
-        result <- returnObject$fromJSONString(httr::content(resp, "text", encoding = "UTF-8"))
-        Response$new(returnObject, resp)
+        {{returnType}}$new()$fromJSONString(httr::content(resp, "text", encoding = "UTF-8"))
         {{/isPrimitiveType}}
         {{/returnType}}
         {{^returnType}}

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -184,6 +184,7 @@
       {{/isPrimitiveType}}
       {{/isListContainer}}
       {{/vars}}
+      self
     }
   )
 )


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Fix return type in API endpoints and the `fromJSONString` function
