### PR TITLE
[go] Generate inline enum models and prefix all enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -585,7 +585,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
             return value;
         } else {
-            return escapeText(value);
+            return "\"" + escapeText(value) + "\"";
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -518,14 +518,14 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
             // For enum var names prepend with this model's name to help prevent namespace collision
             if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
-                String prefix = toEnumVarName(cm.name, cm.dataType) + "_";
+                String prefix = toEnumVarName(cm.name, "string") + "_";
                 cm.allowableValues = prefixAllowableValues(cm.allowableValues, prefix);
             }
             // Also prepend var names used for defining inline enums with inline enum's name
             if (Boolean.TRUE.equals(cm.hasEnums)) {
                 for (CodegenProperty param : cm.vars) {
                     if (Boolean.TRUE.equals(param.isEnum) && param.allowableValues != null) {
-                        String prefix = toEnumVarName(param.name, param.dataType) + "_";
+                        String prefix = toEnumVarName(param.name, "string") + "_";
                         param.allowableValues = prefixAllowableValues(param.allowableValues, prefix);
                     }
                 }
@@ -601,7 +601,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         }
 
         // number
-        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
+        if (datatype.startsWith("float") || datatype.startsWith("int") || datatype.startsWith("uint")) {
             String varName = name;
             varName = varName.replaceAll("-", "MINUS_");
             varName = varName.replaceAll("\\+", "PLUS_");
@@ -622,7 +622,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         if (isReservedWord(enumName)) { // reserved word
             return escapeReservedWord(enumName);
         } else if (enumName.matches("\\d.*")) { // starts with a number
-            return "_" + enumName;
+            return "NUM_" + enumName;
         } else {
             return enumName;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -487,19 +487,6 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                         addedOSImport = true;
                     }
                 }
-                if (model.isEnum) {
-                    // For enum values prepend with var name to help prevent namespace collision
-                    String enumPrefix = toEnumVarName(model.name, model.dataType) + "_";
-                    List<Map<String, Object>> enumVars = (List<Map<String, Object>>) model.allowableValues.get("enumVars");
-                    if (enumVars != null) {
-                        for (Map<String, Object> enumVar : enumVars) {
-                            String enumName = (String) enumVar.get("name");
-                            if (enumName != null) {
-                                enumVar.put("name", enumPrefix + enumName);
-                            }
-                        }
-                    }
-                }
             }
         }
         // recursively add import for mapping one type to multiple imports
@@ -518,6 +505,32 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         }
 
         return postProcessModelsEnum(objs);
