### PR TITLE
Move Ruby module/gem to codegen constant

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -60,7 +60,6 @@ public class CodegenConstants {
     public static final String GEM_NAME = "gemName";
     public static final String GEM_NAME_DESC = "gem name (convention: underscore_case).";
 
-
     public static final String PYTHON_PACKAGE_NAME = "pythonPackageName";
     public static final String PYTHON_PACKAGE_NAME_DESC = "package name for generated python code";
 
@@ -284,13 +283,13 @@ public class CodegenConstants {
     public static final String ENABLE_POST_PROCESS_FILE_DESC = "Enable post-processing file using environment variables.";
 
     public static final String OPEN_API_SPEC_NAME = "openAPISpecName";
-  
+
     public static final String GENERATE_ALIAS_AS_MODEL = "generateAliasAsModel";
     public static final String GENERATE_ALIAS_AS_MODEL_DESC = "Generate alias to map, array as models";
 
     public static final String USE_COMPARE_NET_OBJECTS = "useCompareNetObjects";
     public static final String USE_COMPARE_NET_OBJECTS_DESC = "Use KellermanSoftware.CompareNetObjects for deep recursive object comparison. WARNING: this option incurs potential performance impact.";
-  
+
     public static final String SNAPSHOT_VERSION = "snapshotVersion";
     public static final String SNAPSHOT_VERSION_DESC = "Uses a SNAPSHOT version.";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -54,6 +54,13 @@ public class CodegenConstants {
     public static final String PERL_MODULE_NAME = "perlModuleName";
     public static final String PERL_MODULE_NAME_DESC = "root module name for generated perl code";
 
+    public static final String MODULE_NAME = "moduleName";
+    public static final String MODULE_NAME_DESC = "top module name (convention: CamelCase, usually corresponding to gem name).";
+
+    public static final String GEM_NAME = "gemName";
+    public static final String GEM_NAME_DESC = "gem name (convention: underscore_case).";
+
+
     public static final String PYTHON_PACKAGE_NAME = "pythonPackageName";
     public static final String PYTHON_PACKAGE_NAME_DESC = "package name for generated python code";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -38,8 +38,6 @@ import static org.openapitools.codegen.utils.StringUtils.underscore;
 public class RubyClientCodegen extends AbstractRubyCodegen {
     private static final Logger LOGGER = LoggerFactory.getLogger(RubyClientCodegen.class);
     private static final String NUMERIC_ENUM_PREFIX = "N";
-    public static final String GEM_NAME = "gemName";
-    public static final String MODULE_NAME = "moduleName";
     public static final String GEM_VERSION = "gemVersion";
     public static final String GEM_LICENSE = "gemLicense";
     public static final String GEM_REQUIRED_RUBY_VERSION = "gemRequiredRubyVersion";
@@ -113,10 +111,12 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
             }
         }
 
-        cliOptions.add(new CliOption(GEM_NAME, "gem name (convention: underscore_case).").
+        cliOptions.add(new CliOption(CodegenConstants.GEM_NAME, CodegenConstants.GEM_NAME_DESC).
                 defaultValue("openapi_client"));
-        cliOptions.add(new CliOption(MODULE_NAME, "top module name (convention: CamelCase, usually corresponding" +
-                " to gem name).").defaultValue("OpenAPIClient"));
+
+        cliOptions.add(new CliOption(CodegenConstants.MODULE_NAME, CodegenConstants.MODULE_NAME_DESC).
+                defaultValue("OpenAPIClient"));
+
         cliOptions.add(new CliOption(GEM_VERSION, "gem version.").defaultValue("1.0.0"));
 
         cliOptions.add(new CliOption(GEM_LICENSE, "gem license. ").
@@ -147,11 +147,11 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (additionalProperties.containsKey(GEM_NAME)) {
-            setGemName((String) additionalProperties.get(GEM_NAME));
+        if (additionalProperties.containsKey(CodegenConstants.GEM_NAME)) {
+            setGemName((String) additionalProperties.get(CodegenConstants.GEM_NAME));
         }
-        if (additionalProperties.containsKey(MODULE_NAME)) {
-            setModuleName((String) additionalProperties.get(MODULE_NAME));
+        if (additionalProperties.containsKey(CodegenConstants.MODULE_NAME)) {
+            setModuleName((String) additionalProperties.get(CodegenConstants.MODULE_NAME));
         }
 
         if (gemName == null && moduleName == null) {
@@ -163,8 +163,8 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
             setModuleName(generateModuleName(gemName));
         }
 
-        additionalProperties.put(GEM_NAME, gemName);
-        additionalProperties.put(MODULE_NAME, moduleName);
+        additionalProperties.put(CodegenConstants.GEM_NAME, gemName);
+        additionalProperties.put(CodegenConstants.MODULE_NAME, moduleName);
 
         if (additionalProperties.containsKey(GEM_VERSION)) {
             setGemVersion((String) additionalProperties.get(GEM_VERSION));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/RubyClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/RubyClientOptionsProvider.java
@@ -47,8 +47,8 @@ public class RubyClientOptionsProvider implements OptionsProvider {
     @Override
     public Map<String, String> createOptions() {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
-        return builder.put(RubyClientCodegen.GEM_NAME, GEM_NAME_VALUE)
-                .put(RubyClientCodegen.MODULE_NAME, MODULE_NAME_VALUE)
+        return builder.put(CodegenConstants.GEM_NAME, GEM_NAME_VALUE)
+                .put(CodegenConstants.MODULE_NAME, MODULE_NAME_VALUE)
                 .put(RubyClientCodegen.GEM_VERSION, GEM_VERSION_VALUE)
                 .put(RubyClientCodegen.GEM_LICENSE, GEM_LICENSE_VALUE)
                 .put(RubyClientCodegen.GEM_REQUIRED_RUBY_VERSION, GEM_REQUIRED_RUBY_VERSION_VALUE)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Move module/gem to codegen constant to make it consistent with Python/PHP/Perl/etc module/package/etc

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

