### PR TITLE
[typescript-fetch] Support deepObject serialization in query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -161,7 +161,7 @@ export class Configuration {
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
-export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> };
+export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
@@ -183,15 +183,19 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
-export function querystring(params: HTTPQuery) {
+export function querystring(params: HTTPQuery, prefix: string = '') {
     return Object.keys(params)
         .map((key) => {
+            const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(key)}=`);
-                return `${encodeURIComponent(key)}=${multiValue}`;
+                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+            if (value instanceof Object) {
+                return querystring(value, fullKey);
+            }
+            return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
         .join('&');
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -189,7 +189,8 @@ export function querystring(params: HTTPQuery, prefix: string = '') {
             const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                const multiValue = value.map(singleValue => encodeURIComponent(singleValue))
+                    .join(`&${encodeURIComponent(fullKey)}=`);
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Object) {

--- a/samples/client/petstore-security-test/typescript-fetch/runtime.ts
+++ b/samples/client/petstore-security-test/typescript-fetch/runtime.ts
@@ -172,7 +172,7 @@ export class Configuration {
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
-export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> };
+export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
@@ -194,15 +194,19 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
-export function querystring(params: HTTPQuery) {
+export function querystring(params: HTTPQuery, prefix: string = '') {
     return Object.keys(params)
         .map((key) => {
+            const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(key)}=`);
-                return `${encodeURIComponent(key)}=${multiValue}`;
+                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+            if (value instanceof Object) {
+                return querystring(value, fullKey);
+            }
+            return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
         .join('&');
 }

--- a/samples/client/petstore-security-test/typescript-fetch/runtime.ts
+++ b/samples/client/petstore-security-test/typescript-fetch/runtime.ts
@@ -200,7 +200,8 @@ export function querystring(params: HTTPQuery, prefix: string = '') {
             const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                const multiValue = value.map(singleValue => encodeURIComponent(singleValue))
+                    .join(`&${encodeURIComponent(fullKey)}=`);
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Object) {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -172,7 +172,7 @@ export class Configuration {
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
-export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> };
+export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
@@ -194,15 +194,19 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
-export function querystring(params: HTTPQuery) {
+export function querystring(params: HTTPQuery, prefix: string = '') {
     return Object.keys(params)
         .map((key) => {
+            const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(key)}=`);
-                return `${encodeURIComponent(key)}=${multiValue}`;
+                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+            if (value instanceof Object) {
+                return querystring(value, fullKey);
+            }
+            return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
         .join('&');
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -200,7 +200,8 @@ export function querystring(params: HTTPQuery, prefix: string = '') {
             const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                const multiValue = value.map(singleValue => encodeURIComponent(singleValue))
+                    .join(`&${encodeURIComponent(fullKey)}=`);
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Object) {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -172,7 +172,7 @@ export class Configuration {
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
-export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> };
+export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
@@ -194,15 +194,19 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
-export function querystring(params: HTTPQuery) {
+export function querystring(params: HTTPQuery, prefix: string = '') {
     return Object.keys(params)
         .map((key) => {
+            const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(key)}=`);
-                return `${encodeURIComponent(key)}=${multiValue}`;
+                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+            if (value instanceof Object) {
+                return querystring(value, fullKey);
+            }
+            return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
         .join('&');
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -200,7 +200,8 @@ export function querystring(params: HTTPQuery, prefix: string = '') {
             const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                const multiValue = value.map(singleValue => encodeURIComponent(singleValue))
+                    .join(`&${encodeURIComponent(fullKey)}=`);
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Object) {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -172,7 +172,7 @@ export class Configuration {
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
-export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> };
+export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
@@ -194,15 +194,19 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
-export function querystring(params: HTTPQuery) {
+export function querystring(params: HTTPQuery, prefix: string = '') {
     return Object.keys(params)
         .map((key) => {
+            const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(key)}=`);
-                return `${encodeURIComponent(key)}=${multiValue}`;
+                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+            if (value instanceof Object) {
+                return querystring(value, fullKey);
+            }
+            return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
         .join('&');
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -200,7 +200,8 @@ export function querystring(params: HTTPQuery, prefix: string = '') {
             const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                const multiValue = value.map(singleValue => encodeURIComponent(singleValue))
+                    .join(`&${encodeURIComponent(fullKey)}=`);
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Object) {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -172,7 +172,7 @@ export class Configuration {
 export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
-export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> };
+export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
 export type HTTPBody = Json | FormData;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
@@ -194,15 +194,19 @@ export function exists(json: any, key: string) {
     return value !== null && value !== undefined;
 }
 
-export function querystring(params: HTTPQuery) {
+export function querystring(params: HTTPQuery, prefix: string = '') {
     return Object.keys(params)
         .map((key) => {
+            const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(key)}=`);
-                return `${encodeURIComponent(key)}=${multiValue}`;
+                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+            if (value instanceof Object) {
+                return querystring(value, fullKey);
+            }
+            return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
         .join('&');
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -200,7 +200,8 @@ export function querystring(params: HTTPQuery, prefix: string = '') {
             const fullKey = prefix + (prefix.length ? `[${key}]` : key);
             const value = params[key];
             if (value instanceof Array) {
-                const multiValue = value.join(`&${encodeURIComponent(fullKey)}=`);
+                const multiValue = value.map(singleValue => encodeURIComponent(singleValue))
+                    .join(`&${encodeURIComponent(fullKey)}=`);
                 return `${encodeURIComponent(fullKey)}=${multiValue}`;
             }
             if (value instanceof Object) {


### PR DESCRIPTION
Fixes #2233.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add support for nested objects in query parameters.

Object type query parameters can currently not be properly serialized (see related issue above).  
This PR allows nested object parameters in the `HTTPQuery` type and extends the `querystring` function of the API runtime library to recursively serialize objects with the `deepObject` style as defined in [OpenAPI 3.0](https://swagger.io/docs/specification/serialization/#query).

This method does *not* support arrays of objects, as this would cause an ambiguous serialization due to the use of the `explode` format for arrays.  
E.g. a query string `person[name]=Alice&person[name]=Bob` could be interpreted as an array of person objects with one name property each, or one person object with an array property `name`.

Feedback is highly appreciated.