### PR TITLE
Use oauth token for basic bearer auth in Rust.

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -83,17 +83,17 @@ impl {{{classname}}} for {{{classname}}}Client {
             req_builder = req_builder.basic_auth(auth_conf.0.to_owned(), auth_conf.1.to_owned());
         };
         {{/isBasicBearer}}
+        {{#isBasicBearer}}
+        if let Some(ref token) = configuration.bearer_access_token {
+            req_builder = req_builder.bearer_auth(token.to_owned());
+        };
+        {{/isBasicBearer}}
         {{/isBasic}}
         {{#isOAuth}}
         if let Some(ref token) = configuration.oauth_access_token {
             req_builder = req_builder.bearer_auth(token.to_owned());
         };
         {{/isOAuth}}
-        {{#isBasicBearer}}
-        if let Some(ref token) = configuration.oauth_access_token {
-            req_builder = req_builder.bearer_auth(token.to_owned());
-        };
-        {{/isBasicBearer}}
         {{/authMethods}}
         {{/hasAuthMethods}}
         {{#isMultipart}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -78,15 +78,22 @@ impl {{{classname}}} for {{{classname}}}Client {
         {{/isKeyInHeader}}
         {{/isApiKey}}
         {{#isBasic}}
+        {{^isBasicBearer}}
         if let Some(ref auth_conf) = configuration.basic_auth {
             req_builder = req_builder.basic_auth(auth_conf.0.to_owned(), auth_conf.1.to_owned());
         };
+        {{/isBasicBearer}}
         {{/isBasic}}
         {{#isOAuth}}
         if let Some(ref token) = configuration.oauth_access_token {
             req_builder = req_builder.bearer_auth(token.to_owned());
         };
         {{/isOAuth}}
+        {{#isBasicBearer}}
+        if let Some(ref token) = configuration.oauth_access_token {
+            req_builder = req_builder.bearer_auth(token.to_owned());
+        };
+        {{/isBasicBearer}}
         {{/authMethods}}
         {{/hasAuthMethods}}
         {{#isMultipart}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
@@ -8,6 +8,7 @@ pub struct Configuration {
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
     // TODO: take an oauth2 token source, similar to the go one
 }
@@ -33,6 +34,7 @@ impl Default for Configuration {
             client: reqwest::Client::new(),
             basic_auth: None,
             oauth_access_token: None,
+            bearer_access_token: None,
             api_key: None,
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use `req_builder.bearer_auth` instead of `basic_auth` when `BearerAuth` security schema is specified.

@frol, @farcaller, @bjgill 

