### PR TITLE
Fix Kotlin default value

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -785,4 +785,31 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
             }
         }
     }
+
+    @Override
+    public String toDefaultValue(Schema p) {
+        if (ModelUtils.isBooleanSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            }
+        } else if (ModelUtils.isDateSchema(p)) {
+            // TODO
+        } else if (ModelUtils.isDateTimeSchema(p)) {
+            // TODO
+        } else if (ModelUtils.isNumberSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            }
+        } else if (ModelUtils.isIntegerSchema(p)) {
+            if (p.getDefault() != null) {
+                return p.getDefault().toString();
+            }
+        } else if (ModelUtils.isStringSchema(p)) {
+            if (p.getDefault() != null) {
+                return "'" + p.getDefault() + "'";
+            }
+        }
+
+        return null;
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -80,7 +80,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property1.baseName, "id");
         Assert.assertEquals(property1.dataType, "kotlin.Long");
         Assert.assertEquals(property1.name, "id");
-        Assert.assertEquals(property1.defaultValue, "null");
+        Assert.assertEquals(property1.defaultValue, null);
         Assert.assertEquals(property1.baseType, "kotlin.Long");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
@@ -91,7 +91,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property2.baseName, "name");
         Assert.assertEquals(property2.dataType, "kotlin.String");
         Assert.assertEquals(property2.name, "name");
-        Assert.assertEquals(property2.defaultValue, "null");
+        Assert.assertEquals(property2.defaultValue, null);
         Assert.assertEquals(property2.baseType, "kotlin.String");
         Assert.assertTrue(property2.hasMore);
         Assert.assertTrue(property2.required);
@@ -102,7 +102,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseName, "createdAt");
         Assert.assertEquals(property3.dataType, "java.time.LocalDateTime");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "java.time.LocalDateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
@@ -124,7 +124,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseName, "createdAt");
         Assert.assertEquals(property3.dataType, "org.threeten.bp.LocalDateTime");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "org.threeten.bp.LocalDateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
@@ -146,7 +146,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseName, "createdAt");
         Assert.assertEquals(property3.dataType, "kotlin.String");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "kotlin.String");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
@@ -168,7 +168,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property3.baseName, "createdAt");
         Assert.assertEquals(property3.dataType, "java.time.LocalDateTime");
         Assert.assertEquals(property3.name, "createdAt");
-        Assert.assertEquals(property3.defaultValue, "null");
+        Assert.assertEquals(property3.defaultValue, null);
         Assert.assertEquals(property3.baseType, "java.time.LocalDateTime");
         Assert.assertFalse(property3.hasMore);
         Assert.assertFalse(property3.required);
@@ -195,7 +195,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property.setter, "setExamples");
         Assert.assertEquals(property.dataType, "kotlin.Array<kotlin.String>");
         Assert.assertEquals(property.name, "examples");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "kotlin.Array");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);
