### PR TITLE
Fix #2340

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSCXFExtServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSCXFExtServerCodegenTest.java
@@ -558,7 +558,7 @@ public class JavaJAXRSCXFExtServerCodegenTest {
 
     @Test
     public void testAddOperationToGroup() throws Exception {
-        File output = Files.createTempDirectory("test").toFile();
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
         OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/3_0/tags.yaml", null, new ParseOptions())
@@ -634,11 +634,11 @@ public class JavaJAXRSCXFExtServerCodegenTest {
         assertEquals(group5List.get(1).subresourceOperation, true);
     }
 
-    @Test(enabled = false)
+    @Test()
     public void testGenerateOperationBodyWithCodedTestData() throws Exception {
-        File output = Files.createTempDirectory("test").toFile();
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
-        String outputPath = output.getCanonicalPath().replace('\\', '/');
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
 
         OpenAPI openAPI = new OpenAPIParser()
                 .readLocation("src/test/resources/3_0/petstore.yaml", null, new ParseOptions()).getOpenAPI();
@@ -680,11 +680,11 @@ public class JavaJAXRSCXFExtServerCodegenTest {
         checkFile(generator, outputPath + "/test-data-control.json", false);
     }
 
-    @Test(enabled = false)
+    @Test()
     public void testGenerateOperationBodyWithJsonTestData() throws Exception {
-        File output = Files.createTempDirectory("test").toFile();
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
-        String outputPath = output.getCanonicalPath().replace('\\', '/');
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
 
         OpenAPI openAPI = new OpenAPIParser()
                 .readLocation("src/test/resources/3_0/petstore.yaml", null, new ParseOptions()).getOpenAPI();


### PR DESCRIPTION
Test case was using an invalid mixture of File.getAbsoluteFile|Path()
and File.getCanonicalFile|Path() to identify generated output files.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

