### PR TITLE
Python flask pythonic params

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-aiohttp/__init__main.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/__init__main.mustache
@@ -8,5 +8,8 @@ def main():
         }
     specification_dir = os.path.join(os.path.dirname(__file__), 'openapi')
     app = connexion.AioHttpApp(__name__, specification_dir=specification_dir, options=options)
-    app.add_api('openapi.yaml', arguments={'title': '{{appName}}'}, pass_context_arg_name='request')
+    app.add_api('openapi.yaml',
+                arguments={'title': '{{appName}}'},
+                pythonic_params=True,
+                pass_context_arg_name='request')
     app.run(port={{serverPort}})

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/conftest.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/conftest.mustache
@@ -11,7 +11,11 @@ def client(loop, aiohttp_client):
     options = {
         "swagger_ui": True
         }
-    specification_dir = os.path.join(os.path.dirname(__file__), '..', '{{packageName}}', 'openapi')
-    app = connexion.AioHttpApp(__name__, specification_dir=specification_dir, options=options)
-    app.add_api('openapi.yaml', pass_context_arg_name='request')
+    specification_dir = os.path.join(os.path.dirname(__file__), '..',
+                                     '{{packageName}}',
+                                     'openapi')
+    app = connexion.AioHttpApp(__name__, specification_dir=specification_dir,
+                               options=options)
+    app.add_api('openapi.yaml', pythonic_params=True,
+                pass_context_arg_name='request')
     return loop.run_until_complete(aiohttp_client(app.app))

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/controller_test.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/controller_test.mustache
@@ -29,7 +29,7 @@ async def test_{{operationId}}(client):
     {{paramName}} = {{{example}}}
     {{/bodyParam}}
     {{#queryParams}}
-    {{#-first}}params = [{{/-first}}{{^-first}}                {{/-first}}('{{paramName}}', {{{example}}}){{#hasMore}},{{/hasMore}}{{#-last}}]{{/-last}}
+    {{#-first}}params = [{{/-first}}{{^-first}}                {{/-first}}('{{^vendorExtensions.x-python-connexion-openapi-name}}{{paramName}}{{/vendorExtensions.x-python-connexion-openapi-name}}{{#vendorExtensions.x-python-connexion-openapi-name}}{{vendorExtensions.x-python-connexion-openapi-name}}{{/vendorExtensions.x-python-connexion-openapi-name}}', {{{example}}}){{#hasMore}},{{/hasMore}}{{#-last}}]{{/-last}}
     {{/queryParams}}
     headers = { {{#vendorExtensions.x-prefered-produce}}
         'Accept': '{{mediaType}}',{{/vendorExtensions.x-prefered-produce}}{{#vendorExtensions.x-prefered-consume}}

--- a/modules/openapi-generator/src/main/resources/python-flask/__init__test.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/__init__test.mustache
@@ -12,5 +12,5 @@ class BaseTestCase(TestCase):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../openapi/')
         app.app.json_encoder = JSONEncoder
-        app.add_api('openapi.yaml')
+        app.add_api('openapi.yaml', pythonic_params=True)
         return app.app

--- a/modules/openapi-generator/src/main/resources/python-flask/__main__.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/__main__.mustache
@@ -13,7 +13,9 @@ from {{packageName}} import encoder
 def main():
     app = connexion.App(__name__, specification_dir='./openapi/')
     app.app.json_encoder = encoder.JSONEncoder
-    app.add_api('openapi.yaml', arguments={'title': '{{appName}}'})
+    app.add_api('openapi.yaml',
+                arguments={'title': '{{appName}}'},
+                pythonic_params=True)
     app.run(port={{serverPort}})
 
 

--- a/modules/openapi-generator/src/main/resources/python-flask/controller_test.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/controller_test.mustache
@@ -27,7 +27,7 @@ class {{#operations}}Test{{classname}}(BaseTestCase):
         {{paramName}} = {{{example}}}
         {{/bodyParam}}
         {{#queryParams}}
-        {{#-first}}query_string = [{{/-first}}{{^-first}}                {{/-first}}('{{paramName}}', {{{example}}}){{#hasMore}},{{/hasMore}}{{#-last}}]{{/-last}}
+        {{#-first}}query_string = [{{/-first}}{{^-first}}                {{/-first}}('{{^vendorExtensions.x-python-connexion-openapi-name}}{{paramName}}{{/vendorExtensions.x-python-connexion-openapi-name}}{{#vendorExtensions.x-python-connexion-openapi-name}}{{vendorExtensions.x-python-connexion-openapi-name}}{{/vendorExtensions.x-python-connexion-openapi-name}}', {{{example}}}){{#hasMore}},{{/hasMore}}{{#-last}}]{{/-last}}
         {{/queryParams}}
         headers = { {{#vendorExtensions.x-prefered-produce}}
             'Accept': '{{mediaType}}',{{/vendorExtensions.x-prefered-produce}}{{#vendorExtensions.x-prefered-consume}}

--- a/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore.yaml
@@ -116,6 +116,13 @@ paths:
             type: array
             items:
               type: string
+        - name: maxCount
+          in: query
+          description: Maximum number of items to return
+          required: false
+          schema:
+            type: integer
+            format: int32
       responses:
         '200':
           description: successful operation

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/__main__.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/__main__.py
@@ -8,7 +8,9 @@ from openapi_server import encoder
 def main():
     app = connexion.App(__name__, specification_dir='./openapi/')
     app.app.json_encoder = encoder.JSONEncoder
-    app.add_api('openapi.yaml', arguments={'title': 'OpenAPI Petstore'})
+    app.add_api('openapi.yaml',
+                arguments={'title': 'OpenAPI Petstore'},
+                pythonic_params=True)
     app.run(port=8080)
 
 

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/controllers/pet_controller.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/controllers/pet_controller.py
@@ -49,13 +49,15 @@ def find_pets_by_status(status):  # noqa: E501
     return 'do some magic!'
 
 
-def find_pets_by_tags(tags):  # noqa: E501
+def find_pets_by_tags(tags, max_count=None):  # noqa: E501
     """Finds Pets by tags
 
     Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing. # noqa: E501
 
     :param tags: Tags to filter by
     :type tags: List[str]
+    :param max_count: Maximum number of items to return
+    :type max_count: int
 
     :rtype: List[Pet]
     """

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/openapi/openapi.yaml
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/openapi/openapi.yaml
@@ -114,6 +114,15 @@ paths:
             type: string
           type: array
         style: form
+      - description: Maximum number of items to return
+        explode: true
+        in: query
+        name: maxCount
+        required: false
+        schema:
+          format: int32
+          type: integer
+        style: form
       responses:
         200:
           content:
@@ -138,7 +147,7 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}:
+  /pet/{petId}:
     delete:
       operationId: delete_pet
       parameters:
@@ -152,7 +161,7 @@ paths:
       - description: Pet id to delete
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -176,7 +185,7 @@ paths:
       - description: ID of pet to return
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -208,7 +217,7 @@ paths:
       - description: ID of pet that needs to be updated
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -238,14 +247,14 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}/uploadImage:
+  /pet/{petId}/uploadImage:
     post:
       operationId: upload_file
       parameters:
       - description: ID of pet to update
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -326,7 +335,7 @@ paths:
       tags:
       - store
       x-openapi-router-controller: openapi_server.controllers.store_controller
-  /store/order/{order_id}:
+  /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
       operationId: delete_order
@@ -334,7 +343,7 @@ paths:
       - description: ID of the order that needs to be deleted
         explode: false
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           type: string
@@ -355,7 +364,7 @@ paths:
       - description: ID of pet that needs to be fetched
         explode: false
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           format: int64

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/__init__.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/__init__.py
@@ -12,5 +12,5 @@ class BaseTestCase(TestCase):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../openapi/')
         app.app.json_encoder = JSONEncoder
-        app.add_api('openapi.yaml')
+        app.add_api('openapi.yaml', pythonic_params=True)
         return app.app

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/test_pet_controller.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/test_pet_controller.py
@@ -89,7 +89,8 @@ class TestPetController(BaseTestCase):
 
         Finds Pets by tags
         """
-        query_string = [('tags', 'tags_example')]
+        query_string = [('tags', 'tags_example'),
+                        ('max_count', 56)]
         headers = { 
             'Accept': 'application/json',
             'Authorization': 'Bearer special-key',

--- a/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/test_pet_controller.py
+++ b/samples/server/openapi3/petstore/python-flask-python2/openapi_server/test/test_pet_controller.py
@@ -90,7 +90,7 @@ class TestPetController(BaseTestCase):
         Finds Pets by tags
         """
         query_string = [('tags', 'tags_example'),
-                        ('max_count', 56)]
+                        ('maxCount', 56)]
         headers = { 
             'Accept': 'application/json',
             'Authorization': 'Bearer special-key',

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/__main__.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/__main__.py
@@ -8,7 +8,9 @@ from openapi_server import encoder
 def main():
     app = connexion.App(__name__, specification_dir='./openapi/')
     app.app.json_encoder = encoder.JSONEncoder
-    app.add_api('openapi.yaml', arguments={'title': 'OpenAPI Petstore'})
+    app.add_api('openapi.yaml',
+                arguments={'title': 'OpenAPI Petstore'},
+                pythonic_params=True)
     app.run(port=8080)
 
 

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/controllers/pet_controller.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/controllers/pet_controller.py
@@ -49,13 +49,15 @@ def find_pets_by_status(status):  # noqa: E501
     return 'do some magic!'
 
 
-def find_pets_by_tags(tags):  # noqa: E501
+def find_pets_by_tags(tags, max_count=None):  # noqa: E501
     """Finds Pets by tags
 
     Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing. # noqa: E501
 
     :param tags: Tags to filter by
     :type tags: List[str]
+    :param max_count: Maximum number of items to return
+    :type max_count: int
 
     :rtype: List[Pet]
     """

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/openapi/openapi.yaml
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/openapi/openapi.yaml
@@ -114,6 +114,15 @@ paths:
             type: string
           type: array
         style: form
+      - description: Maximum number of items to return
+        explode: true
+        in: query
+        name: maxCount
+        required: false
+        schema:
+          format: int32
+          type: integer
+        style: form
       responses:
         200:
           content:
@@ -138,7 +147,7 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}:
+  /pet/{petId}:
     delete:
       operationId: delete_pet
       parameters:
@@ -152,7 +161,7 @@ paths:
       - description: Pet id to delete
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -176,7 +185,7 @@ paths:
       - description: ID of pet to return
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -208,7 +217,7 @@ paths:
       - description: ID of pet that needs to be updated
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -238,14 +247,14 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}/uploadImage:
+  /pet/{petId}/uploadImage:
     post:
       operationId: upload_file
       parameters:
       - description: ID of pet to update
         explode: false
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -326,7 +335,7 @@ paths:
       tags:
       - store
       x-openapi-router-controller: openapi_server.controllers.store_controller
-  /store/order/{order_id}:
+  /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
       operationId: delete_order
@@ -334,7 +343,7 @@ paths:
       - description: ID of the order that needs to be deleted
         explode: false
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           type: string
@@ -355,7 +364,7 @@ paths:
       - description: ID of pet that needs to be fetched
         explode: false
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           format: int64

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/test/__init__.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/test/__init__.py
@@ -12,5 +12,5 @@ class BaseTestCase(TestCase):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../openapi/')
         app.app.json_encoder = JSONEncoder
-        app.add_api('openapi.yaml')
+        app.add_api('openapi.yaml', pythonic_params=True)
         return app.app

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/test/test_pet_controller.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/test/test_pet_controller.py
@@ -89,7 +89,8 @@ class TestPetController(BaseTestCase):
 
         Finds Pets by tags
         """
-        query_string = [('tags', 'tags_example')]
+        query_string = [('tags', 'tags_example'),
+                        ('max_count', 56)]
         headers = { 
             'Accept': 'application/json',
             'Authorization': 'Bearer special-key',

--- a/samples/server/openapi3/petstore/python-flask/openapi_server/test/test_pet_controller.py
+++ b/samples/server/openapi3/petstore/python-flask/openapi_server/test/test_pet_controller.py
@@ -90,7 +90,7 @@ class TestPetController(BaseTestCase):
         Finds Pets by tags
         """
         query_string = [('tags', 'tags_example'),
-                        ('max_count', 56)]
+                        ('maxCount', 56)]
         headers = { 
             'Accept': 'application/json',
             'Authorization': 'Bearer special-key',

--- a/samples/server/petstore/python-aiohttp/openapi_server/__init__.py
+++ b/samples/server/petstore/python-aiohttp/openapi_server/__init__.py
@@ -8,5 +8,8 @@ def main():
         }
     specification_dir = os.path.join(os.path.dirname(__file__), 'openapi')
     app = connexion.AioHttpApp(__name__, specification_dir=specification_dir, options=options)
-    app.add_api('openapi.yaml', arguments={'title': 'OpenAPI Petstore'}, pass_context_arg_name='request')
+    app.add_api('openapi.yaml',
+                arguments={'title': 'OpenAPI Petstore'},
+                pythonic_params=True,
+                pass_context_arg_name='request')
     app.run(port=8080)

--- a/samples/server/petstore/python-aiohttp/openapi_server/openapi/openapi.yaml
+++ b/samples/server/petstore/python-aiohttp/openapi_server/openapi/openapi.yaml
@@ -161,7 +161,7 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}:
+  /pet/{petId}:
     delete:
       operationId: delete_pet
       parameters:
@@ -171,7 +171,7 @@ paths:
           type: string
       - description: Pet id to delete
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -194,7 +194,7 @@ paths:
       parameters:
       - description: ID of pet to return
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -226,7 +226,7 @@ paths:
       parameters:
       - description: ID of pet that needs to be updated
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -256,13 +256,13 @@ paths:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
       x-codegen-request-body-name: body
-  /pet/{pet_id}/uploadImage:
+  /pet/{petId}/uploadImage:
     post:
       operationId: upload_file
       parameters:
       - description: ID of pet to update
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -345,14 +345,14 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-openapi-router-controller: openapi_server.controllers.store_controller
-  /store/order/{order_id}:
+  /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
       operationId: delete_order
       parameters:
       - description: ID of the order that needs to be deleted
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           type: string
@@ -373,7 +373,7 @@ paths:
       parameters:
       - description: ID of pet that needs to be fetched
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           format: int64

--- a/samples/server/petstore/python-aiohttp/tests/conftest.py
+++ b/samples/server/petstore/python-aiohttp/tests/conftest.py
@@ -11,7 +11,11 @@ def client(loop, aiohttp_client):
     options = {
         "swagger_ui": True
         }
-    specification_dir = os.path.join(os.path.dirname(__file__), '..', 'openapi_server', 'openapi')
-    app = connexion.AioHttpApp(__name__, specification_dir=specification_dir, options=options)
-    app.add_api('openapi.yaml', pass_context_arg_name='request')
+    specification_dir = os.path.join(os.path.dirname(__file__), '..',
+                                     'openapi_server',
+                                     'openapi')
+    app = connexion.AioHttpApp(__name__, specification_dir=specification_dir,
+                               options=options)
+    app.add_api('openapi.yaml', pythonic_params=True,
+                pass_context_arg_name='request')
     return loop.run_until_complete(aiohttp_client(app.app))

--- a/samples/server/petstore/python-flask-python2/openapi_server/__main__.py
+++ b/samples/server/petstore/python-flask-python2/openapi_server/__main__.py
@@ -8,7 +8,9 @@ from openapi_server import encoder
 def main():
     app = connexion.App(__name__, specification_dir='./openapi/')
     app.app.json_encoder = encoder.JSONEncoder
-    app.add_api('openapi.yaml', arguments={'title': 'OpenAPI Petstore'})
+    app.add_api('openapi.yaml',
+                arguments={'title': 'OpenAPI Petstore'},
+                pythonic_params=True)
     app.run(port=8080)
 
 

--- a/samples/server/petstore/python-flask-python2/openapi_server/openapi/openapi.yaml
+++ b/samples/server/petstore/python-flask-python2/openapi_server/openapi/openapi.yaml
@@ -159,7 +159,7 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}:
+  /pet/{petId}:
     delete:
       operationId: delete_pet
       parameters:
@@ -169,7 +169,7 @@ paths:
           type: string
       - description: Pet id to delete
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -192,7 +192,7 @@ paths:
       parameters:
       - description: ID of pet to return
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -224,7 +224,7 @@ paths:
       parameters:
       - description: ID of pet that needs to be updated
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -252,13 +252,13 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}/uploadImage:
+  /pet/{petId}/uploadImage:
     post:
       operationId: upload_file
       parameters:
       - description: ID of pet to update
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -338,14 +338,14 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-openapi-router-controller: openapi_server.controllers.store_controller
-  /store/order/{order_id}:
+  /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
       operationId: delete_order
       parameters:
       - description: ID of the order that needs to be deleted
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           type: string
@@ -366,7 +366,7 @@ paths:
       parameters:
       - description: ID of pet that needs to be fetched
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           format: int64

--- a/samples/server/petstore/python-flask-python2/openapi_server/test/__init__.py
+++ b/samples/server/petstore/python-flask-python2/openapi_server/test/__init__.py
@@ -12,5 +12,5 @@ class BaseTestCase(TestCase):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../openapi/')
         app.app.json_encoder = JSONEncoder
-        app.add_api('openapi.yaml')
+        app.add_api('openapi.yaml', pythonic_params=True)
         return app.app

--- a/samples/server/petstore/python-flask/openapi_server/__main__.py
+++ b/samples/server/petstore/python-flask/openapi_server/__main__.py
@@ -8,7 +8,9 @@ from openapi_server import encoder
 def main():
     app = connexion.App(__name__, specification_dir='./openapi/')
     app.app.json_encoder = encoder.JSONEncoder
-    app.add_api('openapi.yaml', arguments={'title': 'OpenAPI Petstore'})
+    app.add_api('openapi.yaml',
+                arguments={'title': 'OpenAPI Petstore'},
+                pythonic_params=True)
     app.run(port=8080)
 
 

--- a/samples/server/petstore/python-flask/openapi_server/openapi/openapi.yaml
+++ b/samples/server/petstore/python-flask/openapi_server/openapi/openapi.yaml
@@ -159,7 +159,7 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}:
+  /pet/{petId}:
     delete:
       operationId: delete_pet
       parameters:
@@ -169,7 +169,7 @@ paths:
           type: string
       - description: Pet id to delete
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -192,7 +192,7 @@ paths:
       parameters:
       - description: ID of pet to return
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -224,7 +224,7 @@ paths:
       parameters:
       - description: ID of pet that needs to be updated
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -252,13 +252,13 @@ paths:
       tags:
       - pet
       x-openapi-router-controller: openapi_server.controllers.pet_controller
-  /pet/{pet_id}/uploadImage:
+  /pet/{petId}/uploadImage:
     post:
       operationId: upload_file
       parameters:
       - description: ID of pet to update
         in: path
-        name: pet_id
+        name: petId
         required: true
         schema:
           format: int64
@@ -338,14 +338,14 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-openapi-router-controller: openapi_server.controllers.store_controller
-  /store/order/{order_id}:
+  /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
       operationId: delete_order
       parameters:
       - description: ID of the order that needs to be deleted
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           type: string
@@ -366,7 +366,7 @@ paths:
       parameters:
       - description: ID of pet that needs to be fetched
         in: path
-        name: order_id
+        name: orderId
         required: true
         schema:
           format: int64

--- a/samples/server/petstore/python-flask/openapi_server/test/__init__.py
+++ b/samples/server/petstore/python-flask/openapi_server/test/__init__.py
@@ -12,5 +12,5 @@ class BaseTestCase(TestCase):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../openapi/')
         app.app.json_encoder = JSONEncoder
-        app.add_api('openapi.yaml')
+        app.add_api('openapi.yaml', pythonic_params=True)
         return app.app


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. -- @wing328 @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess

### Description of the PR

We have an OpenAPI spec file with `camelCase` (_query_ and _path_) parameters.
When generating a Python (`connexion`-based) server those parameters are converted to ("_pythonic_") `snake_case` parameters.

During generation of the supporting files there is also an OpenAPI spec file generated for use with `connexion`. This spec file does not match the original one regarding parameter names.

Especially when defining "_query_" parameters, the REST interface will be different than the one defined in the original OpenAPI spec file.
Such (_query_) parameters are incompatible with generated clients (and other server implementations)

Fixes #1671

We have been using this fix some time on a local checkout for generating `python-flask` server implementations without issues.

### Notes ###

1. This PR also updates the `python-aiohttp` but it is untested.
    Please feel free to try it out.

2. These changes do not limit on _query_ or _path_ parameters and should also work on _header_ and _cookie_ parameters.