### PR TITLE
 Fix JaxRS-Jersey template for files upload

### DIFF
--- a/bin/java-jaxrs-petstore-server-all.sh
+++ b/bin/java-jaxrs-petstore-server-all.sh
@@ -18,4 +18,6 @@
 ./bin/jaxrs-spec-petstore-server.sh
 ./bin/jaxrs-usetags-petstore-server.sh
 
+./bin/openapi3/jaxrs-jersey-petstore.sh
+
 echo " Please run ./bin/jaxrs-cxf-petstore-server-test-data.sh manually instead"

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
@@ -76,7 +76,7 @@ public class {{classname}}  {
         {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}},{{/allParams}}securityContext);
+        return delegate.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}securityContext);
     }
 {{/operation}}
 }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
@@ -76,7 +76,7 @@ public class {{classname}}  {
         {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}},{{/allParams}}@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}securityContext);
+        return delegate.{{nickname}}({{#allParams}}{{#isFormParam}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{/isFormParam}}{{^isFile}}{{paramName}}{{/isFile}}{{^isFormParam}}{{#isFile}}{{paramName}}{{/isFile}}{{/isFormParam}}, {{/allParams}}securityContext);
     }
 {{/operation}}
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -65,6 +65,6 @@ public class AnotherFakeApi  {
     public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.call123testSpecialTags(body,securityContext);
+        return delegate.call123testSpecialTags(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
@@ -191,7 +191,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binaryInputStream, binaryDetail, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     
@@ -275,6 +275,6 @@ public class FakeApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFileInputStream, requiredFileDetail, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
@@ -75,7 +75,7 @@ public class FakeApi  {
     public Response createXmlItem(@ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createXmlItem(xmlItem,securityContext);
+        return delegate.createXmlItem(xmlItem, securityContext);
     }
     @POST
     @Path("/outer/boolean")
@@ -87,7 +87,7 @@ public class FakeApi  {
     public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterBooleanSerialize(body,securityContext);
+        return delegate.fakeOuterBooleanSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/composite")
@@ -99,7 +99,7 @@ public class FakeApi  {
     public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterCompositeSerialize(body,securityContext);
+        return delegate.fakeOuterCompositeSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/number")
@@ -111,7 +111,7 @@ public class FakeApi  {
     public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterNumberSerialize(body,securityContext);
+        return delegate.fakeOuterNumberSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/string")
@@ -123,7 +123,7 @@ public class FakeApi  {
     public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterStringSerialize(body,securityContext);
+        return delegate.fakeOuterStringSerialize(body, securityContext);
     }
     @PUT
     @Path("/body-with-file-schema")
@@ -135,7 +135,7 @@ public class FakeApi  {
     public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithFileSchema(body,securityContext);
+        return delegate.testBodyWithFileSchema(body, securityContext);
     }
     @PUT
     @Path("/body-with-query-params")
@@ -148,7 +148,7 @@ public class FakeApi  {
 ,@ApiParam(value = "" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithQueryParams(query,body,securityContext);
+        return delegate.testBodyWithQueryParams(query, body, securityContext);
     }
     @PATCH
     
@@ -160,7 +160,7 @@ public class FakeApi  {
     public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClientModel(body,securityContext);
+        return delegate.testClientModel(body, securityContext);
     }
     @POST
     
@@ -191,7 +191,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number,_double,patternWithoutDelimiter,_byte,integer,int32,int64,_float,string,binaryInputStream, binaryDetail,date,dateTime,password,paramCallback,securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     
@@ -212,7 +212,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEnumParameters(enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,enumFormStringArray,enumFormString,securityContext);
+        return delegate.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, securityContext);
     }
     @DELETE
     
@@ -229,7 +229,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group") Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testGroupParameters(requiredStringGroup,requiredBooleanGroup,requiredInt64Group,stringGroup,booleanGroup,int64Group,securityContext);
+        return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
     }
     @POST
     @Path("/inline-additionalProperties")
@@ -241,7 +241,7 @@ public class FakeApi  {
     public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testInlineAdditionalProperties(param,securityContext);
+        return delegate.testInlineAdditionalProperties(param, securityContext);
     }
     @GET
     @Path("/jsonFormData")
@@ -254,7 +254,7 @@ public class FakeApi  {
 ,@ApiParam(value = "field2", required=true)  @FormParam("param2")  String param2
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testJsonFormData(param,param2,securityContext);
+        return delegate.testJsonFormData(param, param2, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
@@ -275,6 +275,6 @@ public class FakeApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId,requiredFileInputStream, requiredFileDetail,additionalMetadata,securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -67,6 +67,6 @@ public class FakeClassnameTestApi  {
     public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClassname(body,securityContext);
+        return delegate.testClassname(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
@@ -207,6 +207,6 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId, additionalMetadata, file, securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, fileInputStream, fileDetail, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
@@ -72,7 +72,7 @@ public class PetApi  {
     public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.addPet(body,securityContext);
+        return delegate.addPet(body, securityContext);
     }
     @DELETE
     @Path("/{petId}")
@@ -90,7 +90,7 @@ public class PetApi  {
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deletePet(petId,apiKey,securityContext);
+        return delegate.deletePet(petId, apiKey, securityContext);
     }
     @GET
     @Path("/findByStatus")
@@ -109,7 +109,7 @@ public class PetApi  {
     public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true, allowableValues="available, pending, sold", defaultValue="new ArrayList<>()") @DefaultValue("new ArrayList<>()") @QueryParam("status") List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByStatus(status,securityContext);
+        return delegate.findPetsByStatus(status, securityContext);
     }
     @GET
     @Path("/findByTags")
@@ -128,7 +128,7 @@ public class PetApi  {
     public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true, defaultValue="new ArrayList<>()") @DefaultValue("new ArrayList<>()") @QueryParam("tags") List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByTags(tags,securityContext);
+        return delegate.findPetsByTags(tags, securityContext);
     }
     @GET
     @Path("/{petId}")
@@ -146,7 +146,7 @@ public class PetApi  {
     public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getPetById(petId,securityContext);
+        return delegate.getPetById(petId, securityContext);
     }
     @PUT
     
@@ -167,7 +167,7 @@ public class PetApi  {
     public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePet(body,securityContext);
+        return delegate.updatePet(body, securityContext);
     }
     @POST
     @Path("/{petId}")
@@ -186,7 +186,7 @@ public class PetApi  {
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePetWithForm(petId,name,status,securityContext);
+        return delegate.updatePetWithForm(petId, name, status, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImage")
@@ -207,6 +207,6 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId,additionalMetadata,fileInputStream, fileDetail,securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, file, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/StoreApi.java
@@ -68,7 +68,7 @@ public class StoreApi  {
     public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteOrder(orderId,securityContext);
+        return delegate.deleteOrder(orderId, securityContext);
     }
     @GET
     @Path("/inventory")
@@ -97,7 +97,7 @@ public class StoreApi  {
     public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getOrderById(orderId,securityContext);
+        return delegate.getOrderById(orderId, securityContext);
     }
     @POST
     @Path("/order")
@@ -111,6 +111,6 @@ public class StoreApi  {
     public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.placeOrder(body,securityContext);
+        return delegate.placeOrder(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi  {
     public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUser(body,securityContext);
+        return delegate.createUser(body, securityContext);
     }
     @POST
     @Path("/createWithArray")
@@ -78,7 +78,7 @@ public class UserApi  {
     public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithArrayInput(body,securityContext);
+        return delegate.createUsersWithArrayInput(body, securityContext);
     }
     @POST
     @Path("/createWithList")
@@ -90,7 +90,7 @@ public class UserApi  {
     public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithListInput(body,securityContext);
+        return delegate.createUsersWithListInput(body, securityContext);
     }
     @DELETE
     @Path("/{username}")
@@ -104,7 +104,7 @@ public class UserApi  {
     public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteUser(username,securityContext);
+        return delegate.deleteUser(username, securityContext);
     }
     @GET
     @Path("/{username}")
@@ -120,7 +120,7 @@ public class UserApi  {
     public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getUserByName(username,securityContext);
+        return delegate.getUserByName(username, securityContext);
     }
     @GET
     @Path("/login")
@@ -135,7 +135,7 @@ public class UserApi  {
 ,@ApiParam(value = "The password for login in clear text",required=true) @QueryParam("password") String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.loginUser(username,password,securityContext);
+        return delegate.loginUser(username, password, securityContext);
     }
     @GET
     @Path("/logout")
@@ -161,6 +161,6 @@ public class UserApi  {
 ,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updateUser(username,body,securityContext);
+        return delegate.updateUser(username, body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -65,6 +65,6 @@ public class AnotherFakeApi  {
     public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client client
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.call123testSpecialTags(client,securityContext);
+        return delegate.call123testSpecialTags(client, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -85,7 +85,7 @@ public class FakeApi  {
     public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterBooleanSerialize(body,securityContext);
+        return delegate.fakeOuterBooleanSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/composite")
@@ -97,7 +97,7 @@ public class FakeApi  {
     public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite outerComposite
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterCompositeSerialize(outerComposite,securityContext);
+        return delegate.fakeOuterCompositeSerialize(outerComposite, securityContext);
     }
     @POST
     @Path("/outer/number")
@@ -109,7 +109,7 @@ public class FakeApi  {
     public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterNumberSerialize(body,securityContext);
+        return delegate.fakeOuterNumberSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/string")
@@ -121,7 +121,7 @@ public class FakeApi  {
     public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterStringSerialize(body,securityContext);
+        return delegate.fakeOuterStringSerialize(body, securityContext);
     }
     @PUT
     @Path("/body-with-file-schema")
@@ -133,7 +133,7 @@ public class FakeApi  {
     public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass fileSchemaTestClass
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithFileSchema(fileSchemaTestClass,securityContext);
+        return delegate.testBodyWithFileSchema(fileSchemaTestClass, securityContext);
     }
     @PUT
     @Path("/body-with-query-params")
@@ -146,7 +146,7 @@ public class FakeApi  {
 ,@ApiParam(value = "" ,required=true) @NotNull @Valid User user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithQueryParams(query,user,securityContext);
+        return delegate.testBodyWithQueryParams(query, user, securityContext);
     }
     @PATCH
     
@@ -158,7 +158,7 @@ public class FakeApi  {
     public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client client
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClientModel(client,securityContext);
+        return delegate.testClientModel(client, securityContext);
     }
     @POST
     
@@ -189,7 +189,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number,_double,patternWithoutDelimiter,_byte,integer,int32,int64,_float,string,binaryInputStream, binaryDetail,date,dateTime,password,paramCallback,securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binaryInputStream, binaryDetail, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     
@@ -210,7 +210,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEnumParameters(enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,enumFormStringArray,enumFormString,securityContext);
+        return delegate.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, securityContext);
     }
     @DELETE
     
@@ -229,7 +229,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group") Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testGroupParameters(requiredStringGroup,requiredBooleanGroup,requiredInt64Group,stringGroup,booleanGroup,int64Group,securityContext);
+        return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
     }
     @POST
     @Path("/inline-additionalProperties")
@@ -241,7 +241,7 @@ public class FakeApi  {
     public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> requestBody
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testInlineAdditionalProperties(requestBody,securityContext);
+        return delegate.testInlineAdditionalProperties(requestBody, securityContext);
     }
     @GET
     @Path("/jsonFormData")
@@ -254,7 +254,7 @@ public class FakeApi  {
 ,@ApiParam(value = "field2", required=true)  @FormParam("param2")  String param2
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testJsonFormData(param,param2,securityContext);
+        return delegate.testJsonFormData(param, param2, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
@@ -275,6 +275,6 @@ public class FakeApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId,requiredFileInputStream, requiredFileDetail,additionalMetadata,securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFileInputStream, requiredFileDetail, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -67,6 +67,6 @@ public class FakeClassnameTestApi  {
     public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client client
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClassname(client,securityContext);
+        return delegate.testClassname(client, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/PetApi.java
@@ -72,7 +72,7 @@ public class PetApi  {
     public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet pet
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.addPet(pet,securityContext);
+        return delegate.addPet(pet, securityContext);
     }
     @DELETE
     @Path("/{petId}")
@@ -90,7 +90,7 @@ public class PetApi  {
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deletePet(petId,apiKey,securityContext);
+        return delegate.deletePet(petId, apiKey, securityContext);
     }
     @GET
     @Path("/findByStatus")
@@ -109,7 +109,7 @@ public class PetApi  {
     public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true, allowableValues="available, pending, sold", defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("status") List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByStatus(status,securityContext);
+        return delegate.findPetsByStatus(status, securityContext);
     }
     @GET
     @Path("/findByTags")
@@ -128,7 +128,7 @@ public class PetApi  {
     public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("tags") List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByTags(tags,securityContext);
+        return delegate.findPetsByTags(tags, securityContext);
     }
     @GET
     @Path("/{petId}")
@@ -146,7 +146,7 @@ public class PetApi  {
     public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getPetById(petId,securityContext);
+        return delegate.getPetById(petId, securityContext);
     }
     @PUT
     
@@ -167,7 +167,7 @@ public class PetApi  {
     public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet pet
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePet(pet,securityContext);
+        return delegate.updatePet(pet, securityContext);
     }
     @POST
     @Path("/{petId}")
@@ -186,7 +186,7 @@ public class PetApi  {
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePetWithForm(petId,name,status,securityContext);
+        return delegate.updatePetWithForm(petId, name, status, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImage")
@@ -207,6 +207,6 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId,additionalMetadata,fileInputStream, fileDetail,securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, fileInputStream, fileDetail, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/StoreApi.java
@@ -68,7 +68,7 @@ public class StoreApi  {
     public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteOrder(orderId,securityContext);
+        return delegate.deleteOrder(orderId, securityContext);
     }
     @GET
     @Path("/inventory")
@@ -97,7 +97,7 @@ public class StoreApi  {
     public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getOrderById(orderId,securityContext);
+        return delegate.getOrderById(orderId, securityContext);
     }
     @POST
     @Path("/order")
@@ -111,6 +111,6 @@ public class StoreApi  {
     public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order order
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.placeOrder(order,securityContext);
+        return delegate.placeOrder(order, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi  {
     public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUser(user,securityContext);
+        return delegate.createUser(user, securityContext);
     }
     @POST
     @Path("/createWithArray")
@@ -78,7 +78,7 @@ public class UserApi  {
     public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithArrayInput(user,securityContext);
+        return delegate.createUsersWithArrayInput(user, securityContext);
     }
     @POST
     @Path("/createWithList")
@@ -90,7 +90,7 @@ public class UserApi  {
     public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithListInput(user,securityContext);
+        return delegate.createUsersWithListInput(user, securityContext);
     }
     @DELETE
     @Path("/{username}")
@@ -104,7 +104,7 @@ public class UserApi  {
     public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteUser(username,securityContext);
+        return delegate.deleteUser(username, securityContext);
     }
     @GET
     @Path("/{username}")
@@ -120,7 +120,7 @@ public class UserApi  {
     public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getUserByName(username,securityContext);
+        return delegate.getUserByName(username, securityContext);
     }
     @GET
     @Path("/login")
@@ -135,7 +135,7 @@ public class UserApi  {
 ,@ApiParam(value = "The password for login in clear text",required=true) @QueryParam("password") String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.loginUser(username,password,securityContext);
+        return delegate.loginUser(username, password, securityContext);
     }
     @GET
     @Path("/logout")
@@ -161,6 +161,6 @@ public class UserApi  {
 ,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updateUser(username,user,securityContext);
+        return delegate.updateUser(username, user, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -65,6 +65,6 @@ public class AnotherFakeApi  {
     public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.call123testSpecialTags(body,securityContext);
+        return delegate.call123testSpecialTags(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -189,7 +189,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binaryInputStream, binaryDetail, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -73,7 +73,7 @@ public class FakeApi  {
     public Response createXmlItem(@ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createXmlItem(xmlItem,securityContext);
+        return delegate.createXmlItem(xmlItem, securityContext);
     }
     @POST
     @Path("/outer/boolean")
@@ -85,7 +85,7 @@ public class FakeApi  {
     public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterBooleanSerialize(body,securityContext);
+        return delegate.fakeOuterBooleanSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/composite")
@@ -97,7 +97,7 @@ public class FakeApi  {
     public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterCompositeSerialize(body,securityContext);
+        return delegate.fakeOuterCompositeSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/number")
@@ -109,7 +109,7 @@ public class FakeApi  {
     public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterNumberSerialize(body,securityContext);
+        return delegate.fakeOuterNumberSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/string")
@@ -121,7 +121,7 @@ public class FakeApi  {
     public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterStringSerialize(body,securityContext);
+        return delegate.fakeOuterStringSerialize(body, securityContext);
     }
     @PUT
     @Path("/body-with-file-schema")
@@ -133,7 +133,7 @@ public class FakeApi  {
     public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithFileSchema(body,securityContext);
+        return delegate.testBodyWithFileSchema(body, securityContext);
     }
     @PUT
     @Path("/body-with-query-params")
@@ -146,7 +146,7 @@ public class FakeApi  {
 ,@ApiParam(value = "" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithQueryParams(query,body,securityContext);
+        return delegate.testBodyWithQueryParams(query, body, securityContext);
     }
     @PATCH
     
@@ -158,7 +158,7 @@ public class FakeApi  {
     public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClientModel(body,securityContext);
+        return delegate.testClientModel(body, securityContext);
     }
     @POST
     
@@ -189,7 +189,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number,_double,patternWithoutDelimiter,_byte,integer,int32,int64,_float,string,binaryInputStream, binaryDetail,date,dateTime,password,paramCallback,securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     
@@ -210,7 +210,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEnumParameters(enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,enumFormStringArray,enumFormString,securityContext);
+        return delegate.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, securityContext);
     }
     @DELETE
     
@@ -227,7 +227,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group") Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testGroupParameters(requiredStringGroup,requiredBooleanGroup,requiredInt64Group,stringGroup,booleanGroup,int64Group,securityContext);
+        return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
     }
     @POST
     @Path("/inline-additionalProperties")
@@ -239,7 +239,7 @@ public class FakeApi  {
     public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testInlineAdditionalProperties(param,securityContext);
+        return delegate.testInlineAdditionalProperties(param, securityContext);
     }
     @GET
     @Path("/jsonFormData")
@@ -252,6 +252,6 @@ public class FakeApi  {
 ,@ApiParam(value = "field2", required=true)  @FormParam("param2")  String param2
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testJsonFormData(param,param2,securityContext);
+        return delegate.testJsonFormData(param, param2, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -67,6 +67,6 @@ public class FakeClassnameTags123Api  {
     public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClassname(body,securityContext);
+        return delegate.testClassname(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -72,7 +72,7 @@ public class PetApi  {
     public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.addPet(body,securityContext);
+        return delegate.addPet(body, securityContext);
     }
     @DELETE
     @Path("/pet/{petId}")
@@ -90,7 +90,7 @@ public class PetApi  {
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deletePet(petId,apiKey,securityContext);
+        return delegate.deletePet(petId, apiKey, securityContext);
     }
     @GET
     @Path("/pet/findByStatus")
@@ -109,7 +109,7 @@ public class PetApi  {
     public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true, allowableValues="available, pending, sold", defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("status") List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByStatus(status,securityContext);
+        return delegate.findPetsByStatus(status, securityContext);
     }
     @GET
     @Path("/pet/findByTags")
@@ -128,7 +128,7 @@ public class PetApi  {
     public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("tags") List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByTags(tags,securityContext);
+        return delegate.findPetsByTags(tags, securityContext);
     }
     @GET
     @Path("/pet/{petId}")
@@ -146,7 +146,7 @@ public class PetApi  {
     public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getPetById(petId,securityContext);
+        return delegate.getPetById(petId, securityContext);
     }
     @PUT
     
@@ -167,7 +167,7 @@ public class PetApi  {
     public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePet(body,securityContext);
+        return delegate.updatePet(body, securityContext);
     }
     @POST
     @Path("/pet/{petId}")
@@ -186,7 +186,7 @@ public class PetApi  {
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePetWithForm(petId,name,status,securityContext);
+        return delegate.updatePetWithForm(petId, name, status, securityContext);
     }
     @POST
     @Path("/pet/{petId}/uploadImage")
@@ -207,7 +207,7 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId,additionalMetadata,fileInputStream, fileDetail,securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, file, securityContext);
     }
     @POST
     @Path("/fake/{petId}/uploadImageWithRequiredFile")
@@ -228,6 +228,6 @@ public class PetApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId,requiredFileInputStream, requiredFileDetail,additionalMetadata,securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -207,7 +207,7 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId, additionalMetadata, file, securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, fileInputStream, fileDetail, securityContext);
     }
     @POST
     @Path("/fake/{petId}/uploadImageWithRequiredFile")
@@ -228,6 +228,6 @@ public class PetApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFileInputStream, requiredFileDetail, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
@@ -68,7 +68,7 @@ public class StoreApi  {
     public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteOrder(orderId,securityContext);
+        return delegate.deleteOrder(orderId, securityContext);
     }
     @GET
     @Path("/inventory")
@@ -97,7 +97,7 @@ public class StoreApi  {
     public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getOrderById(orderId,securityContext);
+        return delegate.getOrderById(orderId, securityContext);
     }
     @POST
     @Path("/order")
@@ -111,6 +111,6 @@ public class StoreApi  {
     public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.placeOrder(body,securityContext);
+        return delegate.placeOrder(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi  {
     public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUser(body,securityContext);
+        return delegate.createUser(body, securityContext);
     }
     @POST
     @Path("/createWithArray")
@@ -78,7 +78,7 @@ public class UserApi  {
     public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithArrayInput(body,securityContext);
+        return delegate.createUsersWithArrayInput(body, securityContext);
     }
     @POST
     @Path("/createWithList")
@@ -90,7 +90,7 @@ public class UserApi  {
     public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithListInput(body,securityContext);
+        return delegate.createUsersWithListInput(body, securityContext);
     }
     @DELETE
     @Path("/{username}")
@@ -104,7 +104,7 @@ public class UserApi  {
     public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteUser(username,securityContext);
+        return delegate.deleteUser(username, securityContext);
     }
     @GET
     @Path("/{username}")
@@ -120,7 +120,7 @@ public class UserApi  {
     public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getUserByName(username,securityContext);
+        return delegate.getUserByName(username, securityContext);
     }
     @GET
     @Path("/login")
@@ -135,7 +135,7 @@ public class UserApi  {
 ,@ApiParam(value = "The password for login in clear text",required=true) @QueryParam("password") String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.loginUser(username,password,securityContext);
+        return delegate.loginUser(username, password, securityContext);
     }
     @GET
     @Path("/logout")
@@ -161,6 +161,6 @@ public class UserApi  {
 ,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updateUser(username,body,securityContext);
+        return delegate.updateUser(username, body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -65,6 +65,6 @@ public class AnotherFakeApi  {
     public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.call123testSpecialTags(body,securityContext);
+        return delegate.call123testSpecialTags(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
@@ -74,7 +74,7 @@ public class FakeApi  {
     public Response createXmlItem(@ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createXmlItem(xmlItem,securityContext);
+        return delegate.createXmlItem(xmlItem, securityContext);
     }
     @POST
     @Path("/outer/boolean")
@@ -86,7 +86,7 @@ public class FakeApi  {
     public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterBooleanSerialize(body,securityContext);
+        return delegate.fakeOuterBooleanSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/composite")
@@ -98,7 +98,7 @@ public class FakeApi  {
     public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterCompositeSerialize(body,securityContext);
+        return delegate.fakeOuterCompositeSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/number")
@@ -110,7 +110,7 @@ public class FakeApi  {
     public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterNumberSerialize(body,securityContext);
+        return delegate.fakeOuterNumberSerialize(body, securityContext);
     }
     @POST
     @Path("/outer/string")
@@ -122,7 +122,7 @@ public class FakeApi  {
     public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.fakeOuterStringSerialize(body,securityContext);
+        return delegate.fakeOuterStringSerialize(body, securityContext);
     }
     @PUT
     @Path("/body-with-file-schema")
@@ -134,7 +134,7 @@ public class FakeApi  {
     public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithFileSchema(body,securityContext);
+        return delegate.testBodyWithFileSchema(body, securityContext);
     }
     @PUT
     @Path("/body-with-query-params")
@@ -147,7 +147,7 @@ public class FakeApi  {
 ,@ApiParam(value = "" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testBodyWithQueryParams(query,body,securityContext);
+        return delegate.testBodyWithQueryParams(query, body, securityContext);
     }
     @PATCH
     
@@ -159,7 +159,7 @@ public class FakeApi  {
     public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClientModel(body,securityContext);
+        return delegate.testClientModel(body, securityContext);
     }
     @POST
     
@@ -190,7 +190,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number,_double,patternWithoutDelimiter,_byte,integer,int32,int64,_float,string,binaryInputStream, binaryDetail,date,dateTime,password,paramCallback,securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     
@@ -211,7 +211,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEnumParameters(enumHeaderStringArray,enumHeaderString,enumQueryStringArray,enumQueryString,enumQueryInteger,enumQueryDouble,enumFormStringArray,enumFormString,securityContext);
+        return delegate.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString, securityContext);
     }
     @DELETE
     
@@ -228,7 +228,7 @@ public class FakeApi  {
 ,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group") Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testGroupParameters(requiredStringGroup,requiredBooleanGroup,requiredInt64Group,stringGroup,booleanGroup,int64Group,securityContext);
+        return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
     }
     @POST
     @Path("/inline-additionalProperties")
@@ -240,7 +240,7 @@ public class FakeApi  {
     public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testInlineAdditionalProperties(param,securityContext);
+        return delegate.testInlineAdditionalProperties(param, securityContext);
     }
     @GET
     @Path("/jsonFormData")
@@ -253,7 +253,7 @@ public class FakeApi  {
 ,@ApiParam(value = "field2", required=true)  @FormParam("param2")  String param2
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testJsonFormData(param,param2,securityContext);
+        return delegate.testJsonFormData(param, param2, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
@@ -274,6 +274,6 @@ public class FakeApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId,requiredFileInputStream, requiredFileDetail,additionalMetadata,securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
@@ -190,7 +190,7 @@ public class FakeApi  {
 ,@ApiParam(value = "None")  @FormParam("callback")  String paramCallback
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback, securityContext);
+        return delegate.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binaryInputStream, binaryDetail, date, dateTime, password, paramCallback, securityContext);
     }
     @GET
     
@@ -274,6 +274,6 @@ public class FakeApi  {
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata, securityContext);
+        return delegate.uploadFileWithRequiredFile(petId, requiredFileInputStream, requiredFileDetail, additionalMetadata, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -67,6 +67,6 @@ public class FakeClassnameTestApi  {
     public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.testClassname(body,securityContext);
+        return delegate.testClassname(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
@@ -72,7 +72,7 @@ public class PetApi  {
     public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.addPet(body,securityContext);
+        return delegate.addPet(body, securityContext);
     }
     @DELETE
     @Path("/{petId}")
@@ -90,7 +90,7 @@ public class PetApi  {
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deletePet(petId,apiKey,securityContext);
+        return delegate.deletePet(petId, apiKey, securityContext);
     }
     @GET
     @Path("/findByStatus")
@@ -109,7 +109,7 @@ public class PetApi  {
     public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true, allowableValues="available, pending, sold", defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("status") List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByStatus(status,securityContext);
+        return delegate.findPetsByStatus(status, securityContext);
     }
     @GET
     @Path("/findByTags")
@@ -128,7 +128,7 @@ public class PetApi  {
     public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("tags") List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.findPetsByTags(tags,securityContext);
+        return delegate.findPetsByTags(tags, securityContext);
     }
     @GET
     @Path("/{petId}")
@@ -146,7 +146,7 @@ public class PetApi  {
     public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getPetById(petId,securityContext);
+        return delegate.getPetById(petId, securityContext);
     }
     @PUT
     
@@ -167,7 +167,7 @@ public class PetApi  {
     public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePet(body,securityContext);
+        return delegate.updatePet(body, securityContext);
     }
     @POST
     @Path("/{petId}")
@@ -186,7 +186,7 @@ public class PetApi  {
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updatePetWithForm(petId,name,status,securityContext);
+        return delegate.updatePetWithForm(petId, name, status, securityContext);
     }
     @POST
     @Path("/{petId}/uploadImage")
@@ -207,6 +207,6 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId,additionalMetadata,fileInputStream, fileDetail,securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, file, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
@@ -207,6 +207,6 @@ public class PetApi  {
             @FormDataParam("file") FormDataContentDisposition fileDetail
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.uploadFile(petId, additionalMetadata, file, securityContext);
+        return delegate.uploadFile(petId, additionalMetadata, fileInputStream, fileDetail, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/StoreApi.java
@@ -68,7 +68,7 @@ public class StoreApi  {
     public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteOrder(orderId,securityContext);
+        return delegate.deleteOrder(orderId, securityContext);
     }
     @GET
     @Path("/inventory")
@@ -97,7 +97,7 @@ public class StoreApi  {
     public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getOrderById(orderId,securityContext);
+        return delegate.getOrderById(orderId, securityContext);
     }
     @POST
     @Path("/order")
@@ -111,6 +111,6 @@ public class StoreApi  {
     public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.placeOrder(body,securityContext);
+        return delegate.placeOrder(body, securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
@@ -66,7 +66,7 @@ public class UserApi  {
     public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUser(body,securityContext);
+        return delegate.createUser(body, securityContext);
     }
     @POST
     @Path("/createWithArray")
@@ -78,7 +78,7 @@ public class UserApi  {
     public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithArrayInput(body,securityContext);
+        return delegate.createUsersWithArrayInput(body, securityContext);
     }
     @POST
     @Path("/createWithList")
@@ -90,7 +90,7 @@ public class UserApi  {
     public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.createUsersWithListInput(body,securityContext);
+        return delegate.createUsersWithListInput(body, securityContext);
     }
     @DELETE
     @Path("/{username}")
@@ -104,7 +104,7 @@ public class UserApi  {
     public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.deleteUser(username,securityContext);
+        return delegate.deleteUser(username, securityContext);
     }
     @GET
     @Path("/{username}")
@@ -120,7 +120,7 @@ public class UserApi  {
     public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.getUserByName(username,securityContext);
+        return delegate.getUserByName(username, securityContext);
     }
     @GET
     @Path("/login")
@@ -135,7 +135,7 @@ public class UserApi  {
 ,@ApiParam(value = "The password for login in clear text",required=true) @QueryParam("password") String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.loginUser(username,password,securityContext);
+        return delegate.loginUser(username, password, securityContext);
     }
     @GET
     @Path("/logout")
@@ -161,6 +161,6 @@ public class UserApi  {
 ,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
-        return delegate.updateUser(username,body,securityContext);
+        return delegate.updateUser(username, body, securityContext);
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Remove specific File management from template to align it with the service. 

fix #2474

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03)
