### PR TITLE
[PHP-Symfony] Validate input objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
@@ -18,7 +18,10 @@
 {{#isContainer}}
     {{#items}}
         $asserts[] = new Assert\All([
-            new Assert\Type("{{dataType}}")
+            new Assert\Type("{{dataType}}"),
+            {{^isPrimitiveType}}
+            new Assert\Valid(),
+            {{/isPrimitiveType}}
         ]);
     {{/items}}
 {{/isContainer}}
@@ -36,6 +39,9 @@
     {{/isFile}}
     {{^isFile}}
         $asserts[] = new Assert\Type("{{dataType}}");
+        {{^isPrimitiveType}}
+        $asserts[] = new Assert\Valid();
+        {{/isPrimitiveType}}
     {{/isFile}}
     {{/isDateTime}}
     {{/isDate}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -98,6 +98,7 @@ class PetController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\Type("OpenAPI\Server\Model\Pet");
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;
@@ -274,7 +275,7 @@ class PetController extends Controller
             new Assert\Choice([ "available", "pending", "sold" ])
         ]);
         $asserts[] = new Assert\All([
-            new Assert\Type("string")
+            new Assert\Type("string"),
         ]);
         $response = $this->validate($status, $asserts);
         if ($response instanceof Response) {
@@ -362,7 +363,7 @@ class PetController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\All([
-            new Assert\Type("string")
+            new Assert\Type("string"),
         ]);
         $response = $this->validate($tags, $asserts);
         if ($response instanceof Response) {
@@ -546,6 +547,7 @@ class PetController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\Type("OpenAPI\Server\Model\Pet");
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
@@ -327,6 +327,7 @@ class StoreController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\Type("OpenAPI\Server\Model\Order");
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
@@ -94,6 +94,7 @@ class UserController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\Type("OpenAPI\Server\Model\User");
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;
@@ -180,7 +181,8 @@ class UserController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\All([
-            new Assert\Type("OpenAPI\Server\Model\User")
+            new Assert\Type("OpenAPI\Server\Model\User"),
+            new Assert\Valid(),
         ]);
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
@@ -268,7 +270,8 @@ class UserController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\All([
-            new Assert\Type("OpenAPI\Server\Model\User")
+            new Assert\Type("OpenAPI\Server\Model\User"),
+            new Assert\Valid(),
         ]);
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
@@ -680,6 +683,7 @@ class UserController extends Controller
         $asserts = [];
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\Type("OpenAPI\Server\Model\User");
+        $asserts[] = new Assert\Valid();
         $response = $this->validate($body, $asserts);
         if ($response instanceof Response) {
             return $response;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Input object is not validated at the moment. This PR fixes it.

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon