### PR TITLE
[typescript-rxjs] drop unneeded function wrapping 

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -37,7 +37,7 @@ export class {{classname}} extends BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    {{nickname}}Raw({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    private {{nickname}}Raw({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#allParams}}
         {{#required}}
         if (requestParameters.{{paramName}} === null || requestParameters.{{paramName}} === undefined) {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -37,7 +37,7 @@ export class {{classname}} extends BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    private {{nickname}}Raw({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    {{nickname}}Raw({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#allParams}}
         {{#required}}
         if (requestParameters.{{paramName}} === null || requestParameters.{{paramName}} === undefined) {
@@ -184,18 +184,6 @@ export class {{classname}} extends BaseAPI {
             body: formData,
             {{/hasFormParams}}
         });
-    }
-
-    /**
-     {{#notes}}
-     * {{&notes}}
-     {{/notes}}
-     {{#summary}}
-     * {{&summary}}
-     {{/summary}}
-     */
-    {{nickname}}({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
-        return this.{{nickname}}Raw({{#allParams.0}}requestParameters{{/allParams.0}});
     }
 
     {{/operation}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -37,7 +37,7 @@ export class {{classname}} extends BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    {{nickname}}Raw({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    {{nickname}}({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#allParams}}
         {{#required}}
         if (requestParameters.{{paramName}} === null || requestParameters.{{paramName}} === undefined) {

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -102,7 +102,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -185,7 +185,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -227,7 +227,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -259,7 +259,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -298,7 +298,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -344,7 +344,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -93,16 +93,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Add a new pet to the store
-     */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        return this.addPetRaw(requestParameters);
-    }
-
-    /**
      * Deletes a pet
      */
-    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -133,17 +126,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Deletes a pet
-     */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        return this.deletePetRaw(requestParameters);
-    }
-
-    /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -174,18 +160,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple status values can be provided with comma separated strings
-     * Finds Pets by status
-     */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        return this.findPetsByStatusRaw(requestParameters);
-    }
-
-    /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -216,18 +194,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-     * Finds Pets by tags
-     */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        return this.findPetsByTagsRaw(requestParameters);
-    }
-
-    /**
      * Returns a single pet
      * Find pet by ID
      */
-    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -249,17 +219,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Returns a single pet
-     * Find pet by ID
-     */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        return this.getPetByIdRaw(requestParameters);
-    }
-
-    /**
      * Update an existing pet
      */
-    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -289,16 +251,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Update an existing pet
-     */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        return this.updatePetRaw(requestParameters);
-    }
-
-    /**
      * Updates a pet in the store with form data
      */
-    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -335,16 +290,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Updates a pet in the store with form data
-     */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        return this.updatePetWithFormRaw(requestParameters);
-    }
-
-    /**
      * uploads an image
      */
-    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -378,13 +326,6 @@ export class PetApi extends BaseAPI {
             query: queryParameters,
             body: formData,
         });
-    }
-
-    /**
-     * uploads an image
-     */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        return this.uploadFileRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPet(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -95,7 +95,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePet(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -129,7 +129,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -163,7 +163,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -197,7 +197,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -221,7 +221,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -253,7 +253,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -292,7 +292,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -67,7 +67,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -96,7 +96,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -124,7 +124,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -56,18 +56,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-     * Delete purchase order by ID
-     */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        return this.deleteOrderRaw(requestParameters);
-    }
-
-    /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -85,18 +77,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * Returns a map of status codes to quantities
-     * Returns pet inventories by status
-     */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        return this.getInventoryRaw();
-    }
-
-    /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -114,17 +98,9 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     * Find purchase order by ID
-     */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        return this.getOrderByIdRaw(requestParameters);
-    }
-
-    /**
      * Place an order for a pet
      */
-    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -142,13 +118,6 @@ export class StoreApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * Place an order for a pet
-     */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        return this.placeOrderRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -59,7 +59,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventory(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -100,7 +100,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -87,7 +87,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -117,7 +117,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -176,7 +176,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -203,7 +203,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -242,7 +242,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    private logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -266,7 +266,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -77,17 +77,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Create user
-     */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        return this.createUserRaw(requestParameters);
-    }
-
-    /**
      * Creates list of users with given input array
      */
-    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -110,14 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        return this.createUsersWithArrayInputRaw(requestParameters);
-    }
-
-    /**
-     * Creates list of users with given input array
-     */
-    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -138,17 +123,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Creates list of users with given input array
-     */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        return this.createUsersWithListInputRaw(requestParameters);
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -166,17 +144,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Delete user
-     */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        return this.deleteUserRaw(requestParameters);
-    }
-
-    /**
      * Get user by user name
      */
-    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -194,16 +164,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Get user by user name
-     */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        return this.getUserByNameRaw(requestParameters);
-    }
-
-    /**
      * Logs user into the system
      */
-    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -233,16 +196,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs user into the system
-     */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        return this.loginUserRaw(requestParameters);
-    }
-
-    /**
      * Logs out current logged in user session
      */
-    private logoutUserRaw(): Observable<void> {
+    logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -256,17 +212,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs out current logged in user session
-     */
-    logoutUser(): Observable<void> {
-        return this.logoutUserRaw();
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -288,14 +237,6 @@ export class UserApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * This can only be done by the logged in user.
-     * Updated user
-     */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        return this.updateUserRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUser(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -79,7 +79,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -102,7 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -126,7 +126,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -146,7 +146,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -166,7 +166,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUser(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -198,7 +198,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    logoutUser(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -215,7 +215,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -102,7 +102,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -185,7 +185,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -227,7 +227,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -259,7 +259,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -298,7 +298,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -344,7 +344,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -93,16 +93,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Add a new pet to the store
-     */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        return this.addPetRaw(requestParameters);
-    }
-
-    /**
      * Deletes a pet
      */
-    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -133,17 +126,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Deletes a pet
-     */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        return this.deletePetRaw(requestParameters);
-    }
-
-    /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -174,18 +160,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple status values can be provided with comma separated strings
-     * Finds Pets by status
-     */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        return this.findPetsByStatusRaw(requestParameters);
-    }
-
-    /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -216,18 +194,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-     * Finds Pets by tags
-     */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        return this.findPetsByTagsRaw(requestParameters);
-    }
-
-    /**
      * Returns a single pet
      * Find pet by ID
      */
-    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -249,17 +219,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Returns a single pet
-     * Find pet by ID
-     */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        return this.getPetByIdRaw(requestParameters);
-    }
-
-    /**
      * Update an existing pet
      */
-    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -289,16 +251,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Update an existing pet
-     */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        return this.updatePetRaw(requestParameters);
-    }
-
-    /**
      * Updates a pet in the store with form data
      */
-    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -335,16 +290,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Updates a pet in the store with form data
-     */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        return this.updatePetWithFormRaw(requestParameters);
-    }
-
-    /**
      * uploads an image
      */
-    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -378,13 +326,6 @@ export class PetApi extends BaseAPI {
             query: queryParameters,
             body: formData,
         });
-    }
-
-    /**
-     * uploads an image
-     */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        return this.uploadFileRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPet(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -95,7 +95,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePet(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -129,7 +129,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -163,7 +163,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -197,7 +197,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -221,7 +221,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -253,7 +253,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -292,7 +292,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -67,7 +67,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -96,7 +96,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -124,7 +124,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -56,18 +56,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-     * Delete purchase order by ID
-     */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        return this.deleteOrderRaw(requestParameters);
-    }
-
-    /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -85,18 +77,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * Returns a map of status codes to quantities
-     * Returns pet inventories by status
-     */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        return this.getInventoryRaw();
-    }
-
-    /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -114,17 +98,9 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     * Find purchase order by ID
-     */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        return this.getOrderByIdRaw(requestParameters);
-    }
-
-    /**
      * Place an order for a pet
      */
-    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -142,13 +118,6 @@ export class StoreApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * Place an order for a pet
-     */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        return this.placeOrderRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -59,7 +59,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventory(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -100,7 +100,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -87,7 +87,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -117,7 +117,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -176,7 +176,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -203,7 +203,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -242,7 +242,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    private logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -266,7 +266,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -77,17 +77,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Create user
-     */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        return this.createUserRaw(requestParameters);
-    }
-
-    /**
      * Creates list of users with given input array
      */
-    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -110,14 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        return this.createUsersWithArrayInputRaw(requestParameters);
-    }
-
-    /**
-     * Creates list of users with given input array
-     */
-    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -138,17 +123,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Creates list of users with given input array
-     */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        return this.createUsersWithListInputRaw(requestParameters);
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -166,17 +144,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Delete user
-     */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        return this.deleteUserRaw(requestParameters);
-    }
-
-    /**
      * Get user by user name
      */
-    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -194,16 +164,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Get user by user name
-     */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        return this.getUserByNameRaw(requestParameters);
-    }
-
-    /**
      * Logs user into the system
      */
-    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -233,16 +196,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs user into the system
-     */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        return this.loginUserRaw(requestParameters);
-    }
-
-    /**
      * Logs out current logged in user session
      */
-    private logoutUserRaw(): Observable<void> {
+    logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -256,17 +212,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs out current logged in user session
-     */
-    logoutUser(): Observable<void> {
-        return this.logoutUserRaw();
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -288,14 +237,6 @@ export class UserApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * This can only be done by the logged in user.
-     * Updated user
-     */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        return this.updateUserRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUser(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -79,7 +79,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -102,7 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -126,7 +126,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -146,7 +146,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -166,7 +166,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUser(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -198,7 +198,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    logoutUser(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -215,7 +215,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -102,7 +102,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -185,7 +185,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -227,7 +227,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -259,7 +259,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -298,7 +298,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -344,7 +344,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -93,16 +93,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Add a new pet to the store
-     */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        return this.addPetRaw(requestParameters);
-    }
-
-    /**
      * Deletes a pet
      */
-    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -133,17 +126,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Deletes a pet
-     */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        return this.deletePetRaw(requestParameters);
-    }
-
-    /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -174,18 +160,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple status values can be provided with comma separated strings
-     * Finds Pets by status
-     */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        return this.findPetsByStatusRaw(requestParameters);
-    }
-
-    /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -216,18 +194,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-     * Finds Pets by tags
-     */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        return this.findPetsByTagsRaw(requestParameters);
-    }
-
-    /**
      * Returns a single pet
      * Find pet by ID
      */
-    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -249,17 +219,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Returns a single pet
-     * Find pet by ID
-     */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        return this.getPetByIdRaw(requestParameters);
-    }
-
-    /**
      * Update an existing pet
      */
-    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -289,16 +251,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Update an existing pet
-     */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        return this.updatePetRaw(requestParameters);
-    }
-
-    /**
      * Updates a pet in the store with form data
      */
