### PR TITLE
[Kotlin SpringBoot Server] fix optional parameter not correctly declared in service

### DIFF
--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -24,6 +24,7 @@ declare -a scripts=(
 "./bin/kotlin-client-string.sh"
 "./bin/kotlin-client-threetenbp.sh"
 "./bin/kotlin-server-petstore.sh"
+"./bin/kotlin-springboot-petstore-server.sh"
 "./bin/mysql-schema-petstore.sh"
 "./bin/python-petstore-all.sh"
 "./bin/openapi3/python-petstore.sh"

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/service.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/service.mustache
@@ -7,7 +7,7 @@ package {{package}}
 interface {{classname}}Service {
 {{#operation}}
 
-    fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{#hasMore}},{{/hasMore}}{{/allParams}}): {{>returnTypes}}
+    fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}},{{/hasMore}}{{/allParams}}): {{>returnTypes}}
 {{/operation}}
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/serviceImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/serviceImpl.mustache
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service
 class {{classname}}ServiceImpl : {{classname}}Service {
 {{#operation}}
 
-    override fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{#hasMore}},{{/hasMore}}{{/allParams}}): {{>returnTypes}} {
+    override fun {{operationId}}({{#allParams}}{{paramName}}: {{{dataType}}}{{^required}}?{{/required}}{{#hasMore}},{{/hasMore}}{{/allParams}}): {{>returnTypes}} {
         TODO("Implement me")
     }
 {{/operation}}

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiService.kt
@@ -7,7 +7,7 @@ interface PetApiService {
 
     fun addPet(body: Pet): Unit
 
-    fun deletePet(petId: Long,apiKey: String): Unit
+    fun deletePet(petId: Long,apiKey: String?): Unit
 
     fun findPetsByStatus(status: List<String>): List<Pet>
 
@@ -17,7 +17,7 @@ interface PetApiService {
 
     fun updatePet(body: Pet): Unit
 
-    fun updatePetWithForm(petId: Long,name: String,status: String): Unit
+    fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit
 
-    fun uploadFile(petId: Long,additionalMetadata: String,file: org.springframework.core.io.Resource): ModelApiResponse
+    fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.core.io.Resource?): ModelApiResponse
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiServiceImpl.kt
@@ -10,7 +10,7 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun deletePet(petId: Long,apiKey: String): Unit {
+    override fun deletePet(petId: Long,apiKey: String?): Unit {
         TODO("Implement me")
     }
 
@@ -30,11 +30,11 @@ class PetApiServiceImpl : PetApiService {
         TODO("Implement me")
     }
 
-    override fun updatePetWithForm(petId: Long,name: String,status: String): Unit {
+    override fun updatePetWithForm(petId: Long,name: String?,status: String?): Unit {
         TODO("Implement me")
     }
 
-    override fun uploadFile(petId: Long,additionalMetadata: String,file: org.springframework.core.io.Resource): ModelApiResponse {
+    override fun uploadFile(petId: Long,additionalMetadata: String?,file: org.springframework.core.io.Resource?): ModelApiResponse {
         TODO("Implement me")
     }
 }


### PR DESCRIPTION


### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@jimschubert (2017/09), @dr4ke616 (2018/08)

### Description of the PR

fix optional parameter not correctly declared in service (bug released after #1107)
add Kotlin SpringBoot Server in ensure up to date script
