### PR TITLE
[C++][Qt5] Fix import for models with underscore

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -204,7 +204,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
 
     @Override
     public String toModelFilename(String name) {
-        return modelNamePrefix + sanitizeName(initialCaps(name));
+        return toModelName(name);
     }
     
     /**

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.h.mustache
@@ -2,6 +2,7 @@
 #ifndef {{prefix}}_APIROUTER_H
 #define {{prefix}}_APIROUTER_H
 
+#include <functional>
 #include <QObject>
 #include <QStringList>
 #include <QSharedPointer>

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.h
@@ -13,6 +13,7 @@
 #ifndef OAI_APIROUTER_H
 #define OAI_APIROUTER_H
 
+#include <functional>
 #include <QObject>
 #include <QStringList>
 #include <QSharedPointer>


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
- Fix failing build due to deprecation of `initialCaps`, filenames were wrongly named and not found during compilation
- Include `<functional>` for failing build in debian

`CC:` @stkrwork @fvarose @MartinDelille @ravinikam 