### PR TITLE
Add scala-akka tests

### DIFF
--- a/samples/client/petstore/scala-akka/src/test/scala/PetApiTest.scala
+++ b/samples/client/petstore/scala-akka/src/test/scala/PetApiTest.scala
@@ -1,0 +1,116 @@
+import akka.actor.ActorSystem
+import org.junit.runner.RunWith
+import org.openapitools.client._
+import org.openapitools.client.api._
+import org.openapitools.client.core.{ ApiInvoker, ApiKeyValue }
+import org.openapitools.client.model._
+import org.scalatest.Inspectors._
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class PetApiTest extends AsyncFlatSpec with Matchers {
+
+  private implicit val system: ActorSystem = ActorSystem()
+
+  behavior of "PetApi"
+  val api = PetApi()
+  val invoker = ApiInvoker()
+  private implicit val apiKey: ApiKeyValue = ApiKeyValue("special-key")
+
+  it should "add and fetch a pet" in {
+    val petId = 1000
+    val createdPet = Pet(
+      Some(petId),
+      Some(Category(Some(1), Some("sold"))),
+      "dragon",
+      (for (i <- 1 to 10) yield "http://foo.com/photo/" + i).toList,
+      Some((for (i <- 1 to 5) yield org.openapitools.client.model.Tag(Some(i), Some("tag-" + i))).toList),
+      Some(PetEnums.Status.Sold)
+    )
+
+    val addPetRequest = api.addPet(createdPet)
+    val getPetRequest = api.getPetById(petId)
+
+    for {
+      addResponse <- invoker.execute(addPetRequest)
+      response <- invoker.execute(getPetRequest)
+    } yield {
+      addResponse.code should be(200)
+
+      response.code should be(200)
+      val pet = response.content
+
+      pet should have(
+        'id (createdPet.id),
+        'status (createdPet.status),
+        'category (createdPet.category),
+        'name (createdPet.name)
+      )
+      pet.tags should not be empty
+      pet.tags.get should contain theSameElementsInOrderAs createdPet.tags.get
+      pet.photoUrls should contain theSameElementsInOrderAs createdPet.photoUrls
+    }
+  }
+
+  it should "update a pet" in {
+    val petId = Math.random().toInt
+    val createdPet = Pet(
+      Some(petId),
+      Some(Category(Some(1), Some("sold"))),
+      "programmer",
+      (for (i <- 1 to 10) yield "http://foo.com/photo/" + i).toList,
+      Some((for (i <- 1 to 5) yield org.openapitools.client.model.Tag(Some(i), Some("tag-" + i))).toList),
+      Some(PetEnums.Status.Available)
+    )
+
+    for {
+      _ <- invoker.execute(api.addPet(createdPet))
+      pet: core.ApiResponse[Pet] <- invoker.execute(api.getPetById(petId))
+      updatedPet = pet.content.copy(status = Some(PetEnums.Status.Sold))
+      _ <- invoker.execute(api.updatePet(updatedPet))
+      updatedRequested <- invoker.execute(api.getPetById(petId))
+    } yield {
+      pet.content.name should be("programmer")
+      pet.content.status should be(Some(PetEnums.Status.Available))
+
+      updatedRequested.content.name should be("programmer")
+      updatedRequested.content.status should be(Some(PetEnums.Status.Sold))
+    }
+  }
+
+  it should "find pets by status" in {
+    val request = api.findPetsByStatus(List("available"))
+
+    invoker
+      .execute(request)
+      .map { apiResponse =>
+        apiResponse.code should be(200)
+        val pets = apiResponse.content
+        pets should not be empty
+
+        forAll(pets) { pet =>
+          pet.status should contain("available")
+        }
+      }
+  }
+
+  it should "find pets by tag" in {
+    val request = api.findPetsByTags(List("tag1", "tag2"))
+
+    invoker
+      .execute(request)
+      .map { apiResponse =>
+        apiResponse.code should be(200)
+
+        val pets = apiResponse.content
+        pets should not be empty
+
+        forAll(pets) { pet =>
+          val tagNames = pet.tags.toList.flatten.map(_.name).collect { case Some(name) => name }
+          tagNames should contain atLeastOneOf("tag1", "tag2")
+        }
+      }
+  }
+}
+


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add tests for scala-akka client. Tests are incomplete and more of them are still in error, but it's a first step.

