### PR TITLE
Fix JavaDoc errors in ApiClient for resttemplate

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -342,6 +342,8 @@ public class ApiClient {
 
     /**
      * Parse the given string into Date object.
+     * @param str the string to parse
+     * @return the Date parsed from the string
      */
     public Date parseDate(String str) {
         try {
@@ -353,6 +355,8 @@ public class ApiClient {
 
     /**
      * Format the given Date object into string.
+     * @param date the date to format
+     * @return the formatted date as string
      */
     public String formatDate(Date date) {
         return dateFormat.format(date);
@@ -386,7 +390,7 @@ public class ApiClient {
     * Formats the specified collection path parameter to a string value.
     *
     * @param collectionFormat The collection format of the parameter.
-    * @param value The value of the parameter.
+    * @param values The values of the parameter.
     * @return String representation of the parameter
     */
     public String collectionPathParameterToString(CollectionFormat collectionFormat, Collection<? extends CharSequence> values) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -331,6 +331,8 @@ public class ApiClient {
 
     /**
      * Parse the given string into Date object.
+     * @param str the string to parse
+     * @return the Date parsed from the string
      */
     public Date parseDate(String str) {
         try {
@@ -342,6 +344,8 @@ public class ApiClient {
 
     /**
      * Format the given Date object into string.
+     * @param date the date to format
+     * @return the formatted date as string
      */
     public String formatDate(Date date) {
         return dateFormat.format(date);
@@ -375,7 +379,7 @@ public class ApiClient {
     * Formats the specified collection path parameter to a string value.
     *
     * @param collectionFormat The collection format of the parameter.
-    * @param value The value of the parameter.
+    * @param values The values of the parameter.
     * @return String representation of the parameter
     */
     public String collectionPathParameterToString(CollectionFormat collectionFormat, Collection<? extends CharSequence> values) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -326,6 +326,8 @@ public class ApiClient {
 
     /**
      * Parse the given string into Date object.
+     * @param str the string to parse
+     * @return the Date parsed from the string
      */
     public Date parseDate(String str) {
         try {
@@ -337,6 +339,8 @@ public class ApiClient {
 
     /**
      * Format the given Date object into string.
+     * @param date the date to format
+     * @return the formatted date as string
      */
     public String formatDate(Date date) {
         return dateFormat.format(date);
@@ -370,7 +374,7 @@ public class ApiClient {
     * Formats the specified collection path parameter to a string value.
     *
     * @param collectionFormat The collection format of the parameter.
-    * @param value The value of the parameter.
+    * @param values The values of the parameter.
     * @return String representation of the parameter
     */
     public String collectionPathParameterToString(CollectionFormat collectionFormat, Collection<? extends CharSequence> values) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)
### Description of the PR

Currently the java-resttemplate mustache templates will create an ApiClient class which fails the validation done by the javadoc-maven-plugin. This PR fixes this issue.