### PR TITLE
[Ruby] Use Integer instead of Fixnum in Ruby client (#2475)

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -37,7 +37,7 @@ module {{moduleName}}
 {{#allParams}}{{#required}}    # @param {{paramName}} [{{{dataType}}}] {{description}}
 {{/required}}{{/allParams}}    # @param [Hash] opts the optional parameters
 {{#allParams}}{{^required}}    # @option opts [{{{dataType}}}] :{{paramName}} {{description}}
-{{/required}}{{/allParams}}    # @return [Array<({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Fixnum, Hash)>] {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
+{{/required}}{{/allParams}}    # @return [Array<({{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}, Integer, Hash)>] {{#returnType}}{{{returnType}}} data{{/returnType}}{{^returnType}}nil{{/returnType}}, response status code and response headers
     def {{operationId}}_with_http_info({{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: {{classname}}.{{operationId}} ...'

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -36,7 +36,7 @@ module {{moduleName}}
 
     # Call an API with given options.
     #
-    # @return [Array<(Object, Fixnum, Hash)>] an array of 3 elements:
+    # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -374,7 +374,7 @@
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [{{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # To test special tags and operation ID starting with number
     # @param body [Client] client model
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
+    # @return [Array<(Client, Integer, Hash)>] Client data, response status code and response headers
     def call_123_test_special_tags_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: AnotherFakeApi.call_123_test_special_tags ...'

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # this route creates an XmlItem
     # @param xml_item [XmlItem] XmlItem Body
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_xml_item_with_http_info(xml_item, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.create_xml_item ...'
@@ -83,7 +83,7 @@ module Petstore
     # Test serialization of outer boolean types
     # @param [Hash] opts the optional parameters
     # @option opts [Boolean] :body Input boolean as post body
-    # @return [Array<(Boolean, Fixnum, Hash)>] Boolean data, response status code and response headers
+    # @return [Array<(Boolean, Integer, Hash)>] Boolean data, response status code and response headers
     def fake_outer_boolean_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_boolean_serialize ...'
@@ -130,7 +130,7 @@ module Petstore
     # Test serialization of object with outer number type
     # @param [Hash] opts the optional parameters
     # @option opts [OuterComposite] :body Input composite as post body
-    # @return [Array<(OuterComposite, Fixnum, Hash)>] OuterComposite data, response status code and response headers
+    # @return [Array<(OuterComposite, Integer, Hash)>] OuterComposite data, response status code and response headers
     def fake_outer_composite_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_composite_serialize ...'
@@ -177,7 +177,7 @@ module Petstore
     # Test serialization of outer number types
     # @param [Hash] opts the optional parameters
     # @option opts [Float] :body Input number as post body
-    # @return [Array<(Float, Fixnum, Hash)>] Float data, response status code and response headers
+    # @return [Array<(Float, Integer, Hash)>] Float data, response status code and response headers
     def fake_outer_number_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_number_serialize ...'
@@ -224,7 +224,7 @@ module Petstore
     # Test serialization of outer string types
     # @param [Hash] opts the optional parameters
     # @option opts [String] :body Input string as post body
-    # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
     def fake_outer_string_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_string_serialize ...'
@@ -271,7 +271,7 @@ module Petstore
     # For this test, the body for this request much reference a schema named &#x60;File&#x60;.
     # @param body [FileSchemaTestClass] 
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_body_with_file_schema_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_body_with_file_schema ...'
@@ -321,7 +321,7 @@ module Petstore
     # @param query [String] 
     # @param body [User] 
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_body_with_query_params_with_http_info(query, body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_body_with_query_params ...'
@@ -378,7 +378,7 @@ module Petstore
     # To test \&quot;client\&quot; model
     # @param body [Client] client model
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
+    # @return [Array<(Client, Integer, Hash)>] Client data, response status code and response headers
     def test_client_model_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_client_model ...'
@@ -459,7 +459,7 @@ module Petstore
     # @option opts [DateTime] :date_time None
     # @option opts [String] :password None
     # @option opts [String] :callback None
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_endpoint_parameters ...'
@@ -605,7 +605,7 @@ module Petstore
     # @option opts [Float] :enum_query_double Query parameter enum test (double)
     # @option opts [Array<String>] :enum_form_string_array Form parameter enum test (string array)
     # @option opts [String] :enum_form_string Form parameter enum test (string)
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_enum_parameters_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_enum_parameters ...'
@@ -703,7 +703,7 @@ module Petstore
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [Boolean] :boolean_group Boolean in group parameters
     # @option opts [Integer] :int64_group Integer in group parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_group_parameters ...'
@@ -765,7 +765,7 @@ module Petstore
     # test inline additionalProperties
     # @param param [Hash<String, String>] request body
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_inline_additional_properties_with_http_info(param, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_inline_additional_properties ...'
@@ -817,7 +817,7 @@ module Petstore
     # @param param [String] field1
     # @param param2 [String] field2
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_json_form_data_with_http_info(param, param2, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_json_form_data ...'

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # To test class name in snake case
     # @param body [Client] client model
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
+    # @return [Array<(Client, Integer, Hash)>] Client data, response status code and response headers
     def test_classname_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeClassnameTags123Api.test_classname ...'

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -31,7 +31,7 @@ module Petstore
     # Add a new pet to the store
     # @param body [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def add_pet_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.add_pet ...'
@@ -83,7 +83,7 @@ module Petstore
     # @param pet_id [Integer] Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def delete_pet_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.delete_pet ...'
@@ -134,7 +134,7 @@ module Petstore
     # Multiple status values can be provided with comma separated strings
     # @param status [Array<String>] Status values that need to be considered for filter
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
+    # @return [Array<(Array<Pet>, Integer, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_status_with_http_info(status, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.find_pets_by_status ...'
@@ -188,7 +188,7 @@ module Petstore
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     # @param tags [Array<String>] Tags to filter by
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
+    # @return [Array<(Array<Pet>, Integer, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_tags_with_http_info(tags, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.find_pets_by_tags ...'
@@ -242,7 +242,7 @@ module Petstore
     # Returns a single pet
     # @param pet_id [Integer] ID of pet to return
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Pet, Fixnum, Hash)>] Pet data, response status code and response headers
+    # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
     def get_pet_by_id_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.get_pet_by_id ...'
@@ -293,7 +293,7 @@ module Petstore
     # Update an existing pet
     # @param body [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def update_pet_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.update_pet ...'
@@ -347,7 +347,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def update_pet_with_form_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.update_pet_with_form ...'
@@ -403,7 +403,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
-    # @return [Array<(ApiResponse, Fixnum, Hash)>] ApiResponse data, response status code and response headers
+    # @return [Array<(ApiResponse, Integer, Hash)>] ApiResponse data, response status code and response headers
     def upload_file_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.upload_file ...'
@@ -462,7 +462,7 @@ module Petstore
     # @param required_file [File] file to upload
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
-    # @return [Array<(ApiResponse, Fixnum, Hash)>] ApiResponse data, response status code and response headers
+    # @return [Array<(ApiResponse, Integer, Hash)>] ApiResponse data, response status code and response headers
     def upload_file_with_required_file_with_http_info(pet_id, required_file, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.upload_file_with_required_file ...'

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id [String] ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def delete_order_with_http_info(order_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.delete_order ...'
@@ -81,7 +81,7 @@ module Petstore
     # Returns pet inventories by status
     # Returns a map of status codes to quantities
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Hash<String, Integer>, Fixnum, Hash)>] Hash<String, Integer> data, response status code and response headers
+    # @return [Array<(Hash<String, Integer>, Integer, Hash)>] Hash<String, Integer> data, response status code and response headers
     def get_inventory_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.get_inventory ...'
@@ -130,7 +130,7 @@ module Petstore
     # For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     # @param order_id [Integer] ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
+    # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
     def get_order_by_id_with_http_info(order_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.get_order_by_id ...'
@@ -189,7 +189,7 @@ module Petstore
     # Place an order for a pet
     # @param body [Order] order placed for purchasing the pet
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
+    # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
     def place_order_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.place_order ...'

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param body [User] Created user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_user_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.create_user ...'
@@ -81,7 +81,7 @@ module Petstore
     # Creates list of users with given input array
     # @param body [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_users_with_array_input_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.create_users_with_array_input ...'
@@ -129,7 +129,7 @@ module Petstore
     # Creates list of users with given input array
     # @param body [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_users_with_list_input_with_http_info(body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.create_users_with_list_input ...'
@@ -179,7 +179,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username [String] The name that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def delete_user_with_http_info(username, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.delete_user ...'
@@ -227,7 +227,7 @@ module Petstore
     # Get user by user name
     # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
-    # @return [Array<(User, Fixnum, Hash)>] User data, response status code and response headers
+    # @return [Array<(User, Integer, Hash)>] User data, response status code and response headers
     def get_user_by_name_with_http_info(username, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.get_user_by_name ...'
@@ -280,7 +280,7 @@ module Petstore
     # @param username [String] The user name for login
     # @param password [String] The password for login in clear text
     # @param [Hash] opts the optional parameters
-    # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
     def login_user_with_http_info(username, password, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.login_user ...'
@@ -335,7 +335,7 @@ module Petstore
 
     # Logs out current logged in user session
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def logout_user_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.logout_user ...'
@@ -383,7 +383,7 @@ module Petstore
     # @param username [String] name that need to be deleted
     # @param body [User] Updated user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def update_user_with_http_info(username, body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.update_user ...'

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -44,7 +44,7 @@ module Petstore
 
     # Call an API with given options.
     #
-    # @return [Array<(Object, Fixnum, Hash)>] an array of 3 elements:
+    # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_any_type.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_any_type.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_array.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_array.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_boolean.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_boolean.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -184,7 +184,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [map_string, map_number, map_integer, map_boolean, map_array_integer, map_array_anytype, map_map_string, map_map_anytype, anytype_1, anytype_2, anytype_3].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_integer.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_integer.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_number.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_number.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_object.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_object.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_string.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_string.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -99,7 +99,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [class_name, color].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
@@ -96,7 +96,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [code, type, message].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [array_array_number].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [array_number].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
@@ -102,7 +102,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [array_of_string, array_array_of_integer, array_array_of_model].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
@@ -124,7 +124,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [small_camel, capital_camel, small_snake, capital_snake, sca_eth_flow_points, att_name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat.rb
@@ -88,7 +88,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [declawed].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/category.rb
@@ -94,7 +94,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
@@ -79,7 +79,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [_class].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/client.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [client].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog.rb
@@ -88,7 +88,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [breed].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -123,7 +123,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [just_symbol, array_enum].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -189,7 +189,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [enum_string, enum_string_required, enum_integer, enum_number, outer_enum].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [source_uri].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
@@ -89,7 +89,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [file, files].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -396,7 +396,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [integer, int32, int64, number, float, double, string, byte, binary, date, date_time, uuid, password].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
@@ -87,7 +87,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [bar, foo].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/list.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [_123_list].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -135,7 +135,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [map_map_of_string, map_of_enum_string, direct_map, indirect_map].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -98,7 +98,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [uuid, date_time, map].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
@@ -88,7 +88,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name, _class].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
@@ -79,7 +79,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [_return].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/name.rb
@@ -111,7 +111,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name, snake_case, property, _123_number].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [just_number].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -160,7 +160,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, pet_id, quantity, ship_date, status, complete].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
@@ -96,7 +96,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [my_number, my_string, my_boolean].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -172,7 +172,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, category, name, photo_urls, tags, status].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
@@ -87,7 +87,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [bar, baz].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [special_property_name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -87,7 +87,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, name].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/type_holder_default.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/type_holder_default.rb
@@ -145,7 +145,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [string_item, number_item, integer_item, bool_item, array_item].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/type_holder_example.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/type_holder_example.rb
@@ -141,7 +141,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [string_item, number_item, integer_item, bool_item, array_item].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/user.rb
@@ -142,7 +142,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, username, first_name, last_name, email, password, phone, user_status].hash
     end

--- a/samples/client/petstore/ruby/lib/petstore/models/xml_item.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/xml_item.rb
@@ -348,7 +348,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [attribute_string, attribute_number, attribute_integer, attribute_boolean, wrapped_array, name_string, name_number, name_integer, name_boolean, name_array, name_wrapped_array, prefix_string, prefix_number, prefix_integer, prefix_boolean, prefix_array, prefix_wrapped_array, namespace_string, namespace_number, namespace_integer, namespace_boolean, namespace_array, namespace_wrapped_array, prefix_ns_string, prefix_ns_number, prefix_ns_integer, prefix_ns_boolean, prefix_ns_array, prefix_ns_wrapped_array].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # To test special tags and operation ID starting with number
     # @param client [Client] client model
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
+    # @return [Array<(Client, Integer, Hash)>] Client data, response status code and response headers
     def call_123_test_special_tags_with_http_info(client, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: AnotherFakeApi.call_123_test_special_tags ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -27,7 +27,7 @@ module Petstore
     end
 
     # @param [Hash] opts the optional parameters
-    # @return [Array<(InlineResponseDefault, Fixnum, Hash)>] InlineResponseDefault data, response status code and response headers
+    # @return [Array<(InlineResponseDefault, Integer, Hash)>] InlineResponseDefault data, response status code and response headers
     def foo_get_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: DefaultApi.foo_get ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -29,7 +29,7 @@ module Petstore
 
     # Health check endpoint
     # @param [Hash] opts the optional parameters
-    # @return [Array<(HealthCheckResult, Fixnum, Hash)>] HealthCheckResult data, response status code and response headers
+    # @return [Array<(HealthCheckResult, Integer, Hash)>] HealthCheckResult data, response status code and response headers
     def fake_health_get_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_health_get ...'
@@ -76,7 +76,7 @@ module Petstore
     # Test serialization of outer boolean types
     # @param [Hash] opts the optional parameters
     # @option opts [Boolean] :body Input boolean as post body
-    # @return [Array<(Boolean, Fixnum, Hash)>] Boolean data, response status code and response headers
+    # @return [Array<(Boolean, Integer, Hash)>] Boolean data, response status code and response headers
     def fake_outer_boolean_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_boolean_serialize ...'
@@ -125,7 +125,7 @@ module Petstore
     # Test serialization of object with outer number type
     # @param [Hash] opts the optional parameters
     # @option opts [OuterComposite] :outer_composite Input composite as post body
-    # @return [Array<(OuterComposite, Fixnum, Hash)>] OuterComposite data, response status code and response headers
+    # @return [Array<(OuterComposite, Integer, Hash)>] OuterComposite data, response status code and response headers
     def fake_outer_composite_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_composite_serialize ...'
@@ -174,7 +174,7 @@ module Petstore
     # Test serialization of outer number types
     # @param [Hash] opts the optional parameters
     # @option opts [Float] :body Input number as post body
-    # @return [Array<(Float, Fixnum, Hash)>] Float data, response status code and response headers
+    # @return [Array<(Float, Integer, Hash)>] Float data, response status code and response headers
     def fake_outer_number_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_number_serialize ...'
@@ -223,7 +223,7 @@ module Petstore
     # Test serialization of outer string types
     # @param [Hash] opts the optional parameters
     # @option opts [String] :body Input string as post body
-    # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
     def fake_outer_string_serialize_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.fake_outer_string_serialize ...'
@@ -272,7 +272,7 @@ module Petstore
     # For this test, the body for this request much reference a schema named &#x60;File&#x60;.
     # @param file_schema_test_class [FileSchemaTestClass] 
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_body_with_file_schema_with_http_info(file_schema_test_class, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_body_with_file_schema ...'
@@ -322,7 +322,7 @@ module Petstore
     # @param query [String] 
     # @param user [User] 
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_body_with_query_params_with_http_info(query, user, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_body_with_query_params ...'
@@ -379,7 +379,7 @@ module Petstore
     # To test \&quot;client\&quot; model
     # @param client [Client] client model
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
+    # @return [Array<(Client, Integer, Hash)>] Client data, response status code and response headers
     def test_client_model_with_http_info(client, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_client_model ...'
@@ -460,7 +460,7 @@ module Petstore
     # @option opts [DateTime] :date_time None
     # @option opts [String] :password None
     # @option opts [String] :callback None
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_endpoint_parameters ...'
@@ -606,7 +606,7 @@ module Petstore
     # @option opts [Float] :enum_query_double Query parameter enum test (double)
     # @option opts [Array<String>] :enum_form_string_array Form parameter enum test (string array)
     # @option opts [String] :enum_form_string Form parameter enum test (string)
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_enum_parameters_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_enum_parameters ...'
@@ -704,7 +704,7 @@ module Petstore
     # @option opts [Integer] :string_group String in group parameters
     # @option opts [Boolean] :boolean_group Boolean in group parameters
     # @option opts [Integer] :int64_group Integer in group parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_group_parameters ...'
@@ -766,7 +766,7 @@ module Petstore
     # test inline additionalProperties
     # @param request_body [Hash<String, String>] request body
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_inline_additional_properties_with_http_info(request_body, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_inline_additional_properties ...'
@@ -818,7 +818,7 @@ module Petstore
     # @param param [String] field1
     # @param param2 [String] field2
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def test_json_form_data_with_http_info(param, param2, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeApi.test_json_form_data ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # To test class name in snake case
     # @param client [Client] client model
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Client, Fixnum, Hash)>] Client data, response status code and response headers
+    # @return [Array<(Client, Integer, Hash)>] Client data, response status code and response headers
     def test_classname_with_http_info(client, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: FakeClassnameTags123Api.test_classname ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -31,7 +31,7 @@ module Petstore
     # Add a new pet to the store
     # @param pet [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def add_pet_with_http_info(pet, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.add_pet ...'
@@ -83,7 +83,7 @@ module Petstore
     # @param pet_id [Integer] Pet id to delete
     # @param [Hash] opts the optional parameters
     # @option opts [String] :api_key 
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def delete_pet_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.delete_pet ...'
@@ -134,7 +134,7 @@ module Petstore
     # Multiple status values can be provided with comma separated strings
     # @param status [Array<String>] Status values that need to be considered for filter
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
+    # @return [Array<(Array<Pet>, Integer, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_status_with_http_info(status, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.find_pets_by_status ...'
@@ -188,7 +188,7 @@ module Petstore
     # Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
     # @param tags [Array<String>] Tags to filter by
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Array<Pet>, Fixnum, Hash)>] Array<Pet> data, response status code and response headers
+    # @return [Array<(Array<Pet>, Integer, Hash)>] Array<Pet> data, response status code and response headers
     def find_pets_by_tags_with_http_info(tags, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.find_pets_by_tags ...'
@@ -242,7 +242,7 @@ module Petstore
     # Returns a single pet
     # @param pet_id [Integer] ID of pet to return
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Pet, Fixnum, Hash)>] Pet data, response status code and response headers
+    # @return [Array<(Pet, Integer, Hash)>] Pet data, response status code and response headers
     def get_pet_by_id_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.get_pet_by_id ...'
@@ -293,7 +293,7 @@ module Petstore
     # Update an existing pet
     # @param pet [Pet] Pet object that needs to be added to the store
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def update_pet_with_http_info(pet, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.update_pet ...'
@@ -347,7 +347,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :name Updated name of the pet
     # @option opts [String] :status Updated status of the pet
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def update_pet_with_form_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.update_pet_with_form ...'
@@ -403,7 +403,7 @@ module Petstore
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
     # @option opts [File] :file file to upload
-    # @return [Array<(ApiResponse, Fixnum, Hash)>] ApiResponse data, response status code and response headers
+    # @return [Array<(ApiResponse, Integer, Hash)>] ApiResponse data, response status code and response headers
     def upload_file_with_http_info(pet_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.upload_file ...'
@@ -462,7 +462,7 @@ module Petstore
     # @param required_file [File] file to upload
     # @param [Hash] opts the optional parameters
     # @option opts [String] :additional_metadata Additional data to pass to server
-    # @return [Array<(ApiResponse, Fixnum, Hash)>] ApiResponse data, response status code and response headers
+    # @return [Array<(ApiResponse, Integer, Hash)>] ApiResponse data, response status code and response headers
     def upload_file_with_required_file_with_http_info(pet_id, required_file, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: PetApi.upload_file_with_required_file ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
     # @param order_id [String] ID of the order that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def delete_order_with_http_info(order_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.delete_order ...'
@@ -81,7 +81,7 @@ module Petstore
     # Returns pet inventories by status
     # Returns a map of status codes to quantities
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Hash<String, Integer>, Fixnum, Hash)>] Hash<String, Integer> data, response status code and response headers
+    # @return [Array<(Hash<String, Integer>, Integer, Hash)>] Hash<String, Integer> data, response status code and response headers
     def get_inventory_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.get_inventory ...'
@@ -130,7 +130,7 @@ module Petstore
     # For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
     # @param order_id [Integer] ID of pet that needs to be fetched
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
+    # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
     def get_order_by_id_with_http_info(order_id, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.get_order_by_id ...'
@@ -189,7 +189,7 @@ module Petstore
     # Place an order for a pet
     # @param order [Order] order placed for purchasing the pet
     # @param [Hash] opts the optional parameters
-    # @return [Array<(Order, Fixnum, Hash)>] Order data, response status code and response headers
+    # @return [Array<(Order, Integer, Hash)>] Order data, response status code and response headers
     def place_order_with_http_info(order, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: StoreApi.place_order ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -33,7 +33,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param user [User] Created user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_user_with_http_info(user, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.create_user ...'
@@ -83,7 +83,7 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_users_with_array_input_with_http_info(user, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.create_users_with_array_input ...'
@@ -133,7 +133,7 @@ module Petstore
     # Creates list of users with given input array
     # @param user [Array<User>] List of user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def create_users_with_list_input_with_http_info(user, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.create_users_with_list_input ...'
@@ -185,7 +185,7 @@ module Petstore
     # This can only be done by the logged in user.
     # @param username [String] The name that needs to be deleted
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def delete_user_with_http_info(username, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.delete_user ...'
@@ -233,7 +233,7 @@ module Petstore
     # Get user by user name
     # @param username [String] The name that needs to be fetched. Use user1 for testing.
     # @param [Hash] opts the optional parameters
-    # @return [Array<(User, Fixnum, Hash)>] User data, response status code and response headers
+    # @return [Array<(User, Integer, Hash)>] User data, response status code and response headers
     def get_user_by_name_with_http_info(username, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.get_user_by_name ...'
@@ -286,7 +286,7 @@ module Petstore
     # @param username [String] The user name for login
     # @param password [String] The password for login in clear text
     # @param [Hash] opts the optional parameters
-    # @return [Array<(String, Fixnum, Hash)>] String data, response status code and response headers
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
     def login_user_with_http_info(username, password, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.login_user ...'
@@ -341,7 +341,7 @@ module Petstore
 
     # Logs out current logged in user session
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def logout_user_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.logout_user ...'
@@ -389,7 +389,7 @@ module Petstore
     # @param username [String] name that need to be deleted
     # @param user [User] Updated user object
     # @param [Hash] opts the optional parameters
-    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
     def update_user_with_http_info(username, user, opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: UserApi.update_user ...'

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api_client.rb
@@ -44,7 +44,7 @@ module Petstore
 
     # Call an API with given options.
     #
-    # @return [Array<(Object, Fixnum, Hash)>] an array of 3 elements:
+    # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
       request = build_request(http_method, path, opts)

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -91,7 +91,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [map_property, map_of_map_property].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -99,7 +99,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [class_name, color].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/api_response.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/api_response.rb
@@ -96,7 +96,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [code, type, message].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [array_array_number].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [array_number].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/array_test.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/array_test.rb
@@ -102,7 +102,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [array_of_string, array_array_of_integer, array_array_of_model].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/capitalization.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/capitalization.rb
@@ -124,7 +124,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [small_camel, capital_camel, small_snake, capital_snake, sca_eth_flow_points, att_name].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/cat.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/cat.rb
@@ -88,7 +88,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [declawed].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/category.rb
@@ -94,7 +94,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, name].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/class_model.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/class_model.rb
@@ -79,7 +79,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [_class].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/client.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/client.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [client].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/dog.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/dog.rb
@@ -88,7 +88,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [breed].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -123,7 +123,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [just_symbol, array_enum].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -216,7 +216,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [enum_string, enum_string_required, enum_integer, enum_number, outer_enum, outer_enum_integer, outer_enum_default_value, outer_enum_integer_default_value].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/file.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/file.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [source_uri].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
@@ -89,7 +89,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [file, files].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/foo.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/foo.rb
@@ -80,7 +80,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [bar].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -429,7 +429,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [integer, int32, int64, number, float, double, string, byte, binary, date, date_time, uuid, password, pattern_with_digits, pattern_with_digits_and_delimiter].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
@@ -87,7 +87,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [bar, foo].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/health_check_result.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/health_check_result.rb
@@ -79,7 +79,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [nullable_message].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/inline_response_default.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/inline_response_default.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [string].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/list.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/list.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [_123_list].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -135,7 +135,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [map_map_of_string, map_of_enum_string, direct_map, indirect_map].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -98,7 +98,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [uuid, date_time, map].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/model200_response.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/model200_response.rb
@@ -88,7 +88,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name, _class].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/model_return.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/model_return.rb
@@ -79,7 +79,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [_return].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/name.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/name.rb
@@ -111,7 +111,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [name, snake_case, property, _123_number].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/nullable_class.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/nullable_class.rb
@@ -189,7 +189,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [integer_prop, number_prop, boolean_prop, string_prop, date_prop, datetime_prop, array_nullable_prop, array_and_items_nullable_prop, array_items_nullable, object_nullable_prop, object_and_items_nullable_prop, object_items_nullable].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/number_only.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/number_only.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [just_number].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/order.rb
@@ -160,7 +160,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, pet_id, quantity, ship_date, status, complete].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/outer_composite.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/outer_composite.rb
@@ -96,7 +96,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [my_number, my_string, my_boolean].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -172,7 +172,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, category, name, photo_urls, tags, status].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/read_only_first.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/read_only_first.rb
@@ -87,7 +87,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [bar, baz].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/special_model_name.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/special_model_name.rb
@@ -78,7 +78,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [special_property_name].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -87,7 +87,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, name].hash
     end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/models/user.rb
@@ -142,7 +142,7 @@ module Petstore
     end
 
     # Calculates hash code according to all attributes.
-    # @return [Fixnum] Hash code
+    # @return [Integer] Hash code
     def hash
       [id, username, first_name, last_name, email, password, phone, user_status].hash
     end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Close #2475.

Use `Integer` instead of `Fixnum` (it is deprecated) in Ruby client's YARD tags.
