### PR TITLE
Support to generate python client binding sub packages independently using different OpenApi specification file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
@@ -48,6 +48,31 @@ public abstract class AbstractGenerator {
         return output;
     }
 
+    public String mergeFileContent(String fileName, String content) throws IOException {
+
+          File f1 = new File(fileName);
+
+          if(!f1.exists()){
+             return content;
+         }
+
+          FileReader fileReader = new FileReader(f1);
+         BufferedReader bufferedReader = new BufferedReader(fileReader);
+         String line,existingContent = "";
+
+          while((line = bufferedReader.readLine()) != null) {
+             if(existingContent=="")
+                 existingContent = line;
+             else
+                 existingContent += System.lineSeparator() + line;
+         }
+
+          if(!existingContent.isEmpty()) {
+             content = existingContent + System.lineSeparator() + content;
+         }
+         return content;
+    }
+
     public String readTemplate(String name) {
         try {
             Reader reader = getTemplateReader(name);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -712,7 +712,11 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                                 .defaultValue("")
                                 .compile(template);
 
-                        writeToFile(outputFilename, tmpl.execute(bundle));
+                        String contents = tmpl.execute(bundle);
+                        if(support.merge)
+                             contents = mergeFileContent(outputFilename, contents);
+                         writeToFile(outputFilename, contents);
+
                         File written = new File(outputFilename);
                         files.add(written);
                         if (config.isEnablePostProcessFile()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
@@ -22,6 +22,9 @@ public class SupportingFile {
     public String folder;
     public String destinationFilename;
 
+    // to add details of submodule generated to main module
+    public boolean merge = false;
+
     public SupportingFile(String templateFile, String destinationFilename) {
         this(templateFile, "", destinationFilename);
     }
@@ -30,6 +33,13 @@ public class SupportingFile {
         this.templateFile = templateFile;
         this.folder = folder;
         this.destinationFilename = destinationFilename;
+    }
+
+    public SupportingFile(String templateFile, String folder, String destinationFilename, boolean merge) {
+        this.templateFile = templateFile;
+        this.folder = folder;
+        this.destinationFilename = destinationFilename;
+        this.merge = merge;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -206,7 +206,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
         Boolean isSubModule = false;
         if(packageName != null)
-            if(packageName.contains("."))
+            if(packageName.contains(".") && invokerPackage != "")
                 isSubModule = true;
 
         additionalProperties.put(CodegenConstants.PROJECT_NAME, projectName);

--- a/modules/openapi-generator/src/main/resources/python/__init__api_submodule.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__api_submodule.mustache
@@ -1,0 +1,5 @@
+
+# {{apiPackage}}
+{{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
+{{/apis}}{{/apiInfo}}
+

--- a/modules/openapi-generator/src/main/resources/python/__init__model_submodule.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__model_submodule.mustache
@@ -1,0 +1,6 @@
+
+# {{modelPackage}}
+{{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}{{/model}}
+{{/models}}
+
+

--- a/modules/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -9,11 +9,13 @@ from __future__ import absolute_import
 __version__ = "{{packageVersion}}"
 
 # import apis into sdk package
+import {{apiPackage}}
 {{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
 {{/apis}}{{/apiInfo}}
 # import ApiClient
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.configuration import Configuration
 # import models into sdk package
+import {{modelPackage}}
 {{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/python/__init__package_submodule.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__package_submodule.mustache
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+# flake8: noqa
+
+{{>partial_header}}
+
+from __future__ import absolute_import
+
+__version__ = "{{packageVersion}}"
+
+# import apis into sdk package
+import {{apiPackage}}
+{{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
+{{/apis}}{{/apiInfo}}
+
+
+# import models into sdk package
+import {{modelPackage}}
+{{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}
+{{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -9,7 +9,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from {{packageName}}.api_client import ApiClient
+
 
 
 {{#operations}}
@@ -22,6 +22,7 @@ class {{classname}}(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from {{packageName}}.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 {{#operation}}

--- a/samples/client/petstore-security-test/python/README.md
+++ b/samples/client/petstore-security-test/python/README.md
@@ -51,6 +51,7 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
+
 # create an instance of the API class
 api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
 test_code_inject____end____rn_n_r = 'test_code_inject____end____rn_n_r_example' # str | To test code injection */ ' \\\" =end -- \\\\r\\\\n \\\\n \\\\r (optional)
@@ -85,6 +86,7 @@ Class | Method | HTTP request | Description
 - **Type**: API key
 - **API key parameter name**: api_key  */ ' " =end -- \r\n \n \r
 - **Location**: HTTP header
+
 
 ## petstore_auth
 

--- a/samples/client/petstore-security-test/python/docs/FakeApi.md
+++ b/samples/client/petstore-security-test/python/docs/FakeApi.md
@@ -15,6 +15,7 @@ To test code injection */ ' \" =end -- \\r\\n \\n \\r
 To test code injection */ ' \" =end -- \\r\\n \\n \\r
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore-security-test/python/petstore_api/__init__.py
+++ b/samples/client/petstore-security-test/python/petstore_api/__init__.py
@@ -18,10 +18,12 @@ from __future__ import absolute_import
 __version__ = "1.0.0"
 
 # import apis into sdk package
+import petstore_api.api
 from petstore_api.api.fake_api import FakeApi
 
 # import ApiClient
 from petstore_api.api_client import ApiClient
 from petstore_api.configuration import Configuration
 # import models into sdk package
+import petstore_api.models
 from petstore_api.models.model_return import ModelReturn

--- a/samples/client/petstore-security-test/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api/fake_api.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeApi(object):
@@ -30,6 +30,7 @@ class FakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -110,7 +110,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -157,7 +157,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = self.request(
@@ -290,7 +294,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -333,7 +337,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -342,7 +346,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore-security-test/python/petstore_api/configuration.py
+++ b/samples/client/petstore-security-test/python/petstore_api/configuration.py
@@ -60,10 +60,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.username = ""
         # Password for HTTP basic authentication
         self.password = ""
-
-        # access token for OAuth
+        # access token for OAuth/Bearer
         self.access_token = ""
-
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("petstore_api")
@@ -223,7 +221,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'api_key  */ &#39; &quot; &#x3D;end -- \r\n \n \r',
                     'value': self.get_api_key_with_prefix('api_key  */ &#39; &quot; &#x3D;end -- \r\n \n \r')
                 },
-
             'petstore_auth':
                 {
                     'type': 'oauth2',
@@ -231,7 +228,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': 'Bearer ' + self.access_token
                 },
-
         }
 
     def to_debug_report(self):
@@ -245,3 +241,54 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                "Version of the API: 1.0.0 */ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r\n"\
                "SDK Package Version: 1.0.0".\
                format(env=sys.platform, pyversion=sys.version)
+
+    def get_host_settings(self):
+        """Gets an array of host settings
+
+        :return: An array of host settings
+        """
+        return [
+            {
+                'url': "//petstore.swagger.io */ ' " =end -- \r\n \n \r/v2 */ ' " =end -- \r\n \n \r",
+                'description': "No description provided",
+            }
+        ]
+
+    def get_host_from_settings(self, index, variables={}):
+        """Gets host URL based on the index and variables
+        :param index: array index of the host settings
+        :param variables: hash of variable and the corresponding value
+        :return: URL based on host settings
+        """
+
+        servers = self.get_host_settings()
+
+        # check array index out of bound
+        if index < 0 or index >= len(servers):
+            raise ValueError(
+                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                .format(index, len(servers)))
+
+        server = servers[index]
+        url = server['url']
+
+        # go through variable and assign a value
+        for variable_name in server['variables']:
+            if variable_name in variables:
+                if variables[variable_name] in server['variables'][
+                        variable_name]['enum_values']:
+                    url = url.replace("{" + variable_name + "}",
+                                      variables[variable_name])
+                else:
+                    raise ValueError(
+                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
+                        .format(
+                            variable_name, variables[variable_name],
+                            server['variables'][variable_name]['enum_values']))
+            else:
+                # use default value
+                url = url.replace(
+                    "{" + variable_name + "}",
+                    server['variables'][variable_name]['default_value'])
+
+        return url

--- a/samples/client/petstore/python/petstore_api/__init__.py
+++ b/samples/client/petstore/python/petstore_api/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 __version__ = "1.0.0"
 
 # import apis into sdk package
+import petstore_api.api
 from petstore_api.api.another_fake_api import AnotherFakeApi
 from petstore_api.api.fake_api import FakeApi
 from petstore_api.api.fake_classname_tags_123_api import FakeClassnameTags123Api
@@ -28,6 +29,7 @@ from petstore_api.api.user_api import UserApi
 from petstore_api.api_client import ApiClient
 from petstore_api.configuration import Configuration
 # import models into sdk package
+import petstore_api.models
 from petstore_api.models.additional_properties_class import AdditionalPropertiesClass
 from petstore_api.models.animal import Animal
 from petstore_api.models.api_response import ApiResponse

--- a/samples/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class AnotherFakeApi(object):
@@ -29,6 +29,7 @@ class AnotherFakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeApi(object):
@@ -29,6 +29,7 @@ class FakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeClassnameTags123Api(object):
@@ -29,6 +29,7 @@ class FakeClassnameTags123Api(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/api/pet_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class PetApi(object):
@@ -29,6 +29,7 @@ class PetApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python/petstore_api/api/store_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class StoreApi(object):
@@ -29,6 +29,7 @@ class StoreApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python/petstore_api/api/user_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class UserApi(object):
@@ -29,6 +29,7 @@ class UserApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/__init__.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 __version__ = "1.0.0"
 
 # import apis into sdk package
+import petstore_api.api
 from petstore_api.api.another_fake_api import AnotherFakeApi
 from petstore_api.api.default_api import DefaultApi
 from petstore_api.api.fake_api import FakeApi
@@ -29,6 +30,7 @@ from petstore_api.api.user_api import UserApi
 from petstore_api.api_client import ApiClient
 from petstore_api.configuration import Configuration
 # import models into sdk package
+import petstore_api.models
 from petstore_api.models.additional_properties_class import AdditionalPropertiesClass
 from petstore_api.models.animal import Animal
 from petstore_api.models.api_response import ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class AnotherFakeApi(object):
@@ -29,6 +29,7 @@ class AnotherFakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class DefaultApi(object):
@@ -29,6 +29,7 @@ class DefaultApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeApi(object):
@@ -29,6 +29,7 @@ class FakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeClassnameTags123Api(object):
@@ -29,6 +29,7 @@ class FakeClassnameTags123Api(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class PetApi(object):
@@ -29,6 +29,7 @@ class PetApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class StoreApi(object):
@@ -29,6 +29,7 @@ class StoreApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class UserApi(object):
@@ -29,6 +29,7 @@ class UserApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess

### Description of the PR
I was faced with the issue of modularising my api methods into different section, this need arised due to fact that my main_package was independent openapi spec which had few api methods and I had N number of sub packages which had their own independent openapi spec files but lets say that a user only wants selective k packages to be installed independently hence using this merge he can generate selective k binding by running Codegen k times with new specification files of each subpackage, while making sure all sub_packages refer to common api client, configuration and rest python files i.e structure should be similar to :

<img width="498" alt="screenshot 2019-02-15 at 1 26 09 am" src="https://user-images.githubusercontent.com/26245515/52813871-c0528b80-30c0-11e9-92dc-9284dc5a81eb.png">

 
This particular [PR]( https://github.com/OpenAPITools/openapi-generator/pull/2041) talks foundational bug which was later resolved in it.

So lets say if user wants to install sub_package_1, sub_package_7 and sub_package_13 (assuming main_package is default) then First he create main_package normally like any openAPI auto generated client bindings by passing openapi specs and config file.
config file:
```json
{
    "packageName":"main_package",
    "projectName":"python-main-package",
}
```
Then by generating openapi bindings of sub_package_1, sub_package_7 and sub_package_13 but considering client's main_package as its invoker package i.e :
sub_package_1 config file:
```json
{
  "packageName": "main_package.sub_package_1",
   "invokerPackage" : "main_package",
   "generateSourceCodeOnly":true
}
```

This led me to use a new parameter named invokerPackage in config file.

#### Changes that I have done:
1. I have added three new mustache files, first two __init__api_submodule.mustache and __init__model_submodule.mustache files are used to create content that will be append into main_packge/api/__init__.py and main_packge/model/__init__.py respectively.
And third one acts as a sub package __init__.py file without referring to api_client of main_package.
[commit](https://github.com/OpenAPITools/openapi-generator/commit/34b6587007722b3da62083bc151ac0d83f37a264)

2. Added reference of main_package/api and main_package/models in main_package/__init__.py so it main package __init__ can point to sub packages classes which are referred in main_package/api/__init__.py.
[commit](https://github.com/OpenAPITools/openapi-generator/commit/6718e2dd28fe2673c31453b88ae7337c5cda664f)

3. Merge function added to add details of new api classes to main_package/api/__init__.py which is generated at the time of sub_package generation also sub_package models details to main_package/models/__init__.py [commit_1](https://github.com/OpenAPITools/openapi-generator/commit/e44d3db46da0ca15d0d44b7f013a39e68cfb9e86)
[commit_2](https://github.com/OpenAPITools/openapi-generator/commit/111703ea069eb66b4e3344c26556e8065fa5b7f2)

4. A invokerPackage parameter passed when sub package is being generated to give reference from sub package to main package api and model files.
[commit](https://github.com/OpenAPITools/openapi-generator/commit/5b4438353b3c22fe91907fb8a937b7078b00831f)
Correction added to make sure single client generated binding can act as part of a module as need [here](https://github.com/OpenAPITools/openapi-generator/issues/1658) hence just a small correction i.e [commit](https://github.com/OpenAPITools/openapi-generator/commit/b517194c4f6dfba71fa4e6309aa3ec5f230d0924)