### PR TITLE
Fix Scala client (Akka) return type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaClientCodegen.java
@@ -49,13 +49,7 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
     protected boolean registerNonStandardStatusCodes = true;
     protected boolean renderJavadoc = true;
     protected boolean removeOAuthSecurities = true;
-    /**
-     * If set to true, only the default response (the one with le lowest 2XX code) will be considered as a success, and all
-     * others as ApiErrors.
-     * If set to false, all responses defined in the model will be considered as a success upon reception. Only http errors,
-     * unmarshalling problems and any other RuntimeException will be considered as ApiErrors.
-     */
-    protected boolean onlyOneSuccess = true;
+
 
     @SuppressWarnings("hiding")
     protected Logger LOGGER = LoggerFactory.getLogger(ScalaAkkaClientCodegen.class);
@@ -92,7 +86,6 @@ public class ScalaAkkaClientCodegen extends AbstractScalaCodegen implements Code
         additionalProperties.put("fnCapitalize", new CapitalizeLambda());
         additionalProperties.put("fnCamelize", new CamelizeLambda(false));
         additionalProperties.put("fnEnumEntry", new EnumEntryLambda());
-        additionalProperties.put("onlyOneSuccess", onlyOneSuccess);
         additionalProperties.put("mainPackage", mainPackage);
 
         importMapping.remove("Seq");

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/operationReturnType.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/operationReturnType.mustache
@@ -1,1 +1,1 @@
-{{#onlyOneSuccess}}{{^defaultResponse}}Unit{{/defaultResponse}}{{#defaultResponse}}{{#responses}}{{#isDefault}}{{#dataType}}{{dataType}}{{/dataType}}{{^dataType}}Unit{{/dataType}}{{/isDefault}}{{/responses}}{{/defaultResponse}}{{/onlyOneSuccess}}{{^onlyOneSuccess}}{{#responses}}{{#-first}}{{^hasMore}}{{#dataType}}{{dataType}}{{/dataType}}{{^dataType}}Unit{{/dataType}}{{/hasMore}}{{#hasMore}}Any{{/hasMore}}{{/-first}}{{/responses}}{{/onlyOneSuccess}}
+{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Unit{{/returnType}}

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/responseState.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/responseState.mustache
@@ -1,1 +1,1 @@
-{{#onlyOneSuccess}}{{#isDefault}}Success{{/isDefault}}{{^isDefault}}Error{{/isDefault}}{{/onlyOneSuccess}}{{^onlyOneSuccess}}Success{{/onlyOneSuccess}}
+{{#isDefault}}Success{{/isDefault}}{{^isDefault}}Error{{/isDefault}}

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -96,8 +96,8 @@ class PetApi(baseUrl: String) {
    * 
    * @param petId ID of pet to return
    */
-  def getPetById(petId: Long)(implicit apiKey: ApiKeyValue): ApiRequest[Unit] =
-    ApiRequest[Unit](ApiMethods.GET, "http://petstore.swagger.io/v2", "/pet/{petId}", "application/json")
+  def getPetById(petId: Long)(implicit apiKey: ApiKeyValue): ApiRequest[Pet] =
+    ApiRequest[Pet](ApiMethods.GET, "http://petstore.swagger.io/v2", "/pet/{petId}", "application/json")
       .withApiKey(apiKey, "api_key", HEADER)
       .withPathParam("petId", petId)
       .withSuccessResponse[Pet](200)
@@ -145,8 +145,8 @@ class PetApi(baseUrl: String) {
    * @param additionalMetadata Additional data to pass to server
    * @param file file to upload
    */
-  def uploadFile(petId: Long, additionalMetadata: Option[String] = None, file: Option[File] = None): ApiRequest[Unit] =
-    ApiRequest[Unit](ApiMethods.POST, "http://petstore.swagger.io/v2", "/pet/{petId}/uploadImage", "multipart/form-data")
+  def uploadFile(petId: Long, additionalMetadata: Option[String] = None, file: Option[File] = None): ApiRequest[ApiResponse] =
+    ApiRequest[ApiResponse](ApiMethods.POST, "http://petstore.swagger.io/v2", "/pet/{petId}/uploadImage", "multipart/form-data")
       .withFormParam("additionalMetadata", additionalMetadata)
       .withFormParam("file", file)
       .withPathParam("petId", petId)

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/StoreApi.scala
@@ -64,8 +64,8 @@ class StoreApi(baseUrl: String) {
    * 
    * @param orderId ID of pet that needs to be fetched
    */
-  def getOrderById(orderId: Long): ApiRequest[Unit] =
-    ApiRequest[Unit](ApiMethods.GET, "http://petstore.swagger.io/v2", "/store/order/{orderId}", "application/json")
+  def getOrderById(orderId: Long): ApiRequest[Order] =
+    ApiRequest[Order](ApiMethods.GET, "http://petstore.swagger.io/v2", "/store/order/{orderId}", "application/json")
       .withPathParam("orderId", orderId)
       .withSuccessResponse[Order](200)
       .withErrorResponse[Unit](400)
@@ -79,8 +79,8 @@ class StoreApi(baseUrl: String) {
    * 
    * @param body order placed for purchasing the pet
    */
-  def placeOrder(body: Order): ApiRequest[Unit] =
-    ApiRequest[Unit](ApiMethods.POST, "http://petstore.swagger.io/v2", "/store/order", "application/json")
+  def placeOrder(body: Order): ApiRequest[Order] =
+    ApiRequest[Order](ApiMethods.POST, "http://petstore.swagger.io/v2", "/store/order", "application/json")
       .withBody(body)
       .withSuccessResponse[Order](200)
       .withErrorResponse[Unit](400)

--- a/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-akka/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -85,8 +85,8 @@ class UserApi(baseUrl: String) {
    * 
    * @param username The name that needs to be fetched. Use user1 for testing.
    */
-  def getUserByName(username: String): ApiRequest[Unit] =
-    ApiRequest[Unit](ApiMethods.GET, "http://petstore.swagger.io/v2", "/user/{username}", "application/json")
+  def getUserByName(username: String): ApiRequest[User] =
+    ApiRequest[User](ApiMethods.GET, "http://petstore.swagger.io/v2", "/user/{username}", "application/json")
       .withPathParam("username", username)
       .withSuccessResponse[User](200)
       .withErrorResponse[Unit](400)
@@ -104,8 +104,8 @@ class UserApi(baseUrl: String) {
    * @param username The user name for login
    * @param password The password for login in clear text
    */
-  def loginUser(username: String, password: String): ApiRequest[Unit] =
-    ApiRequest[Unit](ApiMethods.GET, "http://petstore.swagger.io/v2", "/user/login", "application/json")
+  def loginUser(username: String, password: String): ApiRequest[String] =
+    ApiRequest[String](ApiMethods.GET, "http://petstore.swagger.io/v2", "/user/login", "application/json")
       .withQueryParam("username", username)
       .withQueryParam("password", password)
       .withSuccessResponse[String](200)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- remove `onlyOneSuccess` (hidden) option
- fix return type

cc @clasnake (2017/07), @jimschubert (2017/09), @shijinkui (2018/01), @ramzimaalej (2018/03)
