### PR TITLE
Add Haskell Servant build to Shippable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ cache:
   - $HOME/samples/server/petstore/rust-server/target
   - $HOME/perl5
   - $HOME/.cargo
-  - $HOME/.stack
   - $HOME/.pub-cache
   - $HOME/samples/server/petstore/cpp-pistache/pistache
   - $HOME/.npm  
@@ -50,10 +49,6 @@ addons:
     - petstore.swagger.io
 
 before_install:
-  # install haskell
-  - curl -sSL https://get.haskellstack.org/ | sh
-  - stack upgrade
-  - stack --version
   # install rust
   - curl https://sh.rustup.rs -sSf | sh -s -- -y -v
   # required when sudo: required for the Ruby petstore tests

--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -5,6 +5,8 @@
 
 NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
 
+set -e
+
 if [ "$NODE_INDEX" = "1" ]; then
   echo "Running node $NODE_INDEX to test 'samples.circleci' defined in pom.xml ..."
   #cp CI/pom.xml.circleci pom.xml
@@ -16,6 +18,13 @@ elif [ "$NODE_INDEX" = "2" ]; then
   #export GO_POST_PROCESS_FILE="/usr/local/bin/gofmt -w"
   # not formatting the code as different go versions may format the code a bit different
   ./bin/utils/ensure-up-to-date
+elif [ "$NODE_INDEX" = "3" ]; then
+  echo "Running node $NODE_INDEX to test haskell"
+  # install haskell
+  url -sSL https://get.haskellstack.org/ | sh
+  stack upgrade
+  stack --version:w
+  mvn --quiet verify -Psamples.misc
 else
   echo "Running node $NODE_INDEX to test 'samples.circleci.jdk7' defined in pom.xml ..."
   sudo update-java-alternatives -s java-1.7.0-openjdk-amd64

--- a/circle.yml
+++ b/circle.yml
@@ -83,6 +83,7 @@ jobs:
         - ~/.gradle
         - ~/.cache/bower
         - ".git"
+        - ~/.stack
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results

--- a/pom.xml
+++ b/pom.xml
@@ -1019,6 +1019,7 @@
             </activation>
             <modules>
                 <!-- clients -->
+                <module>samples/server/petstore/haskell-servant</module>
                 <module>samples/client/petstore/c</module>
                 <!--<module>samples/client/petstore/dart-jaguar/openapi</module>
                 <module>samples/client/petstore/dart-jaguar/flutter_petstore/openapi</module>-->

--- a/pom.xml
+++ b/pom.xml
@@ -1023,7 +1023,6 @@
                 <!--<module>samples/client/petstore/dart-jaguar/openapi</module>
                 <module>samples/client/petstore/dart-jaguar/flutter_petstore/openapi</module>-->
                 <!--<module>samples/client/petstore/dart2/petstore</module>-->
-                <module>samples/client/petstore/haskell-http-client</module>
                 <module>samples/client/petstore/elm-0.18</module>
                 <module>samples/client/petstore/groovy</module>
                 <module>samples/client/petstore/rust</module>
@@ -1061,7 +1060,6 @@
                 <module>samples/server/petstore/python-aiohttp</module>
                 <module>samples/server/petstore/python-flask</module>
                 <module>samples/server/petstore/python-flask-python2</module>
-                <module>samples/server/petstore/haskell-servant</module>
             </modules>
         </profile>
         <!-- test with JDK8 in CircleCI -->
@@ -1238,6 +1236,22 @@
                 <module>samples/server/petstore/spring-mvc</module>
                 <module>samples/server/petstore/spring-mvc-j8-async</module>
                 <module>samples/server/petstore/spring-mvc-j8-localdatetime</module>
+            </modules>
+        </profile>
+        <!-- test with Haskell -->
+        <profile>
+            <id>samples.misc</id>
+            <activation>
+                <property>
+                    <name>env</name>
+                    <value>samples.misc</value>
+                </property>
+            </activation>
+            <modules>
+                <!-- clients -->
+                <module>samples/client/petstore/haskell-http-client</module>
+                <!-- servers -->
+                <module>samples/server/petstore/haskell-servant</module>
             </modules>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1019,7 +1019,6 @@
             </activation>
             <modules>
                 <!-- clients -->
-                <module>samples/server/petstore/haskell-servant</module>
                 <module>samples/client/petstore/c</module>
                 <!--<module>samples/client/petstore/dart-jaguar/openapi</module>
                 <module>samples/client/petstore/dart-jaguar/flutter_petstore/openapi</module>-->
@@ -1062,6 +1061,7 @@
                 <module>samples/server/petstore/python-aiohttp</module>
                 <module>samples/server/petstore/python-flask</module>
                 <module>samples/server/petstore/python-flask-python2</module>
+                <module>samples/server/petstore/haskell-servant</module>
             </modules>
         </profile>
         <!-- test with JDK8 in CircleCI -->

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
@@ -1,3 +1,4 @@
+sdfjask;ljf;klajskl;dfjakls;dj
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
@@ -1,4 +1,3 @@
-sdfjask;ljf;klajskl;dfjakls;dj
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}

--- a/samples/server/petstore/haskell-servant/pom.xml
+++ b/samples/server/petstore/haskell-servant/pom.xml
@@ -1,0 +1,46 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.openapitools</groupId>
+    <artifactId>HaskellServantServerTests</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Haskell Servant Petstore Server</name>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>compile-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>stack</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Test haskell-servant petstore sample in ~~Travis~~ Shippable CI.
