### PR TITLE
[MAVEN PLUGIN] fix javadoc + sonarlint

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/OpenAPIGenerator.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/OpenAPIGenerator.java
@@ -37,7 +37,6 @@ public class OpenAPIGenerator {
 
     public static void main(String[] args) {
         String version = Version.readVersionFromResources();
-        @SuppressWarnings("unchecked")
         Cli.CliBuilder<Runnable> builder =
                 Cli.<Runnable>builder("openapi-generator-cli")
                         .withDescription(

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
@@ -86,10 +86,9 @@ public class ConfigHelp implements Runnable {
                 //noinspection ResultOfMethodCallIgnored
                 out.getParentFile().mkdirs();
 
-                Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8));
-
-                writer.write(sb.toString());
-                writer.close();
+                try (Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8))) {
+                    writer.write(sb.toString());
+                }
             } else {
                 System.out.print(sb.toString());
             }

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 @Command(name = "generate", description = "Generate code with the specified generator.")
 public class Generate implements Runnable {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Generate.class);
+    // private static final Logger LOGGER = LoggerFactory.getLogger(Generate.class);
 
     @Option(name = {"-v", "--verbose"}, description = "verbose mode")
     private Boolean verbose;

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ListGenerators.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ListGenerators.java
@@ -9,7 +9,6 @@ import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.CodegenConfigLoader;
 import org.openapitools.codegen.CodegenType;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -62,7 +61,7 @@ public class ListGenerators implements Runnable {
                 .sorted(Comparator.comparing(CodegenConfig::getName))
                 .collect(Collectors.toList());
 
-        if(list.size() > 0) {
+        if(!list.isEmpty()) {
             if (docusaurus) {
                 sb.append("## ").append(typeName).append(" generators");
             } else {

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Validate.java
@@ -45,8 +45,8 @@ public class Validate implements Runnable {
 
         SwaggerParseResult result = new OpenAPIParser().readLocation(spec, null, null);
         List<String> messageList = result.getMessages();
-        Set<String> errors = new HashSet<String>(messageList);
-        Set<String> warnings = new HashSet<String>();
+        Set<String> errors = new HashSet<>(messageList);
+        Set<String> warnings = new HashSet<>();
 
         StringBuilder sb = new StringBuilder();
         OpenAPI specification = result.getOpenAPI();
@@ -61,7 +61,7 @@ public class Validate implements Runnable {
             }
         }
 
-        if (errors.size() > 0) {
+        if (!errors.isEmpty()) {
             sb.append("Errors:").append(System.lineSeparator());
             errors.forEach(msg ->
                     sb.append("\t-").append(msg).append(System.lineSeparator())

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -267,9 +267,6 @@ public class CodeGenMojo extends AbstractMojo {
 
     /**
      * A map of additional properties that can be referenced by the mustache templates
-     * <additionalProperties>
-     *     <additionalProperty>key=value</additionalProperty>
-     * </additionalProperties>
      */
     @Parameter(name = "additionalProperties")
     private List<String> additionalProperties;

--- a/pom.xml
+++ b/pom.xml
@@ -226,13 +226,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.0</version>
                 <configuration>
                     <source>1.8</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <failOnWarnings>true</failOnWarnings>
-                    <excludePackageNames></excludePackageNames>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.


### Description of the PR

fix `mvn verify -f modules/openapi-generator-cli/pom.xml` who failed locally (with jdk1.8.0_171) cause of javadoc warning with maven-javadoc-plugin 3.0.1 but not with 3.1.0 anymore (actually no error in circleci but probably cause of #705)
fix warning` line 2 column 2 - Error: <additionalproperties> is not recognized!` in circle-ci log in` openapi-generator-maven-plugin` module
fix some sonarlint issues in module `openapi-generator-cli`