-    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -335,16 +290,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Updates a pet in the store with form data
-     */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        return this.updatePetWithFormRaw(requestParameters);
-    }
-
-    /**
      * uploads an image
      */
-    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -378,13 +326,6 @@ export class PetApi extends BaseAPI {
             query: queryParameters,
             body: formData,
         });
-    }
-
-    /**
-     * uploads an image
-     */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        return this.uploadFileRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPet(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -95,7 +95,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePet(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -129,7 +129,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -163,7 +163,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -197,7 +197,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -221,7 +221,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -253,7 +253,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -292,7 +292,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -67,7 +67,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -96,7 +96,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -124,7 +124,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -56,18 +56,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-     * Delete purchase order by ID
-     */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        return this.deleteOrderRaw(requestParameters);
-    }
-
-    /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -85,18 +77,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * Returns a map of status codes to quantities
-     * Returns pet inventories by status
-     */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        return this.getInventoryRaw();
-    }
-
-    /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -114,17 +98,9 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     * Find purchase order by ID
-     */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        return this.getOrderByIdRaw(requestParameters);
-    }
-
-    /**
      * Place an order for a pet
      */
-    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -142,13 +118,6 @@ export class StoreApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * Place an order for a pet
-     */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        return this.placeOrderRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -59,7 +59,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventory(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -100,7 +100,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -87,7 +87,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -117,7 +117,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -176,7 +176,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -203,7 +203,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -242,7 +242,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    private logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -266,7 +266,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -77,17 +77,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Create user
-     */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        return this.createUserRaw(requestParameters);
-    }
-
-    /**
      * Creates list of users with given input array
      */
