### PR TITLE
[R] Handling null values for optional params while building the model json object

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -157,8 +157,8 @@
       }
       {{/vars}}
     },
-    toJSONString = function() {
-      sprintf(
+       toJSONString = function() {
+      outstring = sprintf(
         '{
            {{#vars}}
            "{{baseName}}":
@@ -181,24 +181,32 @@
            {{/vars}}
         }',
         {{#vars}}
+		{{!AAPI Added the if else condition to handle null values}}
+		if (!is.null(self$`{{baseName}}`)) {
         {{#isListContainer}}
         {{#isPrimitiveType}}
-        paste(unlist(lapply(self$`{{{baseName}}}`, function(x) paste0('"', x, '"'))), collapse=","){{#hasMore}},{{/hasMore}}
+        paste(unlist(lapply(self$`{{{baseName}}}`, function(x) paste0('"', x, '"'))), collapse=",")
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        paste(unlist(lapply(self$`{{{baseName}}}`, function(x) jsonlite::toJSON(x$toJSON(), auto_unbox=TRUE))), collapse=","){{#hasMore}},{{/hasMore}}
+        paste(unlist(lapply(self$`{{{baseName}}}`, function(x) jsonlite::toJSON(x$toJSON(), auto_unbox=TRUE))), collapse=",")
         {{/isPrimitiveType}}
         {{/isListContainer}}
         {{^isListContainer}}
         {{#isPrimitiveType}}
-        self$`{{baseName}}`{{#hasMore}},{{/hasMore}}
+        self$`{{baseName}}`
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        jsonlite::toJSON(self$`{{baseName}}`$toJSON(), auto_unbox=TRUE){{#hasMore}},{{/hasMore}}
+        jsonlite::toJSON(self$`{{baseName}}`$toJSON(), auto_unbox=TRUE)
         {{/isPrimitiveType}}
         {{/isListContainer}}
+		}
+		else{
+		"null"
+		}{{#hasMore}},{{/hasMore}}
         {{/vars}}
       )
+	  outstring = gsub("[\r\n]| ", "", outstring)
+	  gsub(':\\[null\\]|:\\\"null\\\"',':null',outstring)
     },
     fromJSONString = function({{classname}}Json) {
       {{classname}}Object <- jsonlite::fromJSON({{classname}}Json)

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -181,8 +181,8 @@
            {{/vars}}
         }',
         {{#vars}}
-		{{!AAPI Added the if else condition to handle null values}}
-		if (!is.null(self$`{{baseName}}`)) {
+        {{! Added the if else condition to handle null values}}
+        if (!is.null(self$`{{baseName}}`)) {
         {{#isListContainer}}
         {{#isPrimitiveType}}
         paste(unlist(lapply(self$`{{{baseName}}}`, function(x) paste0('"', x, '"'))), collapse=",")
@@ -199,10 +199,10 @@
         jsonlite::toJSON(self$`{{baseName}}`$toJSON(), auto_unbox=TRUE)
         {{/isPrimitiveType}}
         {{/isListContainer}}
-		}
-		else{
-		"null"
-		}{{#hasMore}},{{/hasMore}}
+	}
+	else{
+	  "null"
+	}{{#hasMore}},{{/hasMore}}
         {{/vars}}
       )
 	  outstring = gsub("[\r\n]| ", "", outstring)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
**Error when optional parameters are not given for the model object**

When generating the json of a model using the toJSONString() we encounter an error when we dont pass the optional paramameters (which are of non-primitive type)

Below changes handles the listContainer type optional parameters by replacing them with "null". so that it will be ignored by the endpoint.

Please make necessary changes if required.
@wing328 , please look into and take required action.

**Example to test:**
please consider a model which is hanving an example as below
```
{
	"key1" : "value1",
	"key2" : [  {"k1" : "v1"},
                    {"k2" : "v2"} ],
	"key3" : {  "k3" : "v3",
                     "k4" : "v4"
         	      }
}
```


In the above example consider key2 as an optional parameter and of type listContainer (i.e, array). 
Which is throwing an error when we dont provide the value for key2 while generating the model object.
Please review this changes and make required changes to handle such scenarios.

Thanks,
Ramanth.


