### PR TITLE
correction of alias to generate php-symfony

### DIFF
--- a/docs/generators/php-symfony.md
+++ b/docs/generators/php-symfony.md
@@ -20,6 +20,7 @@ sidebar_label: php-symfony
 |artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|
 |composerVendorName|The vendor name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets| |null|
 |bundleName|The name of the Symfony bundle. The template uses {{bundleName}}| |null|
+|bundleAlias|The alias of the Symfony bundle. The template uses {{aliasName}}| |null|
 |composerProjectName|The project name used in the composer package name. The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client| |null|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |phpLegacySupport|Should the generated code be compatible with PHP 5.x?| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -35,6 +35,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
     private static final Logger LOGGER = LoggerFactory.getLogger(PhpSymfonyServerCodegen.class);
 
     public static final String BUNDLE_NAME = "bundleName";
+    public static final String BUNDLE_ALIAS = "bundleAlias";
     public static final String COMPOSER_VENDOR_NAME = "composerVendorName";
     public static final String COMPOSER_PROJECT_NAME = "composerProjectName";
     public static final String PHP_LEGACY_SUPPORT = "phpLegacySupport";
@@ -87,6 +88,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         srcBasePath = ".";
         setInvokerPackage("OpenAPI\\Server");
         setBundleName("OpenAPIServer");
+        setBundleAlias("open_api_server");
         modelDirName = "Model";
         docsBasePath = "Resources" + "/" + "docs";
         apiDocPath = docsBasePath + "/" + apiDirName;
@@ -190,7 +192,10 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         this.bundleName = bundleName;
         this.bundleClassName = bundleName + "Bundle";
         this.bundleExtensionName = bundleName + "Extension";
