### PR TITLE
[Symfony] Replace deprecated Controller with new one

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -19,7 +19,7 @@
 
 namespace {{controllerPackage}};
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use {{servicePackage}}\SerializerInterface;
@@ -33,7 +33,7 @@ use {{servicePackage}}\ValidatorInterface;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class Controller extends BaseController
+class Controller extends AbstractController
 {
     protected $validator;
     protected $serializer;

--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "symfony/validator": "*",
         "jms/serializer-bundle": "^2.0",
-        "symfony/framework-bundle": "^2.3|^3.0|^4.1"
+        "symfony/framework-bundle": "^3.3|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",

--- a/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/services.mustache
@@ -29,6 +29,7 @@ services:
          - [setValidator,  ['@{{bundleAlias}}.service.validator']]
          - [setApiServer,  ['@{{bundleAlias}}.api.api_server']]
         tags: ['controller.service_arguments']
+        autowire: true
 
 {{/operations}}
 {{/apis}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -29,7 +29,7 @@
 
 namespace OpenAPI\Server\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller as BaseController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use OpenAPI\Server\Service\SerializerInterface;
@@ -43,7 +43,7 @@ use OpenAPI\Server\Service\ValidatorInterface;
  * @author   OpenAPI Generator team
  * @link     https://github.com/openapitools/openapi-generator
  */
-class Controller extends BaseController
+class Controller extends AbstractController
 {
     protected $validator;
     protected $serializer;

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
@@ -26,6 +26,7 @@ services:
          - [setValidator,  ['@open_apiserver.service.validator']]
          - [setApiServer,  ['@open_apiserver.api.api_server']]
         tags: ['controller.service_arguments']
+        autowire: true
 
     open_apiserver.controller.store:
         class: OpenAPI\Server\Controller\StoreController
@@ -34,6 +35,7 @@ services:
          - [setValidator,  ['@open_apiserver.service.validator']]
          - [setApiServer,  ['@open_apiserver.api.api_server']]
         tags: ['controller.service_arguments']
+        autowire: true
 
     open_apiserver.controller.user:
         class: OpenAPI\Server\Controller\UserController
@@ -42,4 +44,5 @@ services:
          - [setValidator,  ['@open_apiserver.service.validator']]
          - [setApiServer,  ['@open_apiserver.api.api_server']]
         tags: ['controller.service_arguments']
+        autowire: true
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -22,7 +22,7 @@
         "ext-mbstring": "*",
         "symfony/validator": "*",
         "jms/serializer-bundle": "^2.0",
-        "symfony/framework-bundle": "^2.3|^3.0|^4.1"
+        "symfony/framework-bundle": "^3.3|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

`Symfony\Bundle\FrameworkBundle\Controller\Controller` is deprecated and should be replaced with `Symfony\Bundle\FrameworkBundle\Controller\AbstractController`

cc @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon @Addvilz