### PR TITLE
Fix regexp error on php-slim

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -632,19 +632,19 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     public String apiFileFolder() {
-        return outputFolder + "/" + apiPackage().replace('.', '/');
+        return outputFolder + File.separator + apiPackage().replace('.', File.separatorChar);
     }
 
     public String modelFileFolder() {
-        return outputFolder + "/" + modelPackage().replace('.', '/');
+        return outputFolder + File.separator + modelPackage().replace('.', File.separatorChar);
     }
 
     public String apiTestFileFolder() {
-        return outputFolder + "/" + testPackage().replace('.', '/');
+        return outputFolder + File.separator + testPackage().replace('.', File.separatorChar);
     }
 
     public String modelTestFileFolder() {
-        return outputFolder + "/" + testPackage().replace('.', '/');
+        return outputFolder + File.separator + testPackage().replace('.', File.separatorChar);
     }
 
     public String apiDocFileFolder() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -225,7 +225,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     public String toSrcPath(String packageName, String basePath) {
         packageName = packageName.replace(invokerPackage, ""); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         if (basePath != null && basePath.length() > 0) {
-            basePath = basePath.replaceAll("[\\\\/]?$", "") + '/'; // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
+            basePath = basePath.replaceAll("[\\\\/]?$", "") + File.separator; // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         }
 
         return (basePath

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -232,9 +232,9 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
                 // Replace period, backslash, forward slash with file separator in package name
                 + packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement("/"))
                 // Trim prefix file separators from package path
-                .replaceAll("^/", ""))
+                .replaceAll("^" + File.separator, ""))
                 // Trim trailing file separators from the overall path
-                .replaceAll("/$", "");
+                .replaceAll(File.separator + "$", "");
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.*;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
@@ -228,13 +229,15 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             basePath = basePath.replaceAll("[\\\\/]?$", "") + File.separator; // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
         }
 
