### PR TITLE
Add petstore integration tests to Ruby OAS3 client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,10 @@ before_install:
   - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - docker ps -a
   # Add bats test framework and cURL for Bash script integration tests
-  - sudo add-apt-repository ppa:duggan/bats --yes
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq bats
-  - sudo apt-get install -qq curl
+  #- sudo add-apt-repository ppa:duggan/bats --yes
+  #- sudo apt-get update -qq
+  #- sudo apt-get install -qq bats
+  #- sudo apt-get install -qq curl
   # install dart
   #- sudo apt-get update
   #- sudo apt-get install apt-transport-https

--- a/samples/openapi3/client/petstore/ruby/press_anykey_to_continue.sh
+++ b/samples/openapi3/client/petstore/ruby/press_anykey_to_continue.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# a script to simply wait for X seconds before contining the CI tests
-# the delay can help prevent 2 CI tests running at the same time as 
-# all CI tests use the same petstore server for testing.
-
-TIMEOUT=$(( ( RANDOM % 60 )  + 1 ))
-
-read -p 'Press any key to continue or wait for $TIMEOUT seconds' -t $TIMEOUT

--- a/samples/openapi3/client/petstore/ruby/spec/custom/api_error_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/custom/api_error_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Petstore::ApiClient do
+  describe '#initialize' do
+    it "should save the message if one is given" do
+      err = Petstore::ApiError.new(message: "Hello")
+      expect(err.message).to eq("Hello")
+    end
+
+    it "should save the hash as message if no message is given" do
+      err = Petstore::ApiError.new(code: 500, response_body: "server error")
+      expect(err.message).to eq("{:code=>500, :response_body=>\"server error\"}")
+    end
+  end
+end

--- a/samples/openapi3/client/petstore/ruby/spec/custom/base_object_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/custom/base_object_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+class ArrayMapObject < Petstore::Category
+  attr_accessor :int_arr, :pet_arr, :int_map, :pet_map, :int_arr_map, :pet_arr_map, :boolean_true_arr, :boolean_false_arr
+
+  def self.attribute_map
+    {
+      :int_arr => :int_arr,
+      :pet_arr => :pet_arr,
+      :int_map => :int_map,
+      :pet_map => :pet_map,
+      :int_arr_map => :int_arr_map,
+      :pet_arr_map => :pet_arr_map,
+      :boolean_true_arr  => :boolean_true_arr,
+      :boolean_false_arr => :boolean_false_arr,
+    }
+  end
+
+  def self.openapi_types
+    {
+      :int_arr => :'Array<Integer>',
+      :pet_arr => :'Array<Pet>',
+      :int_map => :'Hash<String, Integer>',
+      :pet_map => :'Hash<String, Pet>',
+      :int_arr_map => :'Hash<String, Array<Integer>>',
+      :pet_arr_map => :'Hash<String, Array<Pet>>',
+      :boolean_true_arr  => :'Array<BOOLEAN>',
+      :boolean_false_arr => :'Array<BOOLEAN>',
+    }
+  end
+end
+
+describe 'BaseObject' do
+  describe 'boolean values' do
+    let(:obj) { Petstore::Cat.new(declawed: false) }
+
+    it 'should have values set' do
+      expect(obj.declawed).not_to be_nil
+      expect(obj.declawed).to eq(false)
+    end
+  end
+
+  describe 'array and map properties' do
+    let(:obj) { ArrayMapObject.new }
+
+    let(:data) do
+      { int_arr: [123, 456],
+       pet_arr: [{ name: 'Kitty' }],
+       int_map: { 'int' => 123 },
+       pet_map: { 'pet' => { name: 'Kitty' } },
+       int_arr_map: { 'int_arr' => [123, 456] },
+       pet_arr_map: { 'pet_arr' => [{ name: 'Kitty' }] },
+       boolean_true_arr:  [true, "true", "TruE", 1, "y", "yes", "1", "t", "T"],
+       boolean_false_arr: [false, "", 0, "0", "f", nil, "null", "\ntrue\n"],
+      }
+    end
+
+    it 'works for #build_from_hash' do
+      obj.build_from_hash(data)
+
+      expect(obj.int_arr).to match_array([123, 456])
+
+      expect(obj.pet_arr).to be_instance_of(Array)
+      expect(obj.pet_arr.size).to eq(1)
+
+      pet = obj.pet_arr.first
+      expect(pet).to be_instance_of(Petstore::Pet)
+      expect(pet.name).to eq('Kitty')
+
+      expect(obj.int_map).to be_instance_of(Hash)
+      expect(obj.int_map).to eq('int' => 123)
+
+      expect(obj.pet_map).to be_instance_of(Hash)
+      pet = obj.pet_map['pet']
+      expect(pet).to be_instance_of(Petstore::Pet)
+      expect(pet.name).to eq('Kitty')
+
+      expect(obj.int_arr_map).to be_instance_of(Hash)
+      arr = obj.int_arr_map['int_arr']
+      expect(arr).to match_array([123, 456])
+
+      expect(obj.pet_arr_map).to be_instance_of(Hash)
+      arr = obj.pet_arr_map['pet_arr']
+      expect(arr).to be_instance_of(Array)
+      expect(arr.size).to eq(1)
+      pet = arr.first
+      expect(pet).to be_instance_of(Petstore::Pet)
+      expect(pet.name).to eq('Kitty')
+
+      expect(obj.boolean_true_arr).to be_instance_of(Array)
+      obj.boolean_true_arr.each do |b|
+        expect(b).to eq(true)
+      end
+
+      expect(obj.boolean_false_arr).to be_instance_of(Array)
+      obj.boolean_false_arr.each do |b|
+        expect(b).to eq(false)
+      end
+    end
+
+    it 'works for #to_hash' do
+      obj.build_from_hash(data)
+      expect_data = data.dup
+      expect_data[:boolean_true_arr].map! { true }
+      expect_data[:boolean_false_arr].map! { false }
+      expect(obj.to_hash).to eq(expect_data)
+    end
+  end
+end

