### PR TITLE
Outputs dataType to YARD tag 

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -19,7 +19,7 @@ module {{moduleName}}
     {{#notes}}
     # {{{notes}}}
     {{/notes}}
-{{#allParams}}{{#required}}    # @param {{paramName}} {{description}}
+{{#allParams}}{{#required}}    # @param {{paramName}} [{{{dataType}}}] {{description}}
 {{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
 {{/required}}{{/allParams}}    # @return [{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}]
@@ -34,7 +34,7 @@ module {{moduleName}}
     {{#notes}}
     # {{notes}}
     {{/notes}}
-{{#allParams}}{{#required}}    # @param {{paramName}} {{description}}
+{{#allParams}}{{#required}}    # @param {{paramName}} [{{{dataType}}}] {{description}}
 {{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
 {{/required}}{{/allParams}}    # @return [Array<({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Fixnum, Hash)>] {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # To test special tags
     # To test special tags and operation ID starting with number
-    # @param body client model
+    # @param body [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
     def call_123_test_special_tags(body, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # To test special tags
     # To test special tags and operation ID starting with number
-    # @param body client model
+    # @param body [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
     def call_123_test_special_tags_with_http_info(body, opts = {})

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # creates an XmlItem
     # this route creates an XmlItem
-    # @param xml_item XmlItem Body
+    # @param xml_item [XmlItem] XmlItem Body
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_xml_item(xml_item, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # creates an XmlItem
     # this route creates an XmlItem
-    # @param xml_item XmlItem Body
+    # @param xml_item [XmlItem] XmlItem Body
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_xml_item_with_http_info(xml_item, opts = {})
@@ -260,7 +260,7 @@ module Petstore
     end
 
     # For this test, the body for this request much reference a schema named `File`.
-    # @param body 
+    # @param body [FileSchemaTestClass] 
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_body_with_file_schema(body, opts = {})
@@ -269,7 +269,7 @@ module Petstore
     end
 
     # For this test, the body for this request much reference a schema named &#x60;File&#x60;.
-    # @param body 
+    # @param body [FileSchemaTestClass] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_body_with_file_schema_with_http_info(body, opts = {})
@@ -309,8 +309,8 @@ module Petstore
       return data, status_code, headers
     end
 
-    # @param query 
-    # @param body 
+    # @param query [String] 
+    # @param body [User] 
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_body_with_query_params(query, body, opts = {})
@@ -318,8 +318,8 @@ module Petstore
       nil
     end
 
-    # @param query 
-    # @param body 
+    # @param query [String] 
+    # @param body [User] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_body_with_query_params_with_http_info(query, body, opts = {})
@@ -366,7 +366,7 @@ module Petstore
 
     # To test \"client\" model
     # To test \"client\" model
-    # @param body client model
+    # @param body [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
     def test_client_model(body, opts = {})
@@ -376,7 +376,7 @@ module Petstore
 
     # To test \&quot;client\&quot; model
     # To test \&quot;client\&quot; model
-    # @param body client model
+    # @param body [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
     def test_client_model_with_http_info(body, opts = {})
@@ -421,10 +421,10 @@ module Petstore
 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    # @param number None
-    # @param double None
-    # @param pattern_without_delimiter None
-    # @param byte None
+    # @param number [Float] None
+    # @param double [Float] None
+    # @param pattern_without_delimiter [String] None
+    # @param byte [String] None
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :integer None
     # @option opts [Integer] :int32 None
@@ -444,10 +444,10 @@ module Petstore
 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    # @param number None
-    # @param double None
-    # @param pattern_without_delimiter None
-    # @param byte None
+    # @param number [Float] None
+    # @param double [Float] None
+    # @param pattern_without_delimiter [String] None
+    # @param byte [String] None
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :integer None
     # @option opts [Integer] :int32 None
@@ -681,9 +681,9 @@ module Petstore
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group Required String in group parameters
-    # @param required_boolean_group Required Boolean in group parameters
-    # @param required_int64_group Required Integer in group parameters
+    # @param required_string_group [Integer] Required String in group parameters
+    # @param required_boolean_group [BOOLEAN] Required Boolean in group parameters
+    # @param required_int64_group [Integer] Required Integer in group parameters
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [BOOLEAN] :boolean_group Boolean in group parameters
@@ -696,9 +696,9 @@ module Petstore
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group Required String in group parameters
-    # @param required_boolean_group Required Boolean in group parameters
-    # @param required_int64_group Required Integer in group parameters
+    # @param required_string_group [Integer] Required String in group parameters
+    # @param required_boolean_group [BOOLEAN] Required Boolean in group parameters
+    # @param required_int64_group [Integer] Required Integer in group parameters
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [BOOLEAN] :boolean_group Boolean in group parameters
@@ -754,7 +754,7 @@ module Petstore
     end
 
     # test inline additionalProperties
-    # @param param request body
+    # @param param [Hash<String, String>] request body
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_inline_additional_properties(param, opts = {})
@@ -763,7 +763,7 @@ module Petstore
     end
 
     # test inline additionalProperties
-    # @param param request body
+    # @param param [Hash<String, String>] request body
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_inline_additional_properties_with_http_info(param, opts = {})
@@ -804,8 +804,8 @@ module Petstore
     end
 
     # test json serialization of form data
-    # @param param field1
-    # @param param2 field2
+    # @param param [String] field1
+    # @param param2 [String] field2
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_json_form_data(param, param2, opts = {})
@@ -814,8 +814,8 @@ module Petstore
     end
 
     # test json serialization of form data
-    # @param param field1
-    # @param param2 field2
+    # @param param [String] field1
+    # @param param2 [String] field2
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_json_form_data_with_http_info(param, param2, opts = {})

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # To test class name in snake case
     # To test class name in snake case
-    # @param body client model
+    # @param body [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
     def test_classname(body, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # To test class name in snake case
     # To test class name in snake case
-    # @param body client model
+    # @param body [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
     def test_classname_with_http_info(body, opts = {})

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -20,7 +20,7 @@ module Petstore
       @api_client = api_client
     end
     # Add a new pet to the store
-    # @param body Pet object that needs to be added to the store
+    # @param body [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def add_pet(body, opts = {})
@@ -29,7 +29,7 @@ module Petstore
     end
 
     # Add a new pet to the store
-    # @param body Pet object that needs to be added to the store
+    # @param body [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def add_pet_with_http_info(body, opts = {})
@@ -70,7 +70,7 @@ module Petstore
     end
 
     # Deletes a pet
-    # @param pet_id Pet id to delete
+    # @param pet_id [Integer] Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
     # @return [nil]
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Deletes a pet
-    # @param pet_id Pet id to delete
+    # @param pet_id [Integer] Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
@@ -122,7 +122,7 @@ module Petstore
 
     # Finds Pets by status
     # Multiple status values can be provided with comma separated strings
-    # @param status Status values that need to be considered for filter
+    # @param status [Array<String>] Status values that need to be considered for filter
     # @param [Hash] opts the optional parameters
     # @return [Array<Pet>]
     def find_pets_by_status(status, opts = {})
@@ -132,7 +132,7 @@ module Petstore
 
     # Finds Pets by status
     # Multiple status values can be provided with comma separated strings
-    # @param status Status values that need to be considered for filter
+    # @param status [Array<String>] Status values that need to be considered for filter
     # @param [Hash] opts the optional parameters
     # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_status_with_http_info(status, opts = {})
@@ -176,7 +176,7 @@ module Petstore
 
     # Finds Pets by tags
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    # @param tags Tags to filter by
+    # @param tags [Array<String>] Tags to filter by
     # @param [Hash] opts the optional parameters
     # @return [Array<Pet>]
     def find_pets_by_tags(tags, opts = {})
@@ -186,7 +186,7 @@ module Petstore
 
     # Finds Pets by tags
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    # @param tags Tags to filter by
+    # @param tags [Array<String>] Tags to filter by
     # @param [Hash] opts the optional parameters
     # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_tags_with_http_info(tags, opts = {})
@@ -230,7 +230,7 @@ module Petstore
 
     # Find pet by ID
     # Returns a single pet
-    # @param pet_id ID of pet to return
+    # @param pet_id [Integer] ID of pet to return
     # @param [Hash] opts the optional parameters
     # @return [Pet]
     def get_pet_by_id(pet_id, opts = {})
@@ -240,7 +240,7 @@ module Petstore
 
     # Find pet by ID
     # Returns a single pet
-    # @param pet_id ID of pet to return
+    # @param pet_id [Integer] ID of pet to return
     # @param [Hash] opts the optional parameters
     # @return [Array<(Pet, Fixnum, Hash)>] Pet data, response status code and response headers
     def get_pet_by_id_with_http_info(pet_id, opts = {})
@@ -282,7 +282,7 @@ module Petstore
     end
 
     # Update an existing pet
-    # @param body Pet object that needs to be added to the store
+    # @param body [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def update_pet(body, opts = {})
@@ -291,7 +291,7 @@ module Petstore
     end
 
     # Update an existing pet
-    # @param body Pet object that needs to be added to the store
+    # @param body [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_pet_with_http_info(body, opts = {})
@@ -332,7 +332,7 @@ module Petstore
     end
 
     # Updates a pet in the store with form data
-    # @param pet_id ID of pet that needs to be updated
+    # @param pet_id [Integer] ID of pet that needs to be updated
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
@@ -343,7 +343,7 @@ module Petstore
     end
 
     # Updates a pet in the store with form data
-    # @param pet_id ID of pet that needs to be updated
+    # @param pet_id [Integer] ID of pet that needs to be updated
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
@@ -388,7 +388,7 @@ module Petstore
     end
 
     # uploads an image
-    # @param pet_id ID of pet to update
+    # @param pet_id [Integer] ID of pet to update
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
@@ -399,7 +399,7 @@ module Petstore
     end
 
     # uploads an image
-    # @param pet_id ID of pet to update
+    # @param pet_id [Integer] ID of pet to update
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
@@ -447,8 +447,8 @@ module Petstore
     end
 
     # uploads an image (required)
-    # @param pet_id ID of pet to update
-    # @param required_file file to upload
+    # @param pet_id [Integer] ID of pet to update
+    # @param required_file [File] file to upload
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @return [ApiResponse]
@@ -458,8 +458,8 @@ module Petstore
     end
 
     # uploads an image (required)
-    # @param pet_id ID of pet to update
-    # @param required_file file to upload
+    # @param pet_id [Integer] ID of pet to update
+    # @param required_file [File] file to upload
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @return [Array<(ApiResponse, Fixnum, Hash)>] ApiResponse data, response status code and response headers

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # Delete purchase order by ID
     # For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-    # @param order_id ID of the order that needs to be deleted
+    # @param order_id [String] ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def delete_order(order_id, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # Delete purchase order by ID
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
-    # @param order_id ID of the order that needs to be deleted
+    # @param order_id [String] ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_order_with_http_info(order_id, opts = {})
@@ -118,7 +118,7 @@ module Petstore
 
     # Find purchase order by ID
     # For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-    # @param order_id ID of pet that needs to be fetched
+    # @param order_id [Integer] ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [Order]
     def get_order_by_id(order_id, opts = {})
@@ -128,7 +128,7 @@ module Petstore
 
     # Find purchase order by ID
     # For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
-    # @param order_id ID of pet that needs to be fetched
+    # @param order_id [Integer] ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def get_order_by_id_with_http_info(order_id, opts = {})
@@ -178,7 +178,7 @@ module Petstore
     end
 
     # Place an order for a pet
-    # @param body order placed for purchasing the pet
+    # @param body [Order] order placed for purchasing the pet
     # @param [Hash] opts the optional parameters
     # @return [Order]
     def place_order(body, opts = {})
@@ -187,7 +187,7 @@ module Petstore
     end
 
     # Place an order for a pet
-    # @param body order placed for purchasing the pet
+    # @param body [Order] order placed for purchasing the pet
     # @param [Hash] opts the optional parameters
     # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def place_order_with_http_info(body, opts = {})

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # Create user
     # This can only be done by the logged in user.
-    # @param body Created user object
+    # @param body [User] Created user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_user(body, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # Create user
     # This can only be done by the logged in user.
-    # @param body Created user object
+    # @param body [User] Created user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_user_with_http_info(body, opts = {})
@@ -70,7 +70,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param body List of user object
+    # @param body [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_users_with_array_input(body, opts = {})
@@ -79,7 +79,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param body List of user object
+    # @param body [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_array_input_with_http_info(body, opts = {})
@@ -118,7 +118,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param body List of user object
+    # @param body [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_users_with_list_input(body, opts = {})
@@ -127,7 +127,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param body List of user object
+    # @param body [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_list_input_with_http_info(body, opts = {})
@@ -167,7 +167,7 @@ module Petstore
 
     # Delete user
     # This can only be done by the logged in user.
-    # @param username The name that needs to be deleted
+    # @param username [String] The name that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def delete_user(username, opts = {})
@@ -177,7 +177,7 @@ module Petstore
 
     # Delete user
     # This can only be done by the logged in user.
-    # @param username The name that needs to be deleted
+    # @param username [String] The name that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_user_with_http_info(username, opts = {})
@@ -216,7 +216,7 @@ module Petstore
     end
 
     # Get user by user name
-    # @param username The name that needs to be fetched. Use user1 for testing.
+    # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
     # @return [User]
     def get_user_by_name(username, opts = {})
@@ -225,7 +225,7 @@ module Petstore
     end
 
     # Get user by user name
-    # @param username The name that needs to be fetched. Use user1 for testing.
+    # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
     # @return [Array<(User, Fixnum, Hash)>] User data, response status code and response headers
     def get_user_by_name_with_http_info(username, opts = {})
@@ -267,8 +267,8 @@ module Petstore
     end
 
     # Logs user into the system
-    # @param username The user name for login
-    # @param password The password for login in clear text
+    # @param username [String] The user name for login
+    # @param password [String] The password for login in clear text
     # @param [Hash] opts the optional parameters
     # @return [String]
     def login_user(username, password, opts = {})
@@ -277,8 +277,8 @@ module Petstore
     end
 
     # Logs user into the system
-    # @param username The user name for login
-    # @param password The password for login in clear text
+    # @param username [String] The user name for login
+    # @param password [String] The password for login in clear text
     # @param [Hash] opts the optional parameters
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def login_user_with_http_info(username, password, opts = {})
@@ -369,8 +369,8 @@ module Petstore
 
     # Updated user
     # This can only be done by the logged in user.
-    # @param username name that need to be deleted
-    # @param body Updated user object
+    # @param username [String] name that need to be deleted
+    # @param body [User] Updated user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def update_user(username, body, opts = {})
@@ -380,8 +380,8 @@ module Petstore
 
     # Updated user
     # This can only be done by the logged in user.
-    # @param username name that need to be deleted
-    # @param body Updated user object
+    # @param username [String] name that need to be deleted
+    # @param body [User] Updated user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_user_with_http_info(username, body, opts = {})

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # To test special tags
     # To test special tags and operation ID starting with number
-    # @param client client model
+    # @param client [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
     def call_123_test_special_tags(client, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # To test special tags
     # To test special tags and operation ID starting with number
-    # @param client client model
+    # @param client [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
     def call_123_test_special_tags_with_http_info(client, opts = {})

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -261,7 +261,7 @@ module Petstore
     end
 
     # For this test, the body for this request much reference a schema named `File`.
-    # @param file_schema_test_class 
+    # @param file_schema_test_class [FileSchemaTestClass] 
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_body_with_file_schema(file_schema_test_class, opts = {})
@@ -270,7 +270,7 @@ module Petstore
     end
 
     # For this test, the body for this request much reference a schema named &#x60;File&#x60;.
-    # @param file_schema_test_class 
+    # @param file_schema_test_class [FileSchemaTestClass] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_body_with_file_schema_with_http_info(file_schema_test_class, opts = {})
@@ -310,8 +310,8 @@ module Petstore
       return data, status_code, headers
     end
 
-    # @param query 
-    # @param user 
+    # @param query [String] 
+    # @param user [User] 
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_body_with_query_params(query, user, opts = {})
@@ -319,8 +319,8 @@ module Petstore
       nil
     end
 
-    # @param query 
-    # @param user 
+    # @param query [String] 
+    # @param user [User] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_body_with_query_params_with_http_info(query, user, opts = {})
@@ -367,7 +367,7 @@ module Petstore
 
     # To test \"client\" model
     # To test \"client\" model
-    # @param client client model
+    # @param client [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
     def test_client_model(client, opts = {})
@@ -377,7 +377,7 @@ module Petstore
 
     # To test \&quot;client\&quot; model
     # To test \&quot;client\&quot; model
-    # @param client client model
+    # @param client [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
     def test_client_model_with_http_info(client, opts = {})
@@ -422,10 +422,10 @@ module Petstore
 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    # @param number None
-    # @param double None
-    # @param pattern_without_delimiter None
-    # @param byte None
+    # @param number [Float] None
+    # @param double [Float] None
+    # @param pattern_without_delimiter [String] None
+    # @param byte [String] None
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :integer None
     # @option opts [Integer] :int32 None
@@ -445,10 +445,10 @@ module Petstore
 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
     # Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-    # @param number None
-    # @param double None
-    # @param pattern_without_delimiter None
-    # @param byte None
+    # @param number [Float] None
+    # @param double [Float] None
+    # @param pattern_without_delimiter [String] None
+    # @param byte [String] None
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :integer None
     # @option opts [Integer] :int32 None
@@ -682,9 +682,9 @@ module Petstore
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group Required String in group parameters
-    # @param required_boolean_group Required Boolean in group parameters
-    # @param required_int64_group Required Integer in group parameters
+    # @param required_string_group [Integer] Required String in group parameters
+    # @param required_boolean_group [BOOLEAN] Required Boolean in group parameters
+    # @param required_int64_group [Integer] Required Integer in group parameters
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [BOOLEAN] :boolean_group Boolean in group parameters
@@ -697,9 +697,9 @@ module Petstore
 
     # Fake endpoint to test group parameters (optional)
     # Fake endpoint to test group parameters (optional)
-    # @param required_string_group Required String in group parameters
-    # @param required_boolean_group Required Boolean in group parameters
-    # @param required_int64_group Required Integer in group parameters
+    # @param required_string_group [Integer] Required String in group parameters
+    # @param required_boolean_group [BOOLEAN] Required Boolean in group parameters
+    # @param required_int64_group [Integer] Required Integer in group parameters
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [BOOLEAN] :boolean_group Boolean in group parameters
@@ -755,7 +755,7 @@ module Petstore
     end
 
     # test inline additionalProperties
-    # @param request_body request body
+    # @param request_body [Hash<String, String>] request body
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_inline_additional_properties(request_body, opts = {})
@@ -764,7 +764,7 @@ module Petstore
     end
 
     # test inline additionalProperties
-    # @param request_body request body
+    # @param request_body [Hash<String, String>] request body
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_inline_additional_properties_with_http_info(request_body, opts = {})
@@ -805,8 +805,8 @@ module Petstore
     end
 
     # test json serialization of form data
-    # @param param field1
-    # @param param2 field2
+    # @param param [String] field1
+    # @param param2 [String] field2
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def test_json_form_data(param, param2, opts = {})
@@ -815,8 +815,8 @@ module Petstore
     end
 
     # test json serialization of form data
-    # @param param field1
-    # @param param2 field2
+    # @param param [String] field1
+    # @param param2 [String] field2
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def test_json_form_data_with_http_info(param, param2, opts = {})

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # To test class name in snake case
     # To test class name in snake case
-    # @param client client model
+    # @param client [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Client]
     def test_classname(client, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # To test class name in snake case
     # To test class name in snake case
-    # @param client client model
+    # @param client [Client] client model
     # @param [Hash] opts the optional parameters
     # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
     def test_classname_with_http_info(client, opts = {})

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -20,7 +20,7 @@ module Petstore
       @api_client = api_client
     end
     # Add a new pet to the store
-    # @param pet Pet object that needs to be added to the store
+    # @param pet [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def add_pet(pet, opts = {})
@@ -29,7 +29,7 @@ module Petstore
     end
 
     # Add a new pet to the store
-    # @param pet Pet object that needs to be added to the store
+    # @param pet [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def add_pet_with_http_info(pet, opts = {})
@@ -70,7 +70,7 @@ module Petstore
     end
 
     # Deletes a pet
-    # @param pet_id Pet id to delete
+    # @param pet_id [Integer] Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
     # @return [nil]
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Deletes a pet
-    # @param pet_id Pet id to delete
+    # @param pet_id [Integer] Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
@@ -122,7 +122,7 @@ module Petstore
 
     # Finds Pets by status
     # Multiple status values can be provided with comma separated strings
-    # @param status Status values that need to be considered for filter
+    # @param status [Array<String>] Status values that need to be considered for filter
     # @param [Hash] opts the optional parameters
     # @return [Array<Pet>]
     def find_pets_by_status(status, opts = {})
@@ -132,7 +132,7 @@ module Petstore
 
     # Finds Pets by status
     # Multiple status values can be provided with comma separated strings
-    # @param status Status values that need to be considered for filter
+    # @param status [Array<String>] Status values that need to be considered for filter
     # @param [Hash] opts the optional parameters
     # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_status_with_http_info(status, opts = {})
@@ -176,7 +176,7 @@ module Petstore
 
     # Finds Pets by tags
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    # @param tags Tags to filter by
+    # @param tags [Array<String>] Tags to filter by
     # @param [Hash] opts the optional parameters
     # @return [Array<Pet>]
     def find_pets_by_tags(tags, opts = {})
@@ -186,7 +186,7 @@ module Petstore
 
     # Finds Pets by tags
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-    # @param tags Tags to filter by
+    # @param tags [Array<String>] Tags to filter by
     # @param [Hash] opts the optional parameters
     # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_tags_with_http_info(tags, opts = {})
@@ -230,7 +230,7 @@ module Petstore
 
     # Find pet by ID
     # Returns a single pet
-    # @param pet_id ID of pet to return
+    # @param pet_id [Integer] ID of pet to return
     # @param [Hash] opts the optional parameters
     # @return [Pet]
     def get_pet_by_id(pet_id, opts = {})
@@ -240,7 +240,7 @@ module Petstore
 
     # Find pet by ID
     # Returns a single pet
-    # @param pet_id ID of pet to return
+    # @param pet_id [Integer] ID of pet to return
     # @param [Hash] opts the optional parameters
     # @return [Array<(Pet, Fixnum, Hash)>] Pet data, response status code and response headers
     def get_pet_by_id_with_http_info(pet_id, opts = {})
@@ -282,7 +282,7 @@ module Petstore
     end
 
     # Update an existing pet
-    # @param pet Pet object that needs to be added to the store
+    # @param pet [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def update_pet(pet, opts = {})
@@ -291,7 +291,7 @@ module Petstore
     end
 
     # Update an existing pet
-    # @param pet Pet object that needs to be added to the store
+    # @param pet [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_pet_with_http_info(pet, opts = {})
@@ -332,7 +332,7 @@ module Petstore
     end
 
     # Updates a pet in the store with form data
-    # @param pet_id ID of pet that needs to be updated
+    # @param pet_id [Integer] ID of pet that needs to be updated
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
@@ -343,7 +343,7 @@ module Petstore
     end
 
     # Updates a pet in the store with form data
-    # @param pet_id ID of pet that needs to be updated
+    # @param pet_id [Integer] ID of pet that needs to be updated
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
@@ -388,7 +388,7 @@ module Petstore
     end
 
     # uploads an image
-    # @param pet_id ID of pet to update
+    # @param pet_id [Integer] ID of pet to update
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
@@ -399,7 +399,7 @@ module Petstore
     end
 
     # uploads an image
-    # @param pet_id ID of pet to update
+    # @param pet_id [Integer] ID of pet to update
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
@@ -447,8 +447,8 @@ module Petstore
     end
 
     # uploads an image (required)
-    # @param pet_id ID of pet to update
-    # @param required_file file to upload
+    # @param pet_id [Integer] ID of pet to update
+    # @param required_file [File] file to upload
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @return [ApiResponse]
@@ -458,8 +458,8 @@ module Petstore
     end
 
     # uploads an image (required)
-    # @param pet_id ID of pet to update
-    # @param required_file file to upload
+    # @param pet_id [Integer] ID of pet to update
+    # @param required_file [File] file to upload
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @return [Array<(ApiResponse, Fixnum, Hash)>] ApiResponse data, response status code and response headers

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # Delete purchase order by ID
     # For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-    # @param order_id ID of the order that needs to be deleted
+    # @param order_id [String] ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def delete_order(order_id, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # Delete purchase order by ID
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
-    # @param order_id ID of the order that needs to be deleted
+    # @param order_id [String] ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_order_with_http_info(order_id, opts = {})
@@ -118,7 +118,7 @@ module Petstore
 
     # Find purchase order by ID
     # For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-    # @param order_id ID of pet that needs to be fetched
+    # @param order_id [Integer] ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [Order]
     def get_order_by_id(order_id, opts = {})
@@ -128,7 +128,7 @@ module Petstore
 
     # Find purchase order by ID
     # For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
-    # @param order_id ID of pet that needs to be fetched
+    # @param order_id [Integer] ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
     # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def get_order_by_id_with_http_info(order_id, opts = {})
@@ -178,7 +178,7 @@ module Petstore
     end
 
     # Place an order for a pet
-    # @param order order placed for purchasing the pet
+    # @param order [Order] order placed for purchasing the pet
     # @param [Hash] opts the optional parameters
     # @return [Order]
     def place_order(order, opts = {})
@@ -187,7 +187,7 @@ module Petstore
     end
 
     # Place an order for a pet
-    # @param order order placed for purchasing the pet
+    # @param order [Order] order placed for purchasing the pet
     # @param [Hash] opts the optional parameters
     # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
     def place_order_with_http_info(order, opts = {})

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -21,7 +21,7 @@ module Petstore
     end
     # Create user
     # This can only be done by the logged in user.
-    # @param user Created user object
+    # @param user [User] Created user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_user(user, opts = {})
@@ -31,7 +31,7 @@ module Petstore
 
     # Create user
     # This can only be done by the logged in user.
-    # @param user Created user object
+    # @param user [User] Created user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_user_with_http_info(user, opts = {})
@@ -72,7 +72,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param user List of user object
+    # @param user [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_users_with_array_input(user, opts = {})
@@ -81,7 +81,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param user List of user object
+    # @param user [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_array_input_with_http_info(user, opts = {})
@@ -122,7 +122,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param user List of user object
+    # @param user [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def create_users_with_list_input(user, opts = {})
@@ -131,7 +131,7 @@ module Petstore
     end
 
     # Creates list of users with given input array
-    # @param user List of user object
+    # @param user [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def create_users_with_list_input_with_http_info(user, opts = {})
@@ -173,7 +173,7 @@ module Petstore
 
     # Delete user
     # This can only be done by the logged in user.
-    # @param username The name that needs to be deleted
+    # @param username [String] The name that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def delete_user(username, opts = {})
@@ -183,7 +183,7 @@ module Petstore
 
     # Delete user
     # This can only be done by the logged in user.
-    # @param username The name that needs to be deleted
+    # @param username [String] The name that needs to be deleted
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def delete_user_with_http_info(username, opts = {})
@@ -222,7 +222,7 @@ module Petstore
     end
 
     # Get user by user name
-    # @param username The name that needs to be fetched. Use user1 for testing.
+    # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
     # @return [User]
     def get_user_by_name(username, opts = {})
@@ -231,7 +231,7 @@ module Petstore
     end
 
     # Get user by user name
-    # @param username The name that needs to be fetched. Use user1 for testing.
+    # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
     # @return [Array<(User, Fixnum, Hash)>] User data, response status code and response headers
     def get_user_by_name_with_http_info(username, opts = {})
@@ -273,8 +273,8 @@ module Petstore
     end
 
     # Logs user into the system
-    # @param username The user name for login
-    # @param password The password for login in clear text
+    # @param username [String] The user name for login
+    # @param password [String] The password for login in clear text
     # @param [Hash] opts the optional parameters
     # @return [String]
     def login_user(username, password, opts = {})
@@ -283,8 +283,8 @@ module Petstore
     end
 
     # Logs user into the system
-    # @param username The user name for login
-    # @param password The password for login in clear text
+    # @param username [String] The user name for login
+    # @param password [String] The password for login in clear text
     # @param [Hash] opts the optional parameters
     # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
     def login_user_with_http_info(username, password, opts = {})
@@ -375,8 +375,8 @@ module Petstore
 
     # Updated user
     # This can only be done by the logged in user.
-    # @param username name that need to be deleted
-    # @param user Updated user object
+    # @param username [String] name that need to be deleted
+    # @param user [User] Updated user object
     # @param [Hash] opts the optional parameters
     # @return [nil]
     def update_user(username, user, opts = {})
@@ -386,8 +386,8 @@ module Petstore
 
     # Updated user
     # This can only be done by the logged in user.
-    # @param username name that need to be deleted
-    # @param user Updated user object
+    # @param username [String] name that need to be deleted
+    # @param user [User] Updated user object
     # @param [Hash] opts the optional parameters
     # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
     def update_user_with_http_info(username, user, opts = {})


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)



YARD supports parameter type tag.
https://www.rubydoc.info/gems/yard/file/docs/Tags.md#param

We can use `dataType` as parameter type.
So it's very useful to output `dataType`.



(details of the change, additional tests that have been done, reference to the issue for tracking, etc)