### PR TITLE
[elm] Update ISO 8601 library (fixes missing time zone designator)

### DIFF
--- a/modules/openapi-generator/src/main/resources/elm/elm.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/elm.mustache
@@ -15,7 +15,7 @@
             "elm/json": "1.1.2",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.2"
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
             "elm/bytes": "1.0.5",

--- a/samples/client/petstore/elm/elm.json
+++ b/samples/client/petstore/elm/elm.json
@@ -15,7 +15,7 @@
             "elm/json": "1.1.2",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.2"
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
             "elm/bytes": "1.0.5",


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.

> I ran the files, and there we're changes, but formatting only. It looks like they we're formatted with elm-format before, but not correctly or with a different version, when I ran the script. I didn't commit them.

- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @eriktim

### Description of the PR

This updates works with ISO 8601 strings with missing ending "Z". This
is e.g. the default configuration used by spring boot in java.

See <https://github.com/rtfeldman/elm-iso8601-date-strings/pull/18>






