### PR TITLE
Gradle - make GenerateTask properties optional

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -403,11 +403,25 @@ open class GenerateTask : DefaultTask() {
                 GeneratorProperties.clearProperty(CodegenConstants.APIS)
             }
 
-            GeneratorProperties.setProperty(CodegenConstants.API_DOCS, generateApiDocumentation.get().toString())
-            GeneratorProperties.setProperty(CodegenConstants.MODEL_DOCS, generateModelDocumentation.get().toString())
-            GeneratorProperties.setProperty(CodegenConstants.MODEL_TESTS, generateModelTests.get().toString())
-            GeneratorProperties.setProperty(CodegenConstants.API_TESTS, generateApiTests.get().toString())
-            GeneratorProperties.setProperty(CodegenConstants.WITH_XML, withXml.get().toString())
+            if (generateApiDocumentation.isPresent) {
+                GeneratorProperties.setProperty(CodegenConstants.API_DOCS, generateApiDocumentation.get().toString())
+            }
+
+            if (generateModelDocumentation.isPresent) {
+                GeneratorProperties.setProperty(CodegenConstants.MODEL_DOCS, generateModelDocumentation.get().toString())
+            }
+
+            if (generateModelTests.isPresent) {
+                GeneratorProperties.setProperty(CodegenConstants.MODEL_TESTS, generateModelTests.get().toString())
+            }
+
+            if (generateApiTests.isPresent) {
+                GeneratorProperties.setProperty(CodegenConstants.API_TESTS, generateApiTests.get().toString())
+            }
+
+            if (withXml.isPresent) {
+                GeneratorProperties.setProperty(CodegenConstants.WITH_XML, withXml.get().toString())
+            }
 
             // now override with any specified parameters
             verbose.ifNotEmpty { value ->


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This allows easier creation of custom `GenerateTask`. Specifically, this makes:

 - generateModelTests
 - generateModelDocumentation
 - generateApiTests
 - generateApiDocumentation
 - withXml

optional, following the same pattern as other properties in GenerateTask.

Without this change, we get `java.lang.IllegalStateException: No value has been specified for this provider.` until these properties are specified for the task, when attempting to define a custom generate task (such as one to generate API docs).

Note I left a couple of items in PR checklist unmarked as they don't seem relevant to this change. Please let me know if this should be handled differently.