### PR TITLE
[Ruby] Escape string interpolation notation of Ruby (#2261)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
@@ -33,10 +33,10 @@ import java.util.Locale;
 
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
-abstract class AbstractRubyCodegen extends DefaultCodegen implements CodegenConfig {
+abstract public class AbstractRubyCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRubyCodegen.class);
 
-    AbstractRubyCodegen() {
+    public AbstractRubyCodegen() {
         super();
 
         setReservedWordsLowerCase(
@@ -177,7 +177,7 @@ abstract class AbstractRubyCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String escapeUnsafeCharacters(String input) {
-        return input.replace("=end", "=_end").replace("=begin", "=_begin");
+        return input.replace("=end", "=_end").replace("=begin", "=_begin").replace("#{", "\\#{");
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/AbstractRubyCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/AbstractRubyCodegenTest.java
@@ -1,0 +1,26 @@
+package org.openapitools.codegen.ruby;
+
+import org.openapitools.codegen.languages.AbstractRubyCodegen;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for AbstractRubyCodegen
+ */
+public class AbstractRubyCodegenTest {
+    private AbstractRubyCodegen codegen;
+
+    @BeforeMethod
+    public void setup() {
+        codegen = new AbstractRubyCodegen() {
+        };
+    }
+
+    @Test
+    public void testEscapeUnsafeCharacters() {
+        Assert.assertEquals(codegen.escapeUnsafeCharacters("=begin"), "=_begin");
+        Assert.assertEquals(codegen.escapeUnsafeCharacters("=end"), "=_end");
+        Assert.assertEquals(codegen.escapeUnsafeCharacters("#{x}"), "\\#{x}");
+    }
+}

--- a/samples/client/petstore-security-test/ruby/docs/ModelReturn.md
+++ b/samples/client/petstore-security-test/ruby/docs/ModelReturn.md
@@ -5,4 +5,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **_return** | **Integer** | property description  */ &#39; \&quot; &#x3D;_end -- \\r\\n \\n \\r | [optional] 
 
+## Code Sample
+
+```ruby
+require 'Petstore'
+
+instance = Petstore::ModelReturn.new(_return: null)
+```
+
 

--- a/samples/client/petstore-security-test/ruby/lib/petstore/api_error.rb
+++ b/samples/client/petstore-security-test/ruby/lib/petstore/api_error.rb
@@ -34,5 +34,24 @@ module Petstore
         super arg
       end
     end
+
+    # Override to_s to display a friendly error message
+    def to_s
+      message
+    end
+
+    def message
+      if @message.nil?
+        msg = "Error message: the server returns an error"
+      else
+        msg = @message
+      end
+
+      msg += "\nHTTP status code: #{code}" if code
+      msg += "\nResponse headers: #{response_headers}" if response_headers
+      msg += "\nResponse body: #{response_body}" if response_body
+
+      msg
+    end
   end
 end

--- a/samples/client/petstore-security-test/ruby/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore-security-test/ruby/lib/petstore/models/model_return.rb
@@ -35,13 +35,20 @@ module Petstore
     # Initializes the object
     # @param [Hash] attributes Model attributes in the form of hash
     def initialize(attributes = {})
-      return unless attributes.is_a?(Hash)
+      if (!attributes.is_a?(Hash))
+        fail ArgumentError, "The input argument (attributes) must be a hash in `Petstore::ModelReturn` initialize method"
+      end
 
-      # convert string to symbol for hash key
-      attributes = attributes.each_with_object({}) { |(k, v), h| h[k.to_sym] = v }
+      # check to see if the attribute exists and convert string to symbol for hash key
+      attributes = attributes.each_with_object({}) { |(k, v), h|
+        if (!self.class.attribute_map.key?(k.to_sym))
+          fail ArgumentError, "`#{k}` is not a valid attribute in `Petstore::ModelReturn`. Please check the name to make sure it's valid. List of attributes: " + self.class.attribute_map.keys.inspect
+        end
+        h[k.to_sym] = v
+      }
 
-      if attributes.has_key?(:'return')
-        self._return = attributes[:'return']
+      if attributes.key?(:'_return')
+        self._return = attributes[:'_return']
       end
     end
 

--- a/samples/client/petstore-security-test/ruby/spec/api/fake_api_spec.rb
+++ b/samples/client/petstore-security-test/ruby/spec/api/fake_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'FakeApi' do
   before do
     # run before each test
-    @instance = Petstore::FakeApi.new
+    @api_instance = Petstore::FakeApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'FakeApi' do
 
   describe 'test an instance of FakeApi' do
     it 'should create an instance of FakeApi' do
-      expect(@instance).to be_instance_of(Petstore::FakeApi)
+      expect(@api_instance).to be_instance_of(Petstore::FakeApi)
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api/another_fake_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/another_fake_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'AnotherFakeApi' do
   before do
     # run before each test
-    @instance = Petstore::AnotherFakeApi.new
+    @api_instance = Petstore::AnotherFakeApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'AnotherFakeApi' do
 
   describe 'test an instance of AnotherFakeApi' do
     it 'should create an instance of AnotherFakeApi' do
-      expect(@instance).to be_instance_of(Petstore::AnotherFakeApi)
+      expect(@api_instance).to be_instance_of(Petstore::AnotherFakeApi)
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'FakeApi' do
   before do
     # run before each test
-    @instance = Petstore::FakeApi.new
+    @api_instance = Petstore::FakeApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'FakeApi' do
 
   describe 'test an instance of FakeApi' do
     it 'should create an instance of FakeApi' do
-      expect(@instance).to be_instance_of(Petstore::FakeApi)
+      expect(@api_instance).to be_instance_of(Petstore::FakeApi)
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api/fake_classname_tags123_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/fake_classname_tags123_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'FakeClassnameTags123Api' do
   before do
     # run before each test
-    @instance = Petstore::FakeClassnameTags123Api.new
+    @api_instance = Petstore::FakeClassnameTags123Api.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'FakeClassnameTags123Api' do
 
   describe 'test an instance of FakeClassnameTags123Api' do
     it 'should create an instance of FakeClassnameTags123Api' do
-      expect(@instance).to be_instance_of(Petstore::FakeClassnameTags123Api)
+      expect(@api_instance).to be_instance_of(Petstore::FakeClassnameTags123Api)
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api/pet_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/pet_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'PetApi' do
   before do
     # run before each test
-    @instance = Petstore::PetApi.new
+    @api_instance = Petstore::PetApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'PetApi' do
 
   describe 'test an instance of PetApi' do
     it 'should create an instance of PetApi' do
-      expect(@instance).to be_instance_of(Petstore::PetApi)
+      expect(@api_instance).to be_instance_of(Petstore::PetApi)
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api/store_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/store_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'StoreApi' do
   before do
     # run before each test
-    @instance = Petstore::StoreApi.new
+    @api_instance = Petstore::StoreApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'StoreApi' do
 
   describe 'test an instance of StoreApi' do
     it 'should create an instance of StoreApi' do
-      expect(@instance).to be_instance_of(Petstore::StoreApi)
+      expect(@api_instance).to be_instance_of(Petstore::StoreApi)
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api/user_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/user_api_spec.rb
@@ -19,7 +19,7 @@ require 'json'
 describe 'UserApi' do
   before do
     # run before each test
-    @instance = Petstore::UserApi.new
+    @api_instance = Petstore::UserApi.new
   end
 
   after do
@@ -28,7 +28,7 @@ describe 'UserApi' do
 
   describe 'test an instance of UserApi' do
     it 'should create an instance of UserApi' do
-      expect(@instance).to be_instance_of(Petstore::UserApi)
+      expect(@api_instance).to be_instance_of(Petstore::UserApi)
     end
   end
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

### Description of the PR

Fix #2261.
This PR has been modified to escape string interpolations in `enum` when generating Ruby client.

- To escape `#{`, modified `AbstractRubyCodegen::escapeUnsafeCharactors`
- Added test class for `AbstractRubyCodegen`
  - For this the visibility of `AbstractRubyCodegen` and its constructor ware changed to public.

E.g.
```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate --skip-validate-spec -g ruby -o /tmp/gem -i 'https://gist.githubusercontent.com/autopp/48160b45f1c17c950ba72feb971786c3/raw/974579f49d9a0eebff0455e54efce842eee64c9b/example.yml'
```

`lib/openapi_client/api/default_api.rb` generated by the above command no longer includes string interpolation.

```
    def foo_get_with_http_info(opts = {})
      if @api_client.config.debugging
        @api_client.config.logger.debug 'Calling API: DefaultApi.foo_get ...'
      end
      allowable_values = ["^injected code: \#{injected.code}$"]
                                           ^^^ Escaped
```

NOTE: Unfortunately #2088 has not been fixed yet.
