### PR TITLE
Fix missing "consumes"

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -541,6 +541,23 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testMediaTypeRangeInConsumes() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/consumes.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        CodegenOperation codegenOperation = codegen.fromOperation(
+                "/test",
+                "post",
+                openAPI.getPaths().get("/test").getPost(),
+                null
+        );
+
+        Assert.assertNotNull(codegenOperation.consumes);
+        Assert.assertEquals(codegenOperation.consumes.get(0).get("mediaType"), "*/*");
+        Assert.assertNull(codegenOperation.consumes.get(0).get("hasMore"));
+    }
+
+    @Test
     public void testResponseWithNoSchemaInHeaders() {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         ApiResponse response2XX = new ApiResponse()

--- a/modules/openapi-generator/src/test/resources/3_0/consumes.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/consumes.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://api.example.com/v3'
+info:
+  version: 1.0.0
+  title: OpenAPI Test
+  license:
+    name: Apache-2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /test:
+    post:
+      operationId: test
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

