### PR TITLE
Send "true" or "false" for boolean params.

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -165,8 +165,9 @@ class ObjectSerializer
      * Take value and turn it into a string suitable for inclusion in
      * the parameter. If it's a string, pass through unchanged
      * If it's a datetime object, format it in ISO8601
+     * If it's a boolean, convert it to "true" or "false".
      *
-     * @param string|\DateTime $value the value of the parameter
+     * @param string|bool|\DateTime $value the value of the parameter
      *
      * @return string the header string
      */
@@ -174,6 +175,8 @@ class ObjectSerializer
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
             return $value->format(\DateTime::ATOM);
+        } else if (is_bool($value)) {
+            return $value ? 'true' : 'false';
         } else {
             return $value;
         }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -175,8 +175,9 @@ class ObjectSerializer
      * Take value and turn it into a string suitable for inclusion in
      * the parameter. If it's a string, pass through unchanged
      * If it's a datetime object, format it in ISO8601
+     * If it's a boolean, convert it to "true" or "false".
      *
-     * @param string|\DateTime $value the value of the parameter
+     * @param string|bool|\DateTime $value the value of the parameter
      *
      * @return string the header string
      */
@@ -184,6 +185,8 @@ class ObjectSerializer
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
             return $value->format(\DateTime::ATOM);
+        } else if (is_bool($value)) {
+            return $value ? 'true' : 'false';
         } else {
             return $value;
         }

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -175,8 +175,9 @@ class ObjectSerializer
      * Take value and turn it into a string suitable for inclusion in
      * the parameter. If it's a string, pass through unchanged
      * If it's a datetime object, format it in ISO8601
+     * If it's a boolean, convert it to "true" or "false".
      *
-     * @param string|\DateTime $value the value of the parameter
+     * @param string|bool|\DateTime $value the value of the parameter
      *
      * @return string the header string
      */
@@ -184,6 +185,8 @@ class ObjectSerializer
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
             return $value->format(\DateTime::ATOM);
+        } else if (is_bool($value)) {
+            return $value ? 'true' : 'false';
         } else {
             return $value;
         }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) ❤️, @ybelenko (2018/07), @renepardon (2018/12)

### Description of the PR

If you pass a PHP boolean value as a parameter in the query/path/form, this will serialize it as "true" or "false" instead of "1" or "".

Fixes #2204.

