### PR TITLE
haskell-http-client: fix indentation in .cabal file

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
@@ -13,10 +13,9 @@ description:    .
                 {{/version}}
                 .
                 OpenAPI version: {{openApiVersion}}
-                .
-                {{^hideGenerationTimestamp}}Generated on: {{generatedDate}}
-                .
-                {{/hideGenerationTimestamp}}
+                .{{^hideGenerationTimestamp}}
+                Generated on: {{generatedDate}}
+                .{{/hideGenerationTimestamp}}
 category:       Web
 homepage:       https://openapi-generator.tech
 author:         Author Name Here

--- a/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
+++ b/samples/client/petstore/haskell-http-client/openapi-petstore.cabal
@@ -12,7 +12,7 @@ description:    .
                 .
                 OpenAPI version: 3.0.1
                 .
-                category:       Web
+category:       Web
 homepage:       https://openapi-generator.tech
 author:         Author Name Here
 maintainer:     author.name@email.com


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The indentation of `category` in the .cabal file is off.