-        return (basePath
-                // Replace period, backslash, forward slash with file separator in package name
-                + packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement("/"))
-                // Trim prefix file separators from package path
-                .replaceAll("^" + File.separator, ""))
-                // Trim trailing file separators from the overall path
-                .replaceAll(File.separator + "$", "");
+        // Trim prefix file separators from package path
+        String packagePath = StringUtils.removeStart(
+            // Replace period, backslash, forward slash with file separator in package name
+            packageName.replaceAll("[\\.\\\\/]", Matcher.quoteReplacement("/")),
+            File.separator
+        );
+
+        // Trim trailing file separators from the overall path
+        return StringUtils.removeEnd(basePath + packagePath, File.separator);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -95,9 +95,9 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
 
     @Override
     public String apiFileFolder() {
-        if (apiPackage.matches("^" + invokerPackage + "\\\\*(.+)")) {
+        if (apiPackage.startsWith(invokerPackage + "\\")) {
             // need to strip out invokerPackage from path
-            return (outputFolder + File.separator + toSrcPath(apiPackage.replaceFirst("^" + invokerPackage + "\\\\*(.+)", "$1"), srcBasePath));
+            return (outputFolder + File.separator + toSrcPath(StringUtils.removeStart(apiPackage, invokerPackage + "\\"), srcBasePath));
         }
         return (outputFolder + File.separator + toSrcPath(apiPackage, srcBasePath));
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,9 +104,9 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
 
     @Override
     public String modelFileFolder() {
-        if (modelPackage.matches("^" + invokerPackage + "\\\\*(.+)")) {
+        if (modelPackage.startsWith(invokerPackage + "\\")) {
             // need to strip out invokerPackage from path
-            return (outputFolder + File.separator + toSrcPath(modelPackage.replaceFirst("^" + invokerPackage + "\\\\*(.+)", "$1"), srcBasePath));
+            return (outputFolder + File.separator + toSrcPath(StringUtils.removeStart(modelPackage, invokerPackage + "\\"), srcBasePath));
         }
         return (outputFolder + File.separator + toSrcPath(modelPackage, srcBasePath));
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
@@ -18,6 +18,7 @@ package org.openapitools.codegen.slim;
 
 import org.openapitools.codegen.languages.PhpSlimServerCodegen;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class PhpSlimServerCodegenTest {
@@ -42,5 +43,25 @@ public class PhpSlimServerCodegenTest {
         // from FastRoute\RouteParser\Std.php
         Assert.assertEquals(codegen.encodePath("/user/{name}[/{id:[0-9]+}]"), "/user/{name}[/{id:[0-9]+}]");
         Assert.assertEquals(codegen.encodePath("/fixedRoutePart/{varName}[/moreFixed/{varName2:\\d+}]"), "/fixedRoutePart/{varName}[/moreFixed/{varName2:\\d+}]");
+    }
+
+    @Test(dataProvider = "modelFileFolderProvider")
+    public void modelFileFolder(String modelPackage, String invokerPackage, String expected) {
+        final PhpSlimServerCodegen codegen = new PhpSlimServerCodegen();
+        codegen.setModelPackage(modelPackage);
+        codegen.setInvokerPackage(invokerPackage);
+
+        Assert.assertEquals(codegen.modelFileFolder(), expected);
+    }
+
+    @DataProvider(name = "modelFileFolderProvider")
+    public Object[][] modelFileFolderProvider() {
+        return new Object[][] {
+            // {modelPackage, invokerPackage, expected}
+            {"Model", "Invoker", "generated-code/slim/lib/Model"},
+            {"Petstore", "Petstore", "generated-code/slim/lib"},
+            {"Package\\SubPackage\\Model", "Package\\SubPackage", "generated-code/slim/lib/Model"},
+            {"Websupport\\InvoiceValidation\\Model", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Model"},
+        };
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
@@ -64,4 +64,24 @@ public class PhpSlimServerCodegenTest {
             {"Websupport\\InvoiceValidation\\Model", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Model"},
         };
     }
+
+    @Test(dataProvider = "apiFileFolderProvider")
+    public void apiFileFolder(String modelPackage, String invokerPackage, String expected) {
+        final PhpSlimServerCodegen codegen = new PhpSlimServerCodegen();
+        codegen.setApiPackage(modelPackage);
+        codegen.setInvokerPackage(invokerPackage);
+
+        Assert.assertEquals(codegen.apiFileFolder(), expected);
+    }
+
+    @DataProvider(name = "apiFileFolderProvider")
+    public Object[][] apiFileFolderProvider() {
+        return new Object[][] {
+                // {apiPackage, invokerPackage, expected}
+                {"Api", "Invoker", "generated-code/slim/lib/Api"},
+                {"Petstore", "Petstore", "generated-code/slim/lib"},
+                {"Package\\SubPackage\\Api", "Package\\SubPackage", "generated-code/slim/lib/Api"},
+                {"Websupport\\InvoiceValidation\\Api", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Api"},
+        };
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/slim/PhpSlimServerCodegenTest.java
@@ -21,6 +21,8 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.File;
+
 public class PhpSlimServerCodegenTest {
 
     @Test
@@ -58,10 +60,10 @@ public class PhpSlimServerCodegenTest {
     public Object[][] modelFileFolderProvider() {
         return new Object[][] {
             // {modelPackage, invokerPackage, expected}
-            {"Model", "Invoker", "generated-code/slim/lib/Model"},
-            {"Petstore", "Petstore", "generated-code/slim/lib"},
-            {"Package\\SubPackage\\Model", "Package\\SubPackage", "generated-code/slim/lib/Model"},
-            {"Websupport\\InvoiceValidation\\Model", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Model"},
+            {"Model", "Invoker", "generated-code/slim/lib/Model".replace('/', File.separatorChar)},
+            {"Petstore", "Petstore", "generated-code/slim/lib".replace('/', File.separatorChar)},
+            {"Package\\SubPackage\\Model", "Package\\SubPackage", "generated-code/slim/lib/Model".replace('/', File.separatorChar)},
+            {"Websupport\\InvoiceValidation\\Model", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Model".replace('/', File.separatorChar)},
         };
     }
 
@@ -78,10 +80,10 @@ public class PhpSlimServerCodegenTest {
     public Object[][] apiFileFolderProvider() {
         return new Object[][] {
                 // {apiPackage, invokerPackage, expected}
-                {"Api", "Invoker", "generated-code/slim/lib/Api"},
-                {"Petstore", "Petstore", "generated-code/slim/lib"},
-                {"Package\\SubPackage\\Api", "Package\\SubPackage", "generated-code/slim/lib/Api"},
-                {"Websupport\\InvoiceValidation\\Api", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Api"},
+                {"Api", "Invoker", "generated-code/slim/lib/Api".replace('/', File.separatorChar)},
+                {"Petstore", "Petstore", "generated-code/slim/lib".replace('/', File.separatorChar)},
+                {"Package\\SubPackage\\Api", "Package\\SubPackage", "generated-code/slim/lib/Api".replace('/', File.separatorChar)},
+                {"Websupport\\InvoiceValidation\\Api", "Websupport\\InvoiceValidation", "generated-code/slim/lib/Api".replace('/', File.separatorChar)},
         };
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixes https://github.com/OpenAPITools/openapi-generator/issues/2402

