### PR TITLE
[typescript-axios] removing namespaces from enums

### DIFF
--- a/bin/windows/typescript-axios-petstore-all.bat
+++ b/bin/windows/typescript-axios-petstore-all.bat
@@ -4,3 +4,4 @@ call bin\windows\typescript-axios-petstore.bat
 call bin\windows\typescript-axios-petstore-target-es6.bat
 call bin\windows\typescript-axios-petstore-with-npm-version.bat
 call bin\windows\typescript-axios-petstore-interfaces.bat
+call bin\windows\typescript-axios-petstore-with-npm-version-and-separate-models-and-api.bat

--- a/docs/generators/typescript-axios.md
+++ b/docs/generators/typescript-axios.md
@@ -19,3 +19,4 @@ sidebar_label: typescript-axios
 |snapshot|When setting this property to true the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |withInterfaces|Setting this property to true will generate interfaces next to the default class implementations.| |false|
 |withSeparateModelsAndApi|Put the model and api in separate folders and in separate classes| |false|
+|withoutPrefixEnums|Dont prefix enum names with class names| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -23,6 +23,7 @@ import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -38,6 +39,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public static final String SNAPSHOT = "snapshot";
     public static final String WITH_INTERFACES = "withInterfaces";
     public static final String SEPARATE_MODELS_AND_API = "withSeparateModelsAndApi";
+    public static final String WITHOUT_PREFIX_ENUMS = "withoutPrefixEnums";
 
     protected String npmName = null;
     protected String npmVersion = "1.0.0";
