### PR TITLE
 haskell-http-client: update katip version bound

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
@@ -79,7 +79,7 @@ library
   default-language: Haskell2010
 
   if flag(UseKatip)
-      build-depends: katip >=0.6 && < 1.0
+      build-depends: katip >=0.8 && < 1.0
       other-modules: {{baseModule}}.LoggingKatip
       cpp-options: -DUSE_KATIP
   else

--- a/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
+++ b/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
@@ -79,7 +79,7 @@ library
   default-language: Haskell2010
 
   if flag(UseKatip)
-      build-depends: katip >=0.6 && < 1.0
+      build-depends: katip >=0.8 && < 1.0
       other-modules: OpenAPIPetstore.LoggingKatip
       cpp-options: -DUSE_KATIP
   else


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

katip-0.8.0.0 is needed due to the interface change in `mkHandleScribe`
