### PR TITLE
[scala-httpclient] mark the generator as deprecated

### DIFF
--- a/bin/scala-httpclient-petstore.sh
+++ b/bin/scala-httpclient-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/scala-httpclient -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-httpclient -o samples/client/petstore/scala-httpclient $@"
+ags="generate -t modules/openapi-generator/src/main/resources/scala-httpclient -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-httpclient-deprecated -o samples/client/petstore/scala-httpclient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/scala-httpclient-petstore.bat
+++ b/bin/windows/scala-httpclient-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g scala-httpclient -o samples\client\petstore\scala-httpclient
+set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g scala-httpclient-deprecated -o samples\client\petstore\scala-httpclient
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -47,7 +47,7 @@ The following generators are available:
     - [rust](generators/rust.md)
     - [scala-akka](generators/scala-akka.md)
     - [scala-gatling](generators/scala-gatling.md)
-    - [scala-httpclient](generators/scala-httpclient.md)
+    - [scala-httpclient-deprecated](generators/scala-httpclient-deprecated.md)
     - [scalaz](generators/scalaz.md)
     - [swift2-deprecated](generators/swift2-deprecated.md)
     - [swift3-deprecated](generators/swift3-deprecated.md)

--- a/docs/generators/scala-httpclient-deprecated.md
+++ b/docs/generators/scala-httpclient-deprecated.md
@@ -1,0 +1,17 @@
+
+---
+id: generator-opts-client-scala-httpclient-deprecated
+title: Config Options for scala-httpclient-deprecated
+sidebar_label: scala-httpclient-deprecated
+---
+
+| Option | Description | Values | Default |
+| ------ | ----------- | ------ | ------- |
+|sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
+|allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
+|prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
+|modelPackage|package for generated models| |null|
+|apiPackage|package for generated api classes| |null|
+|sourceFolder|source folder for generated code| |null|
+|modelPropertyNaming|Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name| |camelCase|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttpClientCodegen.java
@@ -29,6 +29,9 @@ import java.util.HashMap;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
+/*
+ * This generator has been deprecated. Please use scala-akka instead.
+ */
 public class ScalaHttpClientCodegen extends AbstractScalaCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScalaHttpClientCodegen.class);
 
@@ -131,6 +134,9 @@ public class ScalaHttpClientCodegen extends AbstractScalaCodegen implements Code
 
     @Override
     public void processOpts() {
+        LOGGER.warn("IMPORTANT: This generator (scala-http-client-deprecated) is no longer actively maintained and will be deprecated. " +
+                "PLease use 'scala-akka' generator instead.");
+
         super.processOpts();
         if (additionalProperties.containsKey(CodegenConstants.MODEL_PROPERTY_NAMING)) {
             setModelPropertyNaming((String) additionalProperties.get(CodegenConstants.MODEL_PROPERTY_NAMING));
@@ -207,7 +213,7 @@ public class ScalaHttpClientCodegen extends AbstractScalaCodegen implements Code
 
     @Override
     public String getName() {
-        return "scala-httpclient";
+        return "scala-httpclient-deprecated";
     }
 
     @Override


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Renamed `scala-httpclient` to `scala-httpclient-deprecated`. Users should switch to `scala-akka` instead.


cc @clasnake , @jimschubert @shijinkui, @ramzimaalej


