### PR TITLE
[JS][Flow] Fix body serialization when body is falsy

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript-Flowtyped/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript-Flowtyped/api.mustache
@@ -214,7 +214,7 @@ export const {{classname}}FetchParamCreator = function (configuration?: Configur
     {{/hasFormParams}}
     {{#bodyParam}}
             const needsSerialization = (typeof {{paramName}} !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify({{paramName}} || {}) : ((({{paramName}}:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify({{paramName}} != null ? {{paramName}} : {}) : ((({{paramName}}:any):string) || "");
     {{/bodyParam}}
 
             return {

--- a/samples/client/petstore/javascript-flowtyped/src/api.js
+++ b/samples/client/petstore/javascript-flowtyped/src/api.js
@@ -323,7 +323,7 @@ export const PetApiFetchParamCreator = function (configuration?: Configuration) 
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -515,7 +515,7 @@ export const PetApiFetchParamCreator = function (configuration?: Configuration) 
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -878,7 +878,7 @@ export const StoreApiFetchParamCreator = function (configuration?: Configuration
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -997,7 +997,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -1027,7 +1027,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -1057,7 +1057,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -1206,7 +1206,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body || {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
 
             return {
                 url: url.format(localVarUrlObj),


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This fixes serialization of the request body in the javascript-flowtyped generator when the request body is falsy. Before this fix, some request bodies consisting of raw boolean/integer literals would be incorrectly serialized as `"{}"` (e.g. `false` is serialized as `"{}"`).

@CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)