### PR TITLE
[Ruby] Auto recreate specs in OAS3 Ruby sample

### DIFF
--- a/bin/openapi3/ruby-client-petstore.sh
+++ b/bin/openapi3/ruby-client-petstore.sh
@@ -30,6 +30,12 @@ echo "purge ruby petstore lib, docs folder"
 rm -Rf samples/openapi3/client/petstore/ruby/lib
 rm -Rf samples/openapi3/client/petstore/ruby/docs
 
+# purge test files other than integration test
+# NOTE: spec/custom/*.rb and spec/petstore_helper.rb are not generated files
+echo "purge ruby petstore spec"
+find samples/openapi3/client/petstore/ruby/spec -type d -not -name spec -not -name custom | xargs rm -Rf
+find samples/openapi3/client/petstore/ruby/spec -type f -not -name petstore_helper.rb -not -iwholename '*/spec/custom/*' | xargs rm -Rf
+
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-client -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g ruby -c bin/ruby-petstore.json -o samples/openapi3/client/petstore/ruby -DskipFormModel=true $@"

--- a/samples/openapi3/client/petstore/ruby/spec/api/another_fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/another_fake_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'AnotherFakeApi' do
   before do
     # run before each test
-    @instance = Petstore::AnotherFakeApi.new
+    @api_instance = Petstore::AnotherFakeApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'AnotherFakeApi' do
 
   describe 'test an instance of AnotherFakeApi' do
     it 'should create an instance of AnotherFakeApi' do
-      expect(@instance).to be_instance_of(Petstore::AnotherFakeApi)
+      expect(@api_instance).to be_instance_of(Petstore::AnotherFakeApi)
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api/default_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/default_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'DefaultApi' do
   before do
     # run before each test
-    @instance = Petstore::DefaultApi.new
+    @api_instance = Petstore::DefaultApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'DefaultApi' do
 
   describe 'test an instance of DefaultApi' do
     it 'should create an instance of DefaultApi' do
-      expect(@instance).to be_instance_of(Petstore::DefaultApi)
+      expect(@api_instance).to be_instance_of(Petstore::DefaultApi)
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'FakeApi' do
   before do
     # run before each test
-    @instance = Petstore::FakeApi.new
+    @api_instance = Petstore::FakeApi.new
   end
 
   after do
@@ -28,7 +28,17 @@ describe 'FakeApi' do
 
   describe 'test an instance of FakeApi' do
     it 'should create an instance of FakeApi' do
-      expect(@instance).to be_instance_of(Petstore::FakeApi)
+      expect(@api_instance).to be_instance_of(Petstore::FakeApi)
+    end
+  end
+
+  # unit tests for fake_health_get
+  # Health check endpoint
+  # @param [Hash] opts the optional parameters
+  # @return [HealthCheckResult]
+  describe 'fake_health_get test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api/fake_classname_tags123_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/fake_classname_tags123_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'FakeClassnameTags123Api' do
   before do
     # run before each test
-    @instance = Petstore::FakeClassnameTags123Api.new
+    @api_instance = Petstore::FakeClassnameTags123Api.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'FakeClassnameTags123Api' do
 
   describe 'test an instance of FakeClassnameTags123Api' do
     it 'should create an instance of FakeClassnameTags123Api' do
-      expect(@instance).to be_instance_of(Petstore::FakeClassnameTags123Api)
+      expect(@api_instance).to be_instance_of(Petstore::FakeClassnameTags123Api)
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api/pet_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/pet_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'PetApi' do
   before do
     # run before each test
-    @instance = Petstore::PetApi.new
+    @api_instance = Petstore::PetApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'PetApi' do
 
   describe 'test an instance of PetApi' do
     it 'should create an instance of PetApi' do
-      expect(@instance).to be_instance_of(Petstore::PetApi)
+      expect(@api_instance).to be_instance_of(Petstore::PetApi)
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api/store_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/store_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'StoreApi' do
   before do
     # run before each test
-    @instance = Petstore::StoreApi.new
+    @api_instance = Petstore::StoreApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'StoreApi' do
 
   describe 'test an instance of StoreApi' do
     it 'should create an instance of StoreApi' do
-      expect(@instance).to be_instance_of(Petstore::StoreApi)
+      expect(@api_instance).to be_instance_of(Petstore::StoreApi)
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api/user_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/user_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'UserApi' do
   before do
     # run before each test
-    @instance = Petstore::UserApi.new
+    @api_instance = Petstore::UserApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'UserApi' do
 
   describe 'test an instance of UserApi' do
     it 'should create an instance of UserApi' do
-      expect(@instance).to be_instance_of(Petstore::UserApi)
+      expect(@api_instance).to be_instance_of(Petstore::UserApi)
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/models/enum_test_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/models/enum_test_spec.rb
@@ -78,4 +78,22 @@ describe 'EnumTest' do
     end
   end
 
+  describe 'test attribute "outer_enum_integer"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "outer_enum_default_value"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "outer_enum_integer_default_value"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

### Description of the PR

In order to guarantee update of test files in sample for Ruby's OAS3 client (`samples/openapi3/client/petstore/ruby/spec`), `bin/openapi3/ruby-client-petstore.sh` will also purge the test file.

See: https://github.com/OpenAPITools/openapi-generator/pull/2211#issuecomment-467802105
