### PR TITLE
update ZenTest

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.lock.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/Gemfile.lock.mustache
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ZenTest (4.11.1)
+    ZenTest (4.11.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     autotest (4.4.6)

--- a/samples/client/petstore/ruby/Gemfile.lock
+++ b/samples/client/petstore/ruby/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ZenTest (4.11.1)
+    ZenTest (4.11.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     autotest (4.4.6)

--- a/samples/openapi3/client/petstore/ruby/Gemfile.lock
+++ b/samples/openapi3/client/petstore/ruby/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ZenTest (4.11.1)
+    ZenTest (4.11.2)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     autotest (4.4.6)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@frol (2017/07) @farcaller (2017/08) @bjgill (2017/12)

### Description of the PR

ZenTest 4.11.1 requires rubygems 2.x.

But Ruby 2.6.0 include rubygems 3.x.
So we can't use ruby client in Ruby 2.6.0.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

ZenTest 4.11.2 removed rubygems dependency so we should update.
https://github.com/seattlerb/zentest/commit/1883b210aa3dc2377e2d3571f95a5e462c0e1ce7
