### PR TITLE
[haskell-http-client] add support for import-mappings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -84,10 +85,13 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
 
     // vendor extensions
     static final String X_ALL_UNIQUE_PARAMS = "x-allUniqueParams";
+    static final String X_ALL_IMPORT_MAPPINGS = "x-allImportMappings";
+    static final String X_ALL_UNIQUE_IMPORT_PATHS = "x-allUniqueImportPaths";
     static final String X_COLLECTION_FORMAT = "x-collectionFormat";
     static final String X_HADDOCK_PATH = "x-haddockPath";
     static final String X_HAS_BODY_OR_FORM_PARAM = "x-hasBodyOrFormParam";
     static final String X_HAS_ENUM_SECTION = "x-hasEnumSection";
+    static final String X_HAS_IMPORT_MAPPINGS = "x-hasImportMappings";
     static final String X_HAS_MIME_FORM_URL_ENCODED = "x-hasMimeFormUrlEncoded";
     static final String X_HAS_NEW_TAG = "x-hasNewTag";
     static final String X_HAS_OPTIONAL_PARAMS = "x-hasOptionalParams";
@@ -542,12 +546,29 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         additionalProperties.put("configType", getStringProp(PROP_CONFIG_TYPE));
         additionalProperties.put("openApiVersion", openAPI.getOpenapi());
 
+        List<String> allUniqueImportPaths = this.importMapping.values().stream().distinct().collect(Collectors.toList());
+        if (allUniqueImportPaths.size() > 0) {
+            additionalProperties.put(X_ALL_UNIQUE_IMPORT_PATHS, allUniqueImportPaths);
+            supportingFiles.add(new SupportingFile("ImportMappings.mustache", modulePath, "ImportMappings.hs"));
+
+            List<Map<String, String>> allImportMappings = new ArrayList<>();
+            for (Map.Entry<String, String> entry : this.importMapping.entrySet()) {
+                Map<String, String> importMappingEntry = new HashMap<>();
+                importMappingEntry.put("dataType", entry.getKey());
+                importMappingEntry.put("importPath", entry.getValue());
+                allImportMappings.add(importMappingEntry);
+            }
+            additionalProperties.put(X_ALL_IMPORT_MAPPINGS, allImportMappings);
+            additionalProperties.put(X_HAS_IMPORT_MAPPINGS, true);
+        }
+
         super.preprocessOpenAPI(openAPI);
     }
 
     @Override
     public Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs) {
         generateYAMLSpecFile(objs);
+
         return super.postProcessSupportingFileData(objs);
     }
 

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/ImportMappings.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/ImportMappings.mustache
@@ -1,0 +1,6 @@
+{-# OPTIONS_GHC -fno-warn-dodgy-imports #-}
+
+module {{baseModule}}.ImportMappings (module ImportMappings) where
+
+{{#x-allImportMappings}}import {{importPath}} as ImportMappings ({{dataType}}(..))
+{{/x-allImportMappings}}

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/Model.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/Model.mustache
@@ -17,10 +17,11 @@ Module : {{baseModule}}.Model
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches -fno-warn-unused-binds -fno-warn-unused-imports #-}
 
-module {{baseModule}}.Model where
+module {{baseModule}}.Model {{#x-hasImportMappings}}(module {{baseModule}}.Model, module {{baseModule}}.ImportMappings) {{/x-hasImportMappings}}where
 
 import {{baseModule}}.Core
-import {{baseModule}}.MimeTypes
+import {{baseModule}}.MimeTypes{{#x-hasImportMappings}}
+import {{baseModule}}.ImportMappings{{/x-hasImportMappings}}
 
 import Data.Aeson ((.:),(.:!),(.:?),(.=))
 
@@ -53,8 +54,6 @@ import Prelude (($),(/=),(.),(<$>),(<*>),(>>=),(=<<),Maybe(..),Bool(..),Char,Dou
 import qualified Prelude as P
 
 
-{{#imports}}import {{import}}
-{{/imports}}
 
 -- * Parameter newtypes
 {{#x-allUniqueParams}}{{#x-newtype}}

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/TopLevel.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/TopLevel.mustache
@@ -9,8 +9,8 @@ module {{baseModule}}
   , module {{baseModule}}.Core
   , module {{baseModule}}.Logging
   , module {{baseModule}}.MimeTypes
-  , module {{baseModule}}.Model
-  , module {{baseModule}}.ModelLens
+  , module {{baseModule}}.Model{{#generateLenses}}
+  , module {{baseModule}}.ModelLens{{/generateLenses}}
   ) where
 
 {{^x-allowNonUniqueOperationIds}}import {{baseModule}}.API{{/x-allowNonUniqueOperationIds}}
@@ -18,5 +18,5 @@ import {{baseModule}}.Client
 import {{baseModule}}.Core
 import {{baseModule}}.Logging
 import {{baseModule}}.MimeTypes
-import {{baseModule}}.Model
-import {{baseModule}}.ModelLens
+import {{baseModule}}.Model{{#generateLenses}}
+import {{baseModule}}.ModelLens{{/generateLenses}}

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/haskell-http-client.cabal.mustache
@@ -64,7 +64,8 @@ library
     , unordered-containers
     , vector >=0.10.9 && <0.13
   other-modules:
-      Paths_{{pathsName}}
+      Paths_{{pathsName}}{{#x-hasImportMappings}}
+      {{baseModule}}.ImportMappings{{/x-hasImportMappings}}
   exposed-modules:
       {{baseModule}}{{^x-allowNonUniqueOperationIds}}
       {{baseModule}}.API{{/x-allowNonUniqueOperationIds}}{{#apiInfo}}{{#apis}}
@@ -73,8 +74,9 @@ library
       {{baseModule}}.Core
       {{baseModule}}.Logging
       {{baseModule}}.MimeTypes
-      {{baseModule}}.Model
-      {{baseModule}}.ModelLens
+      {{baseModule}}.Model{{#generateLenses}}
+      {{baseModule}}.ModelLens{{/generateLenses}}{{#x-allUniqueImportPaths}}
+      {{.}}{{/x-allUniqueImportPaths}}
   default-language: Haskell2010
 
   if flag(UseKatip)


### PR DESCRIPTION
import mappings take the form of:
```
--import-mappings %DATATYPE%=%MODULE%
```

full example (with --type-mappings):
```
--type-mappings intstr.IntOrString=IntOrString
--import-mappings IntOrString=Kubernetes.CustomTypes
```

The import-mapped module will be an exposed module of the generated library.

The import mappings will be re-exported from ImportMappings, which itself is re-xported from Models.

Model.hs
```
module Kubernetes.Model (module Kubernetes.Model, module Kubernetes.ImportMappings) where
import Kubernetes.ImportMappings
```
ImportMappings.hs:
```
module Kubernetes.ImportMappings (module ImportMappings) where
import Kubernetes.CustomTypes as ImportMappings (IntOrString(..))
```