### PR TITLE
[Spring] fix datatype for non-multipart file request body

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -115,7 +115,7 @@ public interface {{classname}} {
     }
 
     // Override this method
-    default {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{^isFile}}{{{dataType}}}{{/isFile}}{{#isFile}}MultipartFile{{/isFile}} {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}) {
+    default {{#responseWrapper}}{{.}}<{{/responseWrapper}}ResponseEntity<{{>returnTypes}}>{{#responseWrapper}}>{{/responseWrapper}} {{operationId}}({{#allParams}}{{#isFormParam}}{{#isFile}}MultipartFile{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}}{{/isFormParam}}{{^isFormParam}}{{{dataType}}}{{/isFormParam}} {{paramName}}{{#hasMore}},{{/hasMore}}{{^hasMore}}{{#reactive}}, {{/reactive}}{{/hasMore}}{{/allParams}}{{#reactive}}ServerWebExchange exchange{{/reactive}}) {
         {{/delegate-method}}
         {{^isDelegate}}
         {{>methodBody}}


### PR DESCRIPTION
fixes #2191

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The distinction between the following cases was leading to compile errors in the generated code

adressing request body as single file:
```yaml
requestBody:
  content:
    application/octet-stream:
      schema:
        type: string
        format: binary
```
and files in multipart/form-data requests:

```yaml
requestBody:
  content: 
    multipart/form-data:
      schema:
        type: object
        properties:
          id:  
            type: string
            format: uuid
          profileImage:  
            type: string
            format: binary
```
(as described [here](https://swagger.io/docs/specification/describing-request-body/file-upload/)

I found out, that internally multipart parameters are handled in formParams, where the "raw" body is handled in bodyParams.
In the template for formParams is a special case for files in multipart, that was also used for rendering the delegate methods signature.
But request bodies as single file were ignored in that case.

I added the distinction in the template part for the delegate methods signature.

I invoked the sample generation scripts, they did not change any files.

@bbdouglas (2017/07) @JFCote (2017/08) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)