### PR TITLE
[JAVA] remove File.separator use for default project/Test/source Folder

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -74,10 +74,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String scmUrl = "https://github.com/openapitools/openapi-generator";
     protected String licenseName = "Unlicense";
     protected String licenseUrl = "http://unlicense.org";
-    protected String projectFolder = "src" + File.separator + "main";
-    protected String projectTestFolder = "src" + File.separator + "test";
-    protected String sourceFolder = projectFolder + File.separator + "java";
-    protected String testFolder = projectTestFolder + File.separator + "java";
+    protected String projectFolder = "src/main";
+    protected String projectTestFolder = "src/test";
+    protected String sourceFolder = projectFolder + "/java";
+    protected String testFolder = projectTestFolder + "/java";
     protected boolean fullJavaUtil;
     protected String javaUtilPrefix = "";
     protected Boolean serializableModel = false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSCXFCDIServerCodegen.java
@@ -40,7 +40,7 @@ public class JavaJAXRSCXFCDIServerCodegen extends JavaJAXRSSpecServerCodegen imp
     public JavaJAXRSCXFCDIServerCodegen() {
         outputFolder = "generated-code/JavaJaxRS-CXF-CDI";
         artifactId = "openapi-jaxrs-cxf-cdi-server";
-        sourceFolder = "src" + File.separator + "gen" + File.separator + "java";
+        sourceFolder = "src/gen/java";
         useBeanValidation = true;
 
         // Three API templates to support CDI injection


### PR DESCRIPTION

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03)

### Description of the PR

fix #2593 
there's no purpose to use File.separator for default Java libraries path as "/" separator work on all platforms