-    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -110,14 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        return this.createUsersWithArrayInputRaw(requestParameters);
-    }
-
-    /**
-     * Creates list of users with given input array
-     */
-    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -138,17 +123,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Creates list of users with given input array
-     */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        return this.createUsersWithListInputRaw(requestParameters);
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -166,17 +144,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Delete user
-     */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        return this.deleteUserRaw(requestParameters);
-    }
-
-    /**
      * Get user by user name
      */
-    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -194,16 +164,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Get user by user name
-     */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        return this.getUserByNameRaw(requestParameters);
-    }
-
-    /**
      * Logs user into the system
      */
-    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -233,16 +196,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs user into the system
-     */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        return this.loginUserRaw(requestParameters);
-    }
-
-    /**
      * Logs out current logged in user session
      */
-    private logoutUserRaw(): Observable<void> {
+    logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -256,17 +212,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs out current logged in user session
-     */
-    logoutUser(): Observable<void> {
-        return this.logoutUserRaw();
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -288,14 +237,6 @@ export class UserApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * This can only be done by the logged in user.
-     * Updated user
-     */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        return this.updateUserRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUser(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -79,7 +79,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -102,7 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -126,7 +126,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -146,7 +146,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -166,7 +166,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUser(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -198,7 +198,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    logoutUser(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -215,7 +215,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -102,7 +102,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -185,7 +185,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -227,7 +227,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -259,7 +259,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -298,7 +298,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -344,7 +344,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    private addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -93,16 +93,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Add a new pet to the store
-     */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        return this.addPetRaw(requestParameters);
-    }
-
-    /**
      * Deletes a pet
      */
-    private deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -133,17 +126,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Deletes a pet
-     */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        return this.deletePetRaw(requestParameters);
-    }
-
-    /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    private findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -174,18 +160,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple status values can be provided with comma separated strings
-     * Finds Pets by status
-     */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        return this.findPetsByStatusRaw(requestParameters);
-    }
-
-    /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    private findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -216,18 +194,10 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-     * Finds Pets by tags
-     */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        return this.findPetsByTagsRaw(requestParameters);
-    }
-
-    /**
      * Returns a single pet
      * Find pet by ID
      */
-    private getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -249,17 +219,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Returns a single pet
-     * Find pet by ID
-     */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        return this.getPetByIdRaw(requestParameters);
-    }
-
-    /**
      * Update an existing pet
      */
