### PR TITLE
Run "bin/ensure-up-to-date.sh" for SNAPSHOT version only

### DIFF
--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -13,11 +13,13 @@ if [ "$NODE_INDEX" = "1" ]; then
   java -version
   mvn --quiet verify -Psamples.circleci
 elif [ "$NODE_INDEX" = "2" ]; then
-  echo "Running node $NODE_INDEX to test ensure-up-to-date"
-  java -version
-  #export GO_POST_PROCESS_FILE="/usr/local/bin/gofmt -w"
-  # not formatting the code as different go versions may format the code a bit different
-  ./bin/utils/ensure-up-to-date
+  # run ensure-up-to-date sample script on SNAPSHOT version only
+  project_version=`mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout`
+  if [[ $project_version == *"-SNAPSHOT" ]]; then
+    echo "Running node $NODE_INDEX to test ensure-up-to-date"
+    java -version
+    ./bin/utils/ensure-up-to-date
+  fi
 elif [ "$NODE_INDEX" = "3" ]; then
   echo "Running node $NODE_INDEX to test haskell"
   # install haskell


### PR DESCRIPTION
Now we've to manually comment/uncomment the line before/after the release.
Ideally the script "ensure-up-to-date.sh" should only run for SNAPSHOT version only.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.

### Description of the PR

fix #284

