### PR TITLE
Adding retries option to override default value 3 of urllib3

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -100,6 +100,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.proxy = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
+        # Adding retries to override urllib3 default value 3
+        self.retries = None
 
     @property
     def logger_file(self):

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -67,6 +67,9 @@ class RESTClientObject(object):
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
 
+        if configuration.retries is not None:
+            addition_pool_args['retries'] = configuration.retries
+
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:
                 maxsize = configuration.connection_pool_maxsize

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -100,6 +100,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.proxy = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
+        # Adding retries to override urllib3 default value 3
+        self.retries = None
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -100,6 +100,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.proxy = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
+        # Adding retries to override urllib3 default value 3
+        self.retries = None
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -100,6 +100,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.proxy = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
+        # Adding retries to override urllib3 default value 3
+        self.retries = None
 
     @property
     def logger_file(self):

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -75,6 +75,9 @@ class RESTClientObject(object):
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
 
+        if configuration.retries is not None:
+            addition_pool_args['retries'] = configuration.retries
+
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:
                 maxsize = configuration.connection_pool_maxsize

--- a/samples/client/petstore/ruby/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/ruby/docs/AdditionalPropertiesClass.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 **map_string** | **Hash&lt;String, String&gt;** |  | [optional] 
 **map_number** | **Hash&lt;String, Float&gt;** |  | [optional] 
 **map_integer** | **Hash&lt;String, Integer&gt;** |  | [optional] 
-**map_boolean** | **Hash&lt;String, BOOLEAN&gt;** |  | [optional] 
+**map_boolean** | **Hash&lt;String, Boolean&gt;** |  | [optional] 
 **map_array_integer** | **Hash&lt;String, Array&lt;Integer&gt;&gt;** |  | [optional] 
 **map_array_anytype** | **Hash&lt;String, Array&lt;Object&gt;&gt;** |  | [optional] 
 **map_map_string** | **Hash&lt;String, Hash&lt;String, String&gt;&gt;** |  | [optional] 

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_any_type.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_any_type.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_array.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_array.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_boolean.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_boolean.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -59,7 +59,7 @@ module Petstore
         :'map_string' => :'Hash<String, String>',
         :'map_number' => :'Hash<String, Float>',
         :'map_integer' => :'Hash<String, Integer>',
-        :'map_boolean' => :'Hash<String, BOOLEAN>',
+        :'map_boolean' => :'Hash<String, Boolean>',
         :'map_array_integer' => :'Hash<String, Array<Integer>>',
         :'map_array_anytype' => :'Hash<String, Array<Object>>',
         :'map_map_string' => :'Hash<String, Hash<String, String>>',

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_integer.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_integer.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_number.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_number.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_object.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_object.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_string.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_string.rb
@@ -126,7 +126,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -100,6 +100,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.proxy = None
         # Safe chars for path_param
         self.safe_chars_for_path_param = ''
+        # Adding retries to override urllib3 default value 3
+        self.retries = None
 
     @property
     def logger_file(self):

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -75,6 +75,9 @@ class RESTClientObject(object):
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
 
+        if configuration.retries is not None:
+            addition_pool_args['retries'] = configuration.retries
+
         if maxsize is None:
             if configuration.connection_pool_maxsize is not None:
                 maxsize = configuration.connection_pool_maxsize

--- a/samples/openapi3/client/petstore/ruby/docs/NullableClass.md
+++ b/samples/openapi3/client/petstore/ruby/docs/NullableClass.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **integer_prop** | **Integer** |  | [optional] 
 **number_prop** | **Float** |  | [optional] 
-**boolean_prop** | **BOOLEAN** |  | [optional] 
+**boolean_prop** | **Boolean** |  | [optional] 
 **string_prop** | **String** |  | [optional] 
 **date_prop** | **Date** |  | [optional] 
 **datetime_prop** | **DateTime** |  | [optional] 

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/nullable_class.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/nullable_class.rb
@@ -61,7 +61,7 @@ module Petstore
       {
         :'integer_prop' => :'Integer',
         :'number_prop' => :'Float',
-        :'boolean_prop' => :'BOOLEAN',
+        :'boolean_prop' => :'Boolean',
         :'string_prop' => :'String',
         :'date_prop' => :'Date',
         :'datetime_prop' => :'DateTime',
@@ -237,7 +237,7 @@ module Petstore
         value.to_i
       when :Float
         value.to_f
-      when :BOOLEAN
+      when :Boolean
         if value.to_s =~ /\A(true|t|yes|y|1)\z/i
           true
         else


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adding retries option to override the default value of urllib which is 3. This will give option to control number of retries for any request.