-    private updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -289,16 +251,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Update an existing pet
-     */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        return this.updatePetRaw(requestParameters);
-    }
-
-    /**
      * Updates a pet in the store with form data
      */
-    private updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -335,16 +290,9 @@ export class PetApi extends BaseAPI {
     }
 
     /**
-     * Updates a pet in the store with form data
-     */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        return this.updatePetWithFormRaw(requestParameters);
-    }
-
-    /**
      * uploads an image
      */
-    private uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -378,13 +326,6 @@ export class PetApi extends BaseAPI {
             query: queryParameters,
             body: formData,
         });
-    }
-
-    /**
-     * uploads an image
-     */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        return this.uploadFileRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -63,7 +63,7 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPetRaw(requestParameters: AddPetRequest): Observable<void> {
+    addPet(requestParameters: AddPetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -95,7 +95,7 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePetRaw(requestParameters: DeletePetRequest): Observable<void> {
+    deletePet(requestParameters: DeletePetRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -129,7 +129,7 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
+    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -163,7 +163,7 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
+    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -197,7 +197,7 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetByIdRaw(requestParameters: GetPetByIdRequest): Observable<Pet> {
+    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -221,7 +221,7 @@ export class PetApi extends BaseAPI {
     /**
      * Update an existing pet
      */
-    updatePetRaw(requestParameters: UpdatePetRequest): Observable<void> {
+    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -253,7 +253,7 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Observable<void> {
+    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -292,7 +292,7 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFileRaw(requestParameters: UploadFileRequest): Observable<ApiResponse> {
+    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -67,7 +67,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -96,7 +96,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -124,7 +124,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    private deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -56,18 +56,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
-     * Delete purchase order by ID
-     */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        return this.deleteOrderRaw(requestParameters);
-    }
-
-    /**
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    private getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventoryRaw(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -85,18 +77,10 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * Returns a map of status codes to quantities
-     * Returns pet inventories by status
-     */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        return this.getInventoryRaw();
-    }
-
-    /**
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    private getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -114,17 +98,9 @@ export class StoreApi extends BaseAPI {
     }
 
     /**
-     * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
-     * Find purchase order by ID
-     */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        return this.getOrderByIdRaw(requestParameters);
-    }
-
-    /**
      * Place an order for a pet
      */
-    private placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -142,13 +118,6 @@ export class StoreApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * Place an order for a pet
-     */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        return this.placeOrderRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -38,7 +38,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrderRaw(requestParameters: DeleteOrderRequest): Observable<void> {
+    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -59,7 +59,7 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventoryRaw(): Observable<{ [key: string]: number; }> {
+    getInventory(): Observable<{ [key: string]: number; }> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -80,7 +80,7 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Observable<Order> {
+    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -100,7 +100,7 @@ export class StoreApi extends BaseAPI {
     /**
      * Place an order for a pet
      */
-    placeOrderRaw(requestParameters: PlaceOrderRequest): Observable<Order> {
+    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -87,7 +87,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -117,7 +117,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -176,7 +176,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -203,7 +203,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -242,7 +242,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    private logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -266,7 +266,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    private createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -77,17 +77,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Create user
-     */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        return this.createUserRaw(requestParameters);
-    }
-
-    /**
      * Creates list of users with given input array
      */
-    private createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -110,14 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        return this.createUsersWithArrayInputRaw(requestParameters);
-    }
-
-    /**
-     * Creates list of users with given input array
-     */
-    private createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -138,17 +123,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Creates list of users with given input array
-     */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        return this.createUsersWithListInputRaw(requestParameters);
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Delete user
      */
-    private deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -166,17 +144,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * This can only be done by the logged in user.
-     * Delete user
-     */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        return this.deleteUserRaw(requestParameters);
-    }
-
-    /**
      * Get user by user name
      */
-    private getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -194,16 +164,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Get user by user name
-     */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        return this.getUserByNameRaw(requestParameters);
-    }
-
-    /**
      * Logs user into the system
      */
-    private loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -233,16 +196,9 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs user into the system
-     */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        return this.loginUserRaw(requestParameters);
-    }
-
-    /**
      * Logs out current logged in user session
      */
-    private logoutUserRaw(): Observable<void> {
+    logoutUserRaw(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -256,17 +212,10 @@ export class UserApi extends BaseAPI {
     }
 
     /**
-     * Logs out current logged in user session
-     */
-    logoutUser(): Observable<void> {
-        return this.logoutUserRaw();
-    }
-
-    /**
      * This can only be done by the logged in user.
      * Updated user
      */
-    private updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -288,14 +237,6 @@ export class UserApi extends BaseAPI {
             query: queryParameters,
             body: requestParameters.body,
         });
-    }
-
-    /**
-     * This can only be done by the logged in user.
-     * Updated user
-     */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        return this.updateUserRaw(requestParameters);
     }
 
 }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -56,7 +56,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUserRaw(requestParameters: CreateUserRequest): Observable<void> {
+    createUser(requestParameters: CreateUserRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -79,7 +79,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
+    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -102,7 +102,7 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
+    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -126,7 +126,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUserRaw(requestParameters: DeleteUserRequest): Observable<void> {
+    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -146,7 +146,7 @@ export class UserApi extends BaseAPI {
     /**
      * Get user by user name
      */
-    getUserByNameRaw(requestParameters: GetUserByNameRequest): Observable<User> {
+    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -166,7 +166,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs user into the system
      */
-    loginUserRaw(requestParameters: LoginUserRequest): Observable<string> {
+    loginUser(requestParameters: LoginUserRequest): Observable<string> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -198,7 +198,7 @@ export class UserApi extends BaseAPI {
     /**
      * Logs out current logged in user session
      */
-    logoutUserRaw(): Observable<void> {
+    logoutUser(): Observable<void> {
         const queryParameters: HttpQuery = {};
 
         const headerParameters: HttpHeaders = {};
@@ -215,7 +215,7 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUserRaw(requestParameters: UpdateUserRequest): Observable<void> {
+    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This PR removes unneeded wrapping functions within api controllers.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)