@@ -224,7 +224,7 @@ public class KotlinClientCodegenModelTest {
         Assert.assertEquals(property.setter, "setExamples");
         Assert.assertEquals(property.dataType, "kotlin.collections.List<kotlin.String>");
         Assert.assertEquals(property.name, "examples");
-        Assert.assertEquals(property.defaultValue, "null");
+        Assert.assertEquals(property.defaultValue, null);
         Assert.assertEquals(property.baseType, "kotlin.collections.List");
         Assert.assertEquals(property.containerType, "array");
         Assert.assertFalse(property.required);

--- a/samples/client/petstore/kotlin-string/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-string/docs/PetApi.md
@@ -88,8 +88,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| Pet id to delete | [default to null]
- **apiKey** | **kotlin.String**|  | [optional] [default to null]
+ **petId** | **kotlin.Long**| Pet id to delete |
+ **apiKey** | **kotlin.String**|  | [optional]
 
 ### Return type
 
@@ -136,7 +136,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Status values that need to be considered for filter | [default to null] [enum: available, pending, sold]
+ **status** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
 
 ### Return type
 
@@ -183,7 +183,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Tags to filter by | [default to null]
+ **tags** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Tags to filter by |
 
 ### Return type
 
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet to return | [default to null]
+ **petId** | **kotlin.Long**| ID of pet to return |
 
 ### Return type
 
@@ -320,9 +320,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet that needs to be updated | [default to null]
- **name** | **kotlin.String**| Updated name of the pet | [optional] [default to null]
- **status** | **kotlin.String**| Updated status of the pet | [optional] [default to null]
+ **petId** | **kotlin.Long**| ID of pet that needs to be updated |
+ **name** | **kotlin.String**| Updated name of the pet | [optional]
+ **status** | **kotlin.String**| Updated status of the pet | [optional]
 
 ### Return type
 
@@ -369,9 +369,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet to update | [default to null]
- **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] [default to null]
- **file** | **java.io.File**| file to upload | [optional] [default to null]
+ **petId** | **kotlin.Long**| ID of pet to update |
+ **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional]
+ **file** | **java.io.File**| file to upload | [optional]
 
 ### Return type
 

--- a/samples/client/petstore/kotlin-string/docs/StoreApi.md
+++ b/samples/client/petstore/kotlin-string/docs/StoreApi.md
@@ -41,7 +41,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.String**| ID of the order that needs to be deleted | [default to null]
+ **orderId** | **kotlin.String**| ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -131,7 +131,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.Long**| ID of pet that needs to be fetched | [default to null]
+ **orderId** | **kotlin.Long**| ID of pet that needs to be fetched |
 
 ### Return type
 

--- a/samples/client/petstore/kotlin-string/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-string/docs/UserApi.md
@@ -179,7 +179,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be deleted | [default to null]
+ **username** | **kotlin.String**| The name that needs to be deleted |
 
 ### Return type
 
@@ -224,7 +224,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. | [default to null]
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -270,8 +270,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The user name for login | [default to null]
- **password** | **kotlin.String**| The password for login in clear text | [default to null]
+ **username** | **kotlin.String**| The user name for login |
+ **password** | **kotlin.String**| The password for login in clear text |
 
 ### Return type
 
@@ -358,7 +358,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| name that need to be deleted | [default to null]
+ **username** | **kotlin.String**| name that need to be deleted |
  **body** | [**User**](User.md)| Updated user object |
 
 ### Return type

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -52,7 +52,7 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * Deletes a pet
     * 
     * @param petId Pet id to delete 
-    * @param apiKey  (optional, default to null)
+    * @param apiKey  (optional)
     * @return void
     */
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
@@ -206,8 +206,8 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * Updates a pet in the store with form data
     * 
     * @param petId ID of pet that needs to be updated 
-    * @param name Updated name of the pet (optional, default to null)
-    * @param status Updated status of the pet (optional, default to null)
+    * @param name Updated name of the pet (optional)
+    * @param status Updated status of the pet (optional)
     * @return void
     */
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
@@ -238,8 +238,8 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * uploads an image
     * 
     * @param petId ID of pet to update 
-    * @param additionalMetadata Additional data to pass to server (optional, default to null)
-    * @param file file to upload (optional, default to null)
+    * @param additionalMetadata Additional data to pass to server (optional)
+    * @param file file to upload (optional)
     * @return ApiResponse
     */
     @Suppress("UNCHECKED_CAST")

--- a/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/PetApi.md
@@ -88,8 +88,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| Pet id to delete | [default to null]
- **apiKey** | **kotlin.String**|  | [optional] [default to null]
+ **petId** | **kotlin.Long**| Pet id to delete |
+ **apiKey** | **kotlin.String**|  | [optional]
 
 ### Return type
 
@@ -136,7 +136,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Status values that need to be considered for filter | [default to null] [enum: available, pending, sold]
+ **status** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
 
 ### Return type
 
