### PR TITLE
[R] Changes to deserialize the map container type vars

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -213,7 +213,7 @@
 			  self$`{{baseName}}` <- vector("list", length = nrow(data.frame))
 			  for (row in 1:nrow(data.frame)) {
 				  {{baseName}}.node <- {{dataType}}$new()
-				  {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = TRUE], auto_unbox = TRUE))
+				  {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = F], auto_unbox = TRUE))
 				  self$`{{baseName}}`[[row]] <- {{baseName}}.node
 			  }
 			  {{/isPrimitiveType}}
@@ -225,7 +225,7 @@
 			  {{/isPrimitiveType}}
 			  {{^isPrimitiveType}}
 				x <- {{classname}}Object$`{{baseName}}`
-				self$`{{baseName}}` <- sapply(names(x), function(y) {{dataType}}$new()$fromJSONString(jsonlite::toJSON(x[[y]])))  
+				self$`{{baseName}}` <- sapply(names(x), function(y){ Obj <- {{dataType}}$new();Obj$fromJSON(jsonlite::toJSON(x[[y]], auto_unbox = TRUE));Obj})  
 			  {{/isPrimitiveType}}
 		{{/isMapContainer}}  
 	  {{/isContainer}}  

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -235,7 +235,7 @@
       {{/isPrimitiveType}}
       {{^isPrimitiveType}}
       self$`{{baseName}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON({{classname}}Object${{baseName}}, auto_unbox = TRUE))
-      {{/isPrimitiveType}}  
+      {{/isPrimitiveType}}
       {{/isContainer}}
       {{/vars}}
       self

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -212,9 +212,9 @@
       data.frame <- {{classname}}Object$`{{baseName}}`
       self$`{{baseName}}` <- vector("list", length = nrow(data.frame))
       for (row in 1:nrow(data.frame)) {
-      {{baseName}}.node <- {{dataType}}$new()
-      {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = F], auto_unbox = TRUE))
-      self$`{{baseName}}`[[row]] <- {{baseName}}.node
+          {{baseName}}.node <- {{dataType}}$new()
+          {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = F], auto_unbox = TRUE))
+          self$`{{baseName}}`[[row]] <- {{baseName}}.node
        }
       {{/isPrimitiveType}}
       {{/isListContainer}}		

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -203,28 +203,40 @@
     fromJSONString = function({{classname}}Json) {
       {{classname}}Object <- jsonlite::fromJSON({{classname}}Json)
       {{#vars}}
-      {{#isListContainer}}
-      {{#isPrimitiveType}}
-      self$`{{baseName}}` <- lapply({{classname}}Object$`{{baseName}}`, function (x) x)
-      {{/isPrimitiveType}}
-      {{^isPrimitiveType}}
-      data.frame <- {{classname}}Object$`{{baseName}}`
-      self$`{{baseName}}` <- vector("list", length = nrow(data.frame))
-      for (row in 1:nrow(data.frame)) {
-          {{baseName}}.node <- {{dataType}}$new()
-          {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = TRUE], auto_unbox = TRUE))
-          self$`{{baseName}}`[[row]] <- {{baseName}}.node
-      }
-      {{/isPrimitiveType}}
-      {{/isListContainer}}
-      {{^isListContainer}}
-      {{#isPrimitiveType}}
-      self$`{{baseName}}` <- {{classname}}Object$`{{baseName}}`
-      {{/isPrimitiveType}}
-      {{^isPrimitiveType}}
-      self$`{{baseName}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON({{classname}}Object${{baseName}}, auto_unbox = TRUE))
-      {{/isPrimitiveType}}
-      {{/isListContainer}}
+	    {{#isContainer}}	  
+		  {{#isListContainer}}
+			  {{#isPrimitiveType}}
+			  self$`{{baseName}}` <- lapply({{classname}}Object$`{{baseName}}`, function (x) x)
+			  {{/isPrimitiveType}}
+			  {{^isPrimitiveType}}
+			  data.frame <- {{classname}}Object$`{{baseName}}`
+			  self$`{{baseName}}` <- vector("list", length = nrow(data.frame))
+			  for (row in 1:nrow(data.frame)) {
+				  {{baseName}}.node <- {{dataType}}$new()
+				  {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = TRUE], auto_unbox = TRUE))
+				  self$`{{baseName}}`[[row]] <- {{baseName}}.node
+			  }
+			  {{/isPrimitiveType}}
+		 {{/isListContainer}}		
+		 {{#isMapContainer}}
+			  {{#isPrimitiveType}}
+				x <- {{classname}}Object$`{{baseName}}`
+				self$`{{baseName}}` <- sapply(names(x), function(y) x[[y]])  		  
+			  {{/isPrimitiveType}}
+			  {{^isPrimitiveType}}
+				x <- {{classname}}Object$`{{baseName}}`
+				self$`{{baseName}}` <- sapply(names(x), function(y) {{dataType}}$new()$fromJSONString(jsonlite::toJSON(x[[y]])))  
+			  {{/isPrimitiveType}}
+		{{/isMapContainer}}  
+	  {{/isContainer}}  
+	  {{^isContainer}} 
+		{{#isPrimitiveType}}
+		  self$`{{baseName}}` <- {{classname}}Object$`{{baseName}}`
+		{{/isPrimitiveType}}
+		{{^isPrimitiveType}}
+		  self$`{{baseName}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON({{classname}}Object${{baseName}}, auto_unbox = TRUE))
+		{{/isPrimitiveType}}  
+	  {{/isContainer}}
       {{/vars}}
       self
     }

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -203,40 +203,40 @@
     fromJSONString = function({{classname}}Json) {
       {{classname}}Object <- jsonlite::fromJSON({{classname}}Json)
       {{#vars}}
-	    {{#isContainer}}	  
-		  {{#isListContainer}}
-			  {{#isPrimitiveType}}
-			  self$`{{baseName}}` <- lapply({{classname}}Object$`{{baseName}}`, function (x) x)
-			  {{/isPrimitiveType}}
-			  {{^isPrimitiveType}}
-			  data.frame <- {{classname}}Object$`{{baseName}}`
-			  self$`{{baseName}}` <- vector("list", length = nrow(data.frame))
-			  for (row in 1:nrow(data.frame)) {
-				  {{baseName}}.node <- {{dataType}}$new()
-				  {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = F], auto_unbox = TRUE))
-				  self$`{{baseName}}`[[row]] <- {{baseName}}.node
-			  }
-			  {{/isPrimitiveType}}
-		 {{/isListContainer}}		
-		 {{#isMapContainer}}
-			  {{#isPrimitiveType}}
-				x <- {{classname}}Object$`{{baseName}}`
-				self$`{{baseName}}` <- sapply(names(x), function(y) x[[y]])  		  
-			  {{/isPrimitiveType}}
-			  {{^isPrimitiveType}}
-				x <- {{classname}}Object$`{{baseName}}`
-				self$`{{baseName}}` <- sapply(names(x), function(y){ Obj <- {{dataType}}$new();Obj$fromJSON(jsonlite::toJSON(x[[y]], auto_unbox = TRUE));Obj})  
-			  {{/isPrimitiveType}}
-		{{/isMapContainer}}  
-	  {{/isContainer}}  
-	  {{^isContainer}} 
-		{{#isPrimitiveType}}
-		  self$`{{baseName}}` <- {{classname}}Object$`{{baseName}}`
-		{{/isPrimitiveType}}
-		{{^isPrimitiveType}}
-		  self$`{{baseName}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON({{classname}}Object${{baseName}}, auto_unbox = TRUE))
-		{{/isPrimitiveType}}  
-	  {{/isContainer}}
+      {{#isContainer}}	  
+      {{#isListContainer}}
+      {{#isPrimitiveType}}
+      self$`{{baseName}}` <- lapply({{classname}}Object$`{{baseName}}`, function (x) x)
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
+      data.frame <- {{classname}}Object$`{{baseName}}`
+      self$`{{baseName}}` <- vector("list", length = nrow(data.frame))
+      for (row in 1:nrow(data.frame)) {
+      {{baseName}}.node <- {{dataType}}$new()
+      {{baseName}}.node$fromJSON(jsonlite::toJSON(data.frame[row,,drop = F], auto_unbox = TRUE))
+      self$`{{baseName}}`[[row]] <- {{baseName}}.node
+       }
+      {{/isPrimitiveType}}
+      {{/isListContainer}}		
+      {{#isMapContainer}}
+      {{#isPrimitiveType}}
+      x <- {{classname}}Object$`{{baseName}}`
+      self$`{{baseName}}` <- sapply(names(x), function(y) x[[y]])  		  
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
+      x <- {{classname}}Object$`{{baseName}}`
+      self$`{{baseName}}` <- sapply(names(x), function(y){ Obj <- {{dataType}}$new();Obj$fromJSON(jsonlite::toJSON(x[[y]], auto_unbox = TRUE));Obj})  
+      {{/isPrimitiveType}}
+      {{/isMapContainer}}  
+      {{/isContainer}}  
+      {{^isContainer}} 
+      {{#isPrimitiveType}}
+      self$`{{baseName}}` <- {{classname}}Object$`{{baseName}}`
+      {{/isPrimitiveType}}
+      {{^isPrimitiveType}}
+      self$`{{baseName}}` <- {{dataType}}$new()$fromJSON(jsonlite::toJSON({{classname}}Object${{baseName}}, auto_unbox = TRUE))
+      {{/isPrimitiveType}}  
+      {{/isContainer}}
       {{/vars}}
       self
     }


### PR DESCRIPTION
Added deserialize support for models with parameter of map continer type.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Added changes to the model mustache file in the toJSONString() method where the handling of the isMapContainer type vars is handled, which is not handled earlier.

in the isMapContainer handled when it is primitive type map and non-primitive type cases.
which is finally returning a list with names and values equivalent to keys and values of the map.

Please review and take required action.

@wing328 , for your review and suggestion.

Thanks,
Ramanth