### PR TITLE
Add packageName configuration to maven

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -164,6 +164,12 @@ public class CodeGenMojo extends AbstractMojo {
     private String invokerPackage;
 
     /**
+     * The default package to use for the generated objects
+     */
+    @Parameter(name = "packageName")
+    private String packageName;
+
+    /**
      * groupId in generated pom.xml
      */
     @Parameter(name = "groupId")
@@ -508,6 +514,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (isNotEmpty(invokerPackage)) {
                 configurator.setInvokerPackage(invokerPackage);
+            }
+
+            if (isNotEmpty(packageName)) {
+                configurator.setPackageName(packageName);
             }
 
             if (isNotEmpty(groupId)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -81,6 +81,7 @@ public class CodegenConfigurator implements Serializable {
     private String apiPackage;
     private String modelPackage;
     private String invokerPackage;
+    private String packageName;
     private String modelNamePrefix;
     private String modelNameSuffix;
     private String groupId;
@@ -316,6 +317,15 @@ public class CodegenConfigurator implements Serializable {
         return this;
     }
 
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public CodegenConfigurator setPackageName(String packageName) {
+        this.packageName = packageName;
+        return this;
+    }
+
     public String getGroupId() {
         return groupId;
     }
@@ -521,6 +531,7 @@ public class CodegenConfigurator implements Serializable {
         checkAndSetAdditionalProperty(apiPackage, CodegenConstants.API_PACKAGE);
         checkAndSetAdditionalProperty(modelPackage, CodegenConstants.MODEL_PACKAGE);
         checkAndSetAdditionalProperty(invokerPackage, CodegenConstants.INVOKER_PACKAGE);
+        checkAndSetAdditionalProperty(packageName, CodegenConstants.PACKAGE_NAME);
         checkAndSetAdditionalProperty(groupId, CodegenConstants.GROUP_ID);
         checkAndSetAdditionalProperty(artifactId, CodegenConstants.ARTIFACT_ID);
         checkAndSetAdditionalProperty(artifactVersion, CodegenConstants.ARTIFACT_VERSION);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add packageName configuration to maven for Kotlin client generation.

Must fix #2428

@jimschubert @dr4ke616