### PR TITLE
Clean up the license field in various templates.

### DIFF
--- a/docs/generators/ruby.md
+++ b/docs/generators/ruby.md
@@ -14,7 +14,7 @@ sidebar_label: ruby
 |gemName|gem name (convention: underscore_case).| |openapi_client|
 |moduleName|top module name (convention: CamelCase, usually corresponding to gem name).| |OpenAPIClient|
 |gemVersion|gem version.| |1.0.0|
-|gemLicense|gem license. | |proprietary|
+|gemLicense|gem license. | |unlicense|
 |gemRequiredRubyVersion|gem required Ruby version. | |&gt;= 1.9|
 |gemHomepage|gem homepage. | |http://org.openapitools|
 |gemSummary|gem summary. | |A ruby wrapper for the REST APIs|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -54,7 +54,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
     protected String gemVersion = "1.0.0";
     protected String specFolder = "spec";
     protected String libFolder = "lib";
-    protected String gemLicense = "proprietary";
+    protected String gemLicense = "unlicense";
     protected String gemRequiredRubyVersion = ">= 1.9";
     protected String gemHomepage = "http://org.openapitools";
     protected String gemSummary = "A ruby wrapper for the REST APIs";
@@ -120,7 +120,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         cliOptions.add(new CliOption(GEM_VERSION, "gem version.").defaultValue("1.0.0"));
 
         cliOptions.add(new CliOption(GEM_LICENSE, "gem license. ").
-                defaultValue("proprietary"));
+                defaultValue("unlicense"));
 
         cliOptions.add(new CliOption(GEM_REQUIRED_RUBY_VERSION, "gem required Ruby version. ").
                 defaultValue(">= 1.9"));

--- a/modules/openapi-generator/src/main/resources/lumen/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/lumen/composer.mustache
@@ -15,7 +15,7 @@
         "api"
     ],
     "homepage": "http://openapi-generator.tech",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "OpenAPI-Generator contributors",

--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -11,7 +11,7 @@
         "api"
     ],
     "homepage": "https://github.com/openapitools/openapi-generator",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "openapi-generator contributors",

--- a/modules/openapi-generator/src/main/resources/php/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/composer.mustache
@@ -14,7 +14,7 @@
         "api"
     ],
     "homepage": "https://openapi-generator.tech",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "OpenAPI-Generator contributors",

--- a/modules/openapi-generator/src/main/resources/ze-ph/composer.json.mustache
+++ b/modules/openapi-generator/src/main/resources/ze-ph/composer.json.mustache
@@ -1,7 +1,7 @@
 {
     "name": "{{gitUserId}}/{{gitRepoId}}",
     "description": "{{description}}",
-    "license": "proprietary",
+    "license": "unlicense",
     "version": "{{artifactVersion}}",
     "type": "project",
     "require": {

--- a/samples/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/client/petstore/php/OpenAPIClient-php/composer.json
@@ -11,7 +11,7 @@
         "api"
     ],
     "homepage": "https://openapi-generator.tech",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "OpenAPI-Generator contributors",

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/composer.json
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/composer.json
@@ -11,7 +11,7 @@
         "api"
     ],
     "homepage": "https://openapi-generator.tech",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "OpenAPI-Generator contributors",

--- a/samples/server/openapi3/petstore/php-ze-ph/application/config/path_handler.yml
+++ b/samples/server/openapi3/petstore/php-ze-ph/application/config/path_handler.yml
@@ -5,6 +5,7 @@ Articus\PathHandler\RouteInjection\Factory:
     - App\Handler\Fake
     - App\Handler\FakeBodyWithFileSchema
     - App\Handler\FakeBodyWithQueryParams
+    - App\Handler\FakeHealth
     - App\Handler\FakeInlineAdditionalProperties
     - App\Handler\FakeJsonFormData
     - App\Handler\FakeOuterBoolean
@@ -46,6 +47,7 @@ Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory:
   App\Handler\Fake: []
   App\Handler\FakeBodyWithFileSchema: []
   App\Handler\FakeBodyWithQueryParams: []
+  App\Handler\FakeHealth: []
   App\Handler\FakeInlineAdditionalProperties: []
   App\Handler\FakeJsonFormData: []
   App\Handler\FakeOuterBoolean: []

--- a/samples/server/openapi3/petstore/php-ze-ph/composer.json
+++ b/samples/server/openapi3/petstore/php-ze-ph/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "GIT_USER_ID/GIT_REPO_ID",
     "description": "",
