### PR TITLE
[C#][netcore] Fix package name in the localVar types

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -249,10 +249,10 @@ namespace {{packageName}}.{{apiPackage}}
                 {{/produces}}
             };
 
-            var localVarConentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(@contentTypes);
-            if (localVarConentType != null) requestOptions.HeaderParameters.Add("Content-Type", localVarConentType);
+            var localVarContentType = {{packageName}}.Client.ClientUtils.SelectHeaderContentType(@contentTypes);
+            if (localVarContentType != null) requestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
 
-            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(@accepts);
+            var localVarAccept = {{packageName}}.Client.ClientUtils.SelectHeaderAccept(@accepts);
             if (localVarAccept != null) requestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
             {{#pathParams}}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- when package name is set the generated code fails to compile
- fix small typo `ConentType`

`e.g.`
```bash
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
-i ~/api-specs/swagger.yaml  -o ~/genclient -g csharp-netcore \
--additional-properties packageName=MyPackage \
--additional-properties netCoreProjectFile=true \
--additional-properties targetFramework=netcoreapp2.0
```

`cc:`
@wing328 @jimschubert 
