### PR TITLE
openapi-generator-cli.sh: Fix missing single quote

### DIFF
--- a/bin/utils/openapi-generator-cli.sh
+++ b/bin/utils/openapi-generator-cli.sh
@@ -29,7 +29,7 @@ done
 
 function latest.tag {
   local uri="https://api.github.com/repos/${1}/releases"
-  curl -s ${uri} | jq -r 'first(.[]|select(.prerelease==false)).tag_name
+  curl -s ${uri} | jq -r 'first(.[]|select(.prerelease==false)).tag_name'
 }
 
 ghrepo=openapitools/openapi-generator


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
`bin/utils/openapi-generator-cli.sh` is missing a single quote in line 32