### PR TITLE
Remove global options from PHP generators

### DIFF
--- a/docs/generators/php-laravel.md
+++ b/docs/generators/php-laravel.md
@@ -17,6 +17,4 @@ sidebar_label: php-laravel
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |srcBasePath|The directory to serve as source root.| |null|
-|gitUserId|Git user ID, e.g. openapitools.| |null|
-|gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|

--- a/docs/generators/php-lumen.md
+++ b/docs/generators/php-lumen.md
@@ -17,6 +17,4 @@ sidebar_label: php-lumen
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |srcBasePath|The directory to serve as source root.| |null|
-|gitUserId|Git user ID, e.g. openapitools.| |null|
-|gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|

--- a/docs/generators/php-slim.md
+++ b/docs/generators/php-slim.md
@@ -17,6 +17,4 @@ sidebar_label: php-slim
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |srcBasePath|The directory to serve as source root.| |null|
-|gitUserId|Git user ID, e.g. openapitools.| |null|
-|gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|

--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -17,8 +17,6 @@ sidebar_label: php-symfony
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |srcBasePath|The directory to serve as source root.| |null|
-|gitUserId|Git user ID, e.g. openapitools.| |null|
-|gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
 |composerVendorName|The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets| |null|
 |bundleName|The name of the Symfony bundle. The template uses {{bundleName}}| |null|

--- a/docs/generators/php-ze-ph.md
+++ b/docs/generators/php-ze-ph.md
@@ -17,6 +17,4 @@ sidebar_label: php-ze-ph
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |srcBasePath|The directory to serve as source root.| |null|
-|gitUserId|Git user ID, e.g. openapitools.| |null|
-|gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|

--- a/docs/generators/php.md
+++ b/docs/generators/php.md
@@ -17,7 +17,5 @@ sidebar_label: php
 |invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
 |packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
 |srcBasePath|The directory to serve as source root.| |null|
-|gitUserId|Git user ID, e.g. openapitools.| |null|
-|gitRepoId|Git repo ID, e.g. openapi-generator.| |null|
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
 |hideGenerationTimestamp|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -1,4 +1,4 @@