+    }
+
+    @Override
+    public Map<String, Object> postProcessModelsEnum(Map<String, Object> objs) {
+        objs = super.postProcessModelsEnum(objs);
+        
+        List<Object> models = (List<Object>) objs.get("models");
+        for (Object _mo : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+
+            if (Boolean.TRUE.equals(cm.isEnum) && cm.allowableValues != null) {
+                // For enum values prepend names with enum type name to help prevent namespace collision
+                String enumPrefix = toEnumVarName(cm.name, cm.dataType) + "_";
+                if (cm.allowableValues.get("enumVars") != null) {
+                    List<Map<String, Object>> enumVars = (List<Map<String, Object>>) cm.allowableValues.get("enumVars");
+                    for (Map<String, Object> enumVar : enumVars) {
+                        String enumName = (String) enumVar.get("name");
+                        if (enumName != null) {
+                            enumVar.put("name", enumPrefix + enumName);
+                        }
+                    }
+                }
+            }
+        }
+        return objs;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -582,10 +582,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     @Override
     public String toEnumValue(String value, String datatype) {
-        if ("int".equals(datatype) || "double".equals(datatype) || "float".equals(datatype)) {
-            return value;
-        } else {
+        if ("string".equals(datatype)) {
             return "\"" + escapeText(value) + "\"";
+        } else {
+            return value;
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -487,6 +487,19 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                         addedOSImport = true;
                     }
                 }
+                if (model.isEnum) {
+                    // For enum values prepend with var name to help prevent namespace collision
+                    String enumPrefix = toEnumVarName(model.name, model.dataType) + "_";
+                    List<Map<String, Object>> enumVars = (List<Map<String, Object>>) model.allowableValues.get("enumVars");
+                    if (enumVars != null) {
+                        for (Map<String, Object> enumVar : enumVars) {
+                            String enumName = (String) enumVar.get("name");
+                            if (enumName != null) {
+                                enumVar.put("name", enumPrefix + enumName);
+                            }
+                        }
+                    }
+                }
             }
         }
         // recursively add import for mapping one type to multiple imports

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -510,7 +510,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     @Override
     public Map<String, Object> postProcessModelsEnum(Map<String, Object> objs) {
         objs = super.postProcessModelsEnum(objs);
-        
+
         List<Object> models = (List<Object>) objs.get("models");
         for (Object _mo : models) {
             Map<String, Object> mo = (Map<String, Object>) _mo;
@@ -527,6 +527,17 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                     if (Boolean.TRUE.equals(param.isEnum) && param.allowableValues != null) {
                         String prefix = toEnumVarName(param.name, "string") + "_";
                         param.allowableValues = prefixAllowableValues(param.allowableValues, prefix);
+                        // Form datatype for this field: use ClassNameFieldName syntax 
+                        param.dataType = cm.classname + param.nameInCamelCase;
+                        if (Boolean.TRUE.equals(param.isListContainer)) {
+                            // Special case: slice of enums, use []ClassNameFieldName
+                            param.datatypeWithEnum = "[]" + param.dataType;
+                        } else if (Boolean.TRUE.equals(param.isMapContainer)) {
+                            // Special case: map of enums, use map[string]ClassNameFieldName
+                            param.datatypeWithEnum = "map[string]" + param.dataType;
+                        } else {
+                            param.datatypeWithEnum = param.dataType;
+                        }
                     }
                 }
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -524,7 +524,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             // Also prepend var names used for defining inline enums with inline enum's name
             if (Boolean.TRUE.equals(cm.hasEnums)) {
                 for (CodegenProperty param : cm.vars) {
-                    if (param.isEnum && param.allowableValues != null) {
+                    if (Boolean.TRUE.equals(param.isEnum) && param.allowableValues != null) {
                         String prefix = toEnumVarName(param.name, param.dataType) + "_";
                         param.allowableValues = prefixAllowableValues(param.allowableValues, prefix);
                     }

--- a/modules/openapi-generator/src/main/resources/go-gin-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/model.mustache
@@ -11,7 +11,7 @@ type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/form
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
-	{{name}} {{{classname}}} = "{{{value}}}"
+	{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}
@@ -19,6 +19,29 @@ const (
 type {{classname}} struct {
 {{#vars}}{{#description}}
 	// {{{description}}}{{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{classname}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
-}{{/isEnum}}{{/model}}{{/models}}
+}{{/isEnum}}
+{{! Define any inline enums from above}}
+{{#hasEnums}}
+{{#vars}}
+{{#isEnum}}
+
+{{#description}}
+// {{{name}}} : {{{description}}}
+{{/description}}
+type {{classname}}{{nameInCamelCase}} {{^format}}{{datatype}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{classname}}{{nameInCamelCase}}
+const (
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{^-first}}
+	{{/-first}}
+	{{name}} {{classname}}{{nameInCamelCase}} = {{{value}}}
+	{{/enumVars}}
+	{{/allowableValues}}
+)
+{{/isEnum}}
+{{/vars}}
+{{/hasEnums}}{{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/go-gin-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/model.mustache
@@ -19,7 +19,7 @@ const (
 type {{classname}} struct {
 {{#vars}}{{#description}}
 	// {{{description}}}{{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{classname}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 }{{/isEnum}}
 {{! Define any inline enums from above}}
@@ -28,20 +28,22 @@ type {{classname}} struct {
 {{#isEnum}}
 
 {{#description}}
-// {{{name}}} : {{{description}}}
+// {{datatype}} : {{{description}}}
 {{/description}}
-type {{classname}}{{nameInCamelCase}} {{^format}}{{datatype}}{{/format}}{{#format}}{{{format}}}{{/format}}
+type {{datatype}} {{#items}}{{baseType}}{{/items}}{{^items}}{{baseType}}{{/items}}
 
-// List of {{classname}}{{nameInCamelCase}}
+// List of {{datatype}}
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{name}} {{classname}}{{nameInCamelCase}} = {{{value}}}
+	{{name}} {{datatype}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 )
 {{/isEnum}}
 {{/vars}}
-{{/hasEnums}}{{/model}}{{/models}}
+{{/hasEnums}}
+{{/model}}
+{{/models}}

--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -11,7 +11,7 @@ type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/form
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
-	{{name}} {{{classname}}} = "{{{value}}}"
+	{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}
@@ -19,6 +19,29 @@ const (
 type {{classname}} struct {
 {{#vars}}{{#description}}
 	// {{{description}}}{{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{classname}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
-}{{/isEnum}}{{/model}}{{/models}}
+}{{/isEnum}}
+{{! Define any inline enums from above}}
+{{#hasEnums}}
+{{#vars}}
+{{#isEnum}}
+
+{{#description}}
+// {{{name}}} : {{{description}}}
+{{/description}}
+type {{classname}}{{nameInCamelCase}} {{^format}}{{datatype}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{classname}}{{nameInCamelCase}}
+const (
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{^-first}}
+	{{/-first}}
+	{{name}} {{classname}}{{nameInCamelCase}} = {{{value}}}
+	{{/enumVars}}
+	{{/allowableValues}}
+)
+{{/isEnum}}
+{{/vars}}
+{{/hasEnums}}{{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -19,7 +19,7 @@ const (
 type {{classname}} struct {
 {{#vars}}{{#description}}
 	// {{{description}}}{{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{classname}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 }{{/isEnum}}
 {{! Define any inline enums from above}}
@@ -28,20 +28,22 @@ type {{classname}} struct {
 {{#isEnum}}
 
 {{#description}}
-// {{{name}}} : {{{description}}}
+// {{datatype}} : {{{description}}}
 {{/description}}
-type {{classname}}{{nameInCamelCase}} {{^format}}{{datatype}}{{/format}}{{#format}}{{{format}}}{{/format}}
+type {{datatype}} {{#items}}{{baseType}}{{/items}}{{^items}}{{baseType}}{{/items}}
 
-// List of {{classname}}{{nameInCamelCase}}
+// List of {{datatype}}
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{name}} {{classname}}{{nameInCamelCase}} = {{{value}}}
+	{{name}} {{datatype}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 )
 {{/isEnum}}
 {{/vars}}
-{{/hasEnums}}{{/model}}{{/models}}
+{{/hasEnums}}
+{{/model}}
+{{/models}}

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -35,7 +35,7 @@ type {{classname}} struct {
 {{#description}}
 	// {{{description}}}
 {{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{classname}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{datatypeWithEnum}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 }
 {{/isEnum}}
@@ -45,17 +45,17 @@ type {{classname}} struct {
 {{#isEnum}}
 
 {{#description}}
-// {{{name}}} : {{{description}}}
+// {{datatype}} : {{{description}}}
 {{/description}}
-type {{classname}}{{nameInCamelCase}} {{^format}}{{datatype}}{{/format}}{{#format}}{{{format}}}{{/format}}
+type {{datatype}} {{#items}}{{baseType}}{{/items}}{{^items}}{{baseType}}{{/items}}
 
-// List of {{classname}}{{nameInCamelCase}}
+// List of {{datatype}}
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{name}} {{classname}}{{nameInCamelCase}} = {{{value}}}
+	{{name}} {{datatype}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 )

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -35,9 +35,32 @@ type {{classname}} struct {
 {{#description}}
 	// {{{description}}}
 {{/description}}
-	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{#isNullable}}*{{/isNullable}}{{#isEnum}}{{classname}}{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 }
 {{/isEnum}}
+{{! Define any inline enums from above}}
+{{#hasEnums}}
+{{#vars}}
+{{#isEnum}}
+
+{{#description}}
+// {{{name}}} : {{{description}}}
+{{/description}}
+type {{classname}}{{nameInCamelCase}} {{^format}}{{datatype}}{{/format}}{{#format}}{{{format}}}{{/format}}
+
+// List of {{classname}}{{nameInCamelCase}}
+const (
+	{{#allowableValues}}
+	{{#enumVars}}
+	{{^-first}}
+	{{/-first}}
+	{{datatypeWithEnum}}_{{name}} {{classname}}{{nameInCamelCase}} = "{{{value}}}"
+	{{/enumVars}}
+	{{/allowableValues}}
+)
+{{/isEnum}}
+{{/vars}}
+{{/hasEnums}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -23,7 +23,7 @@ const (
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{name}} {{{classname}}} = "{{{value}}}"
+	{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}
@@ -55,7 +55,7 @@ const (
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{name}} {{classname}}{{nameInCamelCase}} = "{{{value}}}"
+	{{name}} {{classname}}{{nameInCamelCase}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 )

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -55,7 +55,7 @@ const (
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{datatypeWithEnum}}_{{name}} {{classname}}{{nameInCamelCase}} = "{{{value}}}"
+	{{name}} {{classname}}{{nameInCamelCase}} = "{{{value}}}"
 	{{/enumVars}}
 	{{/allowableValues}}
 )

--- a/samples/client/petstore/go/go-petstore/docs/EnumArrays.md
+++ b/samples/client/petstore/go/go-petstore/docs/EnumArrays.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustSymbol** | **string** |  | [optional] 
-**ArrayEnum** | **[]string** |  | [optional] 
+**JustSymbol** | **EnumArraysJustSymbol** |  | [optional] 
+**ArrayEnum** | **EnumArraysArrayEnum** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/docs/EnumTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/EnumTest.md
@@ -3,10 +3,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**EnumString** | **string** |  | [optional] 
-**EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int32** |  | [optional] 
-**EnumNumber** | **float64** |  | [optional] 
+**EnumString** | **EnumTestEnumString** |  | [optional] 
+**EnumStringRequired** | **EnumTestEnumStringRequired** |  | 
+**EnumInteger** | **EnumTestEnumInteger** |  | [optional] 
+**EnumNumber** | **EnumTestEnumNumber** |  | [optional] 
 **OuterEnum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go/go-petstore/docs/MapTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/MapTest.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **MapMapOfString** | [**map[string]map[string]string**](map.md) |  | [optional] 
-**MapOfEnumString** | **map[string]string** |  | [optional] 
+**MapOfEnumString** | **MapTestMapOfEnumString** |  | [optional] 
 **DirectMap** | **map[string]bool** |  | [optional] 
 **IndirectMap** | **map[string]bool** |  | [optional] 
 

--- a/samples/client/petstore/go/go-petstore/docs/Order.md
+++ b/samples/client/petstore/go/go-petstore/docs/Order.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **PetId** | **int64** |  | [optional] 
 **Quantity** | **int32** |  | [optional] 
 **ShipDate** | [**time.Time**](time.Time.md) |  | [optional] 
-**Status** | **string** | Order Status | [optional] 
+**Status** | **OrderStatus** | Order Status | [optional] 
 **Complete** | **bool** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go/go-petstore/docs/Pet.md
+++ b/samples/client/petstore/go/go-petstore/docs/Pet.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Name** | **string** |  | 
 **PhotoUrls** | **[]string** |  | 
 **Tags** | [**[]Tag**](Tag.md) |  | [optional] 
-**Status** | **string** | pet status in the store | [optional] 
+**Status** | **PetStatus** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -10,6 +10,22 @@
 package petstore
 
 type EnumArrays struct {
-	JustSymbol string `json:"just_symbol,omitempty"`
-	ArrayEnum []string `json:"array_enum,omitempty"`
+	JustSymbol EnumArraysJustSymbol `json:"just_symbol,omitempty"`
+	ArrayEnum EnumArraysArrayEnum `json:"array_enum,omitempty"`
 }
+
+type EnumArraysJustSymbol string
+
+// List of EnumArraysJustSymbol
+const (
+	JUST_SYMBOL_GREATER_THAN_OR_EQUAL_TO EnumArraysJustSymbol = ">="
+	JUST_SYMBOL_DOLLAR EnumArraysJustSymbol = "$"
+)
+
+type EnumArraysArrayEnum []string
+
+// List of EnumArraysArrayEnum
+const (
+	ARRAY_ENUM_FISH EnumArraysArrayEnum = "fish"
+	ARRAY_ENUM_CRAB EnumArraysArrayEnum = "crab"
+)

--- a/samples/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -11,7 +11,7 @@ package petstore
 
 type EnumArrays struct {
 	JustSymbol EnumArraysJustSymbol `json:"just_symbol,omitempty"`
-	ArrayEnum EnumArraysArrayEnum `json:"array_enum,omitempty"`
+	ArrayEnum []EnumArraysArrayEnum `json:"array_enum,omitempty"`
 }
 
 type EnumArraysJustSymbol string
@@ -22,7 +22,7 @@ const (
 	JUST_SYMBOL_DOLLAR EnumArraysJustSymbol = "$"
 )
 
-type EnumArraysArrayEnum []string
+type EnumArraysArrayEnum string
 
 // List of EnumArraysArrayEnum
 const (

--- a/samples/client/petstore/go/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_class.go
@@ -12,7 +12,7 @@ type EnumClass string
 
 // List of EnumClass
 const (
-	ABC EnumClass = "_abc"
-	EFG EnumClass = "-efg"
-	XYZ EnumClass = "(xyz)"
+	ENUM_CLASS_ABC EnumClass = "_abc"
+	ENUM_CLASS_EFG EnumClass = "-efg"
+	ENUM_CLASS_XYZ EnumClass = "(xyz)"
 )

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -10,9 +10,43 @@
 package petstore
 
 type EnumTest struct {
-	EnumString string `json:"enum_string,omitempty"`
-	EnumStringRequired string `json:"enum_string_required"`
-	EnumInteger int32 `json:"enum_integer,omitempty"`
-	EnumNumber float64 `json:"enum_number,omitempty"`
+	EnumString EnumTestEnumString `json:"enum_string,omitempty"`
+	EnumStringRequired EnumTestEnumStringRequired `json:"enum_string_required"`
+	EnumInteger EnumTestEnumInteger `json:"enum_integer,omitempty"`
+	EnumNumber EnumTestEnumNumber `json:"enum_number,omitempty"`
 	OuterEnum OuterEnum `json:"outerEnum,omitempty"`
 }
+
+type EnumTestEnumString string
+
+// List of EnumTestEnumString
+const (
+	ENUM_STRING_UPPER EnumTestEnumString = "UPPER"
+	ENUM_STRING_LOWER EnumTestEnumString = "lower"
+	ENUM_STRING_EMPTY EnumTestEnumString = ""
+)
+
+type EnumTestEnumStringRequired string
+
+// List of EnumTestEnumStringRequired
+const (
+	ENUM_STRING_REQUIRED_UPPER EnumTestEnumStringRequired = "UPPER"
+	ENUM_STRING_REQUIRED_LOWER EnumTestEnumStringRequired = "lower"
+	ENUM_STRING_REQUIRED_EMPTY EnumTestEnumStringRequired = ""
+)
+
+type EnumTestEnumInteger int32
+
+// List of EnumTestEnumInteger
+const (
+	ENUM_INTEGER__1 EnumTestEnumInteger = "1"
+	ENUM_INTEGER__1 EnumTestEnumInteger = "-1"
+)
+
+type EnumTestEnumNumber float64
+
+// List of EnumTestEnumNumber
+const (
+	ENUM_NUMBER__1_1 EnumTestEnumNumber = "1.1"
+	ENUM_NUMBER__1_2 EnumTestEnumNumber = "-1.2"
+)

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -39,14 +39,14 @@ type EnumTestEnumInteger int32
 
 // List of EnumTestEnumInteger
 const (
-	ENUM_INTEGER__1 EnumTestEnumInteger = "1"
-	ENUM_INTEGER__1 EnumTestEnumInteger = "-1"
+	ENUM_INTEGER__1 EnumTestEnumInteger = 1
+	ENUM_INTEGER__1 EnumTestEnumInteger = -1
 )
 
 type EnumTestEnumNumber float64
 
 // List of EnumTestEnumNumber
 const (
-	ENUM_NUMBER__1_1 EnumTestEnumNumber = "1.1"
-	ENUM_NUMBER__1_2 EnumTestEnumNumber = "-1.2"
+	ENUM_NUMBER__1_1 EnumTestEnumNumber = 1.1
+	ENUM_NUMBER__1_2 EnumTestEnumNumber = -1.2
 )

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -39,14 +39,14 @@ type EnumTestEnumInteger int32
 
 // List of EnumTestEnumInteger
 const (
-	ENUM_INTEGER__1 EnumTestEnumInteger = 1
-	ENUM_INTEGER__1 EnumTestEnumInteger = -1
+	ENUM_INTEGER_1 EnumTestEnumInteger = 1
+	ENUM_INTEGER_MINUS_1 EnumTestEnumInteger = -1
 )
 
 type EnumTestEnumNumber float64
 
 // List of EnumTestEnumNumber
 const (
-	ENUM_NUMBER__1_1 EnumTestEnumNumber = 1.1
-	ENUM_NUMBER__1_2 EnumTestEnumNumber = -1.2
+	ENUM_NUMBER_1_DOT_1 EnumTestEnumNumber = 1.1
+	ENUM_NUMBER_MINUS_1_DOT_2 EnumTestEnumNumber = -1.2
 )

--- a/samples/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_map_test_.go
@@ -11,12 +11,12 @@ package petstore
 
 type MapTest struct {
 	MapMapOfString map[string]map[string]string `json:"map_map_of_string,omitempty"`
-	MapOfEnumString MapTestMapOfEnumString `json:"map_of_enum_string,omitempty"`
+	MapOfEnumString map[string]MapTestMapOfEnumString `json:"map_of_enum_string,omitempty"`
 	DirectMap map[string]bool `json:"direct_map,omitempty"`
 	IndirectMap map[string]bool `json:"indirect_map,omitempty"`
 }
 
-type MapTestMapOfEnumString map[string]string
+type MapTestMapOfEnumString string
 
 // List of MapTestMapOfEnumString
 const (

--- a/samples/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_map_test_.go
@@ -11,7 +11,15 @@ package petstore
 
 type MapTest struct {
 	MapMapOfString map[string]map[string]string `json:"map_map_of_string,omitempty"`
-	MapOfEnumString map[string]string `json:"map_of_enum_string,omitempty"`
+	MapOfEnumString MapTestMapOfEnumString `json:"map_of_enum_string,omitempty"`
 	DirectMap map[string]bool `json:"direct_map,omitempty"`
 	IndirectMap map[string]bool `json:"indirect_map,omitempty"`
 }
+
+type MapTestMapOfEnumString map[string]string
+
+// List of MapTestMapOfEnumString
+const (
+	MAP_OF_ENUM_STRING_UPPER MapTestMapOfEnumString = "UPPER"
+	MAP_OF_ENUM_STRING_LOWER MapTestMapOfEnumString = "lower"
+)

--- a/samples/client/petstore/go/go-petstore/model_order.go
+++ b/samples/client/petstore/go/go-petstore/model_order.go
@@ -18,6 +18,16 @@ type Order struct {
 	Quantity int32 `json:"quantity,omitempty"`
 	ShipDate time.Time `json:"shipDate,omitempty"`
 	// Order Status
-	Status string `json:"status,omitempty"`
+	Status OrderStatus `json:"status,omitempty"`
 	Complete bool `json:"complete,omitempty"`
 }
+
+// Status : Order Status
+type OrderStatus string
+
+// List of OrderStatus
+const (
+	STATUS_PLACED OrderStatus = "placed"
+	STATUS_APPROVED OrderStatus = "approved"
+	STATUS_DELIVERED OrderStatus = "delivered"
+)

--- a/samples/client/petstore/go/go-petstore/model_order.go
+++ b/samples/client/petstore/go/go-petstore/model_order.go
@@ -22,7 +22,7 @@ type Order struct {
 	Complete bool `json:"complete,omitempty"`
 }
 
-// Status : Order Status
+// OrderStatus : Order Status
 type OrderStatus string
 
 // List of OrderStatus

--- a/samples/client/petstore/go/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go/go-petstore/model_outer_enum.go
@@ -12,7 +12,7 @@ type OuterEnum string
 
 // List of OuterEnum
 const (
-	PLACED OuterEnum = "placed"
-	APPROVED OuterEnum = "approved"
-	DELIVERED OuterEnum = "delivered"
+	OUTER_ENUM_PLACED OuterEnum = "placed"
+	OUTER_ENUM_APPROVED OuterEnum = "approved"
+	OUTER_ENUM_DELIVERED OuterEnum = "delivered"
 )

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -16,5 +16,15 @@ type Pet struct {
 	PhotoUrls []string `json:"photoUrls"`
 	Tags []Tag `json:"tags,omitempty"`
 	// pet status in the store
-	Status string `json:"status,omitempty"`
+	Status PetStatus `json:"status,omitempty"`
 }
+
+// Status : pet status in the store
+type PetStatus string
+
+// List of PetStatus
+const (
+	STATUS_AVAILABLE PetStatus = "available"
+	STATUS_PENDING PetStatus = "pending"
+	STATUS_SOLD PetStatus = "sold"
+)

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -19,7 +19,7 @@ type Pet struct {
 	Status PetStatus `json:"status,omitempty"`
 }
 
-// Status : pet status in the store
+// PetStatus : pet status in the store
 type PetStatus string
 
 // List of PetStatus

--- a/samples/server/petstore/go-api-server/go/model_order.go
+++ b/samples/server/petstore/go-api-server/go/model_order.go
@@ -30,7 +30,7 @@ type Order struct {
 	Complete bool `json:"complete,omitempty"`
 }
 
-// Status : Order Status
+// OrderStatus : Order Status
 type OrderStatus string
 
 // List of OrderStatus

--- a/samples/server/petstore/go-api-server/go/model_order.go
+++ b/samples/server/petstore/go-api-server/go/model_order.go
@@ -25,7 +25,17 @@ type Order struct {
 	ShipDate time.Time `json:"shipDate,omitempty"`
 
 	// Order Status
-	Status string `json:"status,omitempty"`
+	Status OrderStatus `json:"status,omitempty"`
 
 	Complete bool `json:"complete,omitempty"`
 }
+
+// Status : Order Status
+type OrderStatus string
+
+// List of OrderStatus
+const (
+	STATUS_PLACED OrderStatus = "placed"
+	STATUS_APPROVED OrderStatus = "approved"
+	STATUS_DELIVERED OrderStatus = "delivered"
+)

--- a/samples/server/petstore/go-api-server/go/model_pet.go
+++ b/samples/server/petstore/go-api-server/go/model_pet.go
@@ -23,5 +23,15 @@ type Pet struct {
 	Tags []Tag `json:"tags,omitempty"`
 
 	// pet status in the store
-	Status string `json:"status,omitempty"`
+	Status PetStatus `json:"status,omitempty"`
 }
+
+// Status : pet status in the store
+type PetStatus string
+
+// List of PetStatus
+const (
+	STATUS_AVAILABLE PetStatus = "available"
+	STATUS_PENDING PetStatus = "pending"
+	STATUS_SOLD PetStatus = "sold"
+)

--- a/samples/server/petstore/go-api-server/go/model_pet.go
+++ b/samples/server/petstore/go-api-server/go/model_pet.go
@@ -26,7 +26,7 @@ type Pet struct {
 	Status PetStatus `json:"status,omitempty"`
 }
 
-// Status : pet status in the store
+// PetStatus : pet status in the store
 type PetStatus string
 
 // List of PetStatus

--- a/samples/server/petstore/go-gin-api-server/go/model_order.go
+++ b/samples/server/petstore/go-gin-api-server/go/model_order.go
@@ -30,7 +30,7 @@ type Order struct {
 	Complete bool `json:"complete,omitempty"`
 }
 
-// Status : Order Status
+// OrderStatus : Order Status
 type OrderStatus string
 
 // List of OrderStatus

--- a/samples/server/petstore/go-gin-api-server/go/model_order.go
+++ b/samples/server/petstore/go-gin-api-server/go/model_order.go
@@ -25,7 +25,17 @@ type Order struct {
 	ShipDate time.Time `json:"shipDate,omitempty"`
 
 	// Order Status
-	Status string `json:"status,omitempty"`
+	Status OrderStatus `json:"status,omitempty"`
 
 	Complete bool `json:"complete,omitempty"`
 }
+
+// Status : Order Status
+type OrderStatus string
+
+// List of OrderStatus
+const (
+	STATUS_PLACED OrderStatus = "placed"
+	STATUS_APPROVED OrderStatus = "approved"
+	STATUS_DELIVERED OrderStatus = "delivered"
+)

--- a/samples/server/petstore/go-gin-api-server/go/model_pet.go
+++ b/samples/server/petstore/go-gin-api-server/go/model_pet.go
@@ -23,5 +23,15 @@ type Pet struct {
 	Tags []Tag `json:"tags,omitempty"`
 
 	// pet status in the store
-	Status string `json:"status,omitempty"`
+	Status PetStatus `json:"status,omitempty"`
 }
+
+// Status : pet status in the store
+type PetStatus string
+
+// List of PetStatus
+const (
+	STATUS_AVAILABLE PetStatus = "available"
+	STATUS_PENDING PetStatus = "pending"
+	STATUS_SOLD PetStatus = "sold"
+)

--- a/samples/server/petstore/go-gin-api-server/go/model_pet.go
+++ b/samples/server/petstore/go-gin-api-server/go/model_pet.go
@@ -26,7 +26,7 @@ type Pet struct {
 	Status PetStatus `json:"status,omitempty"`
 }
 
-// Status : pet status in the store
+// PetStatus : pet status in the store
 type PetStatus string
 
 // List of PetStatus


### PR DESCRIPTION
### PR checklist

- [ ✓ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ✓ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ✓ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. *Default: `master`*.
- [ ✓ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @antihax @bvwells @grokify @kemokemo 

This aims to address the following issues:
https://github.com/OpenAPITools/openapi-generator/issues/535
(also see related closed PR: https://github.com/OpenAPITools/openapi-generator/pull/542)
https://github.com/OpenAPITools/openapi-generator/issues/2050
https://github.com/OpenAPITools/openapi-generator/issues/2360

### Description of the PR

There are four main aspects:
1. Enums that are defined inline were not being generated (see https://github.com/OpenAPITools/openapi-generator/issues/2360 for an example), this PR follows similar logic to the typescript-fetch generation template to remedy this: https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache#L92-L109
2. Enums names often result in namespace collisions within the package being generated (see https://github.com/OpenAPITools/openapi-generator/issues/535), prefixes have been added to help prevent this for most cases.
3. Numeric enum values were improperly being quoted, now only strings are.
4. Numeric enum names were not properly escaping plus/minus signs and decimal points e.g. to differentiate between `-1` and `1` or `1.1` and `11`