### PR TITLE
[Java][Feign] Support OAuth without 'expires_in' data

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/auth/OAuth.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/auth/OAuth.mustache
@@ -120,7 +120,7 @@ public class OAuth implements RequestInterceptor {
 
     public synchronized void setAccessToken(String accessToken, Long expiresIn) {
         this.accessToken = accessToken;
-        this.expirationTimeMillis = System.currentTimeMillis() + expiresIn * MILLIS_PER_SECOND;
+        this.expirationTimeMillis = expiresIn == null ? null : System.currentTimeMillis() + expiresIn * MILLIS_PER_SECOND;
     }
 
     public TokenRequestBuilder getTokenRequestBuilder() {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -112,7 +112,7 @@ public class OAuth implements RequestInterceptor {
 
     public synchronized void setAccessToken(String accessToken, Long expiresIn) {
         this.accessToken = accessToken;
-        this.expirationTimeMillis = System.currentTimeMillis() + expiresIn * MILLIS_PER_SECOND;
+        this.expirationTimeMillis = expiresIn == null ? null : System.currentTimeMillis() + expiresIn * MILLIS_PER_SECOND;
     }
 
     public TokenRequestBuilder getTokenRequestBuilder() {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/auth/OAuth.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/auth/OAuth.java
@@ -113,7 +113,7 @@ public class OAuth implements RequestInterceptor {
 
     public synchronized void setAccessToken(String accessToken, Long expiresIn) {
         this.accessToken = accessToken;
-        this.expirationTimeMillis = System.currentTimeMillis() + expiresIn * MILLIS_PER_SECOND;
+        this.expirationTimeMillis = expiresIn == null ? null : System.currentTimeMillis() + expiresIn * MILLIS_PER_SECOND;
     }
 
     public TokenRequestBuilder getTokenRequestBuilder() {


### PR DESCRIPTION
If OAuth server doesn't provide time of token expiration with the attribute 'expires_in' a NPE append.
With this change the time of expiration is never set (because we don't know it) so for each request we ask again a new token.

Closes #2561