@@ -183,7 +183,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Tags to filter by | [default to null]
+ **tags** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Tags to filter by |
 
 ### Return type
 
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet to return | [default to null]
+ **petId** | **kotlin.Long**| ID of pet to return |
 
 ### Return type
 
@@ -320,9 +320,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet that needs to be updated | [default to null]
- **name** | **kotlin.String**| Updated name of the pet | [optional] [default to null]
- **status** | **kotlin.String**| Updated status of the pet | [optional] [default to null]
+ **petId** | **kotlin.Long**| ID of pet that needs to be updated |
+ **name** | **kotlin.String**| Updated name of the pet | [optional]
+ **status** | **kotlin.String**| Updated status of the pet | [optional]
 
 ### Return type
 
@@ -369,9 +369,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet to update | [default to null]
- **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] [default to null]
- **file** | **java.io.File**| file to upload | [optional] [default to null]
+ **petId** | **kotlin.Long**| ID of pet to update |
+ **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional]
+ **file** | **java.io.File**| file to upload | [optional]
 
 ### Return type
 

--- a/samples/client/petstore/kotlin-threetenbp/docs/StoreApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/StoreApi.md
@@ -41,7 +41,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.String**| ID of the order that needs to be deleted | [default to null]
+ **orderId** | **kotlin.String**| ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -131,7 +131,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.Long**| ID of pet that needs to be fetched | [default to null]
+ **orderId** | **kotlin.Long**| ID of pet that needs to be fetched |
 
 ### Return type
 

--- a/samples/client/petstore/kotlin-threetenbp/docs/UserApi.md
+++ b/samples/client/petstore/kotlin-threetenbp/docs/UserApi.md
@@ -179,7 +179,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be deleted | [default to null]
+ **username** | **kotlin.String**| The name that needs to be deleted |
 
 ### Return type
 
@@ -224,7 +224,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. | [default to null]
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -270,8 +270,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The user name for login | [default to null]
- **password** | **kotlin.String**| The password for login in clear text | [default to null]
+ **username** | **kotlin.String**| The user name for login |
+ **password** | **kotlin.String**| The password for login in clear text |
 
 ### Return type
 
@@ -358,7 +358,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| name that need to be deleted | [default to null]
+ **username** | **kotlin.String**| name that need to be deleted |
  **body** | [**User**](User.md)| Updated user object |
 
 ### Return type

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -53,7 +53,7 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * Deletes a pet
     * 
     * @param petId Pet id to delete 
-    * @param apiKey  (optional, default to null)
+    * @param apiKey  (optional)
     * @return void
     */
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
@@ -207,8 +207,8 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * Updates a pet in the store with form data
     * 
     * @param petId ID of pet that needs to be updated 
-    * @param name Updated name of the pet (optional, default to null)
-    * @param status Updated status of the pet (optional, default to null)
+    * @param name Updated name of the pet (optional)
+    * @param status Updated status of the pet (optional)
     * @return void
     */
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
@@ -239,8 +239,8 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * uploads an image
     * 
     * @param petId ID of pet to update 
-    * @param additionalMetadata Additional data to pass to server (optional, default to null)
-    * @param file file to upload (optional, default to null)
+    * @param additionalMetadata Additional data to pass to server (optional)
+    * @param file file to upload (optional)
     * @return ApiResponse
     */
     @Suppress("UNCHECKED_CAST")

--- a/samples/client/petstore/kotlin/docs/PetApi.md
+++ b/samples/client/petstore/kotlin/docs/PetApi.md
@@ -88,8 +88,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| Pet id to delete | [default to null]
- **apiKey** | **kotlin.String**|  | [optional] [default to null]
+ **petId** | **kotlin.Long**| Pet id to delete |
+ **apiKey** | **kotlin.String**|  | [optional]
 
 ### Return type
 
@@ -136,7 +136,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **status** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Status values that need to be considered for filter | [default to null] [enum: available, pending, sold]
+ **status** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Status values that need to be considered for filter | [enum: available, pending, sold]
 
 ### Return type
 
