### PR TITLE
[TypeScript] Generate oneOf schemas as type unions

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -165,9 +165,9 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                     }
                 }
             }
-            if (cm.oneOf.size() > 0) {
+            if (!cm.oneOf.isEmpty()) {
                 // For oneOfs only import $refs within the oneOf
-                TreeSet<String> oneOfRefs = new TreeSet<String>();
+                TreeSet<String> oneOfRefs = new TreeSet<>();
                 for (String im : cm.imports) {
                     if (cm.oneOf.contains(im)) {
                         oneOfRefs.add(im);

--- a/modules/openapi-generator/src/main/resources/typescript-angular/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/model.mustache
@@ -11,6 +11,6 @@ import { {{classname}} } from './{{filename}}';
  * {{{description}}}
  */
 {{/description}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#isAlias}}{{>modelAlias}}{{/isAlias}}{{^isAlias}}{{#taggedUnions}}{{>modelTaggedUnion}}{{/taggedUnions}}{{^taggedUnions}}{{>modelGeneric}}{{/taggedUnions}}{{/isAlias}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#isAlias}}{{>modelAlias}}{{/isAlias}}{{^isAlias}}{{#taggedUnions}}{{>modelTaggedUnion}}{{/taggedUnions}}{{^taggedUnions}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/taggedUnions}}{{/isAlias}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelOneOf.mustache
@@ -1,0 +1,14 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-aurelia/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-aurelia/modelOneOf.mustache
@@ -1,0 +1,6 @@
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-aurelia/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-aurelia/models.mustache
@@ -1,6 +1,8 @@
 {{>licenseInfo}}
 {{#models}}
 {{#model}}
+{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}
+{{^oneOf}}
 {{#description}}
 /**
  * {{{description}}}
@@ -35,5 +37,6 @@ export type {{{enumName}}} = {{#allowableValues}}{{#values}}'{{{.}}}'{{^-last}} 
 {{/isEnum}}
 {{/vars}}
 {{/hasEnums}}
+{{/oneOf}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/api.mustache
@@ -9,7 +9,7 @@ import globalAxios, { AxiosPromise, AxiosInstance } from 'axios';
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from './base';
 
 {{#models}}
-{{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}{{/model}}
+{{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}
 {{/models}}
 {{#apiInfo}}{{#apis}}
 {{>apiInner}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
@@ -4,6 +4,6 @@
 {{#withSeparateModelsAndApi}}{{#imports}}
 import { {{class}} } from './{{filename}}';{{/imports}}{{/withSeparateModelsAndApi}}
 {{#models}}{{#model}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}
 {{/model}}{{/models}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelOneOf.mustache
@@ -1,0 +1,6 @@
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -2,8 +2,6 @@
 import {
     {{#imports}}
     {{{.}}},
-    {{.}}FromJSON,
-    {{.}}ToJSON,
     {{/imports}}
 } from './';
 
@@ -14,12 +12,3 @@ import {
  * @export
  */
 export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
-
-export function {{classname}}FromJSON(json: any): {{classname}} {
-    //TODO to implement
-    return {{#oneOf}}{{{.}}}FromJSON(json){{^-last}} || {{/-last}}{{/oneOf}};
-}
-
-export function {{classname}}ToJSON(value?: {{classname}}): any {
-    //TODO to implement
-}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -2,6 +2,8 @@
 import {
     {{#imports}}
     {{{.}}},
+    {{.}}FromJSON,
+    {{.}}ToJSON,
     {{/imports}}
 } from './';
 
@@ -12,3 +14,12 @@ import {
  * @export
  */
 export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
+
+export function {{classname}}FromJSON(json: any): {{classname}} {
+    //TODO to implement
+    return {{#oneOf}}{{{.}}}FromJSON(json){{^-last}} || {{/-last}}{{/oneOf}};
+}
+
+export function {{classname}}ToJSON(value?: {{classname}}): any {
+    //TODO to implement
+}

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/model.mustache
@@ -11,6 +11,6 @@ import { {{classname}} } from './{{filename}}';
  * {{{description}}}
  */
 {{/description}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#isAlias}}{{>modelAlias}}{{/isAlias}}{{^isAlias}}{{#taggedUnions}}{{>modelTaggedUnion}}{{/taggedUnions}}{{^taggedUnions}}{{>modelGeneric}}{{/taggedUnions}}{{/isAlias}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{#isAlias}}{{>modelAlias}}{{/isAlias}}{{^isAlias}}{{#taggedUnions}}{{>modelTaggedUnion}}{{/taggedUnions}}{{^taggedUnions}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/taggedUnions}}{{/isAlias}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/modelOneOf.mustache
@@ -1,0 +1,14 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/model.mustache
@@ -8,6 +8,6 @@ import * as models from './models';
  * {{{description}}}
  */
 {{/description}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>modelGeneric}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/modelOneOf.mustache
@@ -1,0 +1,6 @@
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}models.{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelOneOf.mustache
@@ -1,0 +1,14 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/models.mustache
@@ -2,11 +2,6 @@
 {{>licenseInfo}}
 {{#models}}
 {{#model}}
-{{#isEnum}}
-{{>modelEnum}}
-{{/isEnum}}
-{{^isEnum}}
-{{>modelGeneric}}
-{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/package.mustache
@@ -10,7 +10,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "typescript": "^2.4"

--- a/modules/openapi-generator/src/test/resources/3_0/oneOf.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneOf.yaml
@@ -1,64 +1,36 @@
-{
-   "openapi":"3.0.1",
-   "info":{
-      "title":"fruity",
-      "version":"0.0.1"
-   },
-   "paths":{
-      "/":{
-         "get":{
-            "responses":{
-               "200":{
-                  "description":"desc",
-                  "content":{
-                     "application/json":{
-                        "schema":{
-                           "$ref":"#/components/schemas/fruit"
-                        }
-                     }
-                  }
-               }
-            }
-         }
-      }
-   },
-   "components":{
-      "schemas":{
-         "fruit":{
-            "title":"fruit",
-            "type":"object",
-            "properties":{
-               "color":{
-                  "type":"string"
-               }
-            },
-            "oneOf":[
-               {
-                  "$ref":"#/components/schemas/apple"
-               },
-               {
-                  "$ref":"#/components/schemas/banana"
-               }
-            ]
-         },
-         "apple":{
-            "title":"apple",
-            "type":"object",
-            "properties":{
-               "kind":{
-                  "type":"string"
-               }
-            }
-         },
-         "banana":{
-            "title":"banana",
-            "type":"object",
-            "properties":{
-               "count":{
-                  "type":"number"
-               }
-            }
-         }
-      }
-   }
-}
+openapi: 3.0.1
+info:
+   title: fruity
+   version: 0.0.1
+paths:
+   /:
+      get:
+         responses:
+            '200':
+               description: desc
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/fruit'
+components:
+   schemas:
+      fruit:
+         title: fruit
+         properties:
+            color:
+               type: string
+         oneOf:
+            - $ref: '#/components/schemas/apple'
+            - $ref: '#/components/schemas/banana'
+      apple:
+         title: apple
+         type: object
+         properties:
+            kind:
+               type: string
+      banana:
+         title: banana
+         type: object
+         properties:
+            count:
+               type: number

--- a/samples/client/petstore/typescript-aurelia/default/models.ts
+++ b/samples/client/petstore/typescript-aurelia/default/models.ts
@@ -11,7 +11,6 @@
  */
 
 
-
 /**
  * Describes the result of uploading an image resource
  */
@@ -22,7 +21,6 @@ export interface ApiResponse {
 }
 
 
-
 /**
  * A category for a pet
  */
@@ -30,7 +28,6 @@ export interface Category {
   id?: number;
   name?: string;
 }
-
 
 
 /**
@@ -54,7 +51,6 @@ export interface Order {
 export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
 
 
-
 /**
  * A pet for sale in the pet store
  */
@@ -76,7 +72,6 @@ export interface Pet {
 export type PetStatusEnum = 'available' | 'pending' | 'sold';
 
 
-
 /**
  * A tag for a pet
  */
@@ -84,7 +79,6 @@ export interface Tag {
   id?: number;
   name?: string;
 }
-
 
 
 /**

--- a/samples/client/petstore/typescript-aurelia/default/models.ts
+++ b/samples/client/petstore/typescript-aurelia/default/models.ts
@@ -10,6 +10,8 @@
  * Do not edit the class manually.
  */
 
+
+
 /**
  * Describes the result of uploading an image resource
  */
@@ -19,6 +21,8 @@ export interface ApiResponse {
   message?: string;
 }
 
+
+
 /**
  * A category for a pet
  */
@@ -26,6 +30,8 @@ export interface Category {
   id?: number;
   name?: string;
 }
+
+
 
 /**
  * An order for a pets from the pet store
@@ -47,6 +53,8 @@ export interface Order {
  */
 export type OrderStatusEnum = 'placed' | 'approved' | 'delivered';
 
+
+
 /**
  * A pet for sale in the pet store
  */
@@ -67,6 +75,8 @@ export interface Pet {
  */
 export type PetStatusEnum = 'available' | 'pending' | 'sold';
 
+
+
 /**
  * A tag for a pet
  */
@@ -74,6 +84,8 @@ export interface Tag {
   id?: number;
   name?: string;
 }
+
+
 
 /**
  * A User who is purchasing from the pet store

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/package.json
@@ -10,7 +10,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "typescript": "^2.4"

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/package.json
@@ -10,7 +10,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "typescript": "^2.4"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### Description of the PR

- as #2617 but for all other typescript generator 
- fix rxjs package.json (comma)
- fix oneOf.yaml not in yaml format
