### PR TITLE
[typescript-rxjs] fix enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -25,6 +25,7 @@ import org.openapitools.codegen.utils.ModelUtils;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
+import java.util.TreeSet;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -144,8 +145,30 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
-        // don't do enum modifications
-        return objs;
+        // process enum in models
+        List<Object> models = (List<Object>) postProcessModelsEnum(objs).get("models");
+        for (Object _mo : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+            cm.imports = new TreeSet(cm.imports);
+            // name enum with model name, e.g. StatusEnum => PetStatusEnum
+            for (CodegenProperty var : cm.vars) {
+                if (Boolean.TRUE.equals(var.isEnum)) {
+                    // behaviour for enum names is specific for typescript to not use namespaces
+                    var.datatypeWithEnum = var.datatypeWithEnum.replace(var.enumName, cm.classname + var.enumName);
+                }
+            }
+            if (cm.parent != null) {
+                for (CodegenProperty var : cm.allVars) {
+                    if (Boolean.TRUE.equals(var.isEnum)) {
+                        var.datatypeWithEnum = var.datatypeWithEnum
+                                .replace(var.enumName, cm.classname + var.enumName);
+                    }
+                }
+            }
+        }
+
+         return objs;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelGeneric.mustache
@@ -31,7 +31,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
  * @export
  * @enum {string}
  */
-export enum {{enumName}} {
+export enum {{classname}}{{enumName}} {
 {{#allowableValues}}
     {{#enumVars}}
     {{{name}}} = {{{value}}}{{^-last}},{{/-last}}

--- a/samples/client/petstore/typescript-rxjs/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/models/Order.ts
@@ -46,7 +46,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -59,6 +59,9 @@ export interface Order {
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/models/Pet.ts
@@ -57,13 +57,16 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Order.ts
@@ -46,7 +46,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -59,6 +59,9 @@ export interface Order {
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/models/Pet.ts
@@ -57,13 +57,16 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/models/Order.ts
@@ -46,7 +46,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -59,6 +59,9 @@ export interface Order {
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/models/Pet.ts
@@ -57,13 +57,16 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Order.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Order.ts
@@ -46,7 +46,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -59,6 +59,9 @@ export interface Order {
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Pet.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/models/Pet.ts
@@ -57,13 +57,16 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum StatusEnum {
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Based on the discussion of #1947 and copied from #2123 this solves the issue of identical enums exported within barrels by prefixing them with the name of the interface. The namespace issue mentioned in the ticket / pr wasn't an issue for `typescript-rxjs` but it looks like enums weren't properly generated in the past as the diff of the petstore samples shows.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)