### PR TITLE
[typescript-fetch] Guard array mapping against undefined on optional array model properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -74,7 +74,7 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isContainer}}
-        '{{baseName}}': (value.{{name}} as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON),
+        '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}(value.{{name}} as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON),
         {{/isContainer}}
         {{^isContainer}}
         '{{baseName}}': {{datatype}}ToJSON(value.{{name}}),

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -85,7 +85,7 @@ export function PetToJSON(value?: Pet): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : (value.tags as Array<any>).map(TagToJSON),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/Pet.ts
@@ -85,7 +85,7 @@ export function PetToJSON(value?: Pet): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : (value.tags as Array<any>).map(TagToJSON),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -85,7 +85,7 @@ export function PetToJSON(value?: Pet): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : (value.tags as Array<any>).map(TagToJSON),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Pet.ts
@@ -85,7 +85,7 @@ export function PetToJSON(value?: Pet): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : (value.tags as Array<any>).map(TagToJSON),
         'status': value.status,
     };
 }


### PR DESCRIPTION
Fixes #2323 

Apply the same guard against `undefined` as is already used for `Date` (just above).

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
