### PR TITLE
[R] url-encode path parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -78,7 +78,7 @@
       {{#hasPathParams}}
       {{#pathParams}}
       if (!missing(`{{paramName}}`)) {
-        urlPath <- gsub(paste0("\\{", "{{baseName}}", "\\}"), URLencode(`{{paramName}}`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "{{baseName}}", "\\}"), URLencode(as.character(`{{paramName}}`), reserved = TRUE), urlPath)
       }
 
       {{/pathParams}}

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -78,7 +78,7 @@
       {{#hasPathParams}}
       {{#pathParams}}
       if (!missing(`{{paramName}}`)) {
-        urlPath <- gsub(paste0("\\{", "{{baseName}}", "\\}"), `{{paramName}}`, urlPath)
+        urlPath <- gsub(paste0("\\{", "{{baseName}}", "\\}"), URLencode(`{{paramName}}`, reserved = TRUE), urlPath)
       }
 
       {{/pathParams}}

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -104,7 +104,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet.id`), reserved = TRUE), urlPath)
       }
 
       # OAuth token
@@ -199,7 +199,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet.id`), reserved = TRUE), urlPath)
       }
 
       # API key authentication
@@ -274,7 +274,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet.id`), reserved = TRUE), urlPath)
       }
 
       # OAuth token
@@ -312,7 +312,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}/uploadImage"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(as.character(`pet.id`), reserved = TRUE), urlPath)
       }
 
       # OAuth token

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -104,7 +104,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), `pet.id`, urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
       }
 
       # OAuth token
@@ -199,7 +199,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), `pet.id`, urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
       }
 
       # API key authentication
@@ -274,7 +274,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), `pet.id`, urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
       }
 
       # OAuth token
@@ -312,7 +312,7 @@ PetApi <- R6::R6Class(
 
       urlPath <- "/pet/{petId}/uploadImage"
       if (!missing(`pet.id`)) {
-        urlPath <- gsub(paste0("\\{", "petId", "\\}"), `pet.id`, urlPath)
+        urlPath <- gsub(paste0("\\{", "petId", "\\}"), URLencode(`pet.id`, reserved = TRUE), urlPath)
       }
 
       # OAuth token

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -55,7 +55,7 @@ StoreApi <- R6::R6Class(
 
       urlPath <- "/store/order/{orderId}"
       if (!missing(`order.id`)) {
-        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(`order.id`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order.id`), reserved = TRUE), urlPath)
       }
 
 
@@ -113,7 +113,7 @@ StoreApi <- R6::R6Class(
 
       urlPath <- "/store/order/{orderId}"
       if (!missing(`order.id`)) {
-        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(`order.id`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(as.character(`order.id`), reserved = TRUE), urlPath)
       }
 
 

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -55,7 +55,7 @@ StoreApi <- R6::R6Class(
 
       urlPath <- "/store/order/{orderId}"
       if (!missing(`order.id`)) {
-        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), `order.id`, urlPath)
+        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(`order.id`, reserved = TRUE), urlPath)
       }
 
 
@@ -113,7 +113,7 @@ StoreApi <- R6::R6Class(
 
       urlPath <- "/store/order/{orderId}"
       if (!missing(`order.id`)) {
-        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), `order.id`, urlPath)
+        urlPath <- gsub(paste0("\\{", "orderId", "\\}"), URLencode(`order.id`, reserved = TRUE), urlPath)
       }
 
 

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -166,7 +166,7 @@ UserApi <- R6::R6Class(
 
       urlPath <- "/user/{username}"
       if (!missing(`username`)) {
-        urlPath <- gsub(paste0("\\{", "username", "\\}"), `username`, urlPath)
+        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(`username`, reserved = TRUE), urlPath)
       }
 
 
@@ -197,7 +197,7 @@ UserApi <- R6::R6Class(
 
       urlPath <- "/user/{username}"
       if (!missing(`username`)) {
-        urlPath <- gsub(paste0("\\{", "username", "\\}"), `username`, urlPath)
+        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(`username`, reserved = TRUE), urlPath)
       }
 
 
@@ -296,7 +296,7 @@ UserApi <- R6::R6Class(
 
       urlPath <- "/user/{username}"
       if (!missing(`username`)) {
-        urlPath <- gsub(paste0("\\{", "username", "\\}"), `username`, urlPath)
+        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(`username`, reserved = TRUE), urlPath)
       }
 
 

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -166,7 +166,7 @@ UserApi <- R6::R6Class(
 
       urlPath <- "/user/{username}"
       if (!missing(`username`)) {
-        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(`username`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), urlPath)
       }
 
 
@@ -197,7 +197,7 @@ UserApi <- R6::R6Class(
 
       urlPath <- "/user/{username}"
       if (!missing(`username`)) {
-        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(`username`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), urlPath)
       }
 
 
@@ -296,7 +296,7 @@ UserApi <- R6::R6Class(
 
       urlPath <- "/user/{username}"
       if (!missing(`username`)) {
-        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(`username`, reserved = TRUE), urlPath)
+        urlPath <- gsub(paste0("\\{", "username", "\\}"), URLencode(as.character(`username`), reserved = TRUE), urlPath)
       }
 
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To fix issues when path parameters contain special characters that need to be url-encoded.
