### PR TITLE
[Doc] Better highlight of generators docs page with generators specific parameters

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -426,6 +426,8 @@ To pass more than one generator property, these can be combined via comma:
 --additional-properties=key1=value1,key2=value2
 ```
 
+For the full list of generator-specified parameters, refer to [generators docs]((./generators.md))
+
 #### Type Mappings and Import Mappings
 
 Most generators allow for types bound to the OpenAPI Specification's types to be remapped to a user's desired types. Not _all_ type mappings can be reassigned, as some generators define mappings which are tightly coupled to the built-in templates.

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -266,7 +266,7 @@ The gradle plugin is not currently published to https://plugins.gradle.org/m2/.
 |configOptions
 |Map(String,String)
 |None
-|A map of options specific to a generator. To see the full list of generator-specified parameters, please refer to [generators docs](../../docs/generators.md)
+|A map of options specific to a generator. To see the full list of generator-specified parameters, please refer to [generators docs](https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators.md)
 
 |logToStderr
 |Boolean

--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -266,7 +266,7 @@ The gradle plugin is not currently published to https://plugins.gradle.org/m2/.
 |configOptions
 |Map(String,String)
 |None
-|A map of options specific to a generator.
+|A map of options specific to a generator. To see the full list of generator-specified parameters, please refer to [generators docs](../../docs/generators.md)
 
 |logToStderr
 |Boolean

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -51,7 +51,7 @@ mvn clean compile
 - `invokerPackage` - the package to use for the generated invoker objects
 - `modelNamePrefix` and `modelNameSuffix` - Sets the pre- or suffix for model classes and enums
 - `withXml` - enable XML annotations inside the generated models and API (only works with Java `language` and libraries that provide support for JSON and XML)
-- `configOptions` - a map of language-specific parameters. To show a full list of generator-specified parameters (options), please use `configHelp` (explained below)
+- `configOptions` - a map of language-specific parameters. To show a full list of generator-specified parameters (options), please use `configHelp` (explained below) or refer to [generators docs](../../docs/generators.md)
 - `configHelp` - dumps the configuration help for the specified library (generates no sources)
 - `ignoreFileOverride` - specifies the full path to a `.openapi-generator-ignore` used for pattern based overrides of generated outputs
 - `removeOperationIdPrefix` - remove operationId prefix (e.g. user_getName => getName)


### PR DESCRIPTION

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.

### Description of the PR

see #2579 (discussion)

