### PR TITLE
Python apikey cookie

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -523,6 +523,8 @@ class ApiClient(object):
             if auth_setting:
                 if not auth_setting['value']:
                     continue
+                elif auth_setting['in'] == 'cookie':
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -218,7 +218,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
             '{{name}}':
                 {
                     'type': 'api_key',
-                    'in': {{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},
+                    'in': {{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},
                     'key': '{{keyParamName}}',
                     'value': self.get_api_key_with_prefix('{{keyParamName}}')
                 },

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -374,6 +374,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+        - auth_cookie: []
       requestBody:
         content:
           application/json:
@@ -391,6 +393,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+        - auth_cookie: []
       requestBody:
         $ref: '#/components/requestBodies/UserArray'
   /user/createWithList:
@@ -403,6 +407,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+        - auth_cookie: []
       requestBody:
         $ref: '#/components/requestBodies/UserArray'
   /user/login:
@@ -430,6 +436,13 @@ paths:
         '200':
           description: successful operation
           headers:
+            Set-Cookie:
+              description: >-
+                Cookie authentication key for use with the `auth_cookie`
+                apiKey authentication.
+              schema:
+                type: string
+                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
             X-Rate-Limit:
               description: calls per hour allowed by the user
               schema:
@@ -459,6 +472,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+        - auth_cookie: []
   '/user/{username}':
     get:
       tags:
@@ -505,6 +520,8 @@ paths:
           description: Invalid user supplied
         '404':
           description: User not found
+      security:
+        - auth_cookie: []
       requestBody:
         content:
           application/json:
@@ -530,6 +547,8 @@ paths:
           description: Invalid username supplied
         '404':
           description: User not found
+      security:
+        - auth_cookie: []
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'
@@ -567,6 +586,10 @@ components:
       type: apiKey
       name: api_key
       in: header
+    auth_cookie:
+      type: apiKey
+      name: AUTH_KEY
+      in: cookie
   schemas:
     Order:
       title: Pet Order

--- a/samples/client/petstore-security-test/python/petstore_api/api_client.py
+++ b/samples/client/petstore-security-test/python/petstore_api/api_client.py
@@ -517,6 +517,8 @@ class ApiClient(object):
             if auth_setting:
                 if not auth_setting['value']:
                     continue
+                elif auth_setting['in'] == 'cookie':
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -516,6 +516,8 @@ class ApiClient(object):
             if auth_setting:
                 if not auth_setting['value']:
                     continue
+                elif auth_setting['in'] == 'cookie':
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -518,6 +518,8 @@ class ApiClient(object):
             if auth_setting:
                 if not auth_setting['value']:
                     continue
+                elif auth_setting['in'] == 'cookie':
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -516,6 +516,8 @@ class ApiClient(object):
             if auth_setting:
                 if not auth_setting['value']:
                     continue
+                elif auth_setting['in'] == 'cookie':
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -516,6 +516,8 @@ class ApiClient(object):
             if auth_setting:
                 if not auth_setting['value']:
                     continue
+                elif auth_setting['in'] == 'cookie':
+                    headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']
                 elif auth_setting['in'] == 'query':

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/controllers/security_controller_.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/controllers/security_controller_.py
@@ -17,6 +17,22 @@ def info_from_api_key(api_key, required_scopes):
     return {'uid': 'user_id'}
 
 
+def info_from_auth_cookie(api_key, required_scopes):
+    """
+    Check and retrieve authentication information from api_key.
+    Returned value will be passed in 'token_info' parameter of your operation function, if there is one.
+    'sub' or 'uid' will be set in 'user' parameter of your operation function, if there is one.
+
+    :param api_key API key provided by Authorization header
+    :type api_key: str
+    :param required_scopes Always None. Used for other authentication method
+    :type required_scopes: None
+    :return: Information attached to provided api_key or None if api_key is invalid or does not allow access to called API
+    :rtype: dict | None
+    """
+    return {'uid': 'user_id'}
+
+
 def info_from_petstore_auth(token):
     """
     Validate and decode token.

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/openapi/openapi.yaml
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/openapi/openapi.yaml
@@ -395,6 +395,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Create user
       tags:
       - user
@@ -407,6 +409,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Creates list of users with given input array
       tags:
       - user
@@ -419,6 +423,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Creates list of users with given input array
       tags:
       - user
@@ -455,6 +461,13 @@ paths:
                 type: string
           description: successful operation
           headers:
+            Set-Cookie:
+              description: Cookie authentication key for use with the `auth_cookie` apiKey authentication.
+              explode: false
+              schema:
+                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
+                type: string
+              style: simple
             X-Rate-Limit:
               description: calls per hour allowed by the user
               explode: false
@@ -481,6 +494,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Logs out current logged in user session
       tags:
       - user
@@ -503,6 +518,8 @@ paths:
           description: Invalid username supplied
         404:
           description: User not found
+      security:
+      - auth_cookie: []
       summary: Delete user
       tags:
       - user
@@ -560,6 +577,8 @@ paths:
           description: Invalid user supplied
         404:
           description: User not found
+      security:
+      - auth_cookie: []
       summary: Updated user
       tags:
       - user
@@ -803,3 +822,8 @@ components:
       name: api_key
       type: apiKey
       x-apikeyInfoFunc: openapi_server.controllers.security_controller_.info_from_api_key
+    auth_cookie:
+      in: cookie
+      name: AUTH_KEY
+      type: apiKey
+      x-apikeyInfoFunc: openapi_server.controllers.security_controller_.info_from_auth_cookie

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/test_user_controller.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/test_user_controller.py
@@ -30,6 +30,7 @@ class TestUserController(BaseTestCase):
 }
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user',
@@ -48,6 +49,7 @@ class TestUserController(BaseTestCase):
         user = []
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/createWithArray',
@@ -66,6 +68,7 @@ class TestUserController(BaseTestCase):
         user = []
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/createWithList',
@@ -82,6 +85,7 @@ class TestUserController(BaseTestCase):
         Delete user
         """
         headers = { 
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/{username}'.format(username='username_example'),
@@ -129,6 +133,7 @@ class TestUserController(BaseTestCase):
         Logs out current logged in user session
         """
         headers = { 
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/logout',
@@ -154,6 +159,7 @@ class TestUserController(BaseTestCase):
 }
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/{username}'.format(username='username_example'),

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/controllers/security_controller_.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/controllers/security_controller_.py
@@ -17,6 +17,22 @@ def info_from_api_key(api_key, required_scopes):
     return {'uid': 'user_id'}
 
 
+def info_from_auth_cookie(api_key, required_scopes):
+    """
+    Check and retrieve authentication information from api_key.
+    Returned value will be passed in 'token_info' parameter of your operation function, if there is one.
+    'sub' or 'uid' will be set in 'user' parameter of your operation function, if there is one.
+
+    :param api_key API key provided by Authorization header
+    :type api_key: str
+    :param required_scopes Always None. Used for other authentication method
+    :type required_scopes: None
+    :return: Information attached to provided api_key or None if api_key is invalid or does not allow access to called API
+    :rtype: dict | None
+    """
+    return {'uid': 'user_id'}
+
+
 def info_from_petstore_auth(token):
     """
     Validate and decode token.

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/openapi/openapi.yaml
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/openapi/openapi.yaml
@@ -395,6 +395,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Create user
       tags:
       - user
@@ -407,6 +409,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Creates list of users with given input array
       tags:
       - user
@@ -419,6 +423,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Creates list of users with given input array
       tags:
       - user
@@ -455,6 +461,13 @@ paths:
                 type: string
           description: successful operation
           headers:
+            Set-Cookie:
+              description: Cookie authentication key for use with the `auth_cookie` apiKey authentication.
+              explode: false
+              schema:
+                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
+                type: string
+              style: simple
             X-Rate-Limit:
               description: calls per hour allowed by the user
               explode: false
@@ -481,6 +494,8 @@ paths:
       responses:
         default:
           description: successful operation
+      security:
+      - auth_cookie: []
       summary: Logs out current logged in user session
       tags:
       - user
@@ -503,6 +518,8 @@ paths:
           description: Invalid username supplied
         404:
           description: User not found
+      security:
+      - auth_cookie: []
       summary: Delete user
       tags:
       - user
@@ -560,6 +577,8 @@ paths:
           description: Invalid user supplied
         404:
           description: User not found
+      security:
+      - auth_cookie: []
       summary: Updated user
       tags:
       - user
@@ -803,3 +822,8 @@ components:
       name: api_key
       type: apiKey
       x-apikeyInfoFunc: openapi_server.controllers.security_controller_.info_from_api_key
+    auth_cookie:
+      in: cookie
+      name: AUTH_KEY
+      type: apiKey
+      x-apikeyInfoFunc: openapi_server.controllers.security_controller_.info_from_auth_cookie

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/test/test_user_controller.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/test/test_user_controller.py
@@ -30,6 +30,7 @@ class TestUserController(BaseTestCase):
 }
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user',
@@ -48,6 +49,7 @@ class TestUserController(BaseTestCase):
         user = []
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/createWithArray',
@@ -66,6 +68,7 @@ class TestUserController(BaseTestCase):
         user = []
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/createWithList',
@@ -82,6 +85,7 @@ class TestUserController(BaseTestCase):
         Delete user
         """
         headers = { 
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/{username}'.format(username='username_example'),
@@ -129,6 +133,7 @@ class TestUserController(BaseTestCase):
         Logs out current logged in user session
         """
         headers = { 
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/logout',
@@ -154,6 +159,7 @@ class TestUserController(BaseTestCase):
 }
         headers = { 
             'Content-Type': 'application/json',
+            'auth_cookie': 'special-key',
         }
         response = self.client.open(
             '/v2/user/{username}'.format(username='username_example'),


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. -- @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess

### Description of the PR

This PR fixes the missing `APIKey` authentication based on HTTP Cookies in Python clients.
Fixes #2075

I am using this change for quite some time in our local build and it works as expected.
When we receive the `Set-Cookie` header from the OpenAPI server, we update the configuration in the `ApiClient`.

Authentication works seamless from then on. There no need to set/add the `Cookie` header ourselves anymore.

#### TODO

There are some things related to the Cookie authentication which we might include here or add as separate BUG report or PR:

- [ ] Add unit tests for cookie authentication (as suggested in https://github.com/OpenAPITools/openapi-generator/issues/2075#issuecomment-462347814)
- [ ] Create Issue report and/or PR for incorrect Python-flask unit tests regarding APIKey authentication based on HTTP Cookies.

Please advise what to do with these pending changes.