### PR TITLE
[Java] Jersey2 - Always render setBearerToken no matter if OAuth2 is in use.

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -194,7 +194,6 @@ public class ApiClient {
     throw new RuntimeException("No API key authentication configured!");
   }
 
-  {{#hasOAuthMethods}}
   /**
    * Helper method to set bearer token for the first Bearer authentication.
    * @param bearerToken Bearer token
@@ -209,6 +208,7 @@ public class ApiClient {
     throw new RuntimeException("No Bearer authentication configured!");
   }
 
+  {{#hasOAuthMethods}}
   /**
    * Helper method to set access token for the first OAuth2 authentication.
    * @param accessToken Access token


### PR DESCRIPTION
### PR checklist

- [ X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
I think in the merging of #1930, the new setBearerToken(String) method was erroneously included inside the conditional rendering of the OAuth setAccessToken(String) method.


cc @wing328 @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)