-/*ap Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+/* Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
  * Copyright 2018 SmartBear Software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -132,8 +132,6 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, "The main namespace to use for all classes. e.g. Yay\\Pets"));
         cliOptions.add(new CliOption(PACKAGE_NAME, "The main package name for classes. e.g. GeneratedPetstore"));
         cliOptions.add(new CliOption(SRC_BASE_PATH, "The directory to serve as source root."));
-        cliOptions.add(new CliOption(CodegenConstants.GIT_USER_ID, CodegenConstants.GIT_USER_ID_DESC));
-        cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_ID, CodegenConstants.GIT_REPO_ID_DESC));
         cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, "The version to use in the composer package version field. e.g. 1.2.3"));
     }
 
@@ -179,18 +177,6 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             apiPackage = invokerPackage + "\\" + (String) additionalProperties.get(CodegenConstants.API_PACKAGE);
         }
         additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
-
-        if (additionalProperties.containsKey(CodegenConstants.GIT_USER_ID)) {
-            this.setGitUserId((String) additionalProperties.get(CodegenConstants.GIT_USER_ID));
-        } else {
-            additionalProperties.put(CodegenConstants.GIT_USER_ID, gitUserId);
-        }
-
-        if (additionalProperties.containsKey(CodegenConstants.GIT_REPO_ID)) {
-            this.setGitRepoId((String) additionalProperties.get(CodegenConstants.GIT_REPO_ID));
-        } else {
-            additionalProperties.put(CodegenConstants.GIT_REPO_ID, gitRepoId);
-        }
 
         if (additionalProperties.containsKey(CodegenConstants.ARTIFACT_VERSION)) {
             this.setArtifactVersion((String) additionalProperties.get(CodegenConstants.ARTIFACT_VERSION));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/lumen/PhpLumenServerOptionsTest.java
@@ -56,10 +56,6 @@ public class PhpLumenServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSrcBasePath(PhpLumenServerOptionsProvider.SRC_BASE_PATH_VALUE);
             times = 1;
-            clientCodegen.setGitUserId(PhpLumenServerOptionsProvider.GIT_USER_ID_VALUE);
-            times = 1;
-            clientCodegen.setGitRepoId(PhpLumenServerOptionsProvider.GIT_REPO_ID_VALUE);
-            times = 1;
             clientCodegen.setArtifactVersion(PhpLumenServerOptionsProvider.ARTIFACT_VERSION_VALUE);
             times = 1;
         }};

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpClientOptionsProvider.java
@@ -32,8 +32,6 @@ public class PhpClientOptionsProvider implements OptionsProvider {
     public static final String INVOKER_PACKAGE_VALUE = "OpenAPITools\\Client\\Php";
     public static final String PACKAGE_NAME_VALUE = "OpenAPIToolsClient-php";
     public static final String SRC_BASE_PATH_VALUE = "libPhp";
-    public static final String GIT_USER_ID_VALUE = "gitOpenAPIToolsPhp";
-    public static final String GIT_REPO_ID_VALUE = "git-openapi-tools-client-php";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
@@ -54,8 +52,6 @@ public class PhpClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
                 .put(PhpClientCodegen.PACKAGE_NAME, PACKAGE_NAME_VALUE)
                 .put(PhpClientCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)
-                .put(CodegenConstants.GIT_USER_ID, GIT_USER_ID_VALUE)
-                .put(CodegenConstants.GIT_REPO_ID, GIT_REPO_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpLumenServerOptionsProvider.java
@@ -32,8 +32,6 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
     public static final String INVOKER_PACKAGE_VALUE = "lumen";
     public static final String PACKAGE_NAME_VALUE = "php";
     public static final String SRC_BASE_PATH_VALUE = "libPhp";
-    public static final String GIT_USER_ID_VALUE = "gitOpenAPIToolsPhp";
-    public static final String GIT_REPO_ID_VALUE = "git-openapi-tools-php";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
@@ -54,8 +52,6 @@ public class PhpLumenServerOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
-                .put(CodegenConstants.GIT_USER_ID, GIT_USER_ID_VALUE)
-                .put(CodegenConstants.GIT_REPO_ID, GIT_REPO_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, PREPEND_FORM_OR_BODY_PARAMETERS_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PhpSlimServerOptionsProvider.java
@@ -30,8 +30,6 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
     public static final String INVOKER_PACKAGE_VALUE = "OpenAPIServer";
     public static final String PACKAGE_NAME_VALUE = "";
     public static final String SRC_BASE_PATH_VALUE = "src";
-    public static final String GIT_USER_ID_VALUE = "gitOpenAPIToolsPhp";
-    public static final String GIT_REPO_ID_VALUE = "git-openapi-tools-php";
     public static final String ARTIFACT_VERSION_VALUE = "1.0.0";
     public static final String SORT_PARAMS_VALUE = "false";
     public static final String ENSURE_UNIQUE_PARAMS_VALUE = "true";
@@ -52,8 +50,6 @@ public class PhpSlimServerOptionsProvider implements OptionsProvider {
                 .put(AbstractPhpCodegen.SRC_BASE_PATH, SRC_BASE_PATH_VALUE)
                 .put(CodegenConstants.API_PACKAGE, API_PACKAGE_VALUE)
                 .put(CodegenConstants.INVOKER_PACKAGE, INVOKER_PACKAGE_VALUE)
-                .put(CodegenConstants.GIT_USER_ID, GIT_USER_ID_VALUE)
-                .put(CodegenConstants.GIT_REPO_ID, GIT_REPO_ID_VALUE)
                 .put(CodegenConstants.ARTIFACT_VERSION, ARTIFACT_VERSION_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpClientOptionsTest.java
@@ -56,10 +56,6 @@ public class PhpClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSrcBasePath(PhpClientOptionsProvider.SRC_BASE_PATH_VALUE);
             times = 1;
-            clientCodegen.setGitUserId(PhpClientOptionsProvider.GIT_USER_ID_VALUE);
-            times = 1;
-            clientCodegen.setGitRepoId(PhpClientOptionsProvider.GIT_REPO_ID_VALUE);
-            times = 1;
             clientCodegen.setArtifactVersion(PhpClientOptionsProvider.ARTIFACT_VERSION_VALUE);
             times = 1;
         }};

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerOptionsTest.java
@@ -54,10 +54,6 @@ public class PhpSlimServerOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setSrcBasePath(PhpSlimServerOptionsProvider.SRC_BASE_PATH_VALUE);
             times = 1;
-            clientCodegen.setGitUserId(PhpSlimServerOptionsProvider.GIT_USER_ID_VALUE);
-            times = 1;
-            clientCodegen.setGitRepoId(PhpSlimServerOptionsProvider.GIT_REPO_ID_VALUE);
-            times = 1;
             clientCodegen.setArtifactVersion(PhpSlimServerOptionsProvider.ARTIFACT_VERSION_VALUE);
             times = 1;
             clientCodegen.setSortParamsByRequiredFlag(Boolean.valueOf(PhpSlimServerOptionsProvider.SORT_PARAMS_VALUE));


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

These options are global so no need to be included in the PHP generators.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09), @ybelenko (2018/07), @renepardon (2018/12)


