### PR TITLE
[KOTLIN spring-boot] revert delete Category.kt sample

### DIFF
--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -1,0 +1,24 @@
+package org.openapitools.model
+
+import java.util.Objects
+import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.Valid
+import javax.validation.constraints.*
+import io.swagger.annotations.ApiModelProperty
+
+/**
+ * A category for a pet
+ * @param id 
+ * @param name 
+ */
+data class Category (
+
+        @ApiModelProperty(example = "null", value = "")
+        @JsonProperty("id") val id: Long? = null,
+
+        @ApiModelProperty(example = "null", value = "")
+        @JsonProperty("name") val name: String? = null
+) {
+
+}
+


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.


### Description of the PR

revert deleted Category.kt sample for spring-boot with #1982

@wing328   to fix CI error on master