### PR TITLE
Fixed typo in migration-from-swagger-codegen.md

### DIFF
--- a/docs/migration-from-swagger-codegen.md
+++ b/docs/migration-from-swagger-codegen.md
@@ -249,4 +249,4 @@ If your API client is using named parameters in the function call (e.g. Perl req
 
 ## Default basePath
 
-The default `basePath` has been changed from `https://localhost` to `http://locallhost` (http without s)
+The default `basePath` has been changed from `https://localhost` to `http://localhost` (http without s)


### PR DESCRIPTION
### PR checklist
* [x]  Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
* [ ]  Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
* [x]  Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `3.4.x`, `4.0.x`. Default: `master`.
* [ ]  Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This is a fix for a small spelling error in migration-from-swagger-codegen.md.