-    "license": "proprietary",
+    "license": "unlicense",
     "version": "1.0.0",
     "type": "project",
     "require": {

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/EnumTest.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/EnumTest.php
@@ -40,4 +40,25 @@ class EnumTest
      * @var \App\DTO\OuterEnum
      */
     public $outer_enum;
+    /**
+     * @DTA\Data(field="outerEnumInteger", nullable=true)
+     * @DTA\Strategy(name="Object", options={"type":\App\DTO\OuterEnumInteger::class})
+     * @DTA\Validator(name="Dictionary", options={"type":\App\DTO\OuterEnumInteger::class})
+     * @var \App\DTO\OuterEnumInteger
+     */
+    public $outer_enum_integer;
+    /**
+     * @DTA\Data(field="outerEnumDefaultValue", nullable=true)
+     * @DTA\Strategy(name="Object", options={"type":\App\DTO\OuterEnumDefaultValue::class})
+     * @DTA\Validator(name="Dictionary", options={"type":\App\DTO\OuterEnumDefaultValue::class})
+     * @var \App\DTO\OuterEnumDefaultValue
+     */
+    public $outer_enum_default_value;
+    /**
+     * @DTA\Data(field="outerEnumIntegerDefaultValue", nullable=true)
+     * @DTA\Strategy(name="Object", options={"type":\App\DTO\OuterEnumIntegerDefaultValue::class})
+     * @DTA\Validator(name="Dictionary", options={"type":\App\DTO\OuterEnumIntegerDefaultValue::class})
+     * @var \App\DTO\OuterEnumIntegerDefaultValue
+     */
+    public $outer_enum_integer_default_value;
 }

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/HealthCheckResult.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/HealthCheckResult.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Articus\DataTransfer\Annotation as DTA;
+
+/**
+ * Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
+ */
+class HealthCheckResult
+{
+    /**
+     * @DTA\Data(field="NullableMessage", nullable=true)
+     * @DTA\Validator(name="Type", options={"type":"string"})
+     * @var string
+     */
+    public $nullable_message;
+}

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/NullableClass.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/NullableClass.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Articus\DataTransfer\Annotation as DTA;
+
+/**
+ */
+class NullableClass
+{
+    /**
+     * @DTA\Data(field="integer_prop", nullable=true)
+     * @DTA\Validator(name="Type", options={"type":"int"})
+     * @var int
+     */
+    public $integer_prop;
+    /**
+     * @DTA\Data(field="number_prop", nullable=true)
+     * @DTA\Validator(name="Type", options={"type":"float"})
+     * @var float
+     */
+    public $number_prop;
+    /**
+     * @DTA\Data(field="boolean_prop", nullable=true)
+     * @DTA\Validator(name="Type", options={"type":"bool"})
+     * @var bool
+     */
+    public $boolean_prop;
+    /**
+     * @DTA\Data(field="string_prop", nullable=true)
+     * @DTA\Validator(name="Type", options={"type":"string"})
+     * @var string
+     */
+    public $string_prop;
+    /**
+     * @DTA\Data(field="date_prop", nullable=true)
+     * @DTA\Strategy(name="Date")
+     * @DTA\Validator(name="Date")
+     * @var \DateTime
+     */
+    public $date_prop;
+    /**
+     * @DTA\Data(field="datetime_prop", nullable=true)
+     * @DTA\Strategy(name="DateTime")
+     * @DTA\Validator(name="Date", options={"format": \DateTime::RFC3339})
+     * @var \DateTime
+     */
+    public $datetime_prop;
+    /**
+     * @DTA\Data(field="array_nullable_prop", nullable=true)
+     * TODO check validator and strategy are correct and can handle container item type
+     * @DTA\Validator(name="Collection", options={"validators":{
+     *     {"name":"Type", "options":{"type":"object"}}
+     * }})
+     * @var object[]
+     */
+    public $array_nullable_prop;
+    /**
+     * @DTA\Data(field="array_and_items_nullable_prop", nullable=true)
+     * TODO check validator and strategy are correct and can handle container item type
+     * @DTA\Validator(name="Collection", options={"validators":{
+     *     {"name":"Type", "options":{"type":"object"}}
+     * }})
+     * @var object[]
+     */
+    public $array_and_items_nullable_prop;
+    /**
+     * @DTA\Data(field="array_items_nullable", nullable=true)
+     * TODO check validator and strategy are correct and can handle container item type
+     * @DTA\Validator(name="Collection", options={"validators":{
+     *     {"name":"Type", "options":{"type":"object"}}
+     * }})
+     * @var object[]
+     */
+    public $array_items_nullable;
+    /**
+     * @DTA\Data(field="object_nullable_prop", nullable=true)
+     * TODO check validator and strategy are correct and can handle container item type
+     * @DTA\Validator(name="Collection", options={"validators":{
+     *     {"name":"Type", "options":{"type":"object"}}
+     * }})
+     * @var map[string,object]
+     */
+    public $object_nullable_prop;
+    /**
+     * @DTA\Data(field="object_and_items_nullable_prop", nullable=true)
+     * TODO check validator and strategy are correct and can handle container item type
+     * @DTA\Validator(name="Collection", options={"validators":{
+     *     {"name":"Type", "options":{"type":"object"}}
+     * }})
+     * @var map[string,object]
+     */
+    public $object_and_items_nullable_prop;
+    /**
+     * @DTA\Data(field="object_items_nullable", nullable=true)
+     * TODO check validator and strategy are correct and can handle container item type
+     * @DTA\Validator(name="Collection", options={"validators":{
+     *     {"name":"Type", "options":{"type":"object"}}
+     * }})
+     * @var map[string,object]
+     */
+    public $object_items_nullable;
+}

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/OuterEnumDefaultValue.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/OuterEnumDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Articus\DataTransfer\Annotation as DTA;
+
+/**
+ */
+class OuterEnumDefaultValue
+{
+}

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/OuterEnumInteger.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/OuterEnumInteger.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Articus\DataTransfer\Annotation as DTA;
+
+/**
+ */
+class OuterEnumInteger
+{
+}

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/OuterEnumIntegerDefaultValue.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/DTO/OuterEnumIntegerDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\DTO;
+
+use Articus\DataTransfer\Annotation as DTA;
+
+/**
+ */
+class OuterEnumIntegerDefaultValue
+{
+}

