### PR TITLE
Refactor and use some Java 7 features

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/ClientOpts.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/ClientOpts.java
@@ -21,6 +21,7 @@ import org.openapitools.codegen.auth.AuthMethod;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ClientOpts {
     protected String uri;
@@ -78,26 +79,15 @@ public class ClientOpts {
         if (o == null || getClass() != o.getClass()) return false;
 
         ClientOpts that = (ClientOpts) o;
-
-        if (uri != null ? !uri.equals(that.uri) : that.uri != null)
-            return false;
-        if (target != null ? !target.equals(that.target) : that.target != null)
-            return false;
-        if (auth != null ? !auth.equals(that.auth) : that.auth != null)
-            return false;
-        if (properties != null ? !properties.equals(that.properties) : that.properties != null)
-            return false;
-        return outputDirectory != null ? outputDirectory.equals(that.outputDirectory) : that.outputDirectory == null;
-
+        return Objects.equals(uri, that.uri) &&
+            Objects.equals(target, that.target) &&
+            Objects.equals(auth, that.auth) &&
+            Objects.equals(properties, that.properties) &&
+            Objects.equals(outputDirectory, that.outputDirectory);
     }
 
     @Override
     public int hashCode() {
-        int result = uri != null ? uri.hashCode() : 0;
-        result = 31 * result + (target != null ? target.hashCode() : 0);
-        result = 31 * result + (auth != null ? auth.hashCode() : 0);
-        result = 31 * result + (properties != null ? properties.hashCode() : 0);
-        result = 31 * result + (outputDirectory != null ? outputDirectory.hashCode() : 0);
-        return result;
+        return Objects.hash(uri, target, auth, properties, outputDirectory);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -174,45 +174,45 @@ public class CodegenModel {
 
     @Override
     public int hashCode() {
-        int result = parent != null ? parent.hashCode() : 0;
-        result = 31 * result + (parentSchema != null ? parentSchema.hashCode() : 0);
-        result = 31 * result + (interfaces != null ? interfaces.hashCode() : 0);
-        result = 31 * result + (allParents != null ? allParents.hashCode() : 0);
-        result = 31 * result + (parentModel != null ? parentModel.hashCode() : 0);
-        result = 31 * result + (interfaceModels != null ? interfaceModels.hashCode() : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (classname != null ? classname.hashCode() : 0);
-        result = 31 * result + (title != null ? title.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (classVarName != null ? classVarName.hashCode() : 0);
-        result = 31 * result + (modelJson != null ? modelJson.hashCode() : 0);
-        result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
-        result = 31 * result + (xmlPrefix != null ? xmlPrefix.hashCode() : 0);
-        result = 31 * result + (xmlNamespace != null ? xmlNamespace.hashCode() : 0);
-        result = 31 * result + (xmlName != null ? xmlName.hashCode() : 0);
-        result = 31 * result + (classFilename != null ? classFilename.hashCode() : 0);
-        result = 31 * result + (unescapedDescription != null ? unescapedDescription.hashCode() : 0);
-        result = 31 * result + (discriminator != null ? discriminator.hashCode() : 0);
-        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
-        result = 31 * result + (vars != null ? vars.hashCode() : 0);
-        result = 31 * result + (requiredVars != null ? requiredVars.hashCode() : 0);
-        result = 31 * result + (optionalVars != null ? optionalVars.hashCode() : 0);
-        result = 31 * result + (allVars != null ? allVars.hashCode() : 0);
-        result = 31 * result + (allowableValues != null ? allowableValues.hashCode() : 0);
-        result = 31 * result + (mandatory != null ? mandatory.hashCode() : 0);
-        result = 31 * result + (allMandatory != null ? allMandatory.hashCode() : 0);
-        result = 31 * result + (imports != null ? imports.hashCode() : 0);
-        result = 31 * result + (hasVars ? 13 : 31);
-        result = 31 * result + (emptyVars ? 13 : 31);
-        result = 31 * result + (hasMoreModels ? 13 : 31);
-        result = 31 * result + (hasEnums ? 13 : 31);
-        result = 31 * result + (isEnum ? 13 : 31);
-        result = 31 * result + (externalDocumentation != null ? externalDocumentation.hashCode() : 0);
-        result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
-        result = 31 * result + Objects.hash(hasOnlyReadOnly);
-        result = 31 * result + Objects.hash(hasChildren);
-        result = 31 * result + Objects.hash(parentVars);
-        return result;
+        return Objects.hash(
+            parent,
+            parentSchema,
+            interfaces,
+            allParents,
+            parentModel,
+            interfaceModels,
+            name,
+            classname,
+            title,
+            description,
+            classVarName,
+            modelJson,
+            dataType,
+            xmlPrefix,
+            xmlNamespace,
+            xmlName,
+            classFilename,
+            unescapedDescription,
+            discriminator,
+            defaultValue,
+            vars,
+            requiredVars,
+            optionalVars,
+            allVars,
+            allowableValues,
+            mandatory,
+            allMandatory,
+            imports,
+            hasVars,
+            emptyVars,
+            hasMoreModels,
+            hasEnums,
+            isEnum,
+            externalDocumentation,
+            vendorExtensions,
+            hasOnlyReadOnly,
+            hasChildren,
+            parentVars);
     }
 
     public String getParent() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -132,82 +132,44 @@ public class CodegenModel {
 
         CodegenModel that = (CodegenModel) o;
 
-        if (parent != null ? !parent.equals(that.parent) : that.parent != null)
-            return false;
-        if (parentSchema != null ? !parentSchema.equals(that.parentSchema) : that.parentSchema != null)
-            return false;
-        if (interfaces != null ? !interfaces.equals(that.interfaces) : that.interfaces != null)
-            return false;
-        if (allParents != null ? !allParents.equals(that.allParents) : that.allParents != null)
-            return false;
-        if (parentModel != null ? !parentModel.equals(that.parentModel) : that.parentModel != null)
-            return false;
-        if (interfaceModels != null ? !interfaceModels.equals(that.interfaceModels) : that.interfaceModels != null)
-            return false;
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (classname != null ? !classname.equals(that.classname) : that.classname != null)
-            return false;
-        if (title != null ? !title.equals(that.title) : that.title != null)
-            return false;
-        if (description != null ? !description.equals(that.description) : that.description != null)
-            return false;
-        if (classVarName != null ? !classVarName.equals(that.classVarName) : that.classVarName != null)
-            return false;
-        if (modelJson != null ? !modelJson.equals(that.modelJson) : that.modelJson != null)
-            return false;
-        if (dataType != null ? !dataType.equals(that.dataType) : that.dataType != null)
-            return false;
-        if (xmlPrefix != null ? !xmlPrefix.equals(that.xmlPrefix) : that.xmlPrefix != null)
-            return false;
-        if (xmlNamespace != null ? !xmlNamespace.equals(that.xmlNamespace) : that.xmlNamespace != null)
-            return false;
-        if (xmlName != null ? !xmlName.equals(that.xmlName) : that.xmlName != null)
-            return false;
-        if (classFilename != null ? !classFilename.equals(that.classFilename) : that.classFilename != null)
-            return false;
-        if (unescapedDescription != null ? !unescapedDescription.equals(that.unescapedDescription) : that.unescapedDescription != null)
-            return false;
-        if (discriminator != null ? !discriminator.equals(that.discriminator) : that.discriminator != null)
-            return false;
-        if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that.defaultValue != null)
-            return false;
-        if (vars != null ? !vars.equals(that.vars) : that.vars != null)
-            return false;
-        if (requiredVars != null ? !requiredVars.equals(that.requiredVars) : that.requiredVars != null)
-            return false;
-        if (optionalVars != null ? !optionalVars.equals(that.optionalVars) : that.optionalVars != null)
-            return false;
-        if (allVars != null ? !allVars.equals(that.allVars) : that.allVars != null)
-            return false;
-        if (allowableValues != null ? !allowableValues.equals(that.allowableValues) : that.allowableValues != null)
-            return false;
-        if (mandatory != null ? !mandatory.equals(that.mandatory) : that.mandatory != null)
-            return false;
-        if (allMandatory != null ? !allMandatory.equals(that.allMandatory) : that.allMandatory != null)
-            return false;
-        if (imports != null ? !imports.equals(that.imports) : that.imports != null)
-            return false;
-        if (hasVars != that.hasVars)
-            return false;
-        if (emptyVars != that.emptyVars)
-            return false;
-        if (hasMoreModels != that.hasMoreModels)
-            return false;
-        if (hasEnums != that.hasEnums)
-            return false;
-        if (isEnum != that.isEnum)
-            return false;
-        if (externalDocumentation != null ? !externalDocumentation.equals(that.externalDocumentation) : that.externalDocumentation != null)
-            return false;
-        if (!Objects.equals(hasOnlyReadOnly, that.hasOnlyReadOnly))
-            return false;
-        if (!Objects.equals(hasChildren, that.hasChildren))
-            return false;
-        if (!Objects.equals(parentVars, that.parentVars))
-            return false;
-        return vendorExtensions != null ? vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions == null;
-
+        return Objects.equals(parent, that.parent) &&
+            Objects.equals(parentSchema, that.parentSchema) &&
+            Objects.equals(interfaces, that.interfaces) &&
+            Objects.equals(allParents, that.allParents) &&
+            Objects.equals(parentModel, that.parentModel) &&
+            Objects.equals(interfaceModels, that.interfaceModels) &&
+            Objects.equals(name, that.name) &&
+            Objects.equals(classname, that.classname) &&
+            Objects.equals(title, that.title) &&
+            Objects.equals(description, that.description) &&
+            Objects.equals(classVarName, that.classVarName) &&
+            Objects.equals(modelJson, that.modelJson) &&
+            Objects.equals(dataType, that.dataType) &&
+            Objects.equals(xmlPrefix, that.xmlPrefix) &&
+            Objects.equals(xmlNamespace, that.xmlNamespace) &&
+            Objects.equals(xmlName, that.xmlName) &&
+            Objects.equals(classFilename, that.classFilename) &&
+            Objects.equals(unescapedDescription, that.unescapedDescription) &&
+            Objects.equals(discriminator, that.discriminator) &&
+            Objects.equals(defaultValue, that.defaultValue) &&
+            Objects.equals(vars, that.vars) &&
+            Objects.equals(requiredVars, that.requiredVars) &&
+            Objects.equals(optionalVars, that.optionalVars) &&
+            Objects.equals(allVars, that.allVars) &&
+            Objects.equals(allowableValues, that.allowableValues) &&
+            Objects.equals(mandatory, that.mandatory) &&
+            Objects.equals(allMandatory, that.allMandatory) &&
+            Objects.equals(imports, that.imports) &&
+            Objects.equals(hasVars, that.hasVars) &&
+            Objects.equals(emptyVars, that.emptyVars) &&
+            Objects.equals(hasMoreModels, that.hasMoreModels) &&
+            Objects.equals(hasEnums, that.hasEnums) &&
+            Objects.equals(isEnum, that.isEnum) &&
+            Objects.equals(externalDocumentation, that.externalDocumentation) &&
+            Objects.equals(hasOnlyReadOnly, that.hasOnlyReadOnly) &&
+            Objects.equals(hasChildren, that.hasChildren) &&
+            Objects.equals(parentVars, that.parentVars) &&
+            Objects.equals(vendorExtensions, that.vendorExtensions);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -314,63 +314,63 @@ public class CodegenOperation {
 
     @Override
     public int hashCode() {
-        int result = responseHeaders.hashCode();
-        result = 31 * result + (hasAuthMethods ? 13:31);
-        result = 31 * result + (hasConsumes ? 13:31);
-        result = 31 * result + (hasProduces ? 13:31);
-        result = 31 * result + (hasParams ? 13:31);
-        result = 31 * result + (hasOptionalParams ? 13:31);
-        result = 31 * result + (returnTypeIsPrimitive ? 13:31);
-        result = 31 * result + (returnSimpleType ? 13:31);
-        result = 31 * result + (subresourceOperation ? 13:31);
-        result = 31 * result + (isMapContainer ? 13:31);
-        result = 31 * result + (isListContainer ? 13:31);
-        result = 31 * result + (isMultipart ? 13:31);
-        result = 31 * result + (hasMore ? 13:31);
-        result = 31 * result + (isResponseBinary ? 13:31);
-        result = 31 * result + (isResponseFile ? 13:31);
-        result = 31 * result + (hasReference ? 13:31);
-        result = 31 * result + (isDeprecated ? 13:31);
-        result = 31 * result + (isCallbackRequest ? 13:31);
-        result = 31 * result + (path != null ? path.hashCode() : 0);
-        result = 31 * result + (operationId != null ? operationId.hashCode() : 0);
-        result = 31 * result + (returnType != null ? returnType.hashCode() : 0);
-        result = 31 * result + (httpMethod != null ? httpMethod.hashCode() : 0);
-        result = 31 * result + (returnBaseType != null ? returnBaseType.hashCode() : 0);
-        result = 31 * result + (returnContainer != null ? returnContainer.hashCode() : 0);
-        result = 31 * result + (summary != null ? summary.hashCode() : 0);
-        result = 31 * result + (unescapedNotes != null ? unescapedNotes.hashCode() : 0);
-        result = 31 * result + (notes != null ? notes.hashCode() : 0);
-        result = 31 * result + (baseName != null ? baseName.hashCode() : 0);
-        result = 31 * result + (defaultResponse != null ? defaultResponse.hashCode() : 0);
-        result = 31 * result + (discriminator != null ? discriminator.hashCode() : 0);
-        result = 31 * result + (consumes != null ? consumes.hashCode() : 0);
-        result = 31 * result + (produces != null ? produces.hashCode() : 0);
-        result = 31 * result + (servers != null ? servers.hashCode() : 0);
-        result = 31 * result + (bodyParam != null ? bodyParam.hashCode() : 0);
-        result = 31 * result + (allParams != null ? allParams.hashCode() : 0);
-        result = 31 * result + (bodyParams != null ? bodyParams.hashCode() : 0);
-        result = 31 * result + (pathParams != null ? pathParams.hashCode() : 0);
-        result = 31 * result + (queryParams != null ? queryParams.hashCode() : 0);
-        result = 31 * result + (headerParams != null ? headerParams.hashCode() : 0);
-        result = 31 * result + (formParams != null ? formParams.hashCode() : 0);
-        result = 31 * result + (cookieParams != null ? cookieParams.hashCode() : 0);
-        result = 31 * result + (requiredParams!= null ? requiredParams.hashCode() : 0);
-        result = 31 * result + (optionalParams != null ? optionalParams.hashCode() : 0);
-        result = 31 * result + (authMethods != null ? authMethods.hashCode() : 0);
-        result = 31 * result + (tags != null ? tags.hashCode() : 0);
-        result = 31 * result + (responses != null ? responses.hashCode() : 0);
-        result = 31 * result + (callbacks != null ? callbacks.hashCode() : 0);
-        result = 31 * result + (imports != null ? imports.hashCode() : 0);
-        result = 31 * result + (examples != null ? examples.hashCode() : 0);
-        result = 31 * result + (externalDocs != null ? externalDocs.hashCode() : 0);
-        result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
-        result = 31 * result + (nickname != null ? nickname.hashCode() : 0);
-        result = 31 * result + (prioritizedContentTypes != null ? prioritizedContentTypes.hashCode() : 0);
-        result = 31 * result + (operationIdOriginal != null ? operationIdOriginal.hashCode() : 0);
-        result = 31 * result + (operationIdLowerCase != null ? operationIdLowerCase.hashCode() : 0);
-        result = 31 * result + (operationIdCamelCase != null ? operationIdCamelCase.hashCode() : 0);
-        return result;
+        return Objects.hash(
+            responseHeaders,
+            hasAuthMethods,
+            hasConsumes,
+            hasProduces,
+            hasParams,
+            hasOptionalParams,
+            returnTypeIsPrimitive,
+            returnSimpleType,
+            subresourceOperation,
+            isMapContainer,
+            isListContainer,
+            isMultipart,
+            hasMore,
+            isResponseBinary,
+            isResponseFile,
+            hasReference,
+            isDeprecated,
+            isCallbackRequest,
+            path,
+            operationId,
+            returnType,
+            httpMethod,
+            returnBaseType,
+            returnContainer,
+            summary,
+            unescapedNotes,
+            notes,
+            baseName,
+            defaultResponse,
+            discriminator,
+            consumes,
+            produces,
+            servers,
+            bodyParam,
+            allParams,
+            bodyParams,
+            pathParams,
+            queryParams,
+            headerParams,
+            formParams,
+            cookieParams,
+            requiredParams,
+            optionalParams,
+            authMethods,
+            tags,
+            responses,
+            callbacks,
+            imports,
+            examples,
+            externalDocs,
+            vendorExtensions,
+            nickname,
+            prioritizedContentTypes,
+            operationIdOriginal,
+            operationIdLowerCase,
+            operationIdCamelCase);
     }
 
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -31,7 +31,7 @@ public class CodegenOperation {
             isRestfulIndex, isRestfulShow, isRestfulCreate, isRestfulUpdate, isRestfulDestroy,
             isRestful, isDeprecated, isCallbackRequest;
     public String path, operationId, returnType, httpMethod, returnBaseType,
-            returnContainer, summary, unescapedNotes, notes, baseName, defaultResponse; 
+            returnContainer, summary, unescapedNotes, notes, baseName, defaultResponse;
     public CodegenDiscriminator discriminator;
     public List<Map<String, String>> consumes, produces, prioritizedContentTypes;
     public List<CodegenServer> servers = new ArrayList<CodegenServer>();
@@ -68,7 +68,7 @@ public class CodegenOperation {
     private static boolean nonempty(List<?> params) {
         return params != null && params.size() > 0;
     }
-    
+
     /**
      * Check if there's at least one body parameter
      *
@@ -254,118 +254,62 @@ public class CodegenOperation {
 
         CodegenOperation that = (CodegenOperation) o;
 
-        if (responseHeaders != null ? !responseHeaders.equals(that.responseHeaders) : that.responseHeaders != null)
-            return false;
-        if (hasAuthMethods != that.hasAuthMethods)
-            return false;
-        if (hasConsumes != that.hasConsumes)
-            return false;
-        if (hasProduces != that.hasProduces)
-            return false;
-        if (hasParams != that.hasParams)
-            return false;
-        if (hasOptionalParams != that.hasOptionalParams)
-            return false;
-        if (returnTypeIsPrimitive != that.returnTypeIsPrimitive)
-            return false;
-        if (returnSimpleType != that.returnSimpleType)
-            return false;
-        if (subresourceOperation != that.subresourceOperation)
-            return false;
-        if (isMapContainer != that.isMapContainer)
-            return false;
-        if (isListContainer != that.isListContainer)
-            return false;
-        if (isMultipart != that.isMultipart)
-            return false;
-        if (hasMore != that.hasMore)
-            return false;
-        if (isResponseBinary != that.isResponseBinary)
-            return false;
-        if (hasReference != that.hasReference)
-            return false;
-        if (isResponseFile != that.isResponseFile)
-            return false;
-        if (isDeprecated != that.isDeprecated)
-            return false;
-        if (isCallbackRequest != that.isCallbackRequest)
-            return false;
-        if (path != null ? !path.equals(that.path) : that.path != null)
-            return false;
-        if (operationId != null ? !operationId.equals(that.operationId) : that.operationId != null)
-            return false;
-        if (returnType != null ? !returnType.equals(that.returnType) : that.returnType != null)
-            return false;
-        if (httpMethod != null ? !httpMethod.equals(that.httpMethod) : that.httpMethod != null)
-            return false;
-        if (returnBaseType != null ? !returnBaseType.equals(that.returnBaseType) : that.returnBaseType != null)
-            return false;
-        if (returnContainer != null ? !returnContainer.equals(that.returnContainer) : that.returnContainer != null)
-            return false;
-        if (summary != null ? !summary.equals(that.summary) : that.summary != null)
-            return false;
-        if (unescapedNotes != null ? !unescapedNotes.equals(that.unescapedNotes) : that.unescapedNotes != null)
-            return false;
-        if (notes != null ? !notes.equals(that.notes) : that.notes != null)
-            return false;
-        if (baseName != null ? !baseName.equals(that.baseName) : that.baseName != null)
-            return false;
-        if (defaultResponse != null ? !defaultResponse.equals(that.defaultResponse) : that.defaultResponse != null)
-            return false;
-        if (discriminator != null ? !discriminator.equals(that.discriminator) : that.discriminator != null)
-            return false;
-        if (consumes != null ? !consumes.equals(that.consumes) : that.consumes != null)
-            return false;
-        if (produces != null ? !produces.equals(that.produces) : that.produces != null)
-            return false;
-        if (servers != null ? !servers.equals(that.servers) : that.servers != null)
-            return false;
-        if (bodyParam != null ? !bodyParam.equals(that.bodyParam) : that.bodyParam != null)
-            return false;
-        if (allParams != null ? !allParams.equals(that.allParams) : that.allParams != null)
-            return false;
-        if (bodyParams != null ? !bodyParams.equals(that.bodyParams) : that.bodyParams != null)
-            return false;
-        if (pathParams != null ? !pathParams.equals(that.pathParams) : that.pathParams != null)
-            return false;
-        if (queryParams != null ? !queryParams.equals(that.queryParams) : that.queryParams != null)
-            return false;
-        if (headerParams != null ? !headerParams.equals(that.headerParams) : that.headerParams != null)
-            return false;
-        if (formParams != null ? !formParams.equals(that.formParams) : that.formParams != null)
-            return false;
-        if (cookieParams != null ? !cookieParams.equals(that.cookieParams) : that.cookieParams != null)
-            return false;
-        if (requiredParams != null ? !requiredParams.equals(that.requiredParams) : that.requiredParams!= null)
-            return false;
-        if (optionalParams != null ? !optionalParams.equals(that.optionalParams) : that.optionalParams!= null)
-            return false;
-        if (authMethods != null ? !authMethods.equals(that.authMethods) : that.authMethods != null)
-            return false;
-        if (tags != null ? !tags.equals(that.tags) : that.tags != null)
-            return false;
-        if (responses != null ? !responses.equals(that.responses) : that.responses != null)
-            return false;
-        if (callbacks != null ? !callbacks.equals(that.callbacks) : that.callbacks != null)
-            return false;
-        if (imports != null ? !imports.equals(that.imports) : that.imports != null)
-            return false;
-        if (examples != null ? !examples.equals(that.examples) : that.examples != null)
-            return false;
-        if (externalDocs != null ? !externalDocs.equals(that.externalDocs) : that.externalDocs != null)
-            return false;
-        if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
-            return false;
-        if (nickname != null ? !nickname.equals(that.nickname) : that.nickname != null)
-            return false;
-        if ( prioritizedContentTypes != null ? !prioritizedContentTypes.equals(that.prioritizedContentTypes) : that.prioritizedContentTypes != null )
-            return false;
-        if ( operationIdOriginal != null ? !operationIdOriginal.equals(that.operationIdOriginal) : that.operationIdOriginal != null )
-            return false;
-        if ( operationIdLowerCase != null ? !operationIdLowerCase.equals(that.operationIdLowerCase) : that.operationIdLowerCase != null )
-            return false;
-        return operationIdCamelCase != null ? operationIdCamelCase.equals(that.operationIdCamelCase) : that.operationIdCamelCase == null;
-
+        return Objects.equals(responseHeaders, that.responseHeaders) &&
+            Objects.equals(hasAuthMethods, that.hasAuthMethods) &&
+            Objects.equals(hasConsumes, that.hasConsumes) &&
+            Objects.equals(hasProduces, that.hasProduces) &&
+            Objects.equals(hasParams, that.hasParams) &&
+            Objects.equals(hasOptionalParams, that.hasOptionalParams) &&
+            Objects.equals(returnTypeIsPrimitive, that.returnTypeIsPrimitive) &&
+            Objects.equals(returnSimpleType, that.returnSimpleType) &&
+            Objects.equals(subresourceOperation, that.subresourceOperation) &&
+            Objects.equals(isMapContainer, that.isMapContainer) &&
+            Objects.equals(isListContainer, that.isListContainer) &&
+            Objects.equals(isMultipart, that.isMultipart) &&
+            Objects.equals(hasMore, that.hasMore) &&
+            Objects.equals(isResponseBinary, that.isResponseBinary) &&
+            Objects.equals(hasReference, that.hasReference) &&
+            Objects.equals(isResponseFile, that.isResponseFile) &&
+            Objects.equals(isDeprecated, that.isDeprecated) &&
+            Objects.equals(isCallbackRequest, that.isCallbackRequest) &&
+            Objects.equals(path, that.path) &&
+            Objects.equals(operationId, that.operationId) &&
+            Objects.equals(returnType, that.returnType) &&
+            Objects.equals(httpMethod, that.httpMethod) &&
+            Objects.equals(returnBaseType, that.returnBaseType) &&
+            Objects.equals(returnContainer, that.returnContainer) &&
+            Objects.equals(summary, that.summary) &&
+            Objects.equals(unescapedNotes, that.unescapedNotes) &&
+            Objects.equals(notes, that.notes) &&
+            Objects.equals(baseName, that.baseName) &&
+            Objects.equals(defaultResponse, that.defaultResponse) &&
+            Objects.equals(discriminator, that.discriminator) &&
+            Objects.equals(consumes, that.consumes) &&
+            Objects.equals(produces, that.produces) &&
+            Objects.equals(servers, that.servers) &&
+            Objects.equals(bodyParam, that.bodyParam) &&
+            Objects.equals(allParams, that.allParams) &&
+            Objects.equals(bodyParams, that.bodyParams) &&
+            Objects.equals(pathParams, that.pathParams) &&
+            Objects.equals(queryParams, that.queryParams) &&
+            Objects.equals(headerParams, that.headerParams) &&
+            Objects.equals(formParams, that.formParams) &&
+            Objects.equals(cookieParams, that.cookieParams) &&
+            Objects.equals(requiredParams, that.requiredParams) &&
+            Objects.equals(optionalParams, that.optionalParams) &&
+            Objects.equals(authMethods, that.authMethods) &&
+            Objects.equals(tags, that.tags) &&
+            Objects.equals(responses, that.responses) &&
+            Objects.equals(callbacks, that.callbacks) &&
+            Objects.equals(imports, that.imports) &&
+            Objects.equals(examples, that.examples) &&
+            Objects.equals(externalDocs, that.externalDocs) &&
+            Objects.equals(vendorExtensions, that.vendorExtensions) &&
+            Objects.equals(nickname, that.nickname) &&
+            Objects.equals(prioritizedContentTypes, that.prioritizedContentTypes) &&
+            Objects.equals(operationIdOriginal, that.operationIdOriginal) &&
+            Objects.equals(operationIdLowerCase, that.operationIdLowerCase) &&
+            Objects.equals(operationIdCamelCase, that.operationIdCamelCase);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class CodegenParameter {
     public boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
@@ -182,131 +183,69 @@ public class CodegenParameter {
 
         CodegenParameter that = (CodegenParameter) o;
 
-        if (isEnum != that.isEnum) return false;
-        if (isFormParam != that.isFormParam)
-            return false;
-        if (isQueryParam != that.isQueryParam)
-            return false;
-        if (isPathParam != that.isPathParam)
-            return false;
-        if (isHeaderParam != that.isHeaderParam)
-            return false;
-        if (isCookieParam != that.isCookieParam)
-            return false;
-        if (isBodyParam != that.isBodyParam)
-            return false;
-        if (hasMore != that.hasMore)
-            return false;
-        if (isContainer != that.isContainer)
-            return false;
-        if (secondaryParam != that.secondaryParam)
-            return false;
-        if (isCollectionFormatMulti != that.isCollectionFormatMulti)
-            return false;
-        if (isPrimitiveType != that.isPrimitiveType)
-            return false;
-        if (isModel != that.isModel)
-            return false;
-        if (baseName != null ? !baseName.equals(that.baseName) : that.baseName != null)
-            return false;
-        if (paramName != null ? !paramName.equals(that.paramName) : that.paramName != null)
-            return false;
-        if (dataType != null ? !dataType.equals(that.dataType) : that.dataType != null)
-            return false;
-        if (datatypeWithEnum != null ? !datatypeWithEnum.equals(that.datatypeWithEnum) : that.datatypeWithEnum != null)
-            return false;
-        if (enumName != null ? !enumName.equals(that.enumName) : that.enumName != null)
-            return false;
-        if (dataFormat != null ? !dataFormat.equals(that.dataFormat) : that.dataFormat != null)
-            return false;
-        if (collectionFormat != null ? !collectionFormat.equals(that.collectionFormat) : that.collectionFormat != null)
-            return false;
-        if (description != null ? !description.equals(that.description) : that.description != null)
-            return false;
-        if (unescapedDescription != null ? !unescapedDescription.equals(that.unescapedDescription) : that.unescapedDescription != null)
-            return false;
-        if (baseType != null ? !baseType.equals(that.baseType) : that.baseType != null)
-            return false;
-        if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that.defaultValue != null)
-            return false;
-        if (example != null ? !example.equals(that.example) : that.example != null)
-            return false;
-        if (jsonSchema != null ? !jsonSchema.equals(that.jsonSchema) : that.jsonSchema != null)
-            return false;
-        if (isString != that.isString)
-            return false;
-        if (isNumeric != that.isNumeric)
-            return false;
-        if (isInteger != that.isInteger)
-            return false;
-        if (isLong != that.isLong)
-            return false;
-        if (isNumber != that.isNumber)
-            return false;
-        if (isFloat != that.isFloat)
-            return false;
-        if (isDouble != that.isDouble)
-            return false;
-        if (isByteArray != that.isByteArray)
-            return false;
-        if (isBinary != that.isBinary)
-            return false;
-        if (isBoolean != that.isBoolean)
-            return false;
-        if (isDate != that.isDate)
-            return false;
-        if (isDateTime != that.isDateTime)
-            return false;
-        if (isUuid != that.isUuid)
-            return false;
-        if (isEmail != that.isEmail)
-            return false;
-        if (isFreeFormObject != that.isFreeFormObject)
-            return false;
-        if (isListContainer != that.isListContainer)
-            return false;
-        if (isMapContainer != that.isMapContainer)
-            return false;
-        if (isFile != that.isFile)
-            return false;
-        if (_enum != null ? !_enum.equals(that._enum) : that._enum != null)
-            return false;
-        if (allowableValues != null ? !allowableValues.equals(that.allowableValues) : that.allowableValues != null)
-            return false;
-        if (items != null ? !items.equals(that.items) : that.items != null)
-            return false;
-        if (mostInnerItems != null ? !mostInnerItems.equals(that.mostInnerItems) : that.mostInnerItems != null)
-            return false;
-        if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
-            return false;
-        if (hasValidation != that.hasValidation)
-            return false;
-        if (isNullable != that.isNullable)
-            return false;
-        if (required != that.required)
-            return false;
-        if (maximum != null ? !maximum.equals(that.maximum) : that.maximum != null)
-            return false;
-        if (exclusiveMaximum != that.exclusiveMaximum)
-            return false;
-        if (minimum != null ? !minimum.equals(that.minimum) : that.minimum != null)
-            return false;
-        if (exclusiveMinimum != that.exclusiveMinimum)
-            return false;
-        if (maxLength != null ? !maxLength.equals(that.maxLength) : that.maxLength != null)
-            return false;
-        if (minLength != null ? !minLength.equals(that.minLength) : that.minLength != null)
-            return false;
-        if (pattern != null ? !pattern.equals(that.pattern) : that.pattern != null)
-            return false;
-        if (maxItems != null ? !maxItems.equals(that.maxItems) : that.maxItems != null)
-            return false;
-        if (minItems != null ? !minItems.equals(that.minItems) : that.minItems != null)
-            return false;
-        if (uniqueItems != that.uniqueItems)
-            return false;
-        return multipleOf != null ? multipleOf.equals(that.multipleOf) : that.multipleOf == null;
-
+        return Objects.equals(isEnum, that.isEnum) &&
+            Objects.equals(isFormParam, that.isFormParam) &&
+            Objects.equals(isQueryParam, that.isQueryParam) &&
+            Objects.equals(isPathParam, that.isPathParam) &&
+            Objects.equals(isHeaderParam, that.isHeaderParam) &&
+            Objects.equals(isCookieParam, that.isCookieParam) &&
+            Objects.equals(isBodyParam, that.isBodyParam) &&
+            Objects.equals(hasMore, that.hasMore) &&
+            Objects.equals(isContainer, that.isContainer) &&
+            Objects.equals(secondaryParam, that.secondaryParam) &&
+            Objects.equals(isCollectionFormatMulti, that.isCollectionFormatMulti) &&
+            Objects.equals(isPrimitiveType, that.isPrimitiveType) &&
+            Objects.equals(isModel, that.isModel) &&
+            Objects.equals(baseName, that.baseName) &&
+            Objects.equals(paramName, that.paramName) &&
+            Objects.equals(dataType, that.dataType) &&
+            Objects.equals(datatypeWithEnum, that.datatypeWithEnum) &&
+            Objects.equals(enumName, that.enumName) &&
+            Objects.equals(dataFormat, that.dataFormat) &&
+            Objects.equals(collectionFormat, that.collectionFormat) &&
+            Objects.equals(description, that.description) &&
+            Objects.equals(unescapedDescription, that.unescapedDescription) &&
+            Objects.equals(baseType, that.baseType) &&
+            Objects.equals(defaultValue, that.defaultValue) &&
+            Objects.equals(example, that.example) &&
+            Objects.equals(jsonSchema, that.jsonSchema) &&
+            Objects.equals(isString, that.isString) &&
+            Objects.equals(isNumeric, that.isNumeric) &&
+            Objects.equals(isInteger, that.isInteger) &&
+            Objects.equals(isLong, that.isLong) &&
+            Objects.equals(isNumber, that.isNumber) &&
+            Objects.equals(isFloat, that.isFloat) &&
+            Objects.equals(isDouble, that.isDouble) &&
+            Objects.equals(isByteArray, that.isByteArray) &&
+            Objects.equals(isBinary, that.isBinary) &&
+            Objects.equals(isBoolean, that.isBoolean) &&
+            Objects.equals(isDate, that.isDate) &&
+            Objects.equals(isDateTime, that.isDateTime) &&
+            Objects.equals(isUuid, that.isUuid) &&
+            Objects.equals(isEmail, that.isEmail) &&
+            Objects.equals(isFreeFormObject, that.isFreeFormObject) &&
+            Objects.equals(isListContainer, that.isListContainer) &&
+            Objects.equals(isMapContainer, that.isMapContainer) &&
+            Objects.equals(isFile, that.isFile) &&
+            Objects.equals(_enum, that._enum) &&
+            Objects.equals(allowableValues, that.allowableValues) &&
+            Objects.equals(items, that.items) &&
+            Objects.equals(mostInnerItems, that.mostInnerItems) &&
+            Objects.equals(vendorExtensions, that.vendorExtensions) &&
+            Objects.equals(hasValidation, that.hasValidation) &&
+            Objects.equals(isNullable, that.isNullable) &&
+            Objects.equals(required, that.required) &&
+            Objects.equals(maximum, that.maximum) &&
+            Objects.equals(exclusiveMaximum, that.exclusiveMaximum) &&
+            Objects.equals(minimum, that.minimum) &&
+            Objects.equals(exclusiveMinimum, that.exclusiveMinimum) &&
+            Objects.equals(maxLength, that.maxLength) &&
+            Objects.equals(minLength, that.minLength) &&
+            Objects.equals(pattern, that.pattern) &&
+            Objects.equals(maxItems, that.maxItems) &&
+            Objects.equals(minItems, that.minItems) &&
+            Objects.equals(uniqueItems, that.uniqueItems) &&
+            Objects.equals(multipleOf, that.multipleOf);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -250,70 +250,70 @@ public class CodegenParameter {
 
     @Override
     public int hashCode() {
-        int result = isFormParam ? 13 : 31;
-        result = 31 * result + (isQueryParam ? 13 : 31);
-        result = 31 * result + (isPathParam ? 13 : 31);
-        result = 31 * result + (isHeaderParam ? 13 : 31);
-        result = 31 * result + (isCookieParam ? 13 : 31);
-        result = 31 * result + (isBodyParam ? 13 : 31);
-        result = 31 * result + (hasMore ? 13 : 31);
-        result = 31 * result + (isContainer ? 13 : 31);
-        result = 31 * result + (secondaryParam ? 13 : 31);
-        result = 31 * result + (isCollectionFormatMulti ? 13 : 31);
-        result = 31 * result + (isPrimitiveType ? 13 : 31);
-        result = 31 * result + (isModel ? 13 : 31);
-        result = 31 * result + (baseName != null ? baseName.hashCode() : 0);
-        result = 31 * result + (paramName != null ? paramName.hashCode() : 0);
-        result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
-        result = 31 * result + (datatypeWithEnum != null ? datatypeWithEnum.hashCode() : 0);
-        result = 31 * result + (enumName != null ? enumName.hashCode() : 0);
-        result = 31 * result + (dataFormat != null ? dataFormat.hashCode() : 0);
-        result = 31 * result + (collectionFormat != null ? collectionFormat.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (unescapedDescription != null ? unescapedDescription.hashCode() : 0);
-        result = 31 * result + (baseType != null ? baseType.hashCode() : 0);
-        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
-        result = 31 * result + (example != null ? example.hashCode() : 0);
-        result = 31 * result + (jsonSchema != null ? jsonSchema.hashCode() : 0);
-        result = 31 * result + (isString ? 13 : 31);
-        result = 31 * result + (isNumeric ? 13 : 31);
-        result = 31 * result + (isInteger ? 13 : 31);
-        result = 31 * result + (isLong ? 13 : 31);
-        result = 31 * result + (isFloat ? 13 : 31);
-        result = 31 * result + (isNumber ? 13 : 31);
-        result = 31 * result + (isDouble ? 13 : 31);
-        result = 31 * result + (isByteArray ? 13 : 31);
-        result = 31 * result + (isBinary ? 13 : 31);
-        result = 31 * result + (isBoolean ? 13 : 31);
-        result = 31 * result + (isDate ? 13 : 31);
-        result = 31 * result + (isDateTime ? 13 : 31);
-        result = 31 * result + (isUuid ? 13 : 31);
-        result = 31 * result + (isEmail ? 13 : 31);
-        result = 31 * result + (isFreeFormObject ? 13 : 31);
-        result = 31 * result + (isListContainer ? 13 : 31);
-        result = 31 * result + (isMapContainer ? 13 : 31);
-        result = 31 * result + (isFile ? 13 : 31);
-        result = 31 * result + (isEnum ? 1 : 0);
-        result = 31 * result + (_enum != null ? _enum.hashCode() : 0);
-        result = 31 * result + (allowableValues != null ? allowableValues.hashCode() : 0);
-        result = 31 * result + (items != null ? items.hashCode() : 0);
-        result = 31 * result + (mostInnerItems != null ? mostInnerItems.hashCode() : 0);
-        result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
-        result = 31 * result + (hasValidation ? 13 : 31);
-        result = 31 * result + (isNullable ? 13 : 31);
-        result = 31 * result + (required ? 13 : 31);
-        result = 31 * result + (maximum != null ? maximum.hashCode() : 0);
-        result = 31 * result + (exclusiveMaximum ? 13 : 31);
-        result = 31 * result + (minimum != null ? minimum.hashCode() : 0);
-        result = 31 * result + (exclusiveMinimum ? 13 : 31);
-        result = 31 * result + (maxLength != null ? maxLength.hashCode() : 0);
-        result = 31 * result + (minLength != null ? minLength.hashCode() : 0);
-        result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
-        result = 31 * result + (maxItems != null ? maxItems.hashCode() : 0);
-        result = 31 * result + (minItems != null ? minItems.hashCode() : 0);
-        result = 31 * result + (uniqueItems ? 13 : 31);
-        result = 31 * result + (multipleOf != null ? multipleOf.hashCode() : 0);
-        return result;
+        return Objects.hash(
+            isFormParam,
+            isQueryParam,
+            isPathParam,
+            isHeaderParam,
+            isCookieParam,
+            isBodyParam,
+            hasMore,
+            isContainer,
+            secondaryParam,
+            isCollectionFormatMulti,
+            isPrimitiveType,
+            isModel,
+            baseName,
+            paramName,
+            dataType,
+            datatypeWithEnum,
+            enumName,
+            dataFormat,
+            collectionFormat,
+            description,
+            unescapedDescription,
+            baseType,
+            defaultValue,
+            example,
+            jsonSchema,
+            isString,
+            isNumeric,
+            isInteger,
+            isLong,
+            isFloat,
+            isNumber,
+            isDouble,
+            isByteArray,
+            isBinary,
+            isBoolean,
+            isDate,
+            isDateTime,
+            isUuid,
+            isEmail,
+            isFreeFormObject,
+            isListContainer,
+            isMapContainer,
+            isFile,
+            isEnum,
+            _enum,
+            allowableValues,
+            items,
+            mostInnerItems,
+            vendorExtensions,
+            hasValidation,
+            isNullable,
+            required,
+            maximum,
+            exclusiveMaximum,
+            minimum,
+            exclusiveMinimum,
+            maxLength,
+            minLength,
+            pattern,
+            maxItems,
+            minItems,
+            uniqueItems,
+            multipleOf);
     }
 
     @java.lang.Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -412,83 +412,81 @@ public class CodegenProperty implements Cloneable {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((_enum == null) ? 0 : _enum.hashCode());
-        result = prime * result + ((allowableValues == null) ? 0 : allowableValues.hashCode());
-        result = prime * result + ((baseName == null) ? 0 : baseName.hashCode());
-        result = prime * result + ((baseType == null) ? 0 : baseType.hashCode());
-        result = prime * result + ((complexType == null) ? 0 : complexType.hashCode());
-        result = prime * result + ((containerType == null) ? 0 : containerType.hashCode());
-        result = prime * result + ((dataType == null) ? 0 : dataType.hashCode());
-        result = prime * result + ((datatypeWithEnum == null) ? 0 : datatypeWithEnum.hashCode());
-        result = prime * result + ((dataFormat == null) ? 0 : dataFormat.hashCode());
-        result = prime * result + ((defaultValue == null) ? 0 : defaultValue.hashCode());
-        result = prime * result + ((defaultValueWithParam == null) ? 0 : defaultValueWithParam.hashCode());
-        result = prime * result + ((description == null) ? 0 : description.hashCode());
-        result = prime * result + ((title == null) ? 0 : title.hashCode());
-        result = prime * result + ((example == null) ? 0 : example.hashCode());
-        result = prime * result + (exclusiveMaximum ? 13 : 31);
-        result = prime * result + (exclusiveMinimum ? 13 : 31);
-        result = prime * result + ((getter == null) ? 0 : getter.hashCode());
-        result = prime * result + (hasMore ? 13 : 31);
-        result = prime * result + ((hasMoreNonReadOnly ? 13 : 31));
-        result = prime * result + ((isContainer ? 13 : 31));
-        result = prime * result + (isEnum ? 1231 : 1237);
-        result = prime * result + ((isPrimitiveType ? 13 : 31));
-        result = prime * result + ((isModel ? 13 : 31));
-        result = prime * result + ((isReadOnly ? 13 : 31));
-        result = prime * result + ((isWriteOnly ? 13 : 31));
-        result = prime * result + ((isNullable ? 13 : 31));
-        result = prime * result + ((isSelfReference ? 13 : 31));
-        result = prime * result + ((items == null) ? 0 : items.hashCode());
-        result = prime * result + ((mostInnerItems == null) ? 0 : mostInnerItems.hashCode());
-        result = prime * result + ((jsonSchema == null) ? 0 : jsonSchema.hashCode());
-        result = prime * result + ((max == null) ? 0 : max.hashCode());
-        result = prime * result + ((maxLength == null) ? 0 : maxLength.hashCode());
-        result = prime * result + ((maximum == null) ? 0 : maximum.hashCode());
-        result = prime * result + ((min == null) ? 0 : min.hashCode());
-        result = prime * result + ((minLength == null) ? 0 : minLength.hashCode());
-        result = prime * result + ((minimum == null) ? 0 : minimum.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
-        result = prime * result + ((required ? 13 : 31));
-        result = prime * result + ((secondaryParam ? 13 : 31));
-        result = prime * result + ((setter == null) ? 0 : setter.hashCode());
-        result = prime * result + ((unescapedDescription == null) ? 0 : unescapedDescription.hashCode());
-        result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
-        result = prime * result + ((hasValidation ? 13 : 31));
-        result = prime * result + ((isString ? 13 : 31));
-        result = prime * result + ((isNumeric ? 13 : 31));
-        result = prime * result + ((isInteger ? 13 : 31));
-        result = prime * result + ((isLong ? 13 : 31));
-        result = prime * result + ((isNumber ? 13 : 31));
-        result = prime * result + ((isFloat ? 13 : 31));
-        result = prime * result + ((isDouble ? 13 : 31));
-        result = prime * result + ((isByteArray ? 13 : 31));
-        result = prime * result + ((isBinary ? 13 : 31));
-        result = prime * result + ((isFile ? 13 : 31));
-        result = prime * result + ((isBoolean ? 13 : 31));
-        result = prime * result + ((isDate ? 13 : 31));
-        result = prime * result + ((isDateTime ? 13 : 31));
-        result = prime * result + ((isUuid ? 13 : 31));
-        result = prime * result + ((isEmail ? 13 : 31));
-        result = prime * result + ((isFreeFormObject ? 13 : 31));
-        result = prime * result + ((isMapContainer ? 13 : 31));
-        result = prime * result + ((isListContainer ? 13 : 31));
-        result = prime * result + Objects.hashCode(isInherited);
-        result = prime * result + Objects.hashCode(discriminatorValue);
-        result = prime * result + Objects.hashCode(nameInCamelCase);
-        result = prime * result + Objects.hashCode(nameInSnakeCase);
-        result = prime * result + Objects.hashCode(enumName);
-        result = prime * result + ((maxItems == null) ? 0 : maxItems.hashCode());
-        result = prime * result + ((minItems == null) ? 0 : minItems.hashCode());
-        result = prime * result + ((isXmlAttribute ? 13 : 31));
-        result = prime * result + ((xmlPrefix == null) ? 0 : xmlPrefix.hashCode());
-        result = prime * result + ((xmlName == null) ? 0 : xmlName.hashCode());
-        result = prime * result + ((xmlNamespace == null) ? 0 : xmlNamespace.hashCode());
-        result = prime * result + ((isXmlWrapped ? 13 : 31));
-        return result;
+        return Objects.hash(
+            _enum,
+            allowableValues,
+            baseName,
+            baseType,
+            complexType,
+            containerType,
+            dataType,
+            datatypeWithEnum,
+            dataFormat,
+            defaultValue,
+            defaultValueWithParam,
+            description,
+            title,
+            example,
+            exclusiveMaximum,
+            exclusiveMinimum,
+            getter,
+            hasMore,
+            hasMoreNonReadOnly,
+            isContainer,
+            isEnum,
+            isPrimitiveType,
+            isModel,
+            isReadOnly,
+            isWriteOnly,
+            isNullable,
+            isSelfReference,
+            items,
+            mostInnerItems,
+            jsonSchema,
+            max,
+            maxLength,
+            maximum,
+            min,
+            minLength,
+            minimum,
+            name,
+            pattern,
+            required,
+            secondaryParam,
+            setter,
+            unescapedDescription,
+            vendorExtensions,
+            hasValidation,
+            isString,
+            isNumeric,
+            isInteger,
+            isLong,
+            isNumber,
+            isFloat,
+            isDouble,
+            isByteArray,
+            isBinary,
+            isFile,
+            isBoolean,
+            isDate,
+            isDateTime,
+            isUuid,
+            isEmail,
+            isFreeFormObject,
+            isMapContainer,
+            isListContainer,
+            isInherited,
+            discriminatorValue,
+            nameInCamelCase,
+            nameInSnakeCase,
+            enumName,
+            maxItems,
+            minItems,
+            isXmlAttribute,
+            xmlPrefix,
+            xmlName,
+            xmlNamespace,
+            isXmlWrapped);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -499,216 +499,77 @@ public class CodegenProperty implements Cloneable {
         if (getClass() != obj.getClass()) {
             return false;
         }
+
         final CodegenProperty other = (CodegenProperty) obj;
-        if ((this.baseName == null) ? (other.baseName != null) : !this.baseName.equals(other.baseName)) {
-            return false;
-        }
-        if ((this.complexType == null) ? (other.complexType != null) : !this.complexType.equals(other.complexType)) {
-            return false;
-        }
-        if ((this.getter == null) ? (other.getter != null) : !this.getter.equals(other.getter)) {
-            return false;
-        }
-        if ((this.setter == null) ? (other.setter != null) : !this.setter.equals(other.setter)) {
-            return false;
-        }
-        if ((this.description == null) ? (other.description != null) : !this.description.equals(other.description)) {
-            return false;
-        }
-        if ((this.title == null) ? (other.title != null) : !this.title.equals(other.title)) {
-            return false;
-        }
-        if ((this.dataType == null) ? (other.dataType != null) : !this.dataType.equals(other.dataType)) {
-            return false;
-        }
-        if ((this.datatypeWithEnum == null) ? (other.datatypeWithEnum != null) : !this.datatypeWithEnum.equals(other.datatypeWithEnum)) {
-            return false;
-        }
-        if ((this.dataFormat == null) ? (other.dataFormat != null) : !this.dataFormat.equals(other.dataFormat)) {
-            return false;
-        }
-        if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
-            return false;
-        }
-        if ((this.min == null) ? (other.min != null) : !this.min.equals(other.min)) {
-            return false;
-        }
-        if ((this.max == null) ? (other.max != null) : !this.max.equals(other.max)) {
-            return false;
-        }
-        if ((this.defaultValue == null) ? (other.defaultValue != null) : !this.defaultValue.equals(other.defaultValue)) {
-            return false;
-        }
-        if ((this.baseType == null) ? (other.baseType != null) : !this.baseType.equals(other.baseType)) {
-            return false;
-        }
-        if ((this.containerType == null) ? (other.containerType != null) : !this.containerType.equals(other.containerType)) {
-            return false;
-        }
-        if (this.maxLength != other.maxLength && (this.maxLength == null || !this.maxLength.equals(other.maxLength))) {
-            return false;
-        }
-        if (this.minLength != other.minLength && (this.minLength == null || !this.minLength.equals(other.minLength))) {
-            return false;
-        }
-        if ((this.pattern == null) ? (other.pattern != null) : !this.pattern.equals(other.pattern)) {
-            return false;
-        }
-        if ((this.example == null) ? (other.example != null) : !this.example.equals(other.example)) {
-            return false;
-        }
-        if ((this.jsonSchema == null) ? (other.jsonSchema != null) : !this.jsonSchema.equals(other.jsonSchema)) {
-            return false;
-        }
-        if (this.minimum != other.minimum && (this.minimum == null || !this.minimum.equals(other.minimum))) {
-            return false;
-        }
-        if (this.maximum != other.maximum && (this.maximum == null || !this.maximum.equals(other.maximum))) {
-            return false;
-        }
-        if (this.exclusiveMinimum != other.exclusiveMinimum) {
-            return false;
-        }
-        if (this.exclusiveMaximum != other.exclusiveMaximum) {
-            return false;
-        }
-        if (this.required != other.required) {
-            return false;
-        }
-        if (this.secondaryParam != other.secondaryParam) {
-            return false;
-        }
-        if (this.isPrimitiveType != other.isPrimitiveType) {
-            return false;
-        }
-        if (this.isModel != other.isModel) {
-            return false;
-        }
-        if (this.isContainer != other.isContainer) {
-            return false;
-        }
-        if (this.isEnum != other.isEnum) {
-            return false;
-        }
-        if (this.isReadOnly != other.isReadOnly) {
-            return false;
-        }
-        if (this.isWriteOnly != other.isWriteOnly) {
-            return false;
-        }
-        if (this.isNullable != other.isNullable) {
-            return false;
-        }
-        if (this.isSelfReference != other.isSelfReference ) {
-            return false;
-        }
-        if (this._enum != other._enum && (this._enum == null || !this._enum.equals(other._enum))) {
-            return false;
-        }
-        if (this.allowableValues != other.allowableValues && (this.allowableValues == null || !this.allowableValues.equals(other.allowableValues))) {
-            return false;
-        }
 
-        if (this.vendorExtensions != other.vendorExtensions && (this.vendorExtensions == null || !this.vendorExtensions.equals(other.vendorExtensions))) {
-            return false;
-        }
-
-        if (this.hasValidation != other.hasValidation) {
-            return false;
-        }
-
-        if (this.isString != other.isString) {
-            return false;
-        }
-
-        if (this.isNumeric != other.isNumeric) {
-            return false;
-        }
-        if (this.isInteger != other.isInteger) {
-            return false;
-        }
-        if (this.isLong != other.isLong) {
-            return false;
-        }
-        if (this.isNumber != other.isNumber) {
-            return false;
-        }
-        if (this.isFloat != other.isFloat) {
-            return false;
-        }
-        if (this.isDouble != other.isDouble) {
-            return false;
-        }
-        if (this.isByteArray != other.isByteArray) {
-            return false;
-        }
-        if (this.isBoolean != other.isBoolean) {
-            return false;
-        }
-        if (this.isDate != other.isDate) {
-            return false;
-        }
-        if (this.isDateTime != other.isDateTime) {
-            return false;
-        }
-        if (this.isUuid != other.isUuid) {
-            return false;
-        }
-        if (this.isEmail != other.isEmail) {
-            return false;
-        }
-        if (this.isFreeFormObject != other.isFreeFormObject) {
-            return false;
-        }
-        if (this.isBinary != other.isBinary) {
-            return false;
-        }
-        if (this.isFile != other.isFile) {
-            return false;
-        }
-        if (this.isListContainer != other.isListContainer) {
-            return false;
-        }
-        if (this.isMapContainer != other.isMapContainer) {
-            return false;
-        }
-        if (!Objects.equals(this.isInherited, other.isInherited)) {
-            return false;
-        }
-        if (!Objects.equals(this.discriminatorValue, other.discriminatorValue)) {
-            return false;
-        }
-        if (!Objects.equals(this.nameInCamelCase, other.nameInCamelCase)) {
-            return false;
-        }
-        if (!Objects.equals(this.nameInSnakeCase, other.nameInSnakeCase)) {
-            return false;
-        }
-        if (!Objects.equals(this.enumName, other.enumName)) {
-            return false;
-        }
-        if (this.maxItems != other.maxItems && (this.maxItems == null || !this.maxItems.equals(other.maxItems))) {
-            return false;
-        }
-        if (this.minItems != other.minItems && (this.minItems == null || !this.minItems.equals(other.minItems))) {
-            return false;
-        }
-        if (!Objects.equals(this.isXmlAttribute, other.isXmlAttribute)) {
-            return false;
-        }
-        if (!Objects.equals(this.xmlPrefix, other.xmlPrefix)) {
-            return false;
-        }
-        if (!Objects.equals(this.xmlName, other.xmlName)) {
-            return false;
-        }
-        if (!Objects.equals(this.xmlNamespace, other.xmlNamespace)) {
-            return false;
-        }
-        if (!Objects.equals(this.isXmlWrapped, other.isXmlWrapped)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(baseName, other.baseName) &&
+            Objects.equals(complexType, other.complexType) &&
+            Objects.equals(getter, other.getter) &&
+            Objects.equals(setter, other.setter) &&
+            Objects.equals(description, other.description) &&
+            Objects.equals(title, other.title) &&
+            Objects.equals(dataType, other.dataType) &&
+            Objects.equals(datatypeWithEnum, other.datatypeWithEnum) &&
+            Objects.equals(dataFormat, other.dataFormat) &&
+            Objects.equals(name, other.name) &&
+            Objects.equals(min, other.min) &&
+            Objects.equals(max, other.max) &&
+            Objects.equals(defaultValue, other.defaultValue) &&
+            Objects.equals(baseType, other.baseType) &&
+            Objects.equals(containerType, other.containerType) &&
+            Objects.equals(maxLength, other.maxLength) &&
+            Objects.equals(minLength, other.minLength) &&
+            Objects.equals(pattern, other.pattern) &&
+            Objects.equals(example, other.example) &&
+            Objects.equals(jsonSchema, other.jsonSchema) &&
+            Objects.equals(minimum, other.minimum) &&
+            Objects.equals(maximum, other.maximum) &&
+            Objects.equals(exclusiveMinimum, other.exclusiveMinimum) &&
+            Objects.equals(exclusiveMaximum, other.exclusiveMaximum) &&
+            Objects.equals(required, other.required) &&
+            Objects.equals(secondaryParam, other.secondaryParam) &&
+            Objects.equals(isPrimitiveType, other.isPrimitiveType) &&
+            Objects.equals(isModel, other.isModel) &&
+            Objects.equals(isContainer, other.isContainer) &&
+            Objects.equals(isEnum, other.isEnum) &&
+            Objects.equals(isReadOnly, other.isReadOnly) &&
+            Objects.equals(isWriteOnly, other.isWriteOnly) &&
+            Objects.equals(isNullable, other.isNullable) &&
+            Objects.equals(isSelfReference, other.isSelfReference) &&
+            Objects.equals(_enum, other._enum) &&
+            Objects.equals(allowableValues, other.allowableValues) &&
+            Objects.equals(vendorExtensions, other.vendorExtensions) &&
+            Objects.equals(hasValidation, other.hasValidation) &&
+            Objects.equals(isString, other.isString) &&
+            Objects.equals(isNumeric, other.isNumeric) &&
+            Objects.equals(isInteger, other.isInteger) &&
+            Objects.equals(isLong, other.isLong) &&
+            Objects.equals(isNumber, other.isNumber) &&
+            Objects.equals(isFloat, other.isFloat) &&
+            Objects.equals(isDouble, other.isDouble) &&
+            Objects.equals(isByteArray, other.isByteArray) &&
+            Objects.equals(isBoolean, other.isBoolean) &&
+            Objects.equals(isDate, other.isDate) &&
+            Objects.equals(isDateTime, other.isDateTime) &&
+            Objects.equals(isUuid, other.isUuid) &&
+            Objects.equals(isEmail, other.isEmail) &&
+            Objects.equals(isFreeFormObject, other.isFreeFormObject) &&
+            Objects.equals(isBinary, other.isBinary) &&
+            Objects.equals(isFile, other.isFile) &&
+            Objects.equals(isListContainer, other.isListContainer) &&
+            Objects.equals(isMapContainer, other.isMapContainer) &&
+            Objects.equals(isInherited, other.isInherited) &&
+            Objects.equals(discriminatorValue, other.discriminatorValue) &&
+            Objects.equals(nameInCamelCase, other.nameInCamelCase) &&
+            Objects.equals(nameInSnakeCase, other.nameInSnakeCase) &&
+            Objects.equals(enumName, other.enumName) &&
+            Objects.equals(maxItems, other.maxItems) &&
+            Objects.equals(minItems, other.minItems) &&
+            Objects.equals(isXmlAttribute, other.isXmlAttribute) &&
+            Objects.equals(xmlPrefix, other.xmlPrefix) &&
+            Objects.equals(xmlName, other.xmlName) &&
+            Objects.equals(xmlNamespace, other.xmlNamespace) &&
+            Objects.equals(isXmlWrapped, other.isXmlWrapped);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenSecurity.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenSecurity.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 public class CodegenSecurity {
     public String name;
@@ -51,48 +52,27 @@ public class CodegenSecurity {
 
         CodegenSecurity that = (CodegenSecurity) o;
 
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (type != null ? !type.equals(that.type) : that.type != null)
-            return false;
-        if (hasMore != null ? !hasMore.equals(that.hasMore) : that.hasMore != null)
-            return false;
-        if (isBasic != null ? !isBasic.equals(that.isBasic) : that.isBasic != null)
-            return false;
-        if (isBasicBasic != null ? !isBasicBasic.equals(that.isBasicBasic) : that.isBasicBasic != null)
-            return false;
-        if (isBasicBearer != null ? !isBasicBearer.equals(that.isBasicBearer) : that.isBasicBearer != null)
-            return false;
-        if (bearerFormat != null ? !bearerFormat.equals(that.bearerFormat) : that.bearerFormat != null)
-            return false;
-        if (isOAuth != null ? !isOAuth.equals(that.isOAuth) : that.isOAuth != null)
-            return false;
-        if (isApiKey != null ? !isApiKey.equals(that.isApiKey) : that.isApiKey != null)
-            return false;
-        if (vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null)
-            return false;
-        if (keyParamName != null ? !keyParamName.equals(that.keyParamName) : that.keyParamName != null)
-            return false;
-        if (isKeyInQuery != null ? !isKeyInQuery.equals(that.isKeyInQuery) : that.isKeyInQuery != null)
-            return false;
-        if (isKeyInHeader != null ? !isKeyInHeader.equals(that.isKeyInHeader) : that.isKeyInHeader != null)
-            return false;
-        if (flow != null ? !flow.equals(that.flow) : that.flow != null)
-            return false;
-        if (authorizationUrl != null ? !authorizationUrl.equals(that.authorizationUrl) : that.authorizationUrl != null)
-            return false;
-        if (tokenUrl != null ? !tokenUrl.equals(that.tokenUrl) : that.tokenUrl != null)
-            return false;
-        if (isCode != null ? !isCode.equals(that.isCode) : that.isCode != null)
-            return false;
-        if (isPassword != null ? !isPassword.equals(that.isPassword) : that.isPassword != null)
-            return false;
-        if (isApplication != null ? !isApplication.equals(that.isApplication) : that.isApplication != null)
-            return false;
-        if (isImplicit != null ? !isImplicit.equals(that.isImplicit) : that.isImplicit != null)
-            return false;
-        return scopes != null ? scopes.equals(that.scopes) : that.scopes == null;
-
+        return Objects.equals(name, that.name) &&
+            Objects.equals(type, that.type) &&
+            Objects.equals(hasMore, that.hasMore) &&
+            Objects.equals(isBasic, that.isBasic) &&
+            Objects.equals(isBasicBasic, that.isBasicBasic) &&
+            Objects.equals(isBasicBearer, that.isBasicBearer) &&
+            Objects.equals(bearerFormat, that.bearerFormat) &&
+            Objects.equals(isOAuth, that.isOAuth) &&
+            Objects.equals(isApiKey, that.isApiKey) &&
+            Objects.equals(vendorExtensions, that.vendorExtensions) &&
+            Objects.equals(keyParamName, that.keyParamName) &&
+            Objects.equals(isKeyInQuery, that.isKeyInQuery) &&
+            Objects.equals(isKeyInHeader, that.isKeyInHeader) &&
+            Objects.equals(flow, that.flow) &&
+            Objects.equals(authorizationUrl, that.authorizationUrl) &&
+            Objects.equals(tokenUrl, that.tokenUrl) &&
+            Objects.equals(isCode, that.isCode) &&
+            Objects.equals(isPassword, that.isPassword) &&
+            Objects.equals(isApplication, that.isApplication) &&
+            Objects.equals(isImplicit, that.isImplicit) &&
+            Objects.equals(scopes, that.scopes);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenSecurity.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenSecurity.java
@@ -77,27 +77,27 @@ public class CodegenSecurity {
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (hasMore != null ? hasMore.hashCode() : 0);
-        result = 31 * result + (isBasic != null ? isBasic.hashCode() : 0);
-        result = 31 * result + (isBasicBasic != null ? isBasicBasic.hashCode() : 0);
-        result = 31 * result + (isBasicBearer != null ? isBasicBearer.hashCode() : 0);
-        result = 31 * result + (bearerFormat != null ? bearerFormat.hashCode() : 0);
-        result = 31 * result + (isOAuth != null ? isOAuth.hashCode() : 0);
-        result = 31 * result + (isApiKey != null ? isApiKey.hashCode() : 0);
-        result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);
-        result = 31 * result + (keyParamName != null ? keyParamName.hashCode() : 0);
-        result = 31 * result + (isKeyInQuery != null ? isKeyInQuery.hashCode() : 0);
-        result = 31 * result + (isKeyInHeader != null ? isKeyInHeader.hashCode() : 0);
-        result = 31 * result + (flow != null ? flow.hashCode() : 0);
-        result = 31 * result + (authorizationUrl != null ? authorizationUrl.hashCode() : 0);
-        result = 31 * result + (tokenUrl != null ? tokenUrl.hashCode() : 0);
-        result = 31 * result + (isCode != null ? isCode.hashCode() : 0);
-        result = 31 * result + (isPassword != null ? isPassword.hashCode() : 0);
-        result = 31 * result + (isApplication != null ? isApplication.hashCode() : 0);
-        result = 31 * result + (isImplicit != null ? isImplicit.hashCode() : 0);
-        result = 31 * result + (scopes != null ? scopes.hashCode() : 0);
-        return result;
+        return Objects.hash(
+            name,
+            type,
+            hasMore,
+            isBasic,
+            isBasicBasic,
+            isBasicBearer,
+            bearerFormat,
+            isOAuth,
+            isApiKey,
+            vendorExtensions,
+            keyParamName,
+            isKeyInQuery,
+            isKeyInHeader,
+            flow,
+            authorizationUrl,
+            tokenUrl,
+            isCode,
+            isPassword,
+            isApplication,
+            isImplicit,
+            scopes);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
@@ -17,6 +17,8 @@
 
 package org.openapitools.codegen;
 
+import java.util.Objects;
+
 public class SupportingFile {
     public String templateFile;
     public String folder;
@@ -50,12 +52,9 @@ public class SupportingFile {
 
         SupportingFile that = (SupportingFile) o;
 
-        if (templateFile != null ? !templateFile.equals(that.templateFile) : that.templateFile != null)
-            return false;
-        if (folder != null ? !folder.equals(that.folder) : that.folder != null)
-            return false;
-        return destinationFilename != null ? destinationFilename.equals(that.destinationFilename) : that.destinationFilename == null;
-
+        return Objects.equals(templateFile, that.templateFile) &&
+            Objects.equals(folder, that.folder) &&
+            Objects.equals(destinationFilename, that.destinationFilename);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/SupportingFile.java
@@ -59,10 +59,7 @@ public class SupportingFile {
 
     @Override
     public int hashCode() {
-        int result = templateFile != null ? templateFile.hashCode() : 0;
-        result = 31 * result + (folder != null ? folder.hashCode() : 0);
-        result = 31 * result + (destinationFilename != null ? destinationFilename.hashCode() : 0);
-        return result;
+        return Objects.hash(templateFile, folder, destinationFilename);
     }
 }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -366,7 +366,7 @@ public class ModelUtils {
         return false;
     }
 
-    public static boolean isShortchema(Schema schema) {
+    public static boolean isShortSchema(Schema schema) {
         if (SchemaTypeUtil.INTEGER_TYPE.equals(schema.getType()) // type: integer
                 && SchemaTypeUtil.INTEGER32_FORMAT.equals(schema.getFormat())) { // format: short (int32)
             return true;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller - this is not primarily targeting Rust, but does make some changes to the Rust-server generator.

### Description of the PR

I'm now revisiting openapi-generator with a bit more Java expertise than I had a few months ago. There are a few things in the Rust generator that seem worthy of refactoring.

Also, I've recently discovered `Objects.equals` and `Objects.hash` - see https://docs.oracle.com/javase/7/docs/api/java/util/Objects.html. These helpers, introduced in Java 7, vastly reduce the amount of boilerplate required to implement the `equals` and `hashcode` methods. If this PR gets accepted, I'll have a go at giving the same treatment to a bunch of other classes with similar/worse quantities of boilerplate.