### PR TITLE
[Java] Instantiate HttpBearerToken authentications if so declared 

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
@@ -281,6 +281,7 @@ public class ApiClient {
   }
 
   {{/hasOAuthMethods}}
+
   /**
    * Helper method to set access token for the first Bearer authentication.
    * @param bearerToken Bearer token

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -57,10 +57,11 @@ public class ApiClient {
       {{#hasAuthMethods}}
       RequestInterceptor auth;
       {{#authMethods}}if ("{{name}}".equals(authName)) {
-      {{#isBasic}}
+      {{#isBasic}}{{#isBasicBasic}}
         auth = new HttpBasicAuth();
-      {{/isBasic}}
-      {{#isApiKey}}
+      {{/isBasicBasic}}{{^isBasicBasic}}
+        auth = new HttpBearerAuth("{{scheme}}");
+      {{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
         auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");
       {{/isApiKey}}
       {{#isOAuth}}
@@ -223,6 +224,21 @@ public class ApiClient {
     if (contentTypes.length == 0) return "application/json";
     if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
     return contentTypes[0];
+  }
+
+
+  /**
+   * Helper method to configure the bearer token.
+   * @param bearerToken the bearer token.
+   */
+  public void setBearerToken(String bearerToken) {
+    for(RequestInterceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No Bearer authentication configured!");
   }
 
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -66,6 +66,7 @@ import java.util.TimeZone;
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 {{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
@@ -125,8 +126,9 @@ public class ApiClient {
         setUserAgent("Java-SDK");
 
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}
-        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
+        authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{^isBasicBasic}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}");{{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
         // Prevent the authentications from being modified.
@@ -183,6 +185,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set token for HTTP bearer authentication.
+     * @param bearerToken the token
+     */
+    public void setBearerToken(String bearerToken) {
+      for (Authentication auth : authentications.values()) {
+        if (auth instanceof HttpBearerAuth) {
+          ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+          return;
+        }
+      }
+      throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
@@ -33,6 +33,7 @@ import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
 
 import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 {{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
@@ -57,9 +58,11 @@ public class ApiClient {
             {{#hasAuthMethods}}
             Interceptor auth;
             {{#authMethods}}if ("{{name}}".equals(authName)) {
-            {{#isBasic}}
-                auth = new HttpBasicAuth();
-            {{/isBasic}}
+            {{#isBasic}}{{#isBasicBasic}}
+              auth = new HttpBasicAuth();
+            {{/isBasicBasic}}{{^isBasicBasic}}
+              auth = new HttpBearerAuth("{{scheme}}");
+            {{/isBasicBasic}}{{/isBasic}}
             {{#isApiKey}}
                 auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}
             {{#isOAuth}}
@@ -154,6 +157,19 @@ public class ApiClient {
             if (apiAuthorization instanceof ApiKeyAuth) {
                 ApiKeyAuth keyAuth = (ApiKeyAuth) apiAuthorization;
                 keyAuth.setApiKey(apiKey);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Helper method to set token for the first Http Bearer authentication found.
+     * @param bearerToken Bearer token
+     */
+    public void setBearerToken(String bearerToken) {
+        for (Interceptor apiAuthorization : apiAuthorizations.values()) {
+            if (apiAuthorization instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
                 return;
             }
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -26,6 +26,7 @@ import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 {{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
@@ -62,9 +63,11 @@ public class ApiClient {
       {{#hasAuthMethods}}
       Interceptor auth;
       {{#authMethods}}if ("{{name}}".equals(authName)) {
-        {{#isBasic}}
+        {{#isBasic}}{{#isBasicBasic}}
         auth = new HttpBasicAuth();
-        {{/isBasic}}
+        {{/isBasicBasic}}{{^isBasicBasic}}
+        auth = new HttpBearerAuth("{{scheme}}");
+        {{/isBasicBasic}}{{/isBasic}}
         {{#isApiKey}}
         auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");
         {{/isApiKey}}
@@ -203,6 +206,21 @@ public class ApiClient {
       if (apiAuthorization instanceof ApiKeyAuth) {
         ApiKeyAuth keyAuth = (ApiKeyAuth) apiAuthorization;
         keyAuth.setApiKey(apiKey);
+        return this;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Helper method to set token for the first Http Bearer authentication found.
+   * @param bearerToken Bearer token
+   * @return ApiClient
+   */
+  public ApiClient setBearerToken(String bearerToken) {
+    for (Interceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
         return this;
       }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
@@ -40,8 +40,9 @@ public class ApiClient {
 
     public ApiClient() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<{{#supportJava6}}String, Authentication{{/supportJava6}}>();{{#authMethods}}{{#isBasic}}
-        // authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
+        authentications = new HashMap<{{#supportJava6}}String, Authentication{{/supportJava6}}>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        // authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{^isBasicBasic}}
+        // authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}");{{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         // authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
         // Prevent the authentications from being modified.

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -2,6 +2,7 @@ package {{invokerPackage}};
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 {{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
@@ -78,8 +79,9 @@ public class ApiClient {
         this.objectMapper.setDateFormat(dateFormat);
 
         // Setup authentications (key: authentication name, value: authentication).
-        this.authentications = new HashMap<>();{{#authMethods}}{{#isBasic}}
-        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
+        this.authentications = new HashMap<>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{^isBasicBasic}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}");{{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
         // Prevent the authentications from being modified.
@@ -159,6 +161,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set access token for the first Bearer authentication.
+     * @param bearerToken Bearer token
+     */
+    public ApiClient setBearerToken(String bearerToken) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+                return this;
+            }
+        }
+        throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -59,6 +59,7 @@ import java.util.TimeZone;
 
 import {{invokerPackage}}.auth.Authentication;
 import {{invokerPackage}}.auth.HttpBasicAuth;
+import {{invokerPackage}}.auth.HttpBearerAuth;
 import {{invokerPackage}}.auth.ApiKeyAuth;
 {{#hasOAuthMethods}}
 import {{invokerPackage}}.auth.OAuth;
@@ -122,8 +123,9 @@ public class ApiClient {
 
     protected void init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}
-        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasic}}{{#isApiKey}}
+        authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{^isBasicBasic}}
+        authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}");{{/isBasicBasic}}{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
         // Prevent the authentications from being modified.
@@ -180,6 +182,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set access token for the first Bearer authentication.
+     * @param bearerToken Bearer token
+     */
+    public void setBearerToken(String bearerToken) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+                return;
+            }
+        }
+        throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
@@ -44,13 +44,16 @@ public class ApiClient {
     for(String authName : authNames) {
       RequestInterceptor auth;
       if ("api_key".equals(authName)) {
+      
         auth = new ApiKeyAuth("header", "api_key");
       } else if ("api_key_query".equals(authName)) {
+      
         auth = new ApiKeyAuth("query", "api_key_query");
       } else if ("http_basic_test".equals(authName)) {
+      
         auth = new HttpBasicAuth();
-      } else if ("petstore_auth".equals(authName)) {
-        auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
+            } else if ("petstore_auth".equals(authName)) {
+              auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
       }
@@ -194,6 +197,21 @@ public class ApiClient {
     if (contentTypes.length == 0) return "application/json";
     if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
     return contentTypes[0];
+  }
+
+
+  /**
+   * Helper method to configure the bearer token.
+   * @param bearerToken the bearer token.
+   */
+  public void setBearerToken(String bearerToken) {
+    for(RequestInterceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No Bearer authentication configured!");
   }
 
   /**

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
@@ -44,13 +44,16 @@ public class ApiClient {
     for(String authName : authNames) {
       RequestInterceptor auth;
       if ("api_key".equals(authName)) {
+      
         auth = new ApiKeyAuth("header", "api_key");
       } else if ("api_key_query".equals(authName)) {
+      
         auth = new ApiKeyAuth("query", "api_key_query");
       } else if ("http_basic_test".equals(authName)) {
+      
         auth = new HttpBasicAuth();
-      } else if ("petstore_auth".equals(authName)) {
-        auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
+            } else if ("petstore_auth".equals(authName)) {
+              auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
       }
@@ -194,6 +197,21 @@ public class ApiClient {
     if (contentTypes.length == 0) return "application/json";
     if (StringUtil.containsIgnoreCase(contentTypes, "application/json")) return "application/json";
     return contentTypes[0];
+  }
+
+
+  /**
+   * Helper method to configure the bearer token.
+   * @param bearerToken the bearer token.
+   */
+  public void setBearerToken(String bearerToken) {
+    for(RequestInterceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
+        return;
+      }
+    }
+    throw new RuntimeException("No Bearer authentication configured!");
   }
 
   /**

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/ApiClient.java
@@ -270,6 +270,7 @@ public class ApiClient {
     throw new RuntimeException("No OAuth2 authentication configured!");
   }
 
+
   /**
    * Helper method to set access token for the first Bearer authentication.
    * @param bearerToken Bearer token

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -60,6 +60,7 @@ import java.util.TimeZone;
 
 import org.openapitools.client.auth.Authentication;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 
@@ -176,6 +177,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set token for HTTP bearer authentication.
+     * @param bearerToken the token
+     */
+    public void setBearerToken(String bearerToken) {
+      for (Authentication auth : authentications.values()) {
+        if (auth instanceof HttpBearerAuth) {
+          ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+          return;
+        }
+      }
+      throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -55,6 +55,7 @@ import java.util.TimeZone;
 
 import org.openapitools.client.auth.Authentication;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 
@@ -171,6 +172,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set token for HTTP bearer authentication.
+     * @param bearerToken the token
+     */
+    public void setBearerToken(String bearerToken) {
+      for (Authentication auth : authentications.values()) {
+        if (auth instanceof HttpBearerAuth) {
+          ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+          return;
+        }
+      }
+      throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/ApiClient.java
@@ -33,6 +33,7 @@ import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
 
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 import org.openapitools.client.auth.OAuth.AccessTokenListener;
@@ -54,13 +55,18 @@ public class ApiClient {
         for(String authName : authNames) {
             Interceptor auth;
             if ("api_key".equals(authName)) {
+            
                 auth = new ApiKeyAuth("header", "api_key");
             } else if ("api_key_query".equals(authName)) {
+            
                 auth = new ApiKeyAuth("query", "api_key_query");
             } else if ("http_basic_test".equals(authName)) {
-                auth = new HttpBasicAuth();
+            
+              auth = new HttpBasicAuth();
+            
 
             } else if ("petstore_auth".equals(authName)) {
+            
 
                 auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
             } else {
@@ -146,6 +152,19 @@ public class ApiClient {
             if (apiAuthorization instanceof ApiKeyAuth) {
                 ApiKeyAuth keyAuth = (ApiKeyAuth) apiAuthorization;
                 keyAuth.setApiKey(apiKey);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Helper method to set token for the first Http Bearer authentication found.
+     * @param bearerToken Bearer token
+     */
+    public void setBearerToken(String bearerToken) {
+        for (Interceptor apiAuthorization : apiAuthorizations.values()) {
+            if (apiAuthorization instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
                 return;
             }
         }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/ApiClient.java
@@ -15,6 +15,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 import org.openapitools.client.auth.OAuth.AccessTokenListener;
@@ -45,12 +46,17 @@ public class ApiClient {
     for(String authName : authNames) {
       Interceptor auth;
       if ("api_key".equals(authName)) {
+        
         auth = new ApiKeyAuth("header", "api_key");
       } else if ("api_key_query".equals(authName)) {
+        
         auth = new ApiKeyAuth("query", "api_key_query");
       } else if ("http_basic_test".equals(authName)) {
+        
         auth = new HttpBasicAuth();
+        
       } else if ("petstore_auth".equals(authName)) {
+        
         auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
@@ -159,6 +165,21 @@ public class ApiClient {
       if (apiAuthorization instanceof ApiKeyAuth) {
         ApiKeyAuth keyAuth = (ApiKeyAuth) apiAuthorization;
         keyAuth.setApiKey(apiKey);
+        return this;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Helper method to set token for the first Http Bearer authentication found.
+   * @param bearerToken Bearer token
+   * @return ApiClient
+   */
+  public ApiClient setBearerToken(String bearerToken) {
+    for (Interceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
         return this;
       }
     }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/ApiClient.java
@@ -16,6 +16,7 @@ import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 import org.openapitools.client.auth.OAuth.AccessTokenListener;
@@ -46,12 +47,17 @@ public class ApiClient {
     for(String authName : authNames) {
       Interceptor auth;
       if ("api_key".equals(authName)) {
+        
         auth = new ApiKeyAuth("header", "api_key");
       } else if ("api_key_query".equals(authName)) {
+        
         auth = new ApiKeyAuth("query", "api_key_query");
       } else if ("http_basic_test".equals(authName)) {
+        
         auth = new HttpBasicAuth();
+        
       } else if ("petstore_auth".equals(authName)) {
+        
         auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
@@ -161,6 +167,21 @@ public class ApiClient {
       if (apiAuthorization instanceof ApiKeyAuth) {
         ApiKeyAuth keyAuth = (ApiKeyAuth) apiAuthorization;
         keyAuth.setApiKey(apiKey);
+        return this;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Helper method to set token for the first Http Bearer authentication found.
+   * @param bearerToken Bearer token
+   * @return ApiClient
+   */
+  public ApiClient setBearerToken(String bearerToken) {
+    for (Interceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
         return this;
       }
     }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/ApiClient.java
@@ -16,6 +16,7 @@ import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 import org.openapitools.client.auth.OAuth.AccessTokenListener;
@@ -46,12 +47,17 @@ public class ApiClient {
     for(String authName : authNames) {
       Interceptor auth;
       if ("api_key".equals(authName)) {
+        
         auth = new ApiKeyAuth("header", "api_key");
       } else if ("api_key_query".equals(authName)) {
+        
         auth = new ApiKeyAuth("query", "api_key_query");
       } else if ("http_basic_test".equals(authName)) {
+        
         auth = new HttpBasicAuth();
+        
       } else if ("petstore_auth".equals(authName)) {
+        
         auth = new OAuth(OAuthFlow.implicit, "http://petstore.swagger.io/api/oauth/dialog", "", "write:pets, read:pets");
       } else {
         throw new RuntimeException("auth name \"" + authName + "\" not found in available auth names");
@@ -162,6 +168,21 @@ public class ApiClient {
       if (apiAuthorization instanceof ApiKeyAuth) {
         ApiKeyAuth keyAuth = (ApiKeyAuth) apiAuthorization;
         keyAuth.setApiKey(apiKey);
+        return this;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Helper method to set token for the first Http Bearer authentication found.
+   * @param bearerToken Bearer token
+   * @return ApiClient
+   */
+  public ApiClient setBearerToken(String bearerToken) {
+    for (Interceptor apiAuthorization : apiAuthorizations.values()) {
+      if (apiAuthorization instanceof HttpBearerAuth) {
+        ((HttpBearerAuth) apiAuthorization).setBearerToken(bearerToken);
         return this;
       }
     }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
@@ -2,6 +2,7 @@ package org.openapitools.client;
 
 import org.openapitools.client.auth.Authentication;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 
@@ -158,6 +159,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set access token for the first Bearer authentication.
+     * @param bearerToken Bearer token
+     */
+    public ApiClient setBearerToken(String bearerToken) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+                return this;
+            }
+        }
+        throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -59,6 +59,7 @@ import java.util.TimeZone;
 
 import org.openapitools.client.auth.Authentication;
 import org.openapitools.client.auth.HttpBasicAuth;
+import org.openapitools.client.auth.HttpBearerAuth;
 import org.openapitools.client.auth.ApiKeyAuth;
 import org.openapitools.client.auth.OAuth;
 
@@ -179,6 +180,20 @@ public class ApiClient {
      */
     public Authentication getAuthentication(String authName) {
         return authentications.get(authName);
+    }
+
+    /**
+     * Helper method to set access token for the first Bearer authentication.
+     * @param bearerToken Bearer token
+     */
+    public void setBearerToken(String bearerToken) {
+        for (Authentication auth : authentications.values()) {
+            if (auth instanceof HttpBearerAuth) {
+                ((HttpBearerAuth) auth).setBearerToken(bearerToken);
+                return;
+            }
+        }
+        throw new RuntimeException("No Bearer authentication configured!");
     }
 
     /**


### PR DESCRIPTION
and add helper methods.

### PR checklist

- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
If HTTP Basic Auth is declared as below, construct an HttpBearerAuth object.  
```
    components:
      securitySchemes:
        bearer:
          type: http
          scheme: bearer
```
#1930 Setup the HttpBearerAuth objects and did this for jersey2, this patch sets up several more java libraries similarly.

cc @wing328  @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)