### PR TITLE
[Bug][Python]Support body as bytes when Content-Type is unknown

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -1,22 +1,20 @@
 # coding: utf-8
 
-{{>partial_header}}
-
-from __future__ import absolute_import
-
-import io
-import json
-import logging
-import re
-import ssl
-
-import certifi
-# python 2 and python 3 compatibility library
-import six
-from six.moves.urllib.parse import urlencode
-import urllib3
-
 from {{packageName}}.exceptions import ApiException, ApiValueError
+import urllib3
+from six.moves.urllib.parse import urlencode
+import six
+import certifi
+import ssl
+import re
+import logging
+import json
+import io
+from __future__ import absolute_import
+{{> partial_header}}
+
+
+# python 2 and python 3 compatibility library
 
 
 logger = logging.getLogger(__name__)
@@ -181,7 +179,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str):
+                elif isinstance(body, str) or isinstance(body, bytes):
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -1,20 +1,22 @@
 # coding: utf-8
 
-from {{packageName}}.exceptions import ApiException, ApiValueError
-import urllib3
-from six.moves.urllib.parse import urlencode
-import six
-import certifi
-import ssl
-import re
-import logging
-import json
-import io
+{{>partial_header}}
+
 from __future__ import absolute_import
-{{> partial_header}}
 
+import io
+import json
+import logging
+import re
+import ssl
 
+import certifi
 # python 2 and python 3 compatibility library
+import six
+from six.moves.urllib.parse import urlencode
+import urllib3
+
+from {{packageName}}.exceptions import ApiException, ApiValueError
 
 
 logger = logging.getLogger(__name__)

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -1,5 +1,16 @@
 # coding: utf-8
 
+from petstore_api.exceptions import ApiException, ApiValueError
+import urllib3
+from six.moves.urllib.parse import urlencode
+import six
+import certifi
+import ssl
+import re
+import logging
+import json
+import io
+from __future__ import absolute_import
 """
     OpenAPI Petstore
 
@@ -10,21 +21,8 @@
 """
 
 
-from __future__ import absolute_import
 
-import io
-import json
-import logging
-import re
-import ssl
-
-import certifi
 # python 2 and python 3 compatibility library
-import six
-from six.moves.urllib.parse import urlencode
-import urllib3
-
-from petstore_api.exceptions import ApiException, ApiValueError
 
 
 logger = logging.getLogger(__name__)
@@ -189,7 +187,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str):
+                elif isinstance(body, str) or isinstance(body, bytes):
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,

--- a/samples/client/petstore/python/petstore_api/rest.py
+++ b/samples/client/petstore/python/petstore_api/rest.py
@@ -1,16 +1,5 @@
 # coding: utf-8
 
-from petstore_api.exceptions import ApiException, ApiValueError
-import urllib3
-from six.moves.urllib.parse import urlencode
-import six
-import certifi
-import ssl
-import re
-import logging
-import json
-import io
-from __future__ import absolute_import
 """
     OpenAPI Petstore
 
@@ -21,8 +10,21 @@ from __future__ import absolute_import
 """
 
 
+from __future__ import absolute_import
 
+import io
+import json
+import logging
+import re
+import ssl
+
+import certifi
 # python 2 and python 3 compatibility library
+import six
+from six.moves.urllib.parse import urlencode
+import urllib3
+
+from petstore_api.exceptions import ApiException, ApiValueError
 
 
 logger = logging.getLogger(__name__)

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -189,7 +189,7 @@ class RESTClientObject(object):
                 # Pass a `string` parameter directly in the body to support
                 # other content types than Json when `body` argument is
                 # provided in serialized form
-                elif isinstance(body, str):
+                elif isinstance(body, str) or isinstance(body, bytes):
                     request_body = body
                     r = self.pool_manager.request(
                         method, url,


### PR DESCRIPTION
fix #2623

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Accept body as bytes to support binary content types like application/octet-stream

