### PR TITLE
[python-flask] Do not skip unit tests when underlying type defines json

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonAbstractConnexionServerCodegen.java
@@ -802,7 +802,8 @@ public class PythonAbstractConnexionServerCodegen extends DefaultCodegen impleme
             if (operation.consumes != null ) {
                 if (operation.consumes.size() == 1) {
                     Map<String, String> consume = operation.consumes.get(0);
-                    if (! "application/json".equals(consume.get(MEDIA_TYPE))) {
+                    if (!("application/json".equals(consume.get(MEDIA_TYPE))
+                            || consume.get(MEDIA_TYPE).endsWith("+json"))) {
                         skipTests.put("reason", consume.get(MEDIA_TYPE) + " not supported by Connexion");
                         if ("multipart/form-data".equals(consume.get(MEDIA_TYPE))) {
                             operation.isMultipart = Boolean.TRUE;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. -- @wing328 @taxpon @frol @mbohlool @cbornet @kenjones-cisco @tomplus @Jyhess

### Description of the PR

The unit tests skip all _media types_ which are not `application/json`.

In fact it should accept any _media type_ which uses `json` as underlying structure (`*/*+json`).
See also [RFC6838, section 4.2.8](https://tools.ietf.org/html/rfc6838#section-4.2) and [RFC6838, section 4.2.8](https://tools.ietf.org/html/rfc6838#section-4.2.8)) for more information.