### PR TITLE
[C++] [Qt5 Server] server allow api handler override of generated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.cpp.mustache
@@ -12,7 +12,7 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-{{classname}}Request::{{classname}}Request(QHttpEngine::Socket *s, {{classname}}Handler* hdl) : QObject(s), socket(s), handler(hdl) {
+{{classname}}Request::{{classname}}Request(QHttpEngine::Socket *s, QSharedPointer<{{classname}}Handler> hdl) : QObject(s), socket(s), handler(hdl) {
     auto headers = s->headers();
     for(auto itr = headers.begin(); itr != headers.end(); itr++) {
         requestHeaders.insert(QString(itr.key()), QString(itr.value()));
@@ -43,7 +43,7 @@ QHttpEngine::Socket* {{classname}}Request::getRawSocket(){
 {{#operations}}{{#operation}}
 void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}str{{#hasMore}}, {{/hasMore}}{{/pathParams}}{{/hasPathParams}}){
     qDebug() << "{{{basePathWithoutHost}}}{{{path}}}";
-    connect(this, &{{classname}}Request::{{nickname}}, handler, &{{classname}}Handler::{{nickname}});
+    connect(this, &{{classname}}Request::{{nickname}}, handler.data(), &{{classname}}Handler::{{nickname}});
 
     {{#queryParams}}{{queryParam}}
     {{{dataType}}} {{paramName}};

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirequest.h.mustache
@@ -22,7 +22,7 @@ class {{classname}}Request : public QObject
     Q_OBJECT
 
 public:
-    {{classname}}Request(QHttpEngine::Socket *s, {{classname}}Handler* handler);
+    {{classname}}Request(QHttpEngine::Socket *s, QSharedPointer<{{classname}}Handler> handler);
     virtual ~{{classname}}Request();
 
     {{#operations}}{{#operation}}void {{nickname}}Request({{#hasPathParams}}{{#pathParams}}const QString& {{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/pathParams}}{{/hasPathParams}});
@@ -52,7 +52,7 @@ private:
     QMap<QString, QString> requestHeaders;
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
-    {{classname}}Handler *handler;
+    QSharedPointer<{{classname}}Handler> handler;
 
     inline void writeResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
@@ -18,13 +18,17 @@ namespace {{this}} {
 }
 
 {{prefix}}ApiRouter::~{{prefix}}ApiRouter(){
-    {{#apiInfo}}{{#apis}}
-    delete {{classname}}ApiHandler;{{/apis}}{{/apiInfo}}
+
 }
 
 void {{prefix}}ApiRouter::createApiHandlers() { {{#apiInfo}}{{#apis}}
-    {{classname}}ApiHandler = new {{classname}}Handler();{{/apis}}{{/apiInfo}}
+    {{classname}}ApiHandler = QSharedPointer<{{classname}}Handler>::create();{{/apis}}{{/apiInfo}}
 }
+
+{{#apiInfo}}{{#apis}}
+void {{prefix}}ApiRouter::set{{classname}}ApiHandler(QSharedPointer<{{classname}}Handler> handler){
+    {{classname}}ApiHandler = handler;
+}{{/apis}}{{/apiInfo}}
 
 void {{prefix}}ApiRouter::setUpRoutes() {
     {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{^hasPathParams}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.cpp.mustache
@@ -22,18 +22,18 @@ namespace {{this}} {
 }
 
 void {{prefix}}ApiRouter::createApiHandlers() { {{#apiInfo}}{{#apis}}
-    {{classname}}ApiHandler = QSharedPointer<{{classname}}Handler>::create();{{/apis}}{{/apiInfo}}
+    m{{classname}}Handler = QSharedPointer<{{classname}}Handler>::create();{{/apis}}{{/apiInfo}}
 }
 
 {{#apiInfo}}{{#apis}}
-void {{prefix}}ApiRouter::set{{classname}}ApiHandler(QSharedPointer<{{classname}}Handler> handler){
-    {{classname}}ApiHandler = handler;
+void {{prefix}}ApiRouter::set{{classname}}Handler(QSharedPointer<{{classname}}Handler> handler){
+    m{{classname}}Handler = handler;
 }{{/apis}}{{/apiInfo}}
 
 void {{prefix}}ApiRouter::setUpRoutes() {
     {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{^hasPathParams}}
     Routes.insert(QString("%1 %2").arg("{{httpMethod}}").arg("{{{basePathWithoutHost}}}{{{path}}}").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new {{classname}}Request(socket, {{classname}}ApiHandler);
+            auto reqObj = new {{classname}}Request(socket, m{{classname}}Handler);
             reqObj->{{nickname}}Request();
     });{{/hasPathParams}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 }
@@ -71,7 +71,7 @@ bool {{prefix}}ApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *
                 {{#pathParams}}
                 QString {{baseName}} = match.captured(QString("{{baseName}}").toLower());
                 {{/pathParams}}
-                auto reqObj = new {{classname}}Request(socket, {{classname}}ApiHandler);
+                auto reqObj = new {{classname}}Request(socket, m{{classname}}Handler);
                 reqObj->{{nickname}}Request({{#pathParams}}{{baseName}}{{#hasMore}}, {{/hasMore}}{{/pathParams}});
                 return true;
             }

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.h.mustache
@@ -44,7 +44,7 @@ public:
     void setUpRoutes();
     void processRequest(QHttpEngine::Socket *socket);
     {{#apiInfo}}{{#apis}}
-    void set{{classname}}ApiHandler(QSharedPointer<{{classname}}Handler> handler);{{/apis}}{{/apiInfo}}
+    void set{{classname}}Handler(QSharedPointer<{{classname}}Handler> handler);{{/apis}}{{/apiInfo}}
 private:
     QMap<QString, std::function<void(QHttpEngine::Socket *)>> Routes;
     QMultiMap<QString, std::function<void(QHttpEngine::Socket *)>> RoutesWithPathParam;
@@ -53,7 +53,7 @@ private:
     bool handleRequestAndExtractPathParam(QHttpEngine::Socket *socket);
 
     {{#apiInfo}}{{#apis}}
-    QSharedPointer<{{classname}}Handler> {{classname}}ApiHandler;{{/apis}}{{/apiInfo}}
+    QSharedPointer<{{classname}}Handler> m{{classname}}Handler;{{/apis}}{{/apiInfo}}
 protected:
     // override this method to provide custom class derived from ApiHandler classes
     virtual void createApiHandlers();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/apirouter.h.mustache
@@ -43,6 +43,8 @@ public:
 
     void setUpRoutes();
     void processRequest(QHttpEngine::Socket *socket);
+    {{#apiInfo}}{{#apis}}
+    void set{{classname}}ApiHandler(QSharedPointer<{{classname}}Handler> handler);{{/apis}}{{/apiInfo}}
 private:
     QMap<QString, std::function<void(QHttpEngine::Socket *)>> Routes;
     QMultiMap<QString, std::function<void(QHttpEngine::Socket *)>> RoutesWithPathParam;
@@ -51,7 +53,7 @@ private:
     bool handleRequestAndExtractPathParam(QHttpEngine::Socket *socket);
 
     {{#apiInfo}}{{#apis}}
-    {{classname}}Handler *{{classname}}ApiHandler;{{/apis}}{{/apiInfo}}
+    QSharedPointer<{{classname}}Handler> {{classname}}ApiHandler;{{/apis}}{{/apiInfo}}
 protected:
     // override this method to provide custom class derived from ApiHandler classes
     virtual void createApiHandlers();

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/main.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/main.cpp.mustache
@@ -71,10 +71,10 @@ int main(int argc, char * argv[])
     quint16 port = static_cast<quint16>(parser.value(portOption).toInt());
 
     QSharedPointer<{{cppNamespace}}::{{prefix}}ApiRequestHandler> handler(new {{cppNamespace}}::{{prefix}}ApiRequestHandler());
-    {{cppNamespace}}::{{prefix}}ApiRouter  router;
-    router.setUpRoutes();
+    auto router = QSharedPointer<{{cppNamespace}}::{{prefix}}ApiRouter>::create();
+    router->setUpRoutes();
     QObject::connect(handler.data(), &{{cppNamespace}}::{{prefix}}ApiRequestHandler::requestReceived, [&](QHttpEngine::Socket *socket) {
-        router.processRequest(socket);
+        router->processRequest(socket);
     });
 
     QHttpEngine::Server server(handler.data());

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.cpp
@@ -29,62 +29,70 @@ OAIApiRouter::OAIApiRouter() {
 }
 
 OAIApiRouter::~OAIApiRouter(){
-    
-    delete OAIPetApiApiHandler;
-    delete OAIStoreApiApiHandler;
-    delete OAIUserApiApiHandler;
+
 }
 
 void OAIApiRouter::createApiHandlers() { 
-    OAIPetApiApiHandler = new OAIPetApiHandler();
-    OAIStoreApiApiHandler = new OAIStoreApiHandler();
-    OAIUserApiApiHandler = new OAIUserApiHandler();
+    mOAIPetApiHandler = QSharedPointer<OAIPetApiHandler>::create();
+    mOAIStoreApiHandler = QSharedPointer<OAIStoreApiHandler>::create();
+    mOAIUserApiHandler = QSharedPointer<OAIUserApiHandler>::create();
+}
+
+
+void OAIApiRouter::setOAIPetApiHandler(QSharedPointer<OAIPetApiHandler> handler){
+    mOAIPetApiHandler = handler;
+}
+void OAIApiRouter::setOAIStoreApiHandler(QSharedPointer<OAIStoreApiHandler> handler){
+    mOAIStoreApiHandler = handler;
+}
+void OAIApiRouter::setOAIUserApiHandler(QSharedPointer<OAIUserApiHandler> handler){
+    mOAIUserApiHandler = handler;
 }
 
 void OAIApiRouter::setUpRoutes() {
     
     Routes.insert(QString("%1 %2").arg("POST").arg("/v2/pet").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+            auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
             reqObj->addPetRequest();
     });
     Routes.insert(QString("%1 %2").arg("GET").arg("/v2/pet/findByStatus").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+            auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
             reqObj->findPetsByStatusRequest();
     });
     Routes.insert(QString("%1 %2").arg("GET").arg("/v2/pet/findByTags").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+            auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
             reqObj->findPetsByTagsRequest();
     });
     Routes.insert(QString("%1 %2").arg("PUT").arg("/v2/pet").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+            auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
             reqObj->updatePetRequest();
     });
     Routes.insert(QString("%1 %2").arg("GET").arg("/v2/store/inventory").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIStoreApiRequest(socket, OAIStoreApiApiHandler);
+            auto reqObj = new OAIStoreApiRequest(socket, mOAIStoreApiHandler);
             reqObj->getInventoryRequest();
     });
     Routes.insert(QString("%1 %2").arg("POST").arg("/v2/store/order").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIStoreApiRequest(socket, OAIStoreApiApiHandler);
+            auto reqObj = new OAIStoreApiRequest(socket, mOAIStoreApiHandler);
             reqObj->placeOrderRequest();
     });
     Routes.insert(QString("%1 %2").arg("POST").arg("/v2/user").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+            auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
             reqObj->createUserRequest();
     });
     Routes.insert(QString("%1 %2").arg("POST").arg("/v2/user/createWithArray").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+            auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
             reqObj->createUsersWithArrayInputRequest();
     });
     Routes.insert(QString("%1 %2").arg("POST").arg("/v2/user/createWithList").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+            auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
             reqObj->createUsersWithListInputRequest();
     });
     Routes.insert(QString("%1 %2").arg("GET").arg("/v2/user/login").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+            auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
             reqObj->loginUserRequest();
     });
     Routes.insert(QString("%1 %2").arg("GET").arg("/v2/user/logout").toLower(), [this](QHttpEngine::Socket *socket) {
-            auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+            auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
             reqObj->logoutUserRequest();
     });
 }
@@ -120,7 +128,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString petId = match.captured(QString("petId").toLower());
-                auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+                auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
                 reqObj->deletePetRequest(petId);
                 return true;
             }
@@ -132,7 +140,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString petId = match.captured(QString("petId").toLower());
-                auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+                auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
                 reqObj->getPetByIdRequest(petId);
                 return true;
             }
@@ -144,7 +152,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString petId = match.captured(QString("petId").toLower());
-                auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+                auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
                 reqObj->updatePetWithFormRequest(petId);
                 return true;
             }
@@ -156,7 +164,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString petId = match.captured(QString("petId").toLower());
-                auto reqObj = new OAIPetApiRequest(socket, OAIPetApiApiHandler);
+                auto reqObj = new OAIPetApiRequest(socket, mOAIPetApiHandler);
                 reqObj->uploadFileRequest(petId);
                 return true;
             }
@@ -168,7 +176,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString orderId = match.captured(QString("orderId").toLower());
-                auto reqObj = new OAIStoreApiRequest(socket, OAIStoreApiApiHandler);
+                auto reqObj = new OAIStoreApiRequest(socket, mOAIStoreApiHandler);
                 reqObj->deleteOrderRequest(orderId);
                 return true;
             }
@@ -180,7 +188,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString orderId = match.captured(QString("orderId").toLower());
-                auto reqObj = new OAIStoreApiRequest(socket, OAIStoreApiApiHandler);
+                auto reqObj = new OAIStoreApiRequest(socket, mOAIStoreApiHandler);
                 reqObj->getOrderByIdRequest(orderId);
                 return true;
             }
@@ -192,7 +200,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString username = match.captured(QString("username").toLower());
-                auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+                auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
                 reqObj->deleteUserRequest(username);
                 return true;
             }
@@ -204,7 +212,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString username = match.captured(QString("username").toLower());
-                auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+                auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
                 reqObj->getUserByNameRequest(username);
                 return true;
             }
@@ -216,7 +224,7 @@ bool OAIApiRouter::handleRequestAndExtractPathParam(QHttpEngine::Socket *socket)
             QRegularExpressionMatch match = getRequestMatch( completePath, reqPath );
             if ( match.hasMatch() ){
                 QString username = match.captured(QString("username").toLower());
-                auto reqObj = new OAIUserApiRequest(socket, OAIUserApiApiHandler);
+                auto reqObj = new OAIUserApiRequest(socket, mOAIUserApiHandler);
                 reqObj->updateUserRequest(username);
                 return true;
             }

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/handlers/OAIApiRouter.h
@@ -54,6 +54,10 @@ public:
 
     void setUpRoutes();
     void processRequest(QHttpEngine::Socket *socket);
+    
+    void setOAIPetApiHandler(QSharedPointer<OAIPetApiHandler> handler);
+    void setOAIStoreApiHandler(QSharedPointer<OAIStoreApiHandler> handler);
+    void setOAIUserApiHandler(QSharedPointer<OAIUserApiHandler> handler);
 private:
     QMap<QString, std::function<void(QHttpEngine::Socket *)>> Routes;
     QMultiMap<QString, std::function<void(QHttpEngine::Socket *)>> RoutesWithPathParam;
@@ -62,9 +66,9 @@ private:
     bool handleRequestAndExtractPathParam(QHttpEngine::Socket *socket);
 
     
-    OAIPetApiHandler *OAIPetApiApiHandler;
-    OAIStoreApiHandler *OAIStoreApiApiHandler;
-    OAIUserApiHandler *OAIUserApiApiHandler;
+    QSharedPointer<OAIPetApiHandler> mOAIPetApiHandler;
+    QSharedPointer<OAIStoreApiHandler> mOAIStoreApiHandler;
+    QSharedPointer<OAIUserApiHandler> mOAIUserApiHandler;
 protected:
     // override this method to provide custom class derived from ApiHandler classes
     virtual void createApiHandlers();

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/main.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/main.cpp
@@ -82,10 +82,10 @@ int main(int argc, char * argv[])
     quint16 port = static_cast<quint16>(parser.value(portOption).toInt());
 
     QSharedPointer<OpenAPI::OAIApiRequestHandler> handler(new OpenAPI::OAIApiRequestHandler());
-    OpenAPI::OAIApiRouter  router;
-    router.setUpRoutes();
+    auto router = QSharedPointer<OpenAPI::OAIApiRouter>::create();
+    router->setUpRoutes();
     QObject::connect(handler.data(), &OpenAPI::OAIApiRequestHandler::requestReceived, [&](QHttpEngine::Socket *socket) {
-        router.processRequest(socket);
+        router->processRequest(socket);
     });
 
     QHttpEngine::Server server(handler.data());

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -21,7 +21,7 @@
 
 namespace OpenAPI {
 
-OAIPetApiRequest::OAIPetApiRequest(QHttpEngine::Socket *s, OAIPetApiHandler* hdl) : QObject(s), socket(s), handler(hdl) {
+OAIPetApiRequest::OAIPetApiRequest(QHttpEngine::Socket *s, QSharedPointer<OAIPetApiHandler> hdl) : QObject(s), socket(s), handler(hdl) {
     auto headers = s->headers();
     for(auto itr = headers.begin(); itr != headers.end(); itr++) {
         requestHeaders.insert(QString(itr.key()), QString(itr.value()));
@@ -52,10 +52,11 @@ QHttpEngine::Socket* OAIPetApiRequest::getRawSocket(){
 
 void OAIPetApiRequest::addPetRequest(){
     qDebug() << "/v2/pet";
-    connect(this, &OAIPetApiRequest::addPet, handler, &OAIPetApiHandler::addPet);
+    connect(this, &OAIPetApiRequest::addPet, handler.data(), &OAIPetApiHandler::addPet);
 
     
  
+    
     QJsonDocument doc;
     socket->readJson(doc);
     QJsonObject obj = doc.object();
@@ -69,7 +70,7 @@ void OAIPetApiRequest::addPetRequest(){
 
 void OAIPetApiRequest::deletePetRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}";
-    connect(this, &OAIPetApiRequest::deletePet, handler, &OAIPetApiHandler::deletePet);
+    connect(this, &OAIPetApiRequest::deletePet, handler.data(), &OAIPetApiHandler::deletePet);
 
     
     qint64 pet_id;
@@ -87,7 +88,7 @@ void OAIPetApiRequest::deletePetRequest(const QString& pet_idstr){
 
 void OAIPetApiRequest::findPetsByStatusRequest(){
     qDebug() << "/v2/pet/findByStatus";
-    connect(this, &OAIPetApiRequest::findPetsByStatus, handler, &OAIPetApiHandler::findPetsByStatus);
+    connect(this, &OAIPetApiRequest::findPetsByStatus, handler.data(), &OAIPetApiHandler::findPetsByStatus);
 
     
     QList<QString> status;
@@ -103,7 +104,7 @@ void OAIPetApiRequest::findPetsByStatusRequest(){
 
 void OAIPetApiRequest::findPetsByTagsRequest(){
     qDebug() << "/v2/pet/findByTags";
-    connect(this, &OAIPetApiRequest::findPetsByTags, handler, &OAIPetApiHandler::findPetsByTags);
+    connect(this, &OAIPetApiRequest::findPetsByTags, handler.data(), &OAIPetApiHandler::findPetsByTags);
 
     
     QList<QString> tags;
@@ -119,7 +120,7 @@ void OAIPetApiRequest::findPetsByTagsRequest(){
 
 void OAIPetApiRequest::getPetByIdRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}";
-    connect(this, &OAIPetApiRequest::getPetById, handler, &OAIPetApiHandler::getPetById);
+    connect(this, &OAIPetApiRequest::getPetById, handler.data(), &OAIPetApiHandler::getPetById);
 
     
     qint64 pet_id;
@@ -132,10 +133,11 @@ void OAIPetApiRequest::getPetByIdRequest(const QString& pet_idstr){
 
 void OAIPetApiRequest::updatePetRequest(){
     qDebug() << "/v2/pet";
-    connect(this, &OAIPetApiRequest::updatePet, handler, &OAIPetApiHandler::updatePet);
+    connect(this, &OAIPetApiRequest::updatePet, handler.data(), &OAIPetApiHandler::updatePet);
 
     
  
+    
     QJsonDocument doc;
     socket->readJson(doc);
     QJsonObject obj = doc.object();
@@ -149,7 +151,7 @@ void OAIPetApiRequest::updatePetRequest(){
 
 void OAIPetApiRequest::updatePetWithFormRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}";
-    connect(this, &OAIPetApiRequest::updatePetWithForm, handler, &OAIPetApiHandler::updatePetWithForm);
+    connect(this, &OAIPetApiRequest::updatePetWithForm, handler.data(), &OAIPetApiHandler::updatePetWithForm);
 
     
     qint64 pet_id;
@@ -164,7 +166,7 @@ void OAIPetApiRequest::updatePetWithFormRequest(const QString& pet_idstr){
 
 void OAIPetApiRequest::uploadFileRequest(const QString& pet_idstr){
     qDebug() << "/v2/pet/{petId}/uploadImage";
-    connect(this, &OAIPetApiRequest::uploadFile, handler, &OAIPetApiHandler::uploadFile);
+    connect(this, &OAIPetApiRequest::uploadFile, handler.data(), &OAIPetApiHandler::uploadFile);
 
     
     qint64 pet_id;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -33,7 +33,7 @@ class OAIPetApiRequest : public QObject
     Q_OBJECT
 
 public:
-    OAIPetApiRequest(QHttpEngine::Socket *s, OAIPetApiHandler* handler);
+    OAIPetApiRequest(QHttpEngine::Socket *s, QSharedPointer<OAIPetApiHandler> handler);
     virtual ~OAIPetApiRequest();
 
     void addPetRequest();
@@ -91,7 +91,7 @@ private:
     QMap<QString, QString> requestHeaders;
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
-    OAIPetApiHandler *handler;
+    QSharedPointer<OAIPetApiHandler> handler;
 
     inline void writeResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -21,7 +21,7 @@
 
 namespace OpenAPI {
 
-OAIStoreApiRequest::OAIStoreApiRequest(QHttpEngine::Socket *s, OAIStoreApiHandler* hdl) : QObject(s), socket(s), handler(hdl) {
+OAIStoreApiRequest::OAIStoreApiRequest(QHttpEngine::Socket *s, QSharedPointer<OAIStoreApiHandler> hdl) : QObject(s), socket(s), handler(hdl) {
     auto headers = s->headers();
     for(auto itr = headers.begin(); itr != headers.end(); itr++) {
         requestHeaders.insert(QString(itr.key()), QString(itr.value()));
@@ -52,7 +52,7 @@ QHttpEngine::Socket* OAIStoreApiRequest::getRawSocket(){
 
 void OAIStoreApiRequest::deleteOrderRequest(const QString& order_idstr){
     qDebug() << "/v2/store/order/{orderId}";
-    connect(this, &OAIStoreApiRequest::deleteOrder, handler, &OAIStoreApiHandler::deleteOrder);
+    connect(this, &OAIStoreApiRequest::deleteOrder, handler.data(), &OAIStoreApiHandler::deleteOrder);
 
     
     QString order_id;
@@ -65,7 +65,7 @@ void OAIStoreApiRequest::deleteOrderRequest(const QString& order_idstr){
 
 void OAIStoreApiRequest::getInventoryRequest(){
     qDebug() << "/v2/store/inventory";
-    connect(this, &OAIStoreApiRequest::getInventory, handler, &OAIStoreApiHandler::getInventory);
+    connect(this, &OAIStoreApiRequest::getInventory, handler.data(), &OAIStoreApiHandler::getInventory);
 
     
 
@@ -76,7 +76,7 @@ void OAIStoreApiRequest::getInventoryRequest(){
 
 void OAIStoreApiRequest::getOrderByIdRequest(const QString& order_idstr){
     qDebug() << "/v2/store/order/{orderId}";
-    connect(this, &OAIStoreApiRequest::getOrderById, handler, &OAIStoreApiHandler::getOrderById);
+    connect(this, &OAIStoreApiRequest::getOrderById, handler.data(), &OAIStoreApiHandler::getOrderById);
 
     
     qint64 order_id;
@@ -89,10 +89,11 @@ void OAIStoreApiRequest::getOrderByIdRequest(const QString& order_idstr){
 
 void OAIStoreApiRequest::placeOrderRequest(){
     qDebug() << "/v2/store/order";
-    connect(this, &OAIStoreApiRequest::placeOrder, handler, &OAIStoreApiHandler::placeOrder);
+    connect(this, &OAIStoreApiRequest::placeOrder, handler.data(), &OAIStoreApiHandler::placeOrder);
 
     
  
+    
     QJsonDocument doc;
     socket->readJson(doc);
     QJsonObject obj = doc.object();

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -32,7 +32,7 @@ class OAIStoreApiRequest : public QObject
     Q_OBJECT
 
 public:
-    OAIStoreApiRequest(QHttpEngine::Socket *s, OAIStoreApiHandler* handler);
+    OAIStoreApiRequest(QHttpEngine::Socket *s, QSharedPointer<OAIStoreApiHandler> handler);
     virtual ~OAIStoreApiRequest();
 
     void deleteOrderRequest(const QString& order_id);
@@ -74,7 +74,7 @@ private:
     QMap<QString, QString> requestHeaders;
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
-    OAIStoreApiHandler *handler;
+    QSharedPointer<OAIStoreApiHandler> handler;
 
     inline void writeResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -21,7 +21,7 @@
 
 namespace OpenAPI {
 
-OAIUserApiRequest::OAIUserApiRequest(QHttpEngine::Socket *s, OAIUserApiHandler* hdl) : QObject(s), socket(s), handler(hdl) {
+OAIUserApiRequest::OAIUserApiRequest(QHttpEngine::Socket *s, QSharedPointer<OAIUserApiHandler> hdl) : QObject(s), socket(s), handler(hdl) {
     auto headers = s->headers();
     for(auto itr = headers.begin(); itr != headers.end(); itr++) {
         requestHeaders.insert(QString(itr.key()), QString(itr.value()));
@@ -52,10 +52,11 @@ QHttpEngine::Socket* OAIUserApiRequest::getRawSocket(){
 
 void OAIUserApiRequest::createUserRequest(){
     qDebug() << "/v2/user";
-    connect(this, &OAIUserApiRequest::createUser, handler, &OAIUserApiHandler::createUser);
+    connect(this, &OAIUserApiRequest::createUser, handler.data(), &OAIUserApiHandler::createUser);
 
     
  
+    
     QJsonDocument doc;
     socket->readJson(doc);
     QJsonObject obj = doc.object();
@@ -69,7 +70,7 @@ void OAIUserApiRequest::createUserRequest(){
 
 void OAIUserApiRequest::createUsersWithArrayInputRequest(){
     qDebug() << "/v2/user/createWithArray";
-    connect(this, &OAIUserApiRequest::createUsersWithArrayInput, handler, &OAIUserApiHandler::createUsersWithArrayInput);
+    connect(this, &OAIUserApiRequest::createUsersWithArrayInput, handler.data(), &OAIUserApiHandler::createUsersWithArrayInput);
 
     
  
@@ -91,7 +92,7 @@ void OAIUserApiRequest::createUsersWithArrayInputRequest(){
 
 void OAIUserApiRequest::createUsersWithListInputRequest(){
     qDebug() << "/v2/user/createWithList";
-    connect(this, &OAIUserApiRequest::createUsersWithListInput, handler, &OAIUserApiHandler::createUsersWithListInput);
+    connect(this, &OAIUserApiRequest::createUsersWithListInput, handler.data(), &OAIUserApiHandler::createUsersWithListInput);
 
     
  
@@ -113,7 +114,7 @@ void OAIUserApiRequest::createUsersWithListInputRequest(){
 
 void OAIUserApiRequest::deleteUserRequest(const QString& usernamestr){
     qDebug() << "/v2/user/{username}";
-    connect(this, &OAIUserApiRequest::deleteUser, handler, &OAIUserApiHandler::deleteUser);
+    connect(this, &OAIUserApiRequest::deleteUser, handler.data(), &OAIUserApiHandler::deleteUser);
 
     
     QString username;
@@ -126,7 +127,7 @@ void OAIUserApiRequest::deleteUserRequest(const QString& usernamestr){
 
 void OAIUserApiRequest::getUserByNameRequest(const QString& usernamestr){
     qDebug() << "/v2/user/{username}";
-    connect(this, &OAIUserApiRequest::getUserByName, handler, &OAIUserApiHandler::getUserByName);
+    connect(this, &OAIUserApiRequest::getUserByName, handler.data(), &OAIUserApiHandler::getUserByName);
 
     
     QString username;
@@ -139,7 +140,7 @@ void OAIUserApiRequest::getUserByNameRequest(const QString& usernamestr){
 
 void OAIUserApiRequest::loginUserRequest(){
     qDebug() << "/v2/user/login";
-    connect(this, &OAIUserApiRequest::loginUser, handler, &OAIUserApiHandler::loginUser);
+    connect(this, &OAIUserApiRequest::loginUser, handler.data(), &OAIUserApiHandler::loginUser);
 
     
     QString username;
@@ -160,7 +161,7 @@ void OAIUserApiRequest::loginUserRequest(){
 
 void OAIUserApiRequest::logoutUserRequest(){
     qDebug() << "/v2/user/logout";
-    connect(this, &OAIUserApiRequest::logoutUser, handler, &OAIUserApiHandler::logoutUser);
+    connect(this, &OAIUserApiRequest::logoutUser, handler.data(), &OAIUserApiHandler::logoutUser);
 
     
 
@@ -171,12 +172,13 @@ void OAIUserApiRequest::logoutUserRequest(){
 
 void OAIUserApiRequest::updateUserRequest(const QString& usernamestr){
     qDebug() << "/v2/user/{username}";
-    connect(this, &OAIUserApiRequest::updateUser, handler, &OAIUserApiHandler::updateUser);
+    connect(this, &OAIUserApiRequest::updateUser, handler.data(), &OAIUserApiHandler::updateUser);
 
     
     QString username;
     fromStringValue(usernamestr, username);
      
+    
     QJsonDocument doc;
     socket->readJson(doc);
     QJsonObject obj = doc.object();

--- a/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt5-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -32,7 +32,7 @@ class OAIUserApiRequest : public QObject
     Q_OBJECT
 
 public:
-    OAIUserApiRequest(QHttpEngine::Socket *s, OAIUserApiHandler* handler);
+    OAIUserApiRequest(QHttpEngine::Socket *s, QSharedPointer<OAIUserApiHandler> handler);
     virtual ~OAIUserApiRequest();
 
     void createUserRequest();
@@ -90,7 +90,7 @@ private:
     QMap<QString, QString> requestHeaders;
     QMap<QString, QString> responseHeaders;
     QHttpEngine::Socket  *socket;
-    OAIUserApiHandler *handler;
+    QSharedPointer<OAIUserApiHandler> handler;
 
     inline void writeResponseHeaders(){
         QHttpEngine::Socket::HeaderMap resHeaders;


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
- The generated code allows setting a handler which is a derived class of the generated handler code
- using of `QSharedPointer` allows the old handler to be deallocated until all requests are served 
`cc:`
@stkrwork @MartinDelille @fvarose @ravinikam 

