### PR TITLE
#2147: fix compiler error in angular typescript codegen

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -296,17 +296,17 @@ export class {{classname}} {
         if ({{paramName}}) {
         {{#isCollectionFormatMulti}}
             {{paramName}}.forEach((element) => {
-                {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', <any>element){{#useHttpClient}} || formParams{{/useHttpClient}};
+                {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', <any>element){{#useHttpClient}} as any || formParams{{/useHttpClient}};
             })
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}
-            {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}'])){{#useHttpClient}} || formParams{{/useHttpClient}};
+            {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}'])){{#useHttpClient}} as any || formParams{{/useHttpClient}};
         {{/isCollectionFormatMulti}}
         }
         {{/isListContainer}}
         {{^isListContainer}}
         if ({{paramName}} !== undefined) {
-            {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', <any>{{paramName}}){{#useHttpClient}} || formParams{{/useHttpClient}};
+            {{#useHttpClient}}formParams = {{/useHttpClient}}formParams.append('{{baseName}}', <any>{{paramName}}){{#useHttpClient}} as any || formParams{{/useHttpClient}};
         }
         {{/isListContainer}}
 {{/formParams}}

--- a/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
@@ -8,9 +8,7 @@
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B')
-            .replace(/%5B/, "[").replace(/%5D/, "]")
-            ;
+        return k.replace(/\+/gi, '%2B');
     }
     encodeValue(v: string): string {
         v = super.encodeValue(v);

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -425,10 +425,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -498,10 +498,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -425,10 +425,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -498,10 +498,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -425,10 +425,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -498,10 +498,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -427,10 +427,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -500,10 +500,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -427,10 +427,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -500,10 +500,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -425,10 +425,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -498,10 +498,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -425,10 +425,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -498,10 +498,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -427,10 +427,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -500,10 +500,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -427,10 +427,10 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams = formParams.append('name', <any>name) || formParams;
+            formParams = formParams.append('name', <any>name) as any || formParams;
         }
         if (status !== undefined) {
-            formParams = formParams.append('status', <any>status) || formParams;
+            formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
@@ -500,10 +500,10 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) || formParams;
+            formParams = formParams.append('additionalMetadata', <any>additionalMetadata) as any || formParams;
         }
         if (file !== undefined) {
-            formParams = formParams.append('file', <any>file) || formParams;
+            formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixes #2147 
