### PR TITLE
modified the meta command to generate easy debugging for generators 

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Meta.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Meta.java
@@ -83,6 +83,7 @@ public class Meta implements Runnable {
                 ImmutableList.of(
                         new SupportingFile("pom.mustache", "", "pom.xml"),
                         new SupportingFile("generatorClass.mustache", on(File.separator).join("src/main/java", asPath(targetPackage)), mainClass.concat(".java")),
+                        new SupportingFile("debugGeneratorTest.mustache", on(File.separator).join("src/test/java", asPath("org.openapitools.codegen.debug")), "DebugCodegenLauncher.java"),
                         new SupportingFile("README.mustache", "", "README.md"),
                         new SupportingFile("api.template", "src/main/resources" + File.separator + name,"api.mustache"),
                         new SupportingFile("model.template", "src/main/resources" + File.separator + name,"model.mustache"),

--- a/modules/openapi-generator/src/main/resources/codegen/README.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/README.mustache
@@ -64,6 +64,9 @@ The `{{generatorClass}}.java` has comments in it--lots of comments.  There is no
 for reading the code more, though.  See how the `{{generatorClass}}` implements `CodegenConfig`.
 That class has the signature of all values that can be overridden.
 
+You can also step through {{generatorClass}}.java in a debugger.  Just debug the JUnit
+test in DebugCodegenLauncher.  That runs the command line tool and lets you inspect what the code is doing.  
+
 For the templates themselves, you have a number of values available to you for generation.
 You can execute the `java` command from above while passing different debug flags to show
 the object you have available during client generation:

--- a/modules/openapi-generator/src/main/resources/codegen/debugGeneratorTest.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/debugGeneratorTest.mustache
@@ -1,0 +1,32 @@
+package org.openapitools.codegen.debug;
+
+import org.junit.Test;
+import org.openapitools.codegen.OpenAPIGenerator;
+
+/***
+ * This test allows you to easily launch your code generation software under a debugger.
+ * Then run this test under debug mode.  You will be able to step through your java code 
+ * and then see the results in the out directory. 
+ *
+ * To experiment with debugging your code generator:
+ * 1) Set a break point in {{generatorClass}}.java in the postProcessOperationsWithModels() method.
+ * 2) To launch this test in Eclipse: right-click | Debug As | JUnit Test
+ *
+ */
+public class DebugCodegenLauncher 
+{
+  @Test
+  public void launchCodeGeneratorInDebugMode()
+  {
+    // use this test to launch you code generator in the debugger.
+    // this allows you to easily set break points in {{generatorClass}}.
+    String commandLineParams =
+        "generate "+              
+        "-i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml "+ // sample swagger 
+        "-t ./src/main/resources/{{name}} "+          // template directory
+        "-o out/{{name}} "+                           // output directory
+        "-g {{name}} ";                               // use this codegen library
+    
+    OpenAPIGenerator.main( commandLineParams.split(" ") );
+  }
+}

--- a/modules/openapi-generator/src/main/resources/codegen/generatorClass.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/generatorClass.mustache
@@ -31,6 +31,32 @@ public class {{generatorClass}} extends DefaultCodegen implements CodegenConfig 
   public String getName() {
     return "{{name}}";
   }
+  
+  /**
+   * Provides an opportunity to inspect and modify operation data before the code is generated.
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public Map<String, Object> postProcessOperationsWithModels(Map<String, Object> objs, List<Object> allModels) {
+	
+    // to try debugging your code generator:
+    // set a break point on the next line.
+    // then debug the JUnit test called LaunchGeneratorInDebugger
+    
+    Map<String, Object> results = super.postProcessOperationsWithModels(objs, allModels);
+    
+    Map<String, Object> ops = (Map<String, Object>)results.get("operations");
+    ArrayList<CodegenOperation> opList = (ArrayList<CodegenOperation>)ops.get("operation");
+    
+    // iterate over the operation and perhaps modify something
+    for(CodegenOperation co : opList){
+      // example:
+      // co.httpMethod = co.httpMethod.toLowerCase();
+    }
+		
+    return results;
+  }
+  
 
   /**
    * Returns human-friendly help for the generator.  Provide the consumer with help

--- a/modules/openapi-generator/src/main/resources/codegen/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/codegen/pom.mustache
@@ -113,6 +113,16 @@
             <version>${openapi-generator-version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>openapi-generator-cli</artifactId>
+            <version>${openapi-generator-version}</version>
+        </dependency>        
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit-version}</version>
+        </dependency>         
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
…ging new libraries

### PR checklist

- [Y] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).

- [N/A] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. 
This PR doesn't change any generator, it changes the 'meta' command for creating new generators.

- [Y] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`. ( doing so now )

- [N/A] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.  
This change does not target any existing generator, but the meta command to start new ones.

### Description of the PR

I am working on a new generator that is specific to my company.   I found it very difficult to debug the java code that sets up the data sent to the mustache files.   The existing documentation suggests a complex method of running the jar in suspend and then attaching an IDE debugger on a debug port.

A much simpler way to get the generator running in the debugger was to simply create a JUnit test that calls the CLI class programmatically.  When I debug the JUnit test, it calls the CLI, the CLI calls my code and then I've easily got my code running in debug mode without any mucking around with debug ports.

I tested this technique with my own work, and decided to contribute the idea here.  It's a tiny change but hopefully it's helpful to people trying to debug their generators.