@@ -183,7 +183,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **tags** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Tags to filter by | [default to null]
+ **tags** | [**kotlin.Array&lt;kotlin.String&gt;**](kotlin.String.md)| Tags to filter by |
 
 ### Return type
 
@@ -230,7 +230,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet to return | [default to null]
+ **petId** | **kotlin.Long**| ID of pet to return |
 
 ### Return type
 
@@ -320,9 +320,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet that needs to be updated | [default to null]
- **name** | **kotlin.String**| Updated name of the pet | [optional] [default to null]
- **status** | **kotlin.String**| Updated status of the pet | [optional] [default to null]
+ **petId** | **kotlin.Long**| ID of pet that needs to be updated |
+ **name** | **kotlin.String**| Updated name of the pet | [optional]
+ **status** | **kotlin.String**| Updated status of the pet | [optional]
 
 ### Return type
 
@@ -369,9 +369,9 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **petId** | **kotlin.Long**| ID of pet to update | [default to null]
- **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional] [default to null]
- **file** | **java.io.File**| file to upload | [optional] [default to null]
+ **petId** | **kotlin.Long**| ID of pet to update |
+ **additionalMetadata** | **kotlin.String**| Additional data to pass to server | [optional]
+ **file** | **java.io.File**| file to upload | [optional]
 
 ### Return type
 

--- a/samples/client/petstore/kotlin/docs/StoreApi.md
+++ b/samples/client/petstore/kotlin/docs/StoreApi.md
@@ -41,7 +41,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.String**| ID of the order that needs to be deleted | [default to null]
+ **orderId** | **kotlin.String**| ID of the order that needs to be deleted |
 
 ### Return type
 
@@ -131,7 +131,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **orderId** | **kotlin.Long**| ID of pet that needs to be fetched | [default to null]
+ **orderId** | **kotlin.Long**| ID of pet that needs to be fetched |
 
 ### Return type
 

--- a/samples/client/petstore/kotlin/docs/UserApi.md
+++ b/samples/client/petstore/kotlin/docs/UserApi.md
@@ -179,7 +179,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be deleted | [default to null]
+ **username** | **kotlin.String**| The name that needs to be deleted |
 
 ### Return type
 
@@ -224,7 +224,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. | [default to null]
+ **username** | **kotlin.String**| The name that needs to be fetched. Use user1 for testing. |
 
 ### Return type
 
@@ -270,8 +270,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| The user name for login | [default to null]
- **password** | **kotlin.String**| The password for login in clear text | [default to null]
+ **username** | **kotlin.String**| The user name for login |
+ **password** | **kotlin.String**| The password for login in clear text |
 
 ### Return type
 
@@ -358,7 +358,7 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **username** | **kotlin.String**| name that need to be deleted | [default to null]
+ **username** | **kotlin.String**| name that need to be deleted |
  **body** | [**User**](User.md)| Updated user object |
 
 ### Return type

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -52,7 +52,7 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * Deletes a pet
     * 
     * @param petId Pet id to delete 
