### PR TITLE
[C++] [Qt5 Server] Add support for free form object in requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -75,10 +75,15 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     {{/isListContainer}}
     {{^isListContainer}}
     {{^isMapContainer}}
-    {{#isPrimitiveType}}
+    {{#isPrimitiveType}}{{^isFreeFormObject}}
     {{{dataType}}} {{paramName}};
     ::{{cppNamespace}}::fromStringValue(QString(socket->readAll()), {{paramName}});
-    {{/isPrimitiveType}}
+    {{/isFreeFormObject}}{{/isPrimitiveType}}
+    {{#isFreeFormObject}}
+    {{{dataType}}} {{paramName}};
+    QJsonDocument resObject = QJsonDocument::fromJson(socket->readAll());
+    ::{{cppNamespace}}::fromJsonValue({{paramName}}, resObject.object());
+    {{/isFreeFormObject}}
     {{/isMapContainer}}
     {{#isMapContainer}}
     QJsonDocument doc;


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Add  handling of free form object in the API request
- No changes in the generated sample code

`cc:`
@stkrwork @MartinDelille @ravinikam @fvarose 