### PR TITLE
Add .travis.yml and Gemfile.lock to ruby security test folder

### DIFF
--- a/samples/client/petstore-security-test/ruby/.travis.yml
+++ b/samples/client/petstore-security-test/ruby/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.3
+  - 2.4
+  - 2.5
+script:
+  - bundle install --path vendor/bundle
+  - bundle exec rspec
+  - gem build petstore.gemspec
+  - gem install ./petstore-1.0.0.gem

--- a/samples/client/petstore-security-test/ruby/Gemfile.lock
+++ b/samples/client/petstore-security-test/ruby/Gemfile.lock
@@ -1,0 +1,79 @@
+PATH
+  remote: .
+  specs:
+    petstore (1.0.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ZenTest (4.11.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    autotest (4.4.6)
+      ZenTest (>= 4.4.1)
+    autotest-fsevent (0.2.14)
+      sys-uname
+    autotest-growl (0.2.16)
+    autotest-rails-pure (4.1.2)
+    byebug (10.0.2)
+    coderay (1.1.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
+    ffi (1.9.25)
+    hashdiff (0.3.7)
+    json (2.1.0)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    public_suffix (3.0.3)
+    rake (12.0.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    safe_yaml (1.0.4)
+    sys-uname (1.0.3)
+      ffi (>= 1.0.0)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
+    vcr (3.0.3)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  autotest (~> 4.4, >= 4.4.6)
+  autotest-fsevent (~> 0.2, >= 0.2.12)
+  autotest-growl (~> 0.2, >= 0.2.16)
+  autotest-rails-pure (~> 4.1, >= 4.1.2)
+  petstore!
+  pry-byebug
+  rake (~> 12.0.0)
+  rspec (~> 3.6, >= 3.6.0)
+  vcr (~> 3.0, >= 3.0.1)
+  webmock (~> 1.24, >= 1.24.3)
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)


When we run `./bin/security/ruby-client-petstore.sh`, we got changes.
I think someone fogot to commit it.