### PR TITLE
[Slim] Fix AbstractAuthenticator constructor TypeError

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
@@ -125,6 +125,9 @@ class SlimRouter
     {
         $this->slimApp = new App($container);
 
+        // middlewares requires Psr\Container\ContainerInterface instead of array
+        $container = $this->slimApp->getContainer();
+
         {{#hasAuthMethods}}
         $authPackage = '{{authPackage}}';
         $basicAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {

--- a/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
@@ -116,16 +116,16 @@ class SlimRouter
     /**
      * Class constructor
      *
-     * @param ContainerInterface|array $container Either a ContainerInterface or an associative array of app settings
+     * @param ContainerInterface|array $settings Either a ContainerInterface or an associative array of app settings
      *
      * @throws InvalidArgumentException When no container is provided that implements ContainerInterface
      * @throws Exception When implementation class doesn't exists
      */
-    public function __construct($container = [])
+    public function __construct($settings = [])
     {
-        $this->slimApp = new App($container);
+        $this->slimApp = new App($settings);
 
-        // middlewares requires Psr\Container\ContainerInterface instead of array
+        // middlewares requires Psr\Container\ContainerInterface
         $container = $this->slimApp->getContainer();
 
         {{#hasAuthMethods}}

--- a/samples/server/petstore/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim/lib/SlimRouter.php
@@ -586,6 +586,9 @@ class SlimRouter
     {
         $this->slimApp = new App($container);
 
+        // middlewares requires Psr\Container\ContainerInterface instead of array
+        $container = $this->slimApp->getContainer();
+
         $authPackage = 'OpenAPIServer\Auth';
         $basicAuthenticator = function (ServerRequestInterface &$request, TokenSearch $tokenSearch) use ($authPackage) {
             $message = "How about extending AbstractAuthenticator class by {$authPackage}\BasicAuthenticator?";

--- a/samples/server/petstore/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim/lib/SlimRouter.php
@@ -577,16 +577,16 @@ class SlimRouter
     /**
      * Class constructor
      *
-     * @param ContainerInterface|array $container Either a ContainerInterface or an associative array of app settings
+     * @param ContainerInterface|array $settings Either a ContainerInterface or an associative array of app settings
      *
      * @throws InvalidArgumentException When no container is provided that implements ContainerInterface
      * @throws Exception When implementation class doesn't exists
      */
-    public function __construct($container = [])
+    public function __construct($settings = [])
     {
-        $this->slimApp = new App($container);
+        $this->slimApp = new App($settings);
 
-        // middlewares requires Psr\Container\ContainerInterface instead of array
+        // middlewares requires Psr\Container\ContainerInterface
         $container = $this->slimApp->getContainer();
 
         $authPackage = 'OpenAPIServer\Auth';


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Current generator requires `AbstractAuthenticator` user implementation when schema contains security definitions. When implementation class is provided app throws TypeError.

```
[10-Apr-2019 17:42:41 UTC] PHP Fatal error:  Uncaught TypeError: Argument 1 passed to OpenAPIServer\Auth\AbstractAuthenticator::__construct() 
must implement interface Psr\Container\ContainerInterface, array given, called in 
/Applications/MAMP/htdocs/openapi-generator/samples/server/petstore/php-slim/lib/SlimRouter.php on line 650 and defined in 
/Applications/MAMP/htdocs/openapi-generator/samples/server/petstore/php-slim/lib/Auth/AbstractAuthenticator.php:70
```

Fixes #2640 

cc @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @ybelenko, @renepardon
