### PR TITLE
[C++] [Qt5] Use percent encoding for path parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -31,7 +31,7 @@ void
     {{#pathParams}}
     QString {{paramName}}PathParam("{"); 
     {{paramName}}PathParam.append("{{baseName}}").append("}");
-    fullPath.replace({{paramName}}PathParam, ::{{cppNamespace}}::toStringValue({{paramName}}));
+    fullPath.replace({{paramName}}PathParam, QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}})));
     {{/pathParams}}
     {{#queryParams}}{{^collectionFormat}}
     if (fullPath.indexOf("?") > 0)

--- a/samples/client/petstore/cpp-qt5/client/OAIPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIPetApi.cpp
@@ -85,7 +85,7 @@ OAIPetApi::deletePet(const qint64& pet_id, const QString& api_key) {
     fullPath.append(this->host).append(this->basePath).append("/pet/{petId}");
     QString pet_idPathParam("{"); 
     pet_idPathParam.append("petId").append("}");
-    fullPath.replace(pet_idPathParam, ::OpenAPI::toStringValue(pet_id));
+    fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "DELETE");
@@ -323,7 +323,7 @@ OAIPetApi::getPetById(const qint64& pet_id) {
     fullPath.append(this->host).append(this->basePath).append("/pet/{petId}");
     QString pet_idPathParam("{"); 
     pet_idPathParam.append("petId").append("}");
-    fullPath.replace(pet_idPathParam, ::OpenAPI::toStringValue(pet_id));
+    fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "GET");
@@ -419,7 +419,7 @@ OAIPetApi::updatePetWithForm(const qint64& pet_id, const QString& name, const QS
     fullPath.append(this->host).append(this->basePath).append("/pet/{petId}");
     QString pet_idPathParam("{"); 
     pet_idPathParam.append("petId").append("}");
-    fullPath.replace(pet_idPathParam, ::OpenAPI::toStringValue(pet_id));
+    fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "POST");
@@ -472,7 +472,7 @@ OAIPetApi::uploadFile(const qint64& pet_id, const QString& additional_metadata, 
     fullPath.append(this->host).append(this->basePath).append("/pet/{petId}/uploadImage");
     QString pet_idPathParam("{"); 
     pet_idPathParam.append("petId").append("}");
-    fullPath.replace(pet_idPathParam, ::OpenAPI::toStringValue(pet_id));
+    fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "POST");

--- a/samples/client/petstore/cpp-qt5/client/OAIStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIStoreApi.cpp
@@ -37,7 +37,7 @@ OAIStoreApi::deleteOrder(const QString& order_id) {
     fullPath.append(this->host).append(this->basePath).append("/store/order/{orderId}");
     QString order_idPathParam("{"); 
     order_idPathParam.append("orderId").append("}");
-    fullPath.replace(order_idPathParam, ::OpenAPI::toStringValue(order_id));
+    fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(order_id)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "DELETE");
@@ -138,7 +138,7 @@ OAIStoreApi::getOrderById(const qint64& order_id) {
     fullPath.append(this->host).append(this->basePath).append("/store/order/{orderId}");
     QString order_idPathParam("{"); 
     order_idPathParam.append("orderId").append("}");
-    fullPath.replace(order_idPathParam, ::OpenAPI::toStringValue(order_id));
+    fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(order_id)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "GET");

--- a/samples/client/petstore/cpp-qt5/client/OAIUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIUserApi.cpp
@@ -183,7 +183,7 @@ OAIUserApi::deleteUser(const QString& username) {
     fullPath.append(this->host).append(this->basePath).append("/user/{username}");
     QString usernamePathParam("{"); 
     usernamePathParam.append("username").append("}");
-    fullPath.replace(usernamePathParam, ::OpenAPI::toStringValue(username));
+    fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(username)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "DELETE");
@@ -230,7 +230,7 @@ OAIUserApi::getUserByName(const QString& username) {
     fullPath.append(this->host).append(this->basePath).append("/user/{username}");
     QString usernamePathParam("{"); 
     usernamePathParam.append("username").append("}");
-    fullPath.replace(usernamePathParam, ::OpenAPI::toStringValue(username));
+    fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(username)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "GET");
@@ -384,7 +384,7 @@ OAIUserApi::updateUser(const QString& username, const OAIUser& body) {
     fullPath.append(this->host).append(this->basePath).append("/user/{username}");
     QString usernamePathParam("{"); 
     usernamePathParam.append("username").append("}");
-    fullPath.replace(usernamePathParam, ::OpenAPI::toStringValue(username));
+    fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(username)));
     
     OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
     OAIHttpRequestInput input(fullPath, "PUT");


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix missing percent encoding in the path param. 

@stkrwork @ravinikam @MartinDelille @fvarose 