-    * @param apiKey  (optional, default to null)
+    * @param apiKey  (optional)
     * @return void
     */
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String?) : Unit {
@@ -206,8 +206,8 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * Updates a pet in the store with form data
     * 
     * @param petId ID of pet that needs to be updated 
-    * @param name Updated name of the pet (optional, default to null)
-    * @param status Updated status of the pet (optional, default to null)
+    * @param name Updated name of the pet (optional)
+    * @param status Updated status of the pet (optional)
     * @return void
     */
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String?, status: kotlin.String?) : Unit {
@@ -238,8 +238,8 @@ class PetApi(basePath: kotlin.String = "http://petstore.swagger.io/v2") : ApiCli
     * uploads an image
     * 
     * @param petId ID of pet to update 
-    * @param additionalMetadata Additional data to pass to server (optional, default to null)
-    * @param file file to upload (optional, default to null)
+    * @param additionalMetadata Additional data to pass to server (optional)
+    * @param file file to upload (optional)
     * @return ApiResponse
     */
     @Suppress("UNCHECKED_CAST")

--- a/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/Paths.kt
+++ b/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/Paths.kt
@@ -20,7 +20,7 @@ object Paths {
      * Deletes a pet
      * 
      * @param petId Pet id to delete 
-     * @param apiKey  (optional, default to null)
+     * @param apiKey  (optional)
      */
     @KtorExperimentalLocationsAPI
     @Location("/pet/{petId}") class deletePet(val petId: kotlin.Long, val apiKey: kotlin.String)

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -56,7 +56,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
     @RequestMapping(
             value = ["/pet/{petId}"],
             method = [RequestMethod.DELETE])
-    fun deletePet(@ApiParam(value = "Pet id to delete", required=true, defaultValue="null") @PathVariable("petId") petId: Long,@ApiParam(value = "" , defaultValue="null") @RequestHeader(value="api_key", required=false) apiKey: String): ResponseEntity<Unit> {
+    fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: String?): ResponseEntity<Unit> {
         return ResponseEntity(service.deletePet(petId, apiKey), HttpStatus.OK)
     }
 
@@ -73,7 +73,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/findByStatus"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold", defaultValue = "null") @Valid @RequestParam(value = "status", required = true, defaultValue="null") status: List<String>): ResponseEntity<List<Pet>> {
+    fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) status: List<String>): ResponseEntity<List<Pet>> {
         return ResponseEntity(service.findPetsByStatus(status), HttpStatus.OK)
     }
 
@@ -90,7 +90,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/findByTags"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true, defaultValue = "null") @Valid @RequestParam(value = "tags", required = true, defaultValue="null") tags: List<String>): ResponseEntity<List<Pet>> {
+    fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: List<String>): ResponseEntity<List<Pet>> {
         return ResponseEntity(service.findPetsByTags(tags), HttpStatus.OK)
     }
 
@@ -106,7 +106,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/{petId}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getPetById(@ApiParam(value = "ID of pet to return", required=true, defaultValue="null") @PathVariable("petId") petId: Long): ResponseEntity<Pet> {
+    fun getPetById(@ApiParam(value = "ID of pet to return", required=true) @PathVariable("petId") petId: Long): ResponseEntity<Pet> {
         return ResponseEntity(service.getPetById(petId), HttpStatus.OK)
     }
 
@@ -136,7 +136,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             value = ["/pet/{petId}"],
             consumes = ["application/x-www-form-urlencoded"],
             method = [RequestMethod.POST])
-    fun updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required=true, defaultValue="null") @PathVariable("petId") petId: Long,@ApiParam(value = "Updated name of the pet", defaultValue="null") @RequestParam(value="name", required=false) name: String ,@ApiParam(value = "Updated status of the pet", defaultValue="null") @RequestParam(value="status", required=false) status: String ): ResponseEntity<Unit> {
+    fun updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "Updated name of the pet") @RequestParam(value="name", required=false) name: String? ,@ApiParam(value = "Updated status of the pet") @RequestParam(value="status", required=false) status: String? ): ResponseEntity<Unit> {
         return ResponseEntity(service.updatePetWithForm(petId, name, status), HttpStatus.OK)
     }
 
@@ -153,7 +153,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             produces = ["application/json"], 
             consumes = ["multipart/form-data"],
             method = [RequestMethod.POST])
