### PR TITLE
Remove SkipValidSpec option

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -525,7 +525,7 @@ open class GenerateTask : DefaultTask() {
             }
 
             skipValidateSpec.ifNotEmpty { value ->
-                configurator.setValidateSpec(value)
+                configurator.setValidateSpec(!value)
             }
 
             generateAliasAsModel.ifNotEmpty { value ->

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -66,4 +66,64 @@ class GenerateTaskDslTest : TestBase()  {
         assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,
                 "Expected a successful run, but found ${result.task(":openApiGenerate")?.outcome}")
     }
+
+    @Test
+    fun `openApiValidate should fail on invalid spec`() {
+        // Arrange
+        val projectFiles = mapOf(
+                "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
+        )
+
+        withProject(defaultBuildGradle, projectFiles)
+
+        // Act
+        val result = GradleRunner.create()
+                .withProjectDir(temp)
+                .withArguments("openApiGenerate")
+                .withPluginClasspath()
+                .buildAndFail()
+
+        // Assert
+        assertTrue(result.output.contains("issues with the specification"), "Unexpected/no message presented to the user for an invalid spec.")
+        assertEquals(TaskOutcome.FAILED, result.task(":openApiGenerate")?.outcome,
+                "Expected a failed run, but found ${result.task(":openApiValidate")?.outcome}")
+    }
+
+    @Test
+    fun `openApiValidate should ok skip spec validation`() {
+        // Arrange
+        val projectFiles = mapOf(
+                "spec.yaml" to javaClass.classLoader.getResourceAsStream("specs/petstore-v3.0-invalid.yaml")
+        )
+
+        withProject("""
+        plugins {
+          id 'org.openapi.generator'
+        }
+        openApiGenerate {
+            generatorName = "kotlin"
+            inputSpec = file("spec.yaml").absolutePath
+            outputDir = file("build/kotlin").absolutePath
+            apiPackage = "org.openapitools.example.api"
+            invokerPackage = "org.openapitools.example.invoker"
+            modelPackage = "org.openapitools.example.model"
+            skipValidateSpec = true
+            configOptions = [
+                    dateLibrary: "java8"
+            ]
+        }
+    """.trimIndent(), projectFiles)
+
+        // Act
+        val result = GradleRunner.create()
+                .withProjectDir(temp)
+                .withArguments("openApiGenerate")
+                .withPluginClasspath()
+                .build()
+
+        // Assert
+        assertTrue(result.output.contains("validation has been explicitly disabled"), "Unexpected/no message presented to the user for an invalid spec.")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":openApiGenerate")?.outcome,
+                "Expected a successful run, but found ${result.task(":openApiGenerate")?.outcome}")
+    }
 }

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -464,7 +464,7 @@ public class CodeGenMojo extends AbstractMojo {
             }
 
             if (skipValidateSpec != null) {
-                configurator.setSkipOverwrite(skipValidateSpec);
+                configurator.setValidateSpec(!skipValidateSpec);
             }
 
             if (logToStderr != null) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

It looks like `skipValidSpec` try to do the same thing than `validateSpec` so I've removed it because I think it can create wired behavior if both are set. 

But maybe I've missed something and I can do another solution.

Must fix #2319 and #2577

@wing328
@jimschubert
@cbornet
@ackintosh
@jmini