### PR TITLE
Fix boolean example value in ruby client generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -495,34 +495,34 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
             type = p.dataType;
         }
 
-        if ("String".equals(type)) {
+        if ("String".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = p.paramName + "_example";
             }
             example = "'" + escapeText(example) + "'";
-        } else if ("Integer".equals(type)) {
+        } else if ("Integer".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "56";
             }
-        } else if ("Float".equals(type)) {
+        } else if ("Float".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "3.4";
             }
-        } else if ("BOOLEAN".equals(type)) {
+        } else if ("BOOLEAN".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "true";
             }
-        } else if ("File".equals(type)) {
+        } else if ("File".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "/path/to/file";
             }
             example = "File.new('" + escapeText(example) + "')";
-        } else if ("Date".equals(type)) {
+        } else if ("Date".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20";
             }
             example = "Date.parse('" + escapeText(example) + "')";
-        } else if ("DateTime".equals(type)) {
+        } else if ("DateTime".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = "2013-10-20T19:20:30+01:00";
             }

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -77,7 +77,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: nil # Boolean | Input boolean as post body
+  body: true # Boolean | Input boolean as post body
 }
 
 begin
@@ -530,11 +530,11 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 required_string_group = 56 # Integer | Required String in group parameters
-required_boolean_group = nil # Boolean | Required Boolean in group parameters
+required_boolean_group = true # Boolean | Required Boolean in group parameters
 required_int64_group = 56 # Integer | Required Integer in group parameters
 opts = {
   string_group: 56, # Integer | String in group parameters
-  boolean_group: nil, # Boolean | Boolean in group parameters
+  boolean_group: true, # Boolean | Boolean in group parameters
   int64_group: 56 # Integer | Integer in group parameters
 }
 

--- a/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
@@ -72,7 +72,7 @@ require 'petstore'
 
 api_instance = Petstore::FakeApi.new
 opts = {
-  body: nil # Boolean | Input boolean as post body
+  body: true # Boolean | Input boolean as post body
 }
 
 begin
@@ -531,11 +531,11 @@ end
 
 api_instance = Petstore::FakeApi.new
 required_string_group = 56 # Integer | Required String in group parameters
-required_boolean_group = nil # Boolean | Required Boolean in group parameters
+required_boolean_group = true # Boolean | Required Boolean in group parameters
 required_int64_group = 56 # Integer | Required Integer in group parameters
 opts = {
   string_group: 56, # Integer | String in group parameters
-  boolean_group: nil, # Boolean | Boolean in group parameters
+  boolean_group: true, # Boolean | Boolean in group parameters
   int64_group: 56 # Integer | Integer in group parameters
 }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh`, `./bin/security/{LANG}-petstore.sh` and `./bin/openapi3/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

A follow-up to https://github.com/OpenAPITools/openapi-generator/pull/2386#pullrequestreview-215337726

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)