--- a/samples/openapi3/client/petstore/ruby/spec/custom/pet_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/custom/pet_spec.rb
@@ -1,0 +1,218 @@
+require 'petstore_helper'
+require 'spec_helper'
+require 'json'
+
+describe "Pet" do
+  before do
+    @pet_api = Petstore::PetApi.new(API_CLIENT)
+    @pet_id = prepare_pet(@pet_api)
+  end
+
+  after do
+    # remove the testing pet
+    begin
+      @pet_api.delete_pet(@pet_id)
+    rescue Petstore::ApiError => e
+      # ignore ApiError 404 (Not Found)
+      raise e if e.code != 404
+    end
+  end
+
+  describe "pet methods" do
+    it "should construct a new pet object" do
+      tag1 = Petstore::Tag.new('id' => 1, 'name' => 'tag1')
+      tag2 = Petstore::Tag.new('id' => 2, 'name' => 'tag2')
+      category1 = Petstore::Category.new(:id => 1, :name => 'category unknown')
+      # initalize using both string and symbol key
+      pet_hash = {
+        :id => @pet_id,
+        :name => "RUBY UNIT TESTING",
+        :status => "pending",
+        :photo_urls => ["url1", "url2"],
+        :category => category1,
+        :tags => [tag1, tag2]
+      }
+      pet = Petstore::Pet.new(pet_hash)
+      # test new
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+      expect(pet.status).to eq("pending")
+      expect(pet.id).to eq(@pet_id)
+      expect(pet.tags[0].id).to eq(1)
+      expect(pet.tags[1].name).to eq('tag2')
+      expect(pet.category.name).to eq('category unknown')
+
+      # test build_from_hash
+      pet2 = Petstore::Pet.new
+      pet2.build_from_hash(pet.to_hash)
+      expect(pet.to_hash).to eq(pet2.to_hash)
+
+      # make sure sub-object has different object id
+      expect(pet.tags[0].object_id).not_to eq(pet2.tags[0].object_id)
+      expect(pet.tags[1].object_id).not_to eq(pet2.tags[1].object_id)
+      expect(pet.category.object_id).not_to eq(pet2.category.object_id)
+    end
+
+    it "should fetch a pet object" do
+      pet = @pet_api.get_pet_by_id(@pet_id)
+      expect(pet).to be_a(Petstore::Pet)
+      expect(pet.id).to eq(@pet_id)
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+      expect(pet.tags[0].name).to eq("tag test")
+      expect(pet.category.name).to eq("category test")
+    end
+
+    it "should fetch a pet object with http info" do
+      pet, status_code, headers = @pet_api.get_pet_by_id_with_http_info(@pet_id)
+      expect(status_code).to eq(200)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(pet).to be_a(Petstore::Pet)
+      expect(pet.id).to eq(@pet_id)
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+      expect(pet.tags[0].name).to eq("tag test")
+      expect(pet.category.name).to eq("category test")
+    end
+
+    it "should not find a pet that does not exist" do
+      begin
+        @pet_api.get_pet_by_id(-@pet_id)
+        fail 'it should raise error'
+      rescue Petstore::ApiError => e
+        expect(e.code).to eq(404)
+        expect(e.message).to eq('Not Found')
+        expect(e.response_body).to eq('{"code":1,"type":"error","message":"Pet not found"}')
+        expect(e.response_headers).to include('Content-Type')
+        expect(e.response_headers['Content-Type']).to eq('application/json')
+      end
+    end
+
+    # skip the following as original petstore spec does not have endpoints for testing byte array
+    # we will re-enable this after updating the petstore server
+    xit "should create and get pet with byte array (binary, string)" do
+      pet = @pet_api.get_pet_by_id(@pet_id)
+      pet.id = @pet_id + 1
+      str = serialize_json(pet)
+      @pet_api.add_pet_using_byte_array(body: str)
+
+      fetched_str = @pet_api.pet_pet_idtesting_byte_arraytrue_get(pet.id)
+      expect(fetched_str).to be_a(String)
+      fetched = deserialize_json(fetched_str, 'Pet')
+      expect(fetched).to be_a(Petstore::Pet)
+      expect(fetched.id).to eq(pet.id)
+      expect(fetched.category).to be_a(Petstore::Category)
+      expect(fetched.category.name).to eq(pet.category.name)
+
+      @pet_api.delete_pet(pet.id)
+    end
+
+    # skip the following as original petstore spec does not have endpoints for testing byte array
+    # we will re-enable this after updating the petstore server
+    xit "should get pet in object" do
+      pet = @pet_api.get_pet_by_id_in_object(@pet_id)
+      expect(pet).to be_a(Petstore::InlineResponse200)
+      expect(pet.id).to eq(@pet_id)
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+      expect(pet.category).to be_a(Hash)
+      expect(pet.category[:id]).to eq(20002)
+      expect(pet.category[:name]).to eq('category test')
+    end
+
+    it "should update a pet" do
+      pet = @pet_api.get_pet_by_id(@pet_id)
+      expect(pet.id).to eq(@pet_id)
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+      expect(pet.status).to eq('pending')
+
+      @pet_api.update_pet_with_form(@pet_id, name: 'new name', status: 'sold')
+
+      fetched = @pet_api.get_pet_by_id(@pet_id)
+      expect(fetched.id).to eq(@pet_id)
+      expect(fetched.name).to eq("new name")
+      expect(fetched.status).to eq('sold')
+    end
+
+    it "should find pets by status" do
+      pets = @pet_api.find_pets_by_status(['available'])
+      expect(pets.length).to be >= 3
+      pets.each do |pet|
+        expect(pet).to be_a(Petstore::Pet)
+        expect(pet.status).to eq('available')
+      end
+    end
+
+    it "should not find a pet with invalid status" do
+      pets = @pet_api.find_pets_by_status(['invalid-status'])
+      expect(pets.length).to eq(0)
+    end
+
+    it "should find a pet by status" do
+      pets = @pet_api.find_pets_by_status(["available", "sold"])
+      pets.each do |pet|
+        if pet.status != 'available' && pet.status != 'sold'
+          raise "pet status wasn't right"
+        end
+      end
+    end
+
+    it "should create a pet" do
+      id = @pet_id + 1
+
+      pet = Petstore::Pet.new('id' => id, 'name' => "RUBY UNIT TESTING")
+      result = @pet_api.add_pet(pet)
+      # nothing is returned
+      expect(result).to be_nil
+
+      pet = @pet_api.get_pet_by_id(id)
+      expect(pet.id).to eq(id)
+      expect(pet.name).to eq("RUBY UNIT TESTING")
+
+      @pet_api.delete_pet(id)
+    end
+
+    it "should upload a file to a pet" do
+      result = @pet_api.upload_file(@pet_id, file: File.new('hello.txt'))
+      # ApiResponse is returned
+      expect(result).to be_a(Petstore::ApiResponse)
+    end
+
+    it "should upload a file with form parameter to a pet" do
+      result = @pet_api.upload_file(@pet_id, file: File.new('hello.txt'), additional_metadata: 'metadata')
+      # ApiResponse is returned
+      expect(result).to be_a(Petstore::ApiResponse)
+    end
+
+    it "should implement eql? and hash" do
+      pet1 = Petstore::Pet.new
+      pet2 = Petstore::Pet.new
+      expect(pet1).to eq(pet2)
+      expect(pet2).to eq(pet1)
+      expect(pet1.eql?(pet2)).to eq(true)
+      expect(pet2.eql?(pet1)).to eq(true)
+      expect(pet1.hash).to eq(pet2.hash)
+      expect(pet1).to eq(pet1)
+      expect(pet1.eql?(pet1)).to eq(true)
+      expect(pet1.hash).to eq(pet1.hash)
+
+      pet1.name = 'really-happy'
+      pet1.photo_urls = ['http://foo.bar.com/1', 'http://foo.bar.com/2']
+      expect(pet1).not_to eq(pet2)
+      expect(pet2).not_to eq(pet1)
+      expect(pet1.eql?(pet2)).to eq(false)
+      expect(pet2.eql?(pet1)).to eq(false)
+      expect(pet1.hash).not_to eq(pet2.hash)
+      expect(pet1).to eq(pet1)
+      expect(pet1.eql?(pet1)).to eq(true)
+      expect(pet1.hash).to eq(pet1.hash)
+
+      pet2.name = 'really-happy'
+      pet2.photo_urls = ['http://foo.bar.com/1', 'http://foo.bar.com/2']
+      expect(pet1).to eq(pet2)
+      expect(pet2).to eq(pet1)
+      expect(pet1.eql?(pet2)).to eq(true)
+      expect(pet2.eql?(pet1)).to eq(true)
+      expect(pet1.hash).to eq(pet2.hash)
+      expect(pet2).to eq(pet2)
+      expect(pet2.eql?(pet2)).to eq(true)
+      expect(pet2.hash).to eq(pet2.hash)
+    end
+  end
+end

