### PR TITLE
[Typescript-angular] fix handling of --model-name-prefix|suffix options

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 
+import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.openapitools.codegen.utils.StringUtils.*;
 
 public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCodegen {
@@ -501,7 +502,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
                 HashMap<String, String> tsImport = new HashMap<>();
                 // TVG: This is used as class name in the import statements of the model file
                 tsImport.put("classname", im);
-                tsImport.put("filename", toModelFilename(removeModelSuffixIfNecessary(im)));
+                tsImport.put("filename", toModelFilename(removeModelPrefixSuffix(im)));
                 tsImports.add(tsImport);
             }
         }
@@ -590,11 +591,21 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         return modelName + modelSuffix;
     }
 
-    private String removeModelSuffixIfNecessary(String name) {
-        if (modelSuffix.length() == 0 || !name.endsWith(modelSuffix)) {
-            return name;
+    public String removeModelPrefixSuffix(String name) {
+        String result = name;
+        if (modelSuffix.length() > 0 && result.endsWith(modelSuffix)) {
+            result = result.substring(0, result.length() - modelSuffix.length());
         }
-        return name.substring(0, name.length() - modelSuffix.length());
+        String prefix = capitalize(this.modelNamePrefix);
+        String suffix = capitalize(this.modelNameSuffix);
+        if (prefix.length() > 0 && result.startsWith(prefix)) {
+            result = result.substring(prefix.length());
+        }
+        if (suffix.length() > 0 && result.endsWith(suffix)) {
+            result = result.substring(0, result.length() - suffix.length());
+        }
+
+        return result;
     }
 
     /**
@@ -648,7 +659,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
      * @return the transformed name
      */
     private String convertUsingFileNamingConvention(String originalName) {
-        String name = this.removeModelSuffixIfNecessary(originalName);
+        String name = this.removeModelPrefixSuffix(originalName);
         if ("kebab-case".equals(fileNaming)) {
             name = dashize(underscore(name));
         } else {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -76,4 +76,29 @@ public class TypeScriptAngularClientCodegenTest {
 
     }
 
+    @Test
+    public void testRemovePrefixSuffix() {
+        TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
+
+        // simple noop test
+        Assert.assertEquals("TestName", codegen.removeModelPrefixSuffix("TestName"));
+
+        codegen.setModelNamePrefix("abc");
+        codegen.setModelNameSuffix("def");
+        codegen.additionalProperties().put("modelSuffix", "Ghi");
+        codegen.processOpts();
+
+        Assert.assertEquals("TestName", codegen.removeModelPrefixSuffix("TestName"));
+        Assert.assertEquals("TestName", codegen.removeModelPrefixSuffix("TestNameGhi"));
+        Assert.assertEquals("TestNameghi", codegen.removeModelPrefixSuffix("TestNameghi"));
+        Assert.assertEquals("abcTestName", codegen.removeModelPrefixSuffix("abcTestName"));
+        Assert.assertEquals("TestName", codegen.removeModelPrefixSuffix("AbcTestName"));
+        Assert.assertEquals("AbcTestName", codegen.removeModelPrefixSuffix("AbcAbcTestName"));
+        Assert.assertEquals("TestName", codegen.removeModelPrefixSuffix("TestNameDef"));
+        Assert.assertEquals("TestNamedef", codegen.removeModelPrefixSuffix("TestNamedef"));
+        Assert.assertEquals("TestNamedefghi", codegen.removeModelPrefixSuffix("TestNamedefghi"));
+        Assert.assertEquals("TestNameDefghi", codegen.removeModelPrefixSuffix("TestNameDefghi"));
+        Assert.assertEquals("TestName", codegen.removeModelPrefixSuffix("TestNameDefGhi"));
+    }
+
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The `removeModelSuffixIfNecessary` method of `TypeScriptAngularClientCodegen` has been reworked to also remove prefix/suffix defined using `--model-name-prefix|suffix` options.

I have added a test to document the new behaviour.

Fixes #2560. 