### PR TITLE
Support to generate python client binding sub packages independently using different OpenApi specification file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/AbstractGenerator.java
@@ -48,6 +48,24 @@ public abstract class AbstractGenerator {
         return output;
     }
 
+    public String mergeFileContent(String fileName, String content) throws IOException {
+        Reader fileReader = new InputStreamReader(new FileInputStream(fileName), "UTF-8");
+        BufferedReader bufferedReader = new BufferedReader(fileReader);
+        String line,existingContent = "";
+
+        while((line = bufferedReader.readLine()) != null) {
+            if(existingContent=="")
+                existingContent = line;
+            else
+                existingContent += System.lineSeparator() + line;
+        }
+
+        if(!existingContent.isEmpty()) {
+            content = existingContent + System.lineSeparator() + content;
+        }
+        return content;
+    }
+
     public String readTemplate(String name) {
         try {
             Reader reader = getTemplateReader(name);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -712,7 +712,10 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                                 .defaultValue("")
                                 .compile(template);
 
-                        writeToFile(outputFilename, tmpl.execute(bundle));
+                        String contents = tmpl.execute(bundle);
+                        if(support.merge)
+                             contents = mergeFileContent(outputFilename, contents);
+                        writeToFile(outputFilename, contents);
                         File written = new File(outputFilename);
                         files.add(written);
                         if (config.isEnablePostProcessFile()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
@@ -22,6 +22,9 @@ public class SupportingFile {
     public String folder;
     public String destinationFilename;
 
+    // to add details of submodule generated to main module
+    public boolean merge = false;
+
     public SupportingFile(String templateFile, String destinationFilename) {
         this(templateFile, "", destinationFilename);
     }
@@ -30,6 +33,13 @@ public class SupportingFile {
         this.templateFile = templateFile;
         this.folder = folder;
         this.destinationFilename = destinationFilename;
+    }
+
+    public SupportingFile(String templateFile, String folder, String destinationFilename, boolean merge) {
+        this.templateFile = templateFile;
+        this.folder = folder;
+        this.destinationFilename = destinationFilename;
+        this.merge = merge;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -248,9 +248,14 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             supportingFiles.add(new SupportingFile("setup.mustache", "", "setup.py"));
         }
         
-        supportingFiles.add(new SupportingFile("__init__package.mustache", packagePath(), "__init__.py"));
+        if(!isSubModule){
+            supportingFiles.add(new SupportingFile("__init__package.mustache", packagePath(), "__init__.py"));
+        }
+        else{
+            supportingFiles.add(new SupportingFile("__init__package_submodule.mustache", packagePath(), "__init__.py"));
+        }
+        
         supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + modelPackage, "__init__.py"));
-
         supportingFiles.add(new SupportingFile("__init__api.mustache", packagePath() + File.separatorChar + apiPackage, "__init__.py"));
 
         if (Boolean.FALSE.equals(excludeTests)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -40,6 +40,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     public static final String DEFAULT_LIBRARY = "urllib3";
 
     protected String packageName; // e.g. petstore_api
+    protected String invokerPackage;
     protected String packageVersion;
     protected String projectName; // for setup.py, e.g. petstore-api
     protected String packageUrl;
@@ -192,9 +193,21 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             setPackageVersion("1.0.0");
         }
 
+        if (additionalProperties.containsKey(CodegenConstants.INVOKER_PACKAGE)) {
+            setInvokerPackage((String) additionalProperties.get(CodegenConstants.INVOKER_PACKAGE));} 
+        else {
+            setInvokerPackage("");
+        }
+
         Boolean generateSourceCodeOnly = false;
         if (additionalProperties.containsKey(CodegenConstants.SOURCECODEONLY_GENERATION)) {
             generateSourceCodeOnly = Boolean.valueOf(additionalProperties.get(CodegenConstants.SOURCECODEONLY_GENERATION).toString());
+        }
+
+        Boolean isSubModule = false;
+        if(invokerPackage != ""){
+                isSubModule = true;
+                invokerPackage = "." + invokerPackage;
         }
 
         additionalProperties.put(CodegenConstants.PROJECT_NAME, projectName);
@@ -234,29 +247,38 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
             supportingFiles.add(new SupportingFile("travis.mustache", "", ".travis.yml"));
             supportingFiles.add(new SupportingFile("setup.mustache", "", "setup.py"));
         }
-        supportingFiles.add(new SupportingFile("configuration.mustache", packagePath(), "configuration.py"));
+        
         supportingFiles.add(new SupportingFile("__init__package.mustache", packagePath(), "__init__.py"));
         supportingFiles.add(new SupportingFile("__init__model.mustache", packagePath() + File.separatorChar + modelPackage, "__init__.py"));
+
         supportingFiles.add(new SupportingFile("__init__api.mustache", packagePath() + File.separatorChar + apiPackage, "__init__.py"));
 
         if (Boolean.FALSE.equals(excludeTests)) {
             supportingFiles.add(new SupportingFile("__init__test.mustache", testFolder, "__init__.py"));
         }
 
-        supportingFiles.add(new SupportingFile("api_client.mustache", packagePath(), "api_client.py"));
+        if(!isSubModule){
+            supportingFiles.add(new SupportingFile("api_client.mustache", packagePath(), "api_client.py"));
+            supportingFiles.add(new SupportingFile("configuration.mustache", packagePath(), "configuration.py"));
 
-        if ("asyncio".equals(getLibrary())) {
-            supportingFiles.add(new SupportingFile("asyncio/rest.mustache", packagePath(), "rest.py"));
-            additionalProperties.put("asyncio", "true");
-        } else if ("tornado".equals(getLibrary())) {
-            supportingFiles.add(new SupportingFile("tornado/rest.mustache", packagePath(), "rest.py"));
-            additionalProperties.put("tornado", "true");
-        } else {
-            supportingFiles.add(new SupportingFile("rest.mustache", packagePath(), "rest.py"));
+            if ("asyncio".equals(getLibrary())) {
+                supportingFiles.add(new SupportingFile("asyncio/rest.mustache", packagePath(), "rest.py"));
+                additionalProperties.put("asyncio", "true");
+            } else if ("tornado".equals(getLibrary())) {
+                supportingFiles.add(new SupportingFile("tornado/rest.mustache", packagePath(), "rest.py"));
+                additionalProperties.put("tornado", "true");
+            } else {
+                supportingFiles.add(new SupportingFile("rest.mustache", packagePath(), "rest.py"));
+            }
+        }
+        if(isSubModule){
+            // If file already exists merge i.e merge API and MODELS data of submodule __init__ with main module __init__
+            supportingFiles.add(new SupportingFile("append_submodule_api_details.mustache", packageName.replace('.', File.separatorChar ) + File.separatorChar + apiPackage, "__init__.py", true));
+            supportingFiles.add(new SupportingFile("append_submodule_model_details.mustache", packageName.replace('.', File.separatorChar ) + File.separatorChar + modelPackage, "__init__.py", true));
         }
 
-        modelPackage = packageName + "." + modelPackage;
-        apiPackage = packageName + "." + apiPackage;
+        modelPackage = packageName + invokerPackage + "." + modelPackage;
+        apiPackage = packageName + invokerPackage + "." + apiPackage;
 
     }
 
@@ -570,6 +592,10 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         this.packageName = packageName;
     }
 
