### PR TITLE
[haskell-http-client] compare rendered form in PropMime

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/tests/PropMime.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/tests/PropMime.mustache
@@ -32,14 +32,14 @@ type Arbitrary' a = (Arbitrary a, Show a, Typeable a)
 propMime
   :: forall a b mime.
      (ArbitraryMime mime a, Testable b)
-  => String -> (a -> a -> b) -> mime -> Proxy a -> Spec
+  => String -> (BL8.ByteString -> BL8.ByteString -> b) -> mime -> Proxy a -> Spec
 propMime eqDescr eq m _ =
   prop
     (show (typeOf (undefined :: a)) <> " " <> show (typeOf (undefined :: mime)) <> " roundtrip " <> eqDescr) $
   \(x :: a) ->
      let rendered = mimeRender' m x
-         actual = mimeUnrender' m rendered
-         expected = Right x
+         actual = fmap (mimeRender' m) (mimeUnrender' m rendered :: Either String a)
+         expected = Right rendered
          failMsg =
            "ACTUAL: " <> show actual <> "\nRENDERED: " <> BL8.unpack rendered
      in counterexample failMsg $

--- a/samples/client/petstore/haskell-http-client/tests/PropMime.hs
+++ b/samples/client/petstore/haskell-http-client/tests/PropMime.hs
@@ -32,14 +32,14 @@ type Arbitrary' a = (Arbitrary a, Show a, Typeable a)
 propMime
   :: forall a b mime.
      (ArbitraryMime mime a, Testable b)
-  => String -> (a -> a -> b) -> mime -> Proxy a -> Spec
+  => String -> (BL8.ByteString -> BL8.ByteString -> b) -> mime -> Proxy a -> Spec
 propMime eqDescr eq m _ =
   prop
     (show (typeOf (undefined :: a)) <> " " <> show (typeOf (undefined :: mime)) <> " roundtrip " <> eqDescr) $
   \(x :: a) ->
      let rendered = mimeRender' m x
-         actual = mimeUnrender' m rendered
-         expected = Right x
+         actual = fmap (mimeRender' m) (mimeUnrender' m rendered :: Either String a)
+         expected = Right rendered
          failMsg =
            "ACTUAL: " <> show actual <> "\nRENDERED: " <> BL8.unpack rendered
      in counterexample failMsg $


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

It is known that `fromJson` and `toJson` for `Maybe` are not the inverse of each other: https://github.com/bos/aeson/issues/376. It causes failures in the PropMime tests.

```
> encode (Just Null)
"null"
> encode (Nothing :: Maybe Value)
"null"
> > decode "null" :: Maybe Value
Just Null
```

Changing the PropMime tests to compared the rendered form instead.

@jonschoning, what do you think?