--- a/samples/server/openapi3/petstore/php-ze-ph/src/App/Handler/FakeHealth.php
+++ b/samples/server/openapi3/petstore/php-ze-ph/src/App/Handler/FakeHealth.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Articus\PathHandler\Annotation as PHA;
+use Articus\PathHandler\Consumer as PHConsumer;
+use Articus\PathHandler\Producer as PHProducer;
+use Articus\PathHandler\Attribute as PHAttribute;
+use Articus\PathHandler\Exception as PHException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @PHA\Route(pattern="/fake/health")
+ */
+class FakeHealth
+{
+    /**
+     * Health check endpoint
+     * @PHA\Get()
+     * TODO check if producer is valid, if it has correct priority and if it can be moved to class annotation
+     * @PHA\Producer(name=PHProducer\Transfer::class, mediaType="application/json")
+     * @param ServerRequestInterface $request
+     *
+     * @throws PHException\HttpCode 501 if the method is not implemented
+     *
+     * @return \App\DTO\HealthCheckResult
+     */
+    public function fakeHealthGet(ServerRequestInterface $request): \App\DTO\HealthCheckResult
+    {
+        //TODO implement method
+        throw new PHException\HttpCode(501, "Not implemented");
+    }
+}

--- a/samples/server/petstore/php-lumen/lib/composer.json
+++ b/samples/server/petstore/php-lumen/lib/composer.json
@@ -12,7 +12,7 @@
         "api"
     ],
     "homepage": "http://openapi-generator.tech",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "OpenAPI-Generator contributors",

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -8,7 +8,7 @@
         "api"
     ],
     "homepage": "https://github.com/openapitools/openapi-generator",
-    "license": "proprietary",
+    "license": "unlicense",
     "authors": [
         {
             "name": "openapi-generator contributors",

--- a/samples/server/petstore/php-ze-ph/composer.json
+++ b/samples/server/petstore/php-ze-ph/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "GIT_USER_ID/GIT_REPO_ID",
     "description": "",
-    "license": "proprietary",
+    "license": "unlicense",
     "version": "1.0.0",
     "type": "project",
     "require": {


### PR DESCRIPTION
Clean up the license field in various templates to ensure it's unlicense by default.

### PR checklist

- [DONE] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [DONE] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [DONE] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.

### Description of the PR

Changes based on the discussion contained in: https://github.com/OpenAPITools/openapi-generator/issues/2255

The following scripts was executed:
bin/php-lumen-petstore-server.sh
bin/php-ze-ph-petstore-server.sh
bin/php-symfony-petstore.sh
bin/openapi3/php-ze-ph-petstore-server.sh
bin/openapi3/php-petstore.sh
bin/php-petstore.sh
bin/ruby-client-petstore.sh

The script associated with 'php-ze-ph' generated several new files. These areas where not modified by me, so I assume that the content of the 'sample' folder was not up to date.