+    public void setInvokerPackage(String invokerPackage) {
+        this.invokerPackage = invokerPackage;
+    }
+
     public void setProjectName(String projectName) {
         this.projectName = projectName;
     }
@@ -583,7 +609,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
     }
 
     public String packagePath() {
-        return packageName.replace('.', File.separatorChar);
+        return this.packageName.replace('.', File.separatorChar) + this.invokerPackage.replace('.', File.separatorChar);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/python/__init__package.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__package.mustache
@@ -9,11 +9,15 @@ from __future__ import absolute_import
 __version__ = "{{packageVersion}}"
 
 # import apis into sdk package
+import {{apiPackage}}
 {{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
 {{/apis}}{{/apiInfo}}
+
 # import ApiClient
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.configuration import Configuration
+
 # import models into sdk package
+import {{modelPackage}}
 {{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/python/__init__package_submodule.mustache
+++ b/modules/openapi-generator/src/main/resources/python/__init__package_submodule.mustache
@@ -1,0 +1,19 @@
+# coding: utf-8
+
+# flake8: noqa
+
+{{>partial_header}}
+
+from __future__ import absolute_import
+
+__version__ = "{{packageVersion}}"
+
+# import apis into sdk package
+import {{apiPackage}}
+{{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
+{{/apis}}{{/apiInfo}}
+
+# import models into sdk package
+import {{modelPackage}}
+{{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}
+{{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -9,7 +9,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from {{packageName}}.api_client import ApiClient
+
 
 
 {{#operations}}
@@ -22,6 +22,7 @@ class {{classname}}(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from {{packageName}}.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 {{#operation}}

--- a/modules/openapi-generator/src/main/resources/python/append_submodule_api_details.mustache
+++ b/modules/openapi-generator/src/main/resources/python/append_submodule_api_details.mustache
@@ -1,0 +1,4 @@
+
+# {{apiPackage}}
+{{#apiInfo}}{{#apis}}from {{apiPackage}}.{{classVarName}} import {{classname}}
+{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/python/append_submodule_model_details.mustache
+++ b/modules/openapi-generator/src/main/resources/python/append_submodule_model_details.mustache
@@ -1,0 +1,4 @@
+
+# {{modelPackage}}
+{{#models}}{{#model}}from {{modelPackage}}.{{classFilename}} import {{classname}}{{/model}}
+{{/models}}

--- a/samples/client/petstore-security-test/python/README.md
+++ b/samples/client/petstore-security-test/python/README.md
@@ -51,6 +51,7 @@ import petstore_api
 from petstore_api.rest import ApiException
 from pprint import pprint
 
+
 # create an instance of the API class
 api_instance = petstore_api.FakeApi(petstore_api.ApiClient(configuration))
 test_code_inject____end____rn_n_r = 'test_code_inject____end____rn_n_r_example' # str | To test code injection */ ' \\\" =end -- \\\\r\\\\n \\\\n \\\\r (optional)
@@ -85,6 +86,7 @@ Class | Method | HTTP request | Description
 - **Type**: API key
 - **API key parameter name**: api_key  */ ' " =end -- \r\n \n \r
 - **Location**: HTTP header
+
 
 ## petstore_auth
 

--- a/samples/client/petstore-security-test/python/docs/FakeApi.md
+++ b/samples/client/petstore-security-test/python/docs/FakeApi.md
@@ -15,6 +15,7 @@ To test code injection */ ' \" =end -- \\r\\n \\n \\r
 To test code injection */ ' \" =end -- \\r\\n \\n \\r
 
 ### Example
+
 ```python
 from __future__ import print_function
 import time

--- a/samples/client/petstore-security-test/python/petstore_api/__init__.py
+++ b/samples/client/petstore-security-test/python/petstore_api/__init__.py
@@ -18,10 +18,14 @@ from __future__ import absolute_import
 __version__ = "1.0.0"
 
 # import apis into sdk package
+import petstore_api.api
 from petstore_api.api.fake_api import FakeApi
+
 
 # import ApiClient
 from petstore_api.api_client import ApiClient
 from petstore_api.configuration import Configuration
+
 # import models into sdk package
+import petstore_api.models
 from petstore_api.models.model_return import ModelReturn

--- a/samples/client/petstore-security-test/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api/fake_api.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeApi(object):
@@ -30,6 +30,7 @@ class FakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -110,7 +110,7 @@ class ApiClient(object):
             query_params=None, header_params=None, body=None, post_params=None,
             files=None, response_type=None, auth_settings=None,
             _return_http_data_only=None, collection_formats=None,
-            _preload_content=True, _request_timeout=None):
+            _preload_content=True, _request_timeout=None, _host=None):
 
         config = self.configuration
 
@@ -157,7 +157,11 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.configuration.host + resource_path
+        if _host is None:
+            url = self.configuration.host + resource_path
+        else:
+            # use server/host defined in path or operation instead
+            url = _host + resource_path
 
         # perform request and return response
         response_data = self.request(
@@ -290,7 +294,7 @@ class ApiClient(object):
                  body=None, post_params=None, files=None,
                  response_type=None, auth_settings=None, async_req=None,
                  _return_http_data_only=None, collection_formats=None,
-                 _preload_content=True, _request_timeout=None):
+                 _preload_content=True, _request_timeout=None, _host=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
         To make an async_req request, set the async_req parameter.
@@ -333,7 +337,7 @@ class ApiClient(object):
                                    body, post_params, files,
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout)
+                                   _preload_content, _request_timeout, _host)
         else:
             thread = self.pool.apply_async(self.__call_api, (resource_path,
                                            method, path_params, query_params,
@@ -342,7 +346,9 @@ class ApiClient(object):
                                            response_type, auth_settings,
                                            _return_http_data_only,
                                            collection_formats,
-                                           _preload_content, _request_timeout))
+                                           _preload_content,
+                                           _request_timeout,
+                                           _host))
         return thread
 
     def request(self, method, url, query_params=None, headers=None,

--- a/samples/client/petstore-security-test/python/petstore_api/configuration.py
+++ b/samples/client/petstore-security-test/python/petstore_api/configuration.py
@@ -60,10 +60,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.username = ""
         # Password for HTTP basic authentication
         self.password = ""
-
-        # access token for OAuth
+        # access token for OAuth/Bearer
         self.access_token = ""
-
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("petstore_api")
@@ -223,7 +221,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'api_key  */ &#39; &quot; &#x3D;end -- \r\n \n \r',
                     'value': self.get_api_key_with_prefix('api_key  */ &#39; &quot; &#x3D;end -- \r\n \n \r')
                 },
-
             'petstore_auth':
                 {
                     'type': 'oauth2',
@@ -231,7 +228,6 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': 'Bearer ' + self.access_token
                 },
-
         }
 
     def to_debug_report(self):
@@ -245,3 +241,54 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                "Version of the API: 1.0.0 */ &#39; \&quot; &#x3D;end -- \\r\\n \\n \\r\n"\
                "SDK Package Version: 1.0.0".\
                format(env=sys.platform, pyversion=sys.version)
+
+    def get_host_settings(self):
+        """Gets an array of host settings
+
+        :return: An array of host settings
+        """
+        return [
+            {
+                'url': "//petstore.swagger.io */ ' " =end -- \r\n \n \r/v2 */ ' " =end -- \r\n \n \r",
+                'description': "No description provided",
+            }
+        ]
+
+    def get_host_from_settings(self, index, variables={}):
+        """Gets host URL based on the index and variables
+        :param index: array index of the host settings
+        :param variables: hash of variable and the corresponding value
+        :return: URL based on host settings
+        """
+
+        servers = self.get_host_settings()
+
+        # check array index out of bound
+        if index < 0 or index >= len(servers):
+            raise ValueError(
+                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                .format(index, len(servers)))
+
+        server = servers[index]
+        url = server['url']
+
+        # go through variable and assign a value
+        for variable_name in server['variables']:
+            if variable_name in variables:
+                if variables[variable_name] in server['variables'][
+                        variable_name]['enum_values']:
+                    url = url.replace("{" + variable_name + "}",
+                                      variables[variable_name])
+                else:
+                    raise ValueError(
+                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
+                        .format(
+                            variable_name, variables[variable_name],
+                            server['variables'][variable_name]['enum_values']))
+            else:
+                # use default value
+                url = url.replace(
+                    "{" + variable_name + "}",
+                    server['variables'][variable_name]['default_value'])
+
+        return url

--- a/samples/client/petstore/python/petstore_api/__init__.py
+++ b/samples/client/petstore/python/petstore_api/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 __version__ = "1.0.0"
 
 # import apis into sdk package
+import petstore_api.api
 from petstore_api.api.another_fake_api import AnotherFakeApi
 from petstore_api.api.fake_api import FakeApi
 from petstore_api.api.fake_classname_tags_123_api import FakeClassnameTags123Api
@@ -24,10 +25,13 @@ from petstore_api.api.pet_api import PetApi
 from petstore_api.api.store_api import StoreApi
 from petstore_api.api.user_api import UserApi
 
+
 # import ApiClient
 from petstore_api.api_client import ApiClient
 from petstore_api.configuration import Configuration
+
 # import models into sdk package
+import petstore_api.models
 from petstore_api.models.additional_properties_class import AdditionalPropertiesClass
 from petstore_api.models.animal import Animal
 from petstore_api.models.api_response import ApiResponse

--- a/samples/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class AnotherFakeApi(object):
@@ -29,6 +29,7 @@ class AnotherFakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeApi(object):
@@ -29,6 +29,7 @@ class FakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeClassnameTags123Api(object):
@@ -29,6 +29,7 @@ class FakeClassnameTags123Api(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/api/pet_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class PetApi(object):
@@ -29,6 +29,7 @@ class PetApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/client/petstore/python/petstore_api/api/store_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class StoreApi(object):
@@ -29,6 +29,7 @@ class StoreApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python/petstore_api/api/user_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class UserApi(object):
@@ -29,6 +29,7 @@ class UserApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/__init__.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 __version__ = "1.0.0"
 
 # import apis into sdk package
+import petstore_api.api
 from petstore_api.api.another_fake_api import AnotherFakeApi
 from petstore_api.api.default_api import DefaultApi
 from petstore_api.api.fake_api import FakeApi
@@ -25,10 +26,13 @@ from petstore_api.api.pet_api import PetApi
 from petstore_api.api.store_api import StoreApi
 from petstore_api.api.user_api import UserApi
 
+
 # import ApiClient
 from petstore_api.api_client import ApiClient
 from petstore_api.configuration import Configuration
+
 # import models into sdk package
+import petstore_api.models
 from petstore_api.models.additional_properties_class import AdditionalPropertiesClass
 from petstore_api.models.animal import Animal
 from petstore_api.models.api_response import ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class AnotherFakeApi(object):
@@ -29,6 +29,7 @@ class AnotherFakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class DefaultApi(object):
@@ -29,6 +29,7 @@ class DefaultApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeApi(object):
@@ -29,6 +29,7 @@ class FakeApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class FakeClassnameTags123Api(object):
@@ -29,6 +29,7 @@ class FakeClassnameTags123Api(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class PetApi(object):
@@ -29,6 +29,7 @@ class PetApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class StoreApi(object):
@@ -29,6 +29,7 @@ class StoreApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -17,7 +17,7 @@ import re  # noqa: F401
 # python 2 and python 3 compatibility library
 import six
 
-from petstore_api.api_client import ApiClient
+
 
 
 class UserApi(object):
@@ -29,6 +29,7 @@ class UserApi(object):
 
     def __init__(self, api_client=None):
         if api_client is None:
+            from petstore_api.api_client import ApiClient
             api_client = ApiClient()
         self.api_client = api_client
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess

### Description of the PR
I was faced with the issue of modularising my api methods into different section, this need arised due to the fact that my main_package had its own independent openapi specification file. While on the other hand I had N number of sub packages which had their own independent openapi spec files but lets say that a user only wants selective k packages to be installed independently hence using this merge he can generate selective k binding by running Codegen k times with new specification files of each subpackage, while making sure all sub_packages refer to common api client, configuration and rest python files i.e structure should be similar to :

<img width="498" alt="screenshot 2019-02-15 at 1 26 09 am" src="https://user-images.githubusercontent.com/26245515/52813871-c0528b80-30c0-11e9-92dc-9284dc5a81eb.png">

 
This particular [PR]( https://github.com/OpenAPITools/openapi-generator/pull/2041) talks foundational bug which was later resolved in it.

So lets say if user wants to install sub_package_1, sub_package_7 and sub_package_13 (assuming main_package is default) then First he create main_package normally like any openAPI auto generated client bindings by passing openapi specs and config file.
config file:
```json
{
    "packageName":"main_package",
    "projectName":"python-main-package",
}
```
Then by generating openapi bindings of sub_package_1, sub_package_7 and sub_package_13 but considering client's packageName as its root package to refer to main_package api_client.
sub_package_1 config file:
```json
{
  "packageName": "main_package",
   "invokerPackage" : "sub_package_1",
   "generateSourceCodeOnly":true
}
```

This led me to use a new parameter named invokerPackage in config file.

#### Changes that I have done:
1. I have added three new mustache files, first two append_submodule_api_details.mustache and append_submodule_model_details.mustache files are used to create content that will be append into main_packge/api/__init__.py and main_packge/model/__init__.py respectively.
And third one __init__package_submodule.mustache which acts as a sub package __init__.py file without referring to api_client of main_package.
[commit 1](https://github.com/VamshikShetty/openapi-generator/commit/eff26c04baeb5c5f319e295d687406398f78048d)
[commit 2](https://github.com/VamshikShetty/openapi-generator/commit/9c5aa49e6a17cecc31278908c59d5b197640e400)

2. Added reference of main_package/api and main_package/models in main_package/__init__.py so main package __init__ can point to sub packages classes which are referred in main_package/api/__init__.py.
[commit](https://github.com/VamshikShetty/openapi-generator/commit/51501cbef377660436c3803b066818afdf18f4c5)

3. Merge function added to add details of new api classes to main_package/api/__init__.py which is generated at the time of sub_package generation also sub_package models details to main_package/models/__init__.py 
[commit 1](https://github.com/VamshikShetty/openapi-generator/commit/74ebf02cfe0772cc6f61433290c047c716f88213)
[commit 2](https://github.com/VamshikShetty/openapi-generator/commit/d1fe1de63faa70771ac9df9cac5b398dfcaac2fa)
[commit 3](https://github.com/VamshikShetty/openapi-generator/commit/5f3032fc339b70f645c4da7b1a2ef405ebaa4051)

4. Usage of Invoker package to create path to generate sub package's api, models and package init.
[commit](https://github.com/VamshikShetty/openapi-generator/commit/668be4b39986fa21351096e4c49f1b024486e0b1)