### PR TITLE
[Maven] Minor fix on pom

### DIFF
--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -162,7 +162,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <debug>true</debug>
                     <links>
                         <link>http://java.sun.com/javaee/5/docs/api</link>

--- a/pom.xml
+++ b/pom.xml
@@ -228,12 +228,11 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <source>1.8</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <failOnWarnings>true</failOnWarnings>
-                    <excludePackageNames>${javadoc.package.exclude}</excludePackageNames>
+                    <excludePackageNames></excludePackageNames>
                 </configuration>
                 <executions>
                     <execution>
@@ -537,7 +536,7 @@
                 </property>
             </activation>
             <modules>
-                <module>samples/client/petstore/java/okhttp-gson/parcelableModel</module>
+                <module>samples/client/petstore/java/okhttp-gson-parcelableModel</module>
             </modules>
         </profile>
         <profile>
@@ -657,7 +656,7 @@
                 </property>
             </activation>
             <modules>
-                <module>samples/server/petstore/java-msf4/</module>
+                <module>samples/server/petstore/java-msf4j</module>
             </modules>
         </profile>
         <profile>
@@ -850,7 +849,7 @@
                 </property>
             </activation>
             <modules>
-                <module>samples/client/petstore/typescript-angularjs/npm</module>
+                <module>samples/client/petstore/typescript-angularjs</module>
             </modules>
         </profile>
         <profile>
@@ -877,6 +876,7 @@
                 <module>samples/client/petstore/python</module>
             </modules>
         </profile>
+        <!--
         <profile>
             <id>ruby-client</id>
             <activation>
@@ -889,6 +889,7 @@
                 <module>samples/client/petstore/ruby</module>
             </modules>
         </profile>
+        -->
         <profile>
             <id>go-client</id>
             <activation>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.


### Description of the PR

fix pom warnings : 
- uncorrect configuration parameters on maven-javadoc-plugin
- invalid path on some profile