-        this.bundleAlias = snakeCase(bundleName).replaceAll("([A-Z]+)", "\\_$1").toLowerCase(Locale.ROOT);
+    }
+
+    public void setBundleAlias(String alias) {
+        this.bundleAlias = alias.toLowerCase(Locale.ROOT);
     }
 
     public void setPhpLegacySupport(Boolean support) {
@@ -242,6 +247,12 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             this.setBundleName((String) additionalProperties.get(BUNDLE_NAME));
         } else {
             additionalProperties.put(BUNDLE_NAME, bundleName);
+        }
+
+        if (additionalProperties.containsKey(BUNDLE_ALIAS)) {
+            this.setBundleAlias((String) additionalProperties.get(BUNDLE_ALIAS));
+        } else {
+            additionalProperties.put(BUNDLE_ALIAS, bundleAlias);
         }
 
         if (additionalProperties.containsKey(COMPOSER_PROJECT_NAME)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -177,6 +177,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         cliOptions.add(new CliOption(COMPOSER_VENDOR_NAME, "The vendor name used in the composer package name." +
                 " The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. yaypets"));
         cliOptions.add(new CliOption(BUNDLE_NAME, "The name of the Symfony bundle. The template uses {{bundleName}}"));
+        cliOptions.add(new CliOption(BUNDLE_ALIAS, "The alias of the Symfony bundle. The template uses {{aliasName}}"));
         cliOptions.add(new CliOption(COMPOSER_PROJECT_NAME, "The project name used in the composer package name." +
                 " The template uses {{composerVendorName}}/{{composerProjectName}} for the composer package name. e.g. petstore-client"));
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC)
@@ -195,7 +196,11 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
     }
 
     public void setBundleAlias(String alias) {
-        this.bundleAlias = alias.toLowerCase(Locale.ROOT);
+        if (alias != null && !alias.isEmpty()) {
+            this.bundleAlias = alias.toLowerCase(Locale.ROOT);
+        } else {
+            this.bundleAlias = snakeCase(bundleName).replaceAll("([A-Z]+)", "\\_$1").toLowerCase(Locale.ROOT);
+        }
     }
 
     public void setPhpLegacySupport(Boolean support) {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/DependencyInjection/Compiler/OpenAPIServerApiPass.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/DependencyInjection/Compiler/OpenAPIServerApiPass.php
@@ -51,14 +51,14 @@ class OpenAPIServerApiPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container) {
         // always first check if the primary service is defined
-        if (!$container->has('open_apiserver.api.api_server')) {
+        if (!$container->has('open_api_server.api.api_server')) {
             return;
         }
 
-        $definition = $container->findDefinition('open_apiserver.api.api_server');
+        $definition = $container->findDefinition('open_api_server.api.api_server');
 
-        // find all service IDs with the open_apiserver.api tag
-        $taggedServices = $container->findTaggedServiceIds('open_apiserver.api');
+        // find all service IDs with the open_api_server.api tag
+        $taggedServices = $container->findTaggedServiceIds('open_api_server.api');
 
         foreach ($taggedServices as $id => $tags) {
             foreach ($tags as $tag) {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/DependencyInjection/OpenAPIServerExtension.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/DependencyInjection/OpenAPIServerExtension.php
@@ -52,6 +52,6 @@ class OpenAPIServerExtension extends Extension
 
     public function getAlias()
     {
-        return 'open_apiserver';
+        return 'open_api_server';
     }
 }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
@@ -65,7 +65,7 @@ Step 3: Register the routes:
 
 ```yaml
 # app/config/routing.yml
-open_apiserver:
+open_api_server:
     resource: "@OpenAPIServerBundle/Resources/config/routing.yml"
 ```
 
@@ -111,7 +111,7 @@ services:
     acme.my_bundle.api.pet:
         class: Acme\MyBundle\Api\PetApi
         tags:
-            - { name: "open_apiserver.api", api: "pet" }
+            - { name: "open_api_server.api", api: "pet" }
     # ...
 ```
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/routing.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/routing.yml
@@ -3,143 +3,143 @@
 # Do not edit the class manually.
 
 # pet
-open_apiserver_pet_addpet:
+open_api_server_pet_addpet:
     path:     /pet
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.pet:addPetAction
+        _controller: open_api_server.controller.pet:addPetAction
 
-open_apiserver_pet_deletepet:
+open_api_server_pet_deletepet:
     path:     /pet/{petId}
     methods:  [DELETE]
     defaults:
-        _controller: open_apiserver.controller.pet:deletePetAction
+        _controller: open_api_server.controller.pet:deletePetAction
     requirements:
         petId: '\d+'
 
-open_apiserver_pet_findpetsbystatus:
+open_api_server_pet_findpetsbystatus:
     path:     /pet/findByStatus
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.pet:findPetsByStatusAction
+        _controller: open_api_server.controller.pet:findPetsByStatusAction
 
-open_apiserver_pet_findpetsbytags:
+open_api_server_pet_findpetsbytags:
     path:     /pet/findByTags
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.pet:findPetsByTagsAction
+        _controller: open_api_server.controller.pet:findPetsByTagsAction
 
-open_apiserver_pet_getpetbyid:
+open_api_server_pet_getpetbyid:
     path:     /pet/{petId}
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.pet:getPetByIdAction
+        _controller: open_api_server.controller.pet:getPetByIdAction
     requirements:
         petId: '\d+'
 
-open_apiserver_pet_updatepet:
+open_api_server_pet_updatepet:
     path:     /pet
     methods:  [PUT]
     defaults:
-        _controller: open_apiserver.controller.pet:updatePetAction
+        _controller: open_api_server.controller.pet:updatePetAction
 
-open_apiserver_pet_updatepetwithform:
+open_api_server_pet_updatepetwithform:
     path:     /pet/{petId}
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.pet:updatePetWithFormAction
+        _controller: open_api_server.controller.pet:updatePetWithFormAction
     requirements:
         petId: '\d+'
 
-open_apiserver_pet_uploadfile:
+open_api_server_pet_uploadfile:
     path:     /pet/{petId}/uploadImage
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.pet:uploadFileAction
+        _controller: open_api_server.controller.pet:uploadFileAction
     requirements:
         petId: '\d+'
 
 # store
-open_apiserver_store_deleteorder:
+open_api_server_store_deleteorder:
     path:     /store/order/{orderId}
     methods:  [DELETE]
     defaults:
-        _controller: open_apiserver.controller.store:deleteOrderAction
+        _controller: open_api_server.controller.store:deleteOrderAction
     requirements:
         orderId: '[a-z0-9]+'
 
-open_apiserver_store_getinventory:
+open_api_server_store_getinventory:
     path:     /store/inventory
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.store:getInventoryAction
+        _controller: open_api_server.controller.store:getInventoryAction
 
-open_apiserver_store_getorderbyid:
+open_api_server_store_getorderbyid:
     path:     /store/order/{orderId}
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.store:getOrderByIdAction
+        _controller: open_api_server.controller.store:getOrderByIdAction
     requirements:
         orderId: '\d+'
 
-open_apiserver_store_placeorder:
+open_api_server_store_placeorder:
     path:     /store/order
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.store:placeOrderAction
+        _controller: open_api_server.controller.store:placeOrderAction
 
 # user
-open_apiserver_user_createuser:
+open_api_server_user_createuser:
     path:     /user
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.user:createUserAction
+        _controller: open_api_server.controller.user:createUserAction
 
-open_apiserver_user_createuserswitharrayinput:
+open_api_server_user_createuserswitharrayinput:
     path:     /user/createWithArray
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.user:createUsersWithArrayInputAction
+        _controller: open_api_server.controller.user:createUsersWithArrayInputAction
 
-open_apiserver_user_createuserswithlistinput:
+open_api_server_user_createuserswithlistinput:
     path:     /user/createWithList
     methods:  [POST]
     defaults:
-        _controller: open_apiserver.controller.user:createUsersWithListInputAction
+        _controller: open_api_server.controller.user:createUsersWithListInputAction
 
-open_apiserver_user_deleteuser:
+open_api_server_user_deleteuser:
     path:     /user/{username}
     methods:  [DELETE]
     defaults:
-        _controller: open_apiserver.controller.user:deleteUserAction
+        _controller: open_api_server.controller.user:deleteUserAction
     requirements:
         username: '[a-z0-9]+'
 
-open_apiserver_user_getuserbyname:
+open_api_server_user_getuserbyname:
     path:     /user/{username}
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.user:getUserByNameAction
+        _controller: open_api_server.controller.user:getUserByNameAction
     requirements:
         username: '[a-z0-9]+'
 
-open_apiserver_user_loginuser:
+open_api_server_user_loginuser:
     path:     /user/login
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.user:loginUserAction
+        _controller: open_api_server.controller.user:loginUserAction
 
-open_apiserver_user_logoutuser:
+open_api_server_user_logoutuser:
     path:     /user/logout
     methods:  [GET]
     defaults:
-        _controller: open_apiserver.controller.user:logoutUserAction
+        _controller: open_api_server.controller.user:logoutUserAction
 
-open_apiserver_user_updateuser:
+open_api_server_user_updateuser:
     path:     /user/{username}
     methods:  [PUT]
     defaults:
-        _controller: open_apiserver.controller.user:updateUserAction
+        _controller: open_api_server.controller.user:updateUserAction
     requirements:
         username: '[a-z0-9]+'
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/services.yml
@@ -3,48 +3,48 @@
 # Do not edit the class manually.
 
 parameters:
-    open_apiserver.serializer: 'OpenAPI\Server\Service\JmsSerializer'
-    open_apiserver.validator:  'OpenAPI\Server\Service\SymfonyValidator'
+    open_api_server.serializer: 'OpenAPI\Server\Service\JmsSerializer'
+    open_api_server.validator:  'OpenAPI\Server\Service\SymfonyValidator'
 
 services:
-    open_apiserver.api.api_server:
+    open_api_server.api.api_server:
         class: OpenAPI\Server\Api\ApiServer
 
-    open_apiserver.model.model_serializer:
+    open_api_server.model.model_serializer:
         class: OpenAPI\Server\Model\ModelSerializer
 
-    open_apiserver.service.serializer:
-        class: '%open_apiserver.serializer%'
+    open_api_server.service.serializer:
+        class: '%open_api_server.serializer%'
 
-    open_apiserver.service.validator:
-        class: '%open_apiserver.validator%'
+    open_api_server.service.validator:
+        class: '%open_api_server.validator%'
         arguments:
             - '@validator'
 
-    open_apiserver.controller.pet:
+    open_api_server.controller.pet:
         class: OpenAPI\Server\Controller\PetController
         calls:
-         - [setSerializer, ['@open_apiserver.service.serializer']]
-         - [setValidator,  ['@open_apiserver.service.validator']]
-         - [setApiServer,  ['@open_apiserver.api.api_server']]
+         - [setSerializer, ['@open_api_server.service.serializer']]
+         - [setValidator,  ['@open_api_server.service.validator']]
+         - [setApiServer,  ['@open_api_server.api.api_server']]
         tags: ['controller.service_arguments']
         autowire: true
 
-    open_apiserver.controller.store:
+    open_api_server.controller.store:
         class: OpenAPI\Server\Controller\StoreController
         calls:
-         - [setSerializer, ['@open_apiserver.service.serializer']]
-         - [setValidator,  ['@open_apiserver.service.validator']]
-         - [setApiServer,  ['@open_apiserver.api.api_server']]
+         - [setSerializer, ['@open_api_server.service.serializer']]
+         - [setValidator,  ['@open_api_server.service.validator']]
+         - [setApiServer,  ['@open_api_server.api.api_server']]
         tags: ['controller.service_arguments']
         autowire: true
 
-    open_apiserver.controller.user:
+    open_api_server.controller.user:
         class: OpenAPI\Server\Controller\UserController
         calls:
-         - [setSerializer, ['@open_apiserver.service.serializer']]
-         - [setValidator,  ['@open_apiserver.service.validator']]
-         - [setApiServer,  ['@open_apiserver.api.api_server']]
+         - [setSerializer, ['@open_api_server.service.serializer']]
+         - [setValidator,  ['@open_api_server.service.validator']]
+         - [setApiServer,  ['@open_api_server.api.api_server']]
         tags: ['controller.service_arguments']
         autowire: true
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/PetApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/PetApiInterface.md
@@ -22,7 +22,7 @@ services:
     acme.my_bundle.api.pet:
         class: Acme\MyBundle\Api\PetApi
         tags:
-            - { name: "open_apiserver.api", api: "pet" }
+            - { name: "open_api_server.api", api: "pet" }
     # ...
 ```
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/StoreApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/StoreApiInterface.md
@@ -18,7 +18,7 @@ services:
     acme.my_bundle.api.store:
         class: Acme\MyBundle\Api\StoreApi
         tags:
-            - { name: "open_apiserver.api", api: "store" }
+            - { name: "open_api_server.api", api: "store" }
     # ...
 ```
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/UserApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/docs/Api/UserApiInterface.md
@@ -22,7 +22,7 @@ services:
     acme.my_bundle.api.user:
         class: Acme\MyBundle\Api\UserApi
         tags:
-            - { name: "open_apiserver.api", api: "user" }
+            - { name: "open_api_server.api", api: "user" }
     # ...
 ```
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The alias of the Symfony's Bundle who is generate by Openapi was open_apiserver. However, it doesn't work it missing an underscore between api and server. The good alias is open_api_server.

