### PR TITLE
Publish to gradle plugin prior to sonatype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,8 @@ after_success:
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
+        ./gradlew clean publishPlugins;
+        echo "Finished ./gradlew publishPlugins (plugin portal)";
         ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
         echo "Finished ./gradlew uploadArchives";
         popd;
@@ -139,6 +141,8 @@ after_success:
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
+        ./gradlew clean publishPlugins;
+        echo "Finished ./gradlew publishPlugins (plugin portal)";
         ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
         echo "Finished ./gradlew uploadArchives";
         popd;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Publishing to the gradle plugin portal after Sonatype will fail on artifacts unsupported by the portal (asc, sources, etc). This attempts to publish to the portal first, to avoid needing to do a clean/publish after the Sonatype artifacts are published.