### PR TITLE
[Java] Fix Javadoc issue in the client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -190,7 +190,7 @@ public class ApiClient {
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
      */
-     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
+    public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         if(!httpClient.equals(newHttpClient)) {
             OkHttpClient.Builder builder = newHttpClient.newBuilder();
             Iterator<Interceptor> networkInterceptorIterator = httpClient.networkInterceptors().iterator();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api.mustache
@@ -274,8 +274,7 @@ public class {{classname}} {
         {{/optionalParams}}
         /**
          * Build call for {{operationId}}
-         * @param _progressListener Progress listener
-         * @param _progressRequestListener Progress request listener
+         * @param _callback ApiCallback API callback
          * @return Call to execute
          * @throws ApiException If fail to serialize the request body object
          {{#isDeprecated}}

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -174,7 +174,7 @@ public class ApiClient {
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
      */
-     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
+    public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         if(!httpClient.equals(newHttpClient)) {
             OkHttpClient.Builder builder = newHttpClient.newBuilder();
             Iterator<Interceptor> networkInterceptorIterator = httpClient.networkInterceptors().iterator();

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1238,8 +1238,7 @@ public class FakeApi {
 
         /**
          * Build call for testGroupParameters
-         * @param _progressListener Progress listener
-         * @param _progressRequestListener Progress request listener
+         * @param _callback ApiCallback API callback
          * @return Call to execute
          * @throws ApiException If fail to serialize the request body object
          */

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -174,7 +174,7 @@ public class ApiClient {
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
      */
-     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
+    public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         if(!httpClient.equals(newHttpClient)) {
             OkHttpClient.Builder builder = newHttpClient.newBuilder();
             Iterator<Interceptor> networkInterceptorIterator = httpClient.networkInterceptors().iterator();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1238,8 +1238,7 @@ public class FakeApi {
 
         /**
          * Build call for testGroupParameters
-         * @param _progressListener Progress listener
-         * @param _progressRequestListener Progress request listener
+         * @param _callback ApiCallback API callback
          * @return Call to execute
          * @throws ApiException If fail to serialize the request body object
          */


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Minor fix to docstring and code format

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)
