### PR TITLE
[core] fix referenced enum case

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -569,7 +569,8 @@ public class DefaultCodegenTest {
         allowableValues.put("values", Collections.singletonList(1));
         items.setAllowableValues(allowableValues);
         items.dataType = "Integer";
-        array.setItems(items);
+        array.items = items;
+        array.mostInnerItems = items;
         array.dataType = "Array";
         return array;
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. Change in the core: @OpenAPITools/generator-core-team 

### Description of the PR

Fixes #2127

Follow up of PR #1981

When you have a default value defined, in the outer enum case (where a seperated enum file is created) the default value was only working for the string type.

This PR address the issue.

---
Tested with a spec having this outer enum cases:

```yaml
components:
  schemas:
    IntEnum:
      type: integer
      format: int32
      default: 2
      enum:
        - 1
        - 2
        - 3

    LongEnum:
      type: integer
      format: int64
      default: 30
      enum:
        - 20
        - 30
        - 40

    StringEnum:
      type: string
      default: "b"
      enum:
        - "c"
        - "b"
        - "a"

    EnumWithCustomName:
      type: integer
      format: int32
      default: 2
      enum:
        - 1
        - 2
      x-enum-varnames:
        - FOO
        - BAR
```

And following schema:

```yaml
    ObjWithEnumProperties:
      type: object
      properties:
        iprop:
            $ref: "#/components/schemas/IntEnum"
        lprop:
            $ref: "#/components/schemas/LongEnum"
        sprop:
            $ref: "#/components/schemas/StringEnum"
        custom:
            $ref: "#/components/schemas/EnumWithCustomName"
```

The change is made in the core and I think that a lot of generators are impacted.
I have tested it for different java generators.
Setting a `modelNamePrefix` should also be considered during tests.

I recommend to try other generators/config as well.