### PR TITLE
[TypeScript-Fetch] Generate oneOf schemas as type unions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -166,12 +166,14 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                 }
             }
             if (cm.oneOf.size() > 0) {
-                // For oneOfs we should only need to import the $refs within the oneOf used
-                // to form the type union
-                cm.imports = new TreeSet<String>();
-                for (String oneOfRef : cm.oneOf) {
-                    cm.imports.add(oneOfRef);
+                // For oneOfs only import $refs within the oneOf
+                TreeSet<String> oneOfRefs = new TreeSet<String>();
+                for (String im : cm.imports) {
+                    if (cm.oneOf.contains(im)) {
+                        oneOfRefs.add(im);
+                    }
                 }
+                cm.imports = oneOfRefs;
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -165,6 +165,14 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                     }
                 }
             }
+            if (cm.oneOf.size() > 0) {
+                // For oneOfs we should only need to import the $refs within the oneOf used
+                // to form the type union
+                cm.imports = new TreeSet<String>();
+                for (String oneOfRef : cm.oneOf) {
+                    cm.imports.add(oneOfRef);
+                }
+            }
         }
 
         return objs;

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -1,0 +1,14 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/models.mustache
@@ -6,7 +6,14 @@
 {{>modelEnum}}
 {{/isEnum}}
 {{^isEnum}}
+{{#oneOf}}
+{{#-first}}
+{{>modelOneOf}}
+{{/-first}}
+{{/oneOf}}
+{{^oneOf}}
 {{>modelGeneric}}
+{{/oneOf}}
 {{/isEnum}}
 {{/model}}
 {{/models}}


### PR DESCRIPTION
### PR checklist

- [ x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.

The petsore.yaml for openapi3 doesn't include oneOf so there are no updates. See example output below.

- [ x ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ x ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

* Generate type unions for schemas represented with `oneOf` format

Sample input:
```yaml
openapi: 3.0.0
info:
  description: My API Template
  title: Fake Service
  version: 0.0.1
servers:
  - http://fake.com
paths:
  /getme:
    get:
      tags:
      - v1
      operationId: getMe
      responses:
        "200":
          description: Success
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MyOneOf'
components:
  schemas:
    MyOneOf:
      oneOf:
        - $ref: '#/components/schemas/Foo'
        - $ref: '#/components/schemas/Bar'
        - $ref: '#/components/schemas/Baz'
    Foo:
      type: object
      properties:
        kind:
          type: string
        fooProp:
          type: integer
    Bar:
      type: object
      properties:
        kind:
          type: string
        barProp:
          type: string
    Baz:
      type: object
      properties:
        kind:
          type: string
        bazProp:
          type: string
```

Sample output MyOneOf.ts:
```typescript
// tslint:disable
/**
 * Fake Service
 * My API Template
 *
 * OpenAPI spec version: 0.0.1
 * 
 *
 * NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */

import {
    Bar,
    Baz,
    Foo,
} from './';

/**
 * @type MyOneOf
 * @export
 */
export type MyOneOf = Bar | Baz | Foo;
```