### PR TITLE
[Elixir] Allow Elixir deserialization whenever the response is success

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/request_builder.ex.mustache
@@ -116,11 +116,25 @@ defmodule {{moduleName}}.RequestBuilder do
   {:error, term} on failure
   """
   @spec decode(Tesla.Env.t | term()) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
-  def decode(%Tesla.Env{status: 200, body: body}), do: Poison.decode(body)
+  def decode(%Tesla.Env{status: status, body: body}) when is_success(status), do: Poison.decode(body)
   def decode(response), do: {:error, response}
 
   @spec decode(Tesla.Env.t | term(), :false | struct() | [struct()]) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
-  def decode(%Tesla.Env{status: 200} = env, false), do: {:ok, env}
-  def decode(%Tesla.Env{status: 200, body: body}, struct), do: Poison.decode(body, as: struct)
+  def decode(%Tesla.Env{status: status} = env, false) when is_success(status), do: {:ok, env}
+  def decode(%Tesla.Env{status: status, body: body}, struct) when is_success(status), do: Poison.decode(body, as: struct)
   def decode(response, _struct), do: {:error, response}
+
+  @doc """
+  Macro to check if the status code of the response is [succesful](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success).
+
+  ## Parameters
+
+  - status_code (integer) - The status code
+
+  ## Returns
+
+  `true` when status code is 2xx
+  """
+  @spec is_success(integer()) :: boolean()
+  defmacrop is_success(status), do: status >= 200 and status < 300
 end

--- a/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/request_builder.ex
@@ -119,11 +119,25 @@ defmodule OpenapiPetstore.RequestBuilder do
   {:error, term} on failure
   """
   @spec decode(Tesla.Env.t | term()) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
-  def decode(%Tesla.Env{status: 200, body: body}), do: Poison.decode(body)
+  def decode(%Tesla.Env{status: status, body: body}) when is_success(status), do: Poison.decode(body)
   def decode(response), do: {:error, response}
 
   @spec decode(Tesla.Env.t | term(), :false | struct() | [struct()]) :: {:ok, struct()} | {:error, Tesla.Env.t} | {:error, term()}
-  def decode(%Tesla.Env{status: 200} = env, false), do: {:ok, env}
-  def decode(%Tesla.Env{status: 200, body: body}, struct), do: Poison.decode(body, as: struct)
+  def decode(%Tesla.Env{status: status} = env, false) when is_success(status), do: {:ok, env}
+  def decode(%Tesla.Env{status: status, body: body}, struct) when is_success(status), do: Poison.decode(body, as: struct)
   def decode(response, _struct), do: {:error, response}
+
+  @doc """
+  Macro to check if the status code of the response is [succesful](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success).
+
+  ## Parameters
+
+  - status_code (integer) - The status code
+
+  ## Returns
+
+  `true` when status code is 2xx
+  """
+  @spec is_success(integer()) :: boolean()
+  defmacrop is_success(status), do: status >= 200 and status < 300
 end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
 - Define macro that return true when response is success (Status Code 2xx)
 - Guard functions that are hardcoded to status 200

closes #2334 
cc @mrmstn