--- a/samples/openapi3/client/petstore/ruby/spec/custom/store_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/custom/store_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe "Store" do
+  before do
+    @api = Petstore::StoreApi.new(API_CLIENT)
+  end
+
+  it "should fetch an order" do
+    @order_id = prepare_store(@api)
+
+    item = @api.get_order_by_id(@order_id)
+    expect(item.id).to eq(@order_id)
+
+    @api.delete_order(@order_id)
+  end
+
+  it "should fetch the inventory" do
+    result = @api.get_inventory
+    expect(result).to be_a(Hash)
+    expect(result).not_to be_empty
+    result.each do |k, v|
+      expect(k).to be_a(Symbol)
+      expect(v).to be_a(Integer)
+    end
+  end
+
+  # mark as pending since original petstore does not return object
+  # will re-enable this after updating the petstore server
+  xit "should fetch the inventory in object" do
+    result = @api.get_inventory_in_object
+    expect(result).to be_a(Hash)
+    expect(result).not_to be_empty
+    result.each do |k, v|
+      expect(k).to be_a(Symbol)
+      expect(v).to be_a(Integer)
+    end
+  end
+end

--- a/samples/openapi3/client/petstore/ruby/spec/petstore_helper.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/petstore_helper.rb
@@ -1,0 +1,52 @@
+# load the gem
+require 'petstore'
+
+# API client (shared between all the test cases)
+API_CLIENT = Petstore::ApiClient.new(Petstore::Configuration.new)
+
+# randomly generate an ID
+def random_id
+  rand(1000000) + 20000
+end
+
+# create a random pet, return its id
+def prepare_pet(pet_api)
+  pet_id = random_id
+  category = Petstore::Category.new('id' => 20002, 'name' => 'category test')
+  tag = Petstore::Tag.new('id' => 30002, 'name' => 'tag test')
+  pet = Petstore::Pet.new('id' => pet_id, 'name' => "RUBY UNIT TESTING", 'photo_urls' => 'photo url',
+                          'category' => category, 'tags' => [tag], 'status' => 'pending')
+  pet_api.add_pet(pet)
+  pet_id
+end
+
+# create a random order, return its id
+def prepare_store(store_api)
+  order_id = 5
+  order = Petstore::Order.new("id" => order_id,
+          "petId" => 123,
+          "quantity" => 789,
+          "shipDate" => "2015-04-06T23:42:01.678Z",
+          "status" => "placed",
+          "complete" => false)
+  store_api.place_order(order)
+  order_id
+end
+
+# A random string to tack onto stuff to ensure we're not seeing
+# data from a previous test run
+RAND = ("a".."z").to_a.sample(8).join
+
+# helper method to serialize object to json string
+def serialize_json(o)
+  API_CLIENT.object_to_http_body(o)
+end
+
+# helper method to deserialize json string back to object
+def deserialize_json(s, type)
+  headers = { 'Content-Type' => 'application/json' }
+  response = double('response', headers: headers, body: s)
+  API_CLIENT.deserialize(response, type)
+end
+
+


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)