@@ -61,6 +63,7 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         this.cliOptions.add(new CliOption(SNAPSHOT, "When setting this property to true the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(SEPARATE_MODELS_AND_API, "Put the model and api in separate folders and in separate classes", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(WITHOUT_PREFIX_ENUMS, "Dont prefix enum names with class names", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
@@ -193,22 +196,49 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
-        Map<String, Object> ret = super.postProcessModels(objs);
-        // Deduce the model file name in kebab case
-        List<Map<String, Object>> models = (List<Map<String, Object>>) ret.get("models");
-        for (Map<String, Object> m : models) {
-            CodegenModel model = (CodegenModel) m.get("model");
-            model.classFilename = model.classname.replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT);
+        List<Object> models = (List<Object>) postProcessModelsEnum(objs).get("models");
+
+        boolean withoutPrefixEnums = (boolean)additionalProperties.getOrDefault(WITHOUT_PREFIX_ENUMS, false);
+
+        for (Object _mo  : models) {
+            Map<String, Object> mo = (Map<String, Object>) _mo;
+            CodegenModel cm = (CodegenModel) mo.get("model");
+
+            // Deduce the model file name in kebab case
+            cm.classFilename = cm.classname.replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT);
+
+            //processed enum names
+            if(!withoutPrefixEnums) {
+                cm.imports = new TreeSet(cm.imports);
+                // name enum with model name, e.g. StatusEnum => PetStatusEnum
+                for (CodegenProperty var : cm.vars) {
+                    if (Boolean.TRUE.equals(var.isEnum)) {
+                        String oldEnum=var.enumName;
+                        var.datatypeWithEnum = var.datatypeWithEnum.replace(oldEnum, cm.classname + var.enumName);
+                        var.enumName = var.enumName.replace(oldEnum, cm.classname + var.enumName);
+                    }
+                }
+                if (cm.parent != null) {
+                    for (CodegenProperty var : cm.allVars) {
+                        if (Boolean.TRUE.equals(var.isEnum)) {
+                            String oldEnum=var.enumName;
+                            var.datatypeWithEnum = var.datatypeWithEnum.replace(oldEnum, cm.classname + var.enumName);
+                            var.enumName = var.enumName.replace(oldEnum, cm.classname + var.enumName);
+                        }
+                    }
+                }
+            }
         }
+        
         // Apply the model file name to the imports as well
-        for (Map<String, String> m : (List<Map<String, String>>) ret.get("imports")) {
+        for (Map<String, String> m : (List<Map<String, String>>) objs.get("imports")) {
             String javaImport = m.get("import").substring(modelPackage.length() + 1);
             String tsImport = tsModelPackage + "/" + javaImport;
             m.put("tsImport", tsImport);
             m.put("class", javaImport);
             m.put("filename", javaImport.replaceAll("([a-z0-9])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT));
         }
-        return ret;
+        return objs;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -213,17 +213,15 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
                 // name enum with model name, e.g. StatusEnum => PetStatusEnum
                 for (CodegenProperty var : cm.vars) {
                     if (Boolean.TRUE.equals(var.isEnum)) {
-                        String oldEnum=var.enumName;
-                        var.datatypeWithEnum = var.datatypeWithEnum.replace(oldEnum, cm.classname + var.enumName);
-                        var.enumName = var.enumName.replace(oldEnum, cm.classname + var.enumName);
+                        var.datatypeWithEnum = var.datatypeWithEnum.replace(var.enumName, cm.classname + var.enumName);
+                        var.enumName = var.enumName.replace(var.enumName, cm.classname + var.enumName);
                     }
                 }
                 if (cm.parent != null) {
                     for (CodegenProperty var : cm.allVars) {
                         if (Boolean.TRUE.equals(var.isEnum)) {
-                            String oldEnum=var.enumName;
-                            var.datatypeWithEnum = var.datatypeWithEnum.replace(oldEnum, cm.classname + var.enumName);
-                            var.enumName = var.enumName.replace(oldEnum, cm.classname + var.enumName);
+                            var.datatypeWithEnum = var.datatypeWithEnum.replace(var.enumName, cm.classname + var.enumName);
+                            var.enumName = var.enumName.replace(var.enumName, cm.classname + var.enumName);
                         }
                     }
                 }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -18,24 +18,19 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{/vars}}
 }{{#hasEnums}}
 
-/**
- * @export
- * @namespace {{classname}}
- */
-export namespace {{classname}} {
 {{#vars}}
-    {{#isEnum}}
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum {{enumName}} {
-    {{#allowableValues}}
-        {{#enumVars}}
-        {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
-        {{/enumVars}}
-    {{/allowableValues}}
-    }
-    {{/isEnum}}
+{{#isEnum}}
+/**
+    * @export
+    * @enum {string}
+    */
+export enum {{enumName}} {
+{{#allowableValues}}
+    {{#enumVars}}
+    {{{name}}} = {{{value}}}{{^-last}},{{/-last}}
+    {{/enumVars}}
+{{/allowableValues}}
+}
+{{/isEnum}}
 {{/vars}}
-}{{/hasEnums}}
+{{/hasEnums}}

--- a/samples/client/petstore/typescript-axios/builds/default/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/api.ts
@@ -43,7 +43,6 @@ export interface ApiResponse {
      */
     message?: string;
 }
-
 /**
  * A category for a pet
  * @export
@@ -63,7 +62,6 @@ export interface Category {
      */
     name?: string;
 }
-
 /**
  * An order for a pets from the pet store
  * @export
@@ -99,7 +97,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: Order.StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -109,19 +107,13 @@ export interface Order {
 }
 
 /**
- * @export
- * @namespace Order
- */
-export namespace Order {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Placed = 'placed',
-        Approved = 'approved',
-        Delivered = 'delivered'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 
 /**
@@ -165,23 +157,17 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: Pet.StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
- * @export
- * @namespace Pet
- */
-export namespace Pet {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Available = 'available',
-        Pending = 'pending',
-        Sold = 'sold'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 
 /**
@@ -203,7 +189,6 @@ export interface Tag {
      */
     name?: string;
 }
-
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -259,7 +244,6 @@ export interface User {
      */
     userStatus?: number;
 }
-
 
 /**
  * PetApi - axios parameter creator

--- a/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
@@ -43,7 +43,6 @@ export interface ApiResponse {
      */
     message?: string;
 }
-
 /**
  * A category for a pet
  * @export
@@ -63,7 +62,6 @@ export interface Category {
      */
     name?: string;
 }
-
 /**
  * An order for a pets from the pet store
  * @export
@@ -99,7 +97,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: Order.StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -109,19 +107,13 @@ export interface Order {
 }
 
 /**
- * @export
- * @namespace Order
- */
-export namespace Order {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Placed = 'placed',
-        Approved = 'approved',
-        Delivered = 'delivered'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 
 /**
@@ -165,23 +157,17 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: Pet.StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
- * @export
- * @namespace Pet
- */
-export namespace Pet {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Available = 'available',
-        Pending = 'pending',
-        Sold = 'sold'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 
 /**
@@ -203,7 +189,6 @@ export interface Tag {
      */
     name?: string;
 }
-
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -259,7 +244,6 @@ export interface User {
      */
     userStatus?: number;
 }
-
 
 /**
  * PetApi - axios parameter creator

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
@@ -43,7 +43,6 @@ export interface ApiResponse {
      */
     message?: string;
 }
-
 /**
  * A category for a pet
  * @export
@@ -63,7 +62,6 @@ export interface Category {
      */
     name?: string;
 }
-
 /**
  * An order for a pets from the pet store
  * @export
@@ -99,7 +97,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: Order.StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -109,19 +107,13 @@ export interface Order {
 }
 
 /**
- * @export
- * @namespace Order
- */
-export namespace Order {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Placed = 'placed',
-        Approved = 'approved',
-        Delivered = 'delivered'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 
 /**
@@ -165,23 +157,17 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: Pet.StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
- * @export
- * @namespace Pet
- */
-export namespace Pet {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Available = 'available',
-        Pending = 'pending',
-        Sold = 'sold'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 
 /**
@@ -203,7 +189,6 @@ export interface Tag {
      */
     name?: string;
 }
-
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -259,7 +244,6 @@ export interface User {
      */
     userStatus?: number;
 }
-
 
 /**
  * PetApi - axios parameter creator

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/api-response.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/api-response.ts
@@ -41,4 +41,3 @@ export interface ApiResponse {
 }
 
 
-

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/category.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/category.ts
@@ -35,4 +35,3 @@ export interface Category {
 }
 
 
-

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/order.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/order.ts
@@ -49,7 +49,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: Order.StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -59,19 +59,13 @@ export interface Order {
 }
 
 /**
- * @export
- * @namespace Order
- */
-export namespace Order {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Placed = 'placed',
-        Approved = 'approved',
-        Delivered = 'delivered'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/pet.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/pet.ts
@@ -57,23 +57,17 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: Pet.StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
- * @export
- * @namespace Pet
- */
-export namespace Pet {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Available = 'available',
-        Pending = 'pending',
-        Sold = 'sold'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/tag.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/tag.ts
@@ -35,4 +35,3 @@ export interface Tag {
 }
 
 
-

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/user.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/user.ts
@@ -71,4 +71,3 @@ export interface User {
 }
 
 
-

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
@@ -43,7 +43,6 @@ export interface ApiResponse {
      */
     message?: string;
 }
-
 /**
  * A category for a pet
  * @export
@@ -63,7 +62,6 @@ export interface Category {
      */
     name?: string;
 }
-
 /**
  * An order for a pets from the pet store
  * @export
@@ -99,7 +97,7 @@ export interface Order {
      * @type {string}
      * @memberof Order
      */
-    status?: Order.StatusEnum;
+    status?: OrderStatusEnum;
     /**
      * 
      * @type {boolean}
@@ -109,19 +107,13 @@ export interface Order {
 }
 
 /**
- * @export
- * @namespace Order
- */
-export namespace Order {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Placed = 'placed',
-        Approved = 'approved',
-        Delivered = 'delivered'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum OrderStatusEnum {
+    Placed = 'placed',
+    Approved = 'approved',
+    Delivered = 'delivered'
 }
 
 /**
@@ -165,23 +157,17 @@ export interface Pet {
      * @type {string}
      * @memberof Pet
      */
-    status?: Pet.StatusEnum;
+    status?: PetStatusEnum;
 }
 
 /**
- * @export
- * @namespace Pet
- */
-export namespace Pet {
-    /**
-     * @export
-     * @enum {string}
-     */
-    export enum StatusEnum {
-        Available = 'available',
-        Pending = 'pending',
-        Sold = 'sold'
-    }
+    * @export
+    * @enum {string}
+    */
+export enum PetStatusEnum {
+    Available = 'available',
+    Pending = 'pending',
+    Sold = 'sold'
 }
 
 /**
@@ -203,7 +189,6 @@ export interface Tag {
      */
     name?: string;
 }
-
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -259,7 +244,6 @@ export interface User {
      */
     userStatus?: number;
 }
-
 
 /**
  * PetApi - axios parameter creator

--- a/samples/client/petstore/typescript-axios/tests/default/test/PetApi.ts
+++ b/samples/client/petstore/typescript-axios/tests/default/test/PetApi.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { PetApi, Pet, Category } from "@swagger/typescript-axios-petstore";
+import { PetApi, Pet, PetStatusEnum, Category } from "@swagger/typescript-axios-petstore";
 import axios, {AxiosInstance, AxiosResponse} from "axios";
 
 describe("PetApi", () => {
@@ -85,7 +85,7 @@ function createTestFixture(ts = Date.now()) {
     name: `pet${ts}`,
     category: category,
     photoUrls: ["http://foo.bar.com/1", "http://foo.bar.com/2"],
-    status: Pet.StatusEnum.Available,
+    status: PetStatusEnum.Available,
     tags: []
   };
 

--- a/samples/client/petstore/typescript-axios/tests/default/test/PetApiFactory.ts
+++ b/samples/client/petstore/typescript-axios/tests/default/test/PetApiFactory.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import {
   PetApiFactory,
   Pet,
+  PetStatusEnum,
   Category
 } from "@swagger/typescript-axios-petstore";
 import { Configuration } from "@swagger/typescript-axios-petstore";
@@ -106,7 +107,7 @@ function createTestFixture(ts = Date.now()) {
     name: `pet${ts}`,
     category: category,
     photoUrls: ["http://foo.bar.com/1", "http://foo.bar.com/2"],
-    status: Pet.StatusEnum.Available,
+    status: PetStatusEnum.Available,
     tags: []
   };
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Removing namespaces from typescript-axios, according to suggestions made in #1947. Added "withoutPrefixEnums" option for disabling class name prefixing for enums. Tested new option locally and it works, but I'm not sure how to add new testcase cause "petstore.json" has overlappping enum names


@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

