### PR TITLE
[BUG][Kotlin Client] API using case other than camelCase not generated properly

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -27,7 +27,8 @@ data class {{classname}} (
     */
     enum class {{nameInCamelCase}}(val value: {{dataType}}){
     {{#allowableValues}}{{#enumVars}}
-        @Json(name = {{{value}}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+        @Json(name = {{{value}}})
+        {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
     {{/enumVars}}{{/allowableValues}}
     }
 {{/isEnum}}{{/vars}}{{/hasEnums}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -1,6 +1,4 @@
-{{#hasEnums}}
 import com.squareup.moshi.Json
-{{/hasEnums}}
 {{#parcelizeModels}}
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -1,4 +1,5 @@
 {{#description}}
     /* {{{description}}} */
 {{/description}}
+    @Json(name = "{{{baseName}}}")
     val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -1,4 +1,5 @@
 {{#description}}
     /* {{{description}}} */
 {{/description}}
+    @Json(name = "{{{baseName}}}")
     val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -6,6 +6,7 @@ import com.squareup.moshi.Json
 */
 enum class {{classname}}(val value: {{dataType}}){
 {{#allowableValues}}{{#enumVars}}
-    @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}}) {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
+    {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
 {{/enumVars}}{{/allowableValues}}
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -12,6 +12,7 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * Describes the result of uploading an image resource
  * @param code 
@@ -19,8 +20,11 @@ package org.openapitools.client.models
  * @param message 
  */
 data class ApiResponse (
+    @Json(name = "code")
     val code: kotlin.Int? = null,
+    @Json(name = "type")
     val type: kotlin.String? = null,
+    @Json(name = "message")
     val message: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -12,13 +12,16 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * A category for a pet
  * @param id 
  * @param name 
  */
 data class Category (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "name")
     val name: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -23,12 +23,18 @@ import com.squareup.moshi.Json
  * @param complete 
  */
 data class Order (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "petId")
     val petId: kotlin.Long? = null,
+    @Json(name = "quantity")
     val quantity: kotlin.Int? = null,
+    @Json(name = "shipDate")
     val shipDate: kotlin.String? = null,
     /* Order Status */
+    @Json(name = "status")
     val status: Order.Status? = null,
+    @Json(name = "complete")
     val complete: kotlin.Boolean? = null
 ) {
 
@@ -38,11 +44,14 @@ data class Order (
     */
     enum class Status(val value: kotlin.String){
     
-        @Json(name = "placed") placed("placed"),
+        @Json(name = "placed")
+        placed("placed"),
     
-        @Json(name = "approved") approved("approved"),
+        @Json(name = "approved")
+        approved("approved"),
     
-        @Json(name = "delivered") delivered("delivered");
+        @Json(name = "delivered")
+        delivered("delivered");
     
     }
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -25,12 +25,18 @@ import com.squareup.moshi.Json
  * @param status pet status in the store
  */
 data class Pet (
+    @Json(name = "name")
     val name: kotlin.String,
+    @Json(name = "photoUrls")
     val photoUrls: kotlin.Array<kotlin.String>,
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "category")
     val category: Category? = null,
+    @Json(name = "tags")
     val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
+    @Json(name = "status")
     val status: Pet.Status? = null
 ) {
 
@@ -40,11 +46,14 @@ data class Pet (
     */
     enum class Status(val value: kotlin.String){
     
-        @Json(name = "available") available("available"),
+        @Json(name = "available")
+        available("available"),
     
-        @Json(name = "pending") pending("pending"),
+        @Json(name = "pending")
+        pending("pending"),
     
-        @Json(name = "sold") sold("sold");
+        @Json(name = "sold")
+        sold("sold");
     
     }
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -12,13 +12,16 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * A tag for a pet
  * @param id 
  * @param name 
  */
 data class Tag (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "name")
     val name: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -12,6 +12,7 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * A User who is purchasing from the pet store
  * @param id 
@@ -24,14 +25,22 @@ package org.openapitools.client.models
  * @param userStatus User Status
  */
 data class User (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "username")
     val username: kotlin.String? = null,
+    @Json(name = "firstName")
     val firstName: kotlin.String? = null,
+    @Json(name = "lastName")
     val lastName: kotlin.String? = null,
+    @Json(name = "email")
     val email: kotlin.String? = null,
+    @Json(name = "password")
     val password: kotlin.String? = null,
+    @Json(name = "phone")
     val phone: kotlin.String? = null,
     /* User Status */
+    @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
 ) {
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -13,6 +13,7 @@ package org.openapitools.client.models
 
 import org.threeten.bp.LocalDateTime
 
+import com.squareup.moshi.Json
 /**
  * Describes the result of uploading an image resource
  * @param code 
@@ -20,8 +21,11 @@ import org.threeten.bp.LocalDateTime
  * @param message 
  */
 data class ApiResponse (
+    @Json(name = "code")
     val code: kotlin.Int? = null,
+    @Json(name = "type")
     val type: kotlin.String? = null,
+    @Json(name = "message")
     val message: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -13,13 +13,16 @@ package org.openapitools.client.models
 
 import org.threeten.bp.LocalDateTime
 
+import com.squareup.moshi.Json
 /**
  * A category for a pet
  * @param id 
  * @param name 
  */
 data class Category (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "name")
     val name: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -24,12 +24,18 @@ import com.squareup.moshi.Json
  * @param complete 
  */
 data class Order (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "petId")
     val petId: kotlin.Long? = null,
+    @Json(name = "quantity")
     val quantity: kotlin.Int? = null,
+    @Json(name = "shipDate")
     val shipDate: org.threeten.bp.LocalDateTime? = null,
     /* Order Status */
+    @Json(name = "status")
     val status: Order.Status? = null,
+    @Json(name = "complete")
     val complete: kotlin.Boolean? = null
 ) {
 
@@ -39,11 +45,14 @@ data class Order (
     */
     enum class Status(val value: kotlin.String){
     
-        @Json(name = "placed") placed("placed"),
+        @Json(name = "placed")
+        placed("placed"),
     
-        @Json(name = "approved") approved("approved"),
+        @Json(name = "approved")
+        approved("approved"),
     
-        @Json(name = "delivered") delivered("delivered");
+        @Json(name = "delivered")
+        delivered("delivered");
     
     }
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -26,12 +26,18 @@ import com.squareup.moshi.Json
  * @param status pet status in the store
  */
 data class Pet (
+    @Json(name = "name")
     val name: kotlin.String,
+    @Json(name = "photoUrls")
     val photoUrls: kotlin.Array<kotlin.String>,
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "category")
     val category: Category? = null,
+    @Json(name = "tags")
     val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
+    @Json(name = "status")
     val status: Pet.Status? = null
 ) {
 
@@ -41,11 +47,14 @@ data class Pet (
     */
     enum class Status(val value: kotlin.String){
     
-        @Json(name = "available") available("available"),
+        @Json(name = "available")
+        available("available"),
     
-        @Json(name = "pending") pending("pending"),
+        @Json(name = "pending")
+        pending("pending"),
     
-        @Json(name = "sold") sold("sold");
+        @Json(name = "sold")
+        sold("sold");
     
     }
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -13,13 +13,16 @@ package org.openapitools.client.models
 
 import org.threeten.bp.LocalDateTime
 
+import com.squareup.moshi.Json
 /**
  * A tag for a pet
  * @param id 
  * @param name 
  */
 data class Tag (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "name")
     val name: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -13,6 +13,7 @@ package org.openapitools.client.models
 
 import org.threeten.bp.LocalDateTime
 
+import com.squareup.moshi.Json
 /**
  * A User who is purchasing from the pet store
  * @param id 
@@ -25,14 +26,22 @@ import org.threeten.bp.LocalDateTime
  * @param userStatus User Status
  */
 data class User (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "username")
     val username: kotlin.String? = null,
+    @Json(name = "firstName")
     val firstName: kotlin.String? = null,
+    @Json(name = "lastName")
     val lastName: kotlin.String? = null,
+    @Json(name = "email")
     val email: kotlin.String? = null,
+    @Json(name = "password")
     val password: kotlin.String? = null,
+    @Json(name = "phone")
     val phone: kotlin.String? = null,
     /* User Status */
+    @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
 ) {
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/ApiResponse.kt
@@ -12,6 +12,7 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * Describes the result of uploading an image resource
  * @param code 
@@ -19,8 +20,11 @@ package org.openapitools.client.models
  * @param message 
  */
 data class ApiResponse (
+    @Json(name = "code")
     val code: kotlin.Int? = null,
+    @Json(name = "type")
     val type: kotlin.String? = null,
+    @Json(name = "message")
     val message: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Category.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Category.kt
@@ -12,13 +12,16 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * A category for a pet
  * @param id 
  * @param name 
  */
 data class Category (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "name")
     val name: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -23,12 +23,18 @@ import com.squareup.moshi.Json
  * @param complete 
  */
 data class Order (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "petId")
     val petId: kotlin.Long? = null,
+    @Json(name = "quantity")
     val quantity: kotlin.Int? = null,
+    @Json(name = "shipDate")
     val shipDate: java.time.LocalDateTime? = null,
     /* Order Status */
+    @Json(name = "status")
     val status: Order.Status? = null,
+    @Json(name = "complete")
     val complete: kotlin.Boolean? = null
 ) {
 
@@ -38,11 +44,14 @@ data class Order (
     */
     enum class Status(val value: kotlin.String){
     
-        @Json(name = "placed") placed("placed"),
+        @Json(name = "placed")
+        placed("placed"),
     
-        @Json(name = "approved") approved("approved"),
+        @Json(name = "approved")
+        approved("approved"),
     
-        @Json(name = "delivered") delivered("delivered");
+        @Json(name = "delivered")
+        delivered("delivered");
     
     }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -25,12 +25,18 @@ import com.squareup.moshi.Json
  * @param status pet status in the store
  */
 data class Pet (
+    @Json(name = "name")
     val name: kotlin.String,
+    @Json(name = "photoUrls")
     val photoUrls: kotlin.Array<kotlin.String>,
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "category")
     val category: Category? = null,
+    @Json(name = "tags")
     val tags: kotlin.Array<Tag>? = null,
     /* pet status in the store */
+    @Json(name = "status")
     val status: Pet.Status? = null
 ) {
 
@@ -40,11 +46,14 @@ data class Pet (
     */
     enum class Status(val value: kotlin.String){
     
-        @Json(name = "available") available("available"),
+        @Json(name = "available")
+        available("available"),
     
-        @Json(name = "pending") pending("pending"),
+        @Json(name = "pending")
+        pending("pending"),
     
-        @Json(name = "sold") sold("sold");
+        @Json(name = "sold")
+        sold("sold");
     
     }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Tag.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/Tag.kt
@@ -12,13 +12,16 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * A tag for a pet
  * @param id 
  * @param name 
  */
 data class Tag (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "name")
     val name: kotlin.String? = null
 ) {
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/User.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/models/User.kt
@@ -12,6 +12,7 @@
 package org.openapitools.client.models
 
 
+import com.squareup.moshi.Json
 /**
  * A User who is purchasing from the pet store
  * @param id 
@@ -24,14 +25,22 @@ package org.openapitools.client.models
  * @param userStatus User Status
  */
 data class User (
+    @Json(name = "id")
     val id: kotlin.Long? = null,
+    @Json(name = "username")
     val username: kotlin.String? = null,
+    @Json(name = "firstName")
     val firstName: kotlin.String? = null,
+    @Json(name = "lastName")
     val lastName: kotlin.String? = null,
+    @Json(name = "email")
     val email: kotlin.String? = null,
+    @Json(name = "password")
     val password: kotlin.String? = null,
+    @Json(name = "phone")
     val phone: kotlin.String? = null,
     /* User Status */
+    @Json(name = "userStatus")
     val userStatus: kotlin.Int? = null
 ) {
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. (/cc @jimschubert @dr4ke616)

### Description of the PR

Generating from a json file, if an API uses anything other than camelCase, the property names are not generated with the proper Json name. The generated code does not serialize/deserialize properly.

Adding a `@Json` annotation on the properties fixes it.