### PR TITLE
Fix NPE when server url is null

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/URLPathUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/URLPathUtilsTest.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 public class URLPathUtilsTest {
 
     @Test
-    public void testDefaultValues() throws Exception {
+    public void testDefaultValues() {
         OpenAPI openAPI = new OpenAPI();
         URL serverURL = URLPathUtils.getServerURL(openAPI);
 
@@ -44,7 +44,7 @@ public class URLPathUtilsTest {
     }
 
     @Test
-    public void testUrl() throws Exception {
+    public void testUrl() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.addServersItem(new Server().url("https://abcdef.xyz:9999/some/path"));
         URL serverURL = URLPathUtils.getServerURL(openAPI);
@@ -59,7 +59,7 @@ public class URLPathUtilsTest {
     }
 
     @Test
-    public void testSanitizeUrl() throws Exception {
+    public void testSanitizeUrl() {
         String[][] testData = {
             { "https://abc1.xyz:9999/some/path", "https://abc1.xyz:9999/some/path" },
             { "HTTPS://abc2.xyz:9999/some/path", "https://abc2.xyz:9999/some/path" },
@@ -79,7 +79,7 @@ public class URLPathUtilsTest {
     }
 
     @Test
-    public void testGetServerURLWithVariables() throws Exception {
+    public void testGetServerURLWithVariables() {
         Server s1 = new Server().url("http://localhost:{port}/").variables(new ServerVariables().addServerVariable("port", new ServerVariable()._default("8080").description("the server port")));
         Assert.assertEquals(URLPathUtils.getServerURL(s1).toString(), "http://localhost:8080/");
 
@@ -112,5 +112,13 @@ public class URLPathUtilsTest {
                     new ServerVariables().addServerVariable("version", new ServerVariable()._default("v1"))
                         .addServerVariable("user", new ServerVariable()._default("{user}")));
         Assert.assertEquals(URLPathUtils.getServerURL(s9).toString(), "https://{user}.example.com/v1");
+    }
+
+    @Test
+    public void useDefaultUrlWhenServerUrlIsNull() {
+        Server server = new Server().url(null);
+
+        URL serverURL = URLPathUtils.getServerURL(server);
+        Assert.assertEquals(serverURL.toString(), "http://localhost");
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

If the server url is null I use the default url like it's done if the url is malformed.

Fix #2625

@wing328
@jimschubert
@cbornet
@ackintosh
@jmini