-    fun uploadFile(@ApiParam(value = "ID of pet to update", required=true, defaultValue="null") @PathVariable("petId") petId: Long,@ApiParam(value = "Additional data to pass to server", defaultValue="null") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: String ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: MultipartFile): ResponseEntity<ModelApiResponse> {
+    fun uploadFile(@ApiParam(value = "ID of pet to update", required=true) @PathVariable("petId") petId: Long,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: String? ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: MultipartFile): ResponseEntity<ModelApiResponse> {
         return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.OK)
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
@@ -7,7 +7,7 @@ interface PetApiService {
 
     fun addPet(body: Pet): Unit
 
-    fun deletePet(petId: Long,apiKey: String): Unit
+    fun deletePet(petId: Long,apiKey: String?): Unit
 
     fun findPetsByStatus(status: List<String>): List<Pet>
 
@@ -17,7 +17,7 @@ interface PetApiService {
 
     fun updatePet(body: Pet): Unit
 
-    fun updatePetWithForm(petId: Long,name: String,status: String): Unit
+    fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit
 
-    fun uploadFile(petId: Long,additionalMetadata: String,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse
+    fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
@@ -11,7 +11,7 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun deletePet(petId: Long,apiKey: String): Unit {
+    override fun deletePet(petId: Long,apiKey: String?): Unit {
         TODO("Implement me")
     }
 
@@ -31,11 +31,11 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun updatePetWithForm(petId: Long,name: String,status: String): Unit {
+    override fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit {
         TODO("Implement me")
     }
 
-    override fun uploadFile(petId: Long,additionalMetadata: String,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse {
+    override fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.web.multipart.MultipartFile): ModelApiResponse {
         TODO("Implement me")
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -39,7 +39,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
     @RequestMapping(
             value = ["/store/order/{orderId}"],
             method = [RequestMethod.DELETE])
-    fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true, defaultValue="null") @PathVariable("orderId") orderId: String): ResponseEntity<Unit> {
+    fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true) @PathVariable("orderId") orderId: String): ResponseEntity<Unit> {
         return ResponseEntity(service.deleteOrder(orderId), HttpStatus.OK)
     }
 
@@ -71,7 +71,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             value = ["/store/order/{orderId}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true, defaultValue="null") @PathVariable("orderId") orderId: Long): ResponseEntity<Order> {
+    fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true) @PathVariable("orderId") orderId: Long): ResponseEntity<Order> {
         return ResponseEntity(service.getOrderById(orderId), HttpStatus.OK)
     }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -78,7 +78,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/{username}"],
             method = [RequestMethod.DELETE])
-    fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true, defaultValue="null") @PathVariable("username") username: String): ResponseEntity<Unit> {
+    fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true) @PathVariable("username") username: String): ResponseEntity<Unit> {
         return ResponseEntity(service.deleteUser(username), HttpStatus.OK)
     }
 
@@ -93,7 +93,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/{username}"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true, defaultValue="null") @PathVariable("username") username: String): ResponseEntity<User> {
+    fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true) @PathVariable("username") username: String): ResponseEntity<User> {
         return ResponseEntity(service.getUserByName(username), HttpStatus.OK)
     }
 
@@ -108,7 +108,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/login"],
             produces = ["application/xml", "application/json"], 
             method = [RequestMethod.GET])
-    fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true, defaultValue = "null") @Valid @RequestParam(value = "username", required = true, defaultValue="null") username: String,@NotNull @ApiParam(value = "The password for login in clear text", required = true, defaultValue = "null") @Valid @RequestParam(value = "password", required = true, defaultValue="null") password: String): ResponseEntity<String> {
+    fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: String,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: String): ResponseEntity<String> {
         return ResponseEntity(service.loginUser(username, password), HttpStatus.OK)
     }
 
@@ -134,7 +134,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     @RequestMapping(
             value = ["/user/{username}"],
             method = [RequestMethod.PUT])
-    fun updateUser(@ApiParam(value = "name that need to be deleted", required=true, defaultValue="null") @PathVariable("username") username: String,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody body: User): ResponseEntity<Unit> {
+    fun updateUser(@ApiParam(value = "name that need to be deleted", required=true) @PathVariable("username") username: String,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody body: User): ResponseEntity<Unit> {
         return ResponseEntity(service.updateUser(username, body), HttpStatus.OK)
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix Kotlin default value "null" with `null`

cc @jimschubert (2017/09), @dr4ke616 (2018/08)


