### PR TITLE
Null-safe check of CodegenSecurity Booleans (#2608)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1249,7 +1249,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
     private boolean hasOAuthMethods(List<CodegenSecurity> authMethods) {
         for (CodegenSecurity cs : authMethods) {
-            if (cs.isOAuth) {
+            if (Boolean.TRUE.equals(cs.isOAuth)) {
                 return true;
             }
         }
@@ -1259,7 +1259,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
 
     private boolean hasBearerMethods(List<CodegenSecurity> authMethods) {
         for (CodegenSecurity cs : authMethods) {
-            if (cs.isBasicBearer) {
+            if (Boolean.TRUE.equals(cs.isBasicBearer)) {
                 return true;
             }
         }
@@ -1271,7 +1271,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         List<CodegenSecurity> oauthMethods = new ArrayList<>();
 
         for (CodegenSecurity cs : authMethods) {
-            if (cs.isOAuth) {
+            if (Boolean.TRUE.equals(cs.isOAuth)) {
                 oauthMethods.add(cs);
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ProcessUtils.java
@@ -59,7 +59,7 @@ public class ProcessUtils {
             for (CodegenOperation operation : ops) {
                 if (operation.authMethods != null && !operation.authMethods.isEmpty()) {
                     for (CodegenSecurity cs : operation.authMethods) {
-                        if (cs.isOAuth) {
+                        if (Boolean.TRUE.equals(cs.isOAuth)) {
                             return true;
                         }
                     }
@@ -83,7 +83,7 @@ public class ProcessUtils {
             for (CodegenOperation operation : ops) {
                 if (operation.authMethods != null && !operation.authMethods.isEmpty()) {
                     for (CodegenSecurity cs : operation.authMethods) {
-                        if (cs.isBasicBearer) {
+                        if (Boolean.TRUE.equals(cs.isBasicBearer)) {
                             return true;
                         }
                     }


### PR DESCRIPTION
### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Replaced occurrences of if (cs.isXxx) by if (Boolean.TRUE.equals(cs.isXxx)) in DefaultGenerator and ProcessUtils.

