### PR TITLE
[C] Update README and adding object.c/h files

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
@@ -40,6 +40,7 @@ sudo make install
 ```
 
 ## Compile the sample:
+This will compile the generated code and create a library in build folder which has to be linked to the codes where API will be used.
 ```bash
 mkdir build
 cd build
@@ -51,15 +52,17 @@ make
 sudo make install
 ```
 ## How to use compiled library
-Considering the test/source code which uses the API is written in main.c(respective api include is written and all objects necessary are defined)
+Considering the test/source code which uses the API is written in main.c(respective api include is written and all objects necessary are defined and created)
 
-To compile main.c use following command
+To compile main.c(considering the file is present in build folder) use following command
 -L - locaiton of the library(not required if cmake with normal installation is performed)
 -l library name
 ```bash
 gcc main.c -L. -lpetstore -o main
 ```
+once compile, you can run it with ``` ./main ```
 
+Note: You dont need to specify includes for models and include folder seperately as they are path linked. You just have to import the api.h file in your code, the include linking will work.
 
 ## Author
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "object.h"
+
+object_t *object_create() {
+    object_t *object = malloc(sizeof(object_t));
+
+    return object;
+}
+
+void object_free(object_t *object) {
+    free (object);
+}
+
+cJSON *object_convertToJSON(object_t *object) {
+    cJSON *item = cJSON_CreateObject();
+
+    return item;
+fail:
+    cJSON_Delete(item);
+    return NULL;
+}
+
+object_t *object_parseFromJSON(char *jsonString){
+    object_t *object = NULL;
+
+    return object;
+end:
+    return NULL;
+}

--- a/modules/openapi-generator/src/main/resources/C-libcurl/object-header.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/object-header.mustache
@@ -1,0 +1,26 @@
+/*
+ * object.h
+ */
+
+#ifndef _object_H_
+#define _object_H_
+
+#include <string.h>
+#include "../external/cJSON.h"
+#include "../include/list.h"
+#include "../include/keyValuePair.h"
+
+
+typedef struct object_t {
+    void *temporary;
+} object_t;
+
+object_t *object_create();
+
+void object_free(object_t *object);
+
+object_t *object_parseFromJSON(char *jsonString);
+
+cJSON *object_convertToJSON(object_t *object);
+
+#endif /* _object_H_ */


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- update handling of reserved keywords to make it same in all cases
- update README mustache to give info about how to compile the library and use the library
- add object header and body mustache to create object models
- set isEnum which is required for handling enum variables in C codegen in CLibCurlClientCodegen.java to avoid conflict with other codegen

cc
@wing328 