### PR TITLE
Handle collection params in path (assume csv for now).

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift4/APIHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/APIHelper.mustache
@@ -45,6 +45,12 @@ public struct APIHelper {
         })
     }
 
+    public static func mapValueToPathItem(_ source: Any) -> Any {
+        if let collection = source as? Array<Any?> {
+            return collection.filter({ $0 != nil }).map({"\($0!)"}).joined(separator: ",")
+        }
+        return source
+    }
 
     public static func mapValuesToQueryItems(_ source: [String:Any?]) -> [URLQueryItem]? {
         let destination = source.filter({ $0.value != nil}).reduce(into: [URLQueryItem]()) { (result, item) in

--- a/modules/openapi-generator/src/main/resources/swift4/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/api.mustache
@@ -143,7 +143,7 @@ open class {{classname}} {
      */
     open class func {{operationId}}WithRequestBuilder({{#allParams}}{{paramName}}: {{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}_{{operationId}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}? = nil{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) -> RequestBuilder<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {
         {{^pathParams}}let{{/pathParams}}{{#pathParams}}{{^secondaryParam}}var{{/secondaryParam}}{{/pathParams}} path = "{{{path}}}"{{#pathParams}}
-        let {{paramName}}PreEscape = "\({{paramName}}{{#isEnum}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}})"
+        let {{paramName}}PreEscape = "\({{#isEnum}}{{paramName}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{^isContainer}}.rawValue{{/isContainer}}{{/isEnum}}{{^isEnum}}APIHelper.mapValueToPathItem({{paramName}}){{/isEnum}})"
         let {{paramName}}PostEscape = {{paramName}}PreEscape.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
         path = path.replacingOccurrences(of: "{{=<% %>=}}{<%baseName%>}<%={{ }}=%>", with: {{paramName}}PostEscape, options: .literal, range: nil){{/pathParams}}
         let URLString = {{projectName}}API.basePath + path

--- a/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift4/default/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -45,6 +45,12 @@ public struct APIHelper {
         })
     }
 
+    public static func mapValueToPathItem(_ source: Any) -> Any {
+        if let collection = source as? Array<Any?> {
+            return collection.filter({ $0 != nil }).map({"\($0!)"}).joined(separator: ",")
+        }
+        return source
+    }
 
     public static func mapValuesToQueryItems(_ source: [String:Any?]) -> [URLQueryItem]? {
         let destination = source.filter({ $0.value != nil}).reduce(into: [URLQueryItem]()) { (result, item) in


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](**https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee**) to review the pull request if your PR is targeting a particular programming language. @jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @d-date (2018/03)

### Description of the PR

Handle path params that are collections in swift4, for #2125.

Assumes the collectionFormat is CSV for now, although that could be added as a parameter.

I'm not very familiar with Swift, so please let me know if this could be improved.