### PR TITLE
[#2442] - implement yamlsample config help output;

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,8 +72,8 @@ SYNOPSIS
 
 OPTIONS
         -f <output format>, --format <output format>
-            Write output files in the desired format. Options are 'text' and
-            'markdown'. Default is 'text'.
+            Write output files in the desired format. Options are 'text',
+            'markdown' or 'yamlsample'. Default is 'text'.
 
         -g <generator name>, --generator-name <generator name>
             generator to get config help for

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/ConfigHelp.java
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.nio.file.Paths;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
@@ -40,30 +40,34 @@ public class ConfigHelp implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Generate.class);
 
-    @Option(name = {"-g", "--generator-name"}, title = "generator name",
-            description = "generator to get config help for")
+    public static final String FORMAT_TEXT = "text";
+    public static final String FORMAT_MARKDOWN = "markdown";
+    public static final String FORMAT_YAMLSAMPLE = "yamlsample";
+
+    @Option(name = {"-g",
+            "--generator-name"}, title = "generator name", description = "generator to get config help for")
     private String generatorName;
 
-    @Option(name = {"--named-header"}, title = "named header",
-            description = "Header includes the generator name, for clarity in output")
+    @Option(name = {
+            "--named-header"}, title = "named header", description = "Header includes the generator name, for clarity in output")
     private Boolean namedHeader;
 
-    @Option(name = {"-o", "--output"}, title = "output location",
-            description = "Optionally write help to this location, otherwise default is standard output")
+    @Option(name = {"-o",
+            "--output"}, title = "output location", description = "Optionally write help to this location, otherwise default is standard output")
     private String outputFile;
 
-    @Option(name = {"-f", "--format"}, title = "output format",
-            description = "Write output files in the desired format. Options are 'text' and 'markdown'. Default is 'text'.")
+    @Option(name = {"-f",
+            "--format"}, title = "output format", description = "Write output files in the desired format. Options are 'text', 'markdown' or 'yamlsample'. Default is 'text'.", allowedValues = {
+            FORMAT_TEXT, FORMAT_MARKDOWN, FORMAT_YAMLSAMPLE})
     private String format;
 
-    @Option(name = {"--markdown-header"}, title = "markdown header",
-            description = "When format=markdown, include this option to write out markdown headers (e.g. for docusaurus).")
+    @Option(name = {
+            "--markdown-header"}, title = "markdown header", description = "When format=markdown, include this option to write out markdown headers (e.g. for docusaurus).")
     private Boolean markdownHeader;
 
     private String newline = System.lineSeparator();
 
-    @Override
-    public void run() {
+    @Override public void run() {
         if (isEmpty(generatorName)) {
             LOGGER.error("[error] A generator name (--generator-name / -g) is required.");
             System.exit(1);
@@ -73,20 +77,34 @@ public class ConfigHelp implements Runnable {
             StringBuilder sb = new StringBuilder();
             CodegenConfig config = CodegenConfigLoader.forName(generatorName);
 
-            if (StringUtils.isEmpty(format) || "text".equalsIgnoreCase(format)) {
-                generatePlainTextHelp(sb, config);
-            } else if ("markdown".equalsIgnoreCase(format)) {
-                generateMarkdownHelp(sb, config);
-            } else {
-                LOGGER.warn("[warning] Unrecognized format option: %s.%n", format);
+            String desiredFormat = StringUtils.defaultIfBlank(format, FORMAT_TEXT);
+
+            switch (desiredFormat) {
+                case FORMAT_MARKDOWN:
+                    generateMarkdownHelp(sb, config);
+                    break;
+                case FORMAT_YAMLSAMPLE:
+                    generateYamlSample(sb, config);
+                    break;
+                case FORMAT_TEXT:
+                    generatePlainTextHelp(sb, config);
+                    break;
+                default:
+                    LOGGER.warn("[warning] Unrecognized format option: {}", format);
+                    break;
             }
+
 
             if (!isEmpty(outputFile)) {
                 File out = Paths.get(outputFile).toFile();
                 //noinspection ResultOfMethodCallIgnored
-                out.getParentFile().mkdirs();
+                File parentFolder = out.getParentFile();
+                if (parentFolder != null && parentFolder.isDirectory()) {
+                    parentFolder.mkdirs();
+                }
 
-                try (Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8))) {
+                try (Writer writer = new BufferedWriter(
+                        new OutputStreamWriter(new FileOutputStream(out), StandardCharsets.UTF_8))) {
                     writer.write(sb.toString());
                 }
             } else {
@@ -101,12 +119,41 @@ public class ConfigHelp implements Runnable {
         }
     }
 
+    private void generateYamlSample(StringBuilder sb, CodegenConfig config) {
+
+        for (CliOption langCliOption : config.cliOptions()) {
+
+            sb.append("# Description: ").append(langCliOption.getDescription()).append(newline);
+
+            Map<String, String> enums = langCliOption.getEnum();
+            if (enums != null) {
+                sb.append("# Available Values:").append(newline);
+
+                for (Map.Entry<String, String> entry : enums.entrySet()) {
+                    sb.append("#    ").append(entry.getKey()).append(newline);
+                    sb.append("#         ").append(entry.getValue()).append(newline);
+                }
+            }
+
+            String defaultValue = langCliOption.getDefault();
+
+            if (defaultValue != null) {
+                sb.append(langCliOption.getOpt()).append(": ").append(defaultValue).append(newline);
+            } else {
+                sb.append("# ").append(langCliOption.getOpt()).append(": ").append(newline);
+            }
+
+            sb.append(newline);
+        }
+    }
+
     private void generateMarkdownHelp(StringBuilder sb, CodegenConfig config) {
         sb.append(newline);
 
         if (Boolean.TRUE.equals(markdownHeader)) {
             sb.append("---").append(newline);
-            sb.append("id: generator-opts-").append(config.getTag().toValue()).append("-").append(config.getName()).append(newline);
+            sb.append("id: generator-opts-").append(config.getTag().toValue()).append("-")
+                    .append(config.getName()).append(newline);
             sb.append("title: Config Options for ").append(generatorName).append(newline);
             sb.append("sidebar_label: ").append(generatorName).append(newline);
             sb.append("---").append(newline);
@@ -167,7 +214,8 @@ public class ConfigHelp implements Runnable {
         for (CliOption langCliOption : config.cliOptions()) {
             sb.append("\t").append(langCliOption.getOpt());
             sb.append(newline);
-            sb.append("\t    ").append(langCliOption.getOptionHelp().replaceAll("\n", System.lineSeparator() + "\t    "));
+            sb.append("\t    ").append(langCliOption.getOptionHelp()
+                    .replaceAll("\n", System.lineSeparator() + "\t    "));
             sb.append(newline);
             sb.append(newline);
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Added another option for the `config-help --format` called `yamlsample` that will basically outputs key value pairs with default values. Also comments with the description of the cli option. If the value doesn't have default value it is commented out and the user has the possibility to uncomment and set a value.
