### PR TITLE
dart2 linter updates for prefer_equal_for_default_values, prefer_is_empty

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -46,7 +46,7 @@ class {{classname}} {
 
     List<String> contentTypes = [{{#consumes}}"{{{mediaType}}}"{{#hasMore}},{{/hasMore}}{{/consumes}}];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [{{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}}];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -18,7 +18,7 @@ class ApiClient {
   final _regList = RegExp(r'^List<(.*)>$');
   final _regMap = RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "{{{basePath}}}"}) {
+  ApiClient({this.basePath = "{{{basePath}}}"}) {
     // Setup authentications (key: authentication name, value: authentication).{{#authMethods}}{{#isBasic}}
     _authentications['{{name}}'] = HttpBasicAuth();{{/isBasic}}{{#isApiKey}}
     _authentications['{{name}}'] = ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{^isKeyInHeader}}"query"{{/isKeyInHeader}}, "{{keyParamName}}");{{/isApiKey}}{{#isOAuth}}

--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -83,7 +83,7 @@ class {{classname}} {
 
   static Map<String, {{classname}}> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, {{classname}}>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new {{classname}}.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/README.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/README.md
@@ -44,7 +44,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 import 'package:openapi/api.dart';
 
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
+//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
 var body = new Pet(); // Pet | Pet object that needs to be added to the store

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
@@ -28,7 +28,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -78,7 +78,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -128,7 +128,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -179,7 +179,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -229,7 +229,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -328,7 +328,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -389,7 +389,7 @@ class PetApi {
 
     List<String> contentTypes = ["multipart/form-data"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
@@ -28,7 +28,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -74,7 +74,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -125,7 +125,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
@@ -28,7 +28,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -77,7 +77,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -126,7 +126,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -224,7 +224,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -326,7 +326,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -378,7 +378,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
@@ -47,7 +47,7 @@ class ApiResponse {
 
   static Map<String, ApiResponse> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, ApiResponse>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new ApiResponse.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
@@ -39,7 +39,7 @@ class Category {
 
   static Map<String, Category> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Category>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Category.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
@@ -72,7 +72,7 @@ class Order {
 
   static Map<String, Order> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Order>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Order.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
@@ -72,7 +72,7 @@ class Pet {
 
   static Map<String, Pet> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Pet>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Pet.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
@@ -39,7 +39,7 @@ class Tag {
 
   static Map<String, Tag> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Tag>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Tag.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
@@ -87,7 +87,7 @@ class User {
 
   static Map<String, User> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, User>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new User.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/README.md
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/README.md
@@ -44,7 +44,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 import 'package:openapi/api.dart';
 
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
+//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
 var body = new Pet(); // Pet | Pet object that needs to be added to the store

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api/pet_api.dart
@@ -28,7 +28,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -78,7 +78,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -128,7 +128,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -179,7 +179,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -229,7 +229,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -328,7 +328,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -389,7 +389,7 @@ class PetApi {
 
     List<String> contentTypes = ["multipart/form-data"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api/store_api.dart
@@ -28,7 +28,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -74,7 +74,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -125,7 +125,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api/user_api.dart
@@ -28,7 +28,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -77,7 +77,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -126,7 +126,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -224,7 +224,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -326,7 +326,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -378,7 +378,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/api_response.dart
@@ -47,7 +47,7 @@ class ApiResponse {
 
   static Map<String, ApiResponse> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, ApiResponse>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new ApiResponse.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/category.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/category.dart
@@ -39,7 +39,7 @@ class Category {
 
   static Map<String, Category> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Category>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Category.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/order.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/order.dart
@@ -72,7 +72,7 @@ class Order {
 
   static Map<String, Order> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Order>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Order.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/pet.dart
@@ -72,7 +72,7 @@ class Pet {
 
   static Map<String, Pet> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Pet>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Pet.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/tag.dart
@@ -39,7 +39,7 @@ class Tag {
 
   static Map<String, Tag> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Tag>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Tag.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/user.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/user.dart
@@ -87,7 +87,7 @@ class User {
 
   static Map<String, User> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, User>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new User.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi-browser-client/README.md
+++ b/samples/client/petstore/dart2/openapi-browser-client/README.md
@@ -44,7 +44,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 import 'package:openapi/api.dart';
 
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
+//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
 var body = new Pet(); // Pet | Pet object that needs to be added to the store

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/api/pet_api.dart
@@ -28,7 +28,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -78,7 +78,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -128,7 +128,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -179,7 +179,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -229,7 +229,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -328,7 +328,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -389,7 +389,7 @@ class PetApi {
 
     List<String> contentTypes = ["multipart/form-data"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/api/store_api.dart
@@ -28,7 +28,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -74,7 +74,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -125,7 +125,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/api/user_api.dart
@@ -28,7 +28,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -77,7 +77,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -126,7 +126,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -224,7 +224,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -326,7 +326,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -378,7 +378,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/api_response.dart
@@ -47,7 +47,7 @@ class ApiResponse {
 
   static Map<String, ApiResponse> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, ApiResponse>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new ApiResponse.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/category.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/category.dart
@@ -39,7 +39,7 @@ class Category {
 
   static Map<String, Category> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Category>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Category.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/order.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/order.dart
@@ -72,7 +72,7 @@ class Order {
 
   static Map<String, Order> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Order>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Order.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/pet.dart
@@ -72,7 +72,7 @@ class Pet {
 
   static Map<String, Pet> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Pet>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Pet.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/tag.dart
@@ -39,7 +39,7 @@ class Tag {
 
   static Map<String, Tag> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Tag>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Tag.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/user.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/user.dart
@@ -87,7 +87,7 @@ class User {
 
   static Map<String, User> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, User>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new User.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi/README.md
+++ b/samples/client/petstore/dart2/openapi/README.md
@@ -44,7 +44,7 @@ Please follow the [installation procedure](#installation--usage) and then run th
 import 'package:openapi/api.dart';
 
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
+//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
 
 var api_instance = new PetApi();
 var body = new Pet(); // Pet | Pet object that needs to be added to the store

--- a/samples/client/petstore/dart2/openapi/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api/pet_api.dart
@@ -28,7 +28,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -78,7 +78,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -128,7 +128,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -179,7 +179,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -229,7 +229,7 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -328,7 +328,7 @@ class PetApi {
 
     List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -389,7 +389,7 @@ class PetApi {
 
     List<String> contentTypes = ["multipart/form-data"];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/openapi/lib/api/store_api.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api/store_api.dart
@@ -28,7 +28,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -74,7 +74,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -125,7 +125,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/openapi/lib/api/user_api.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api/user_api.dart
@@ -28,7 +28,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -77,7 +77,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -126,7 +126,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -175,7 +175,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -224,7 +224,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -279,7 +279,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -326,7 +326,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
@@ -378,7 +378,7 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {

--- a/samples/client/petstore/dart2/openapi/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/api_response.dart
@@ -47,7 +47,7 @@ class ApiResponse {
 
   static Map<String, ApiResponse> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, ApiResponse>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new ApiResponse.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi/lib/model/category.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/category.dart
@@ -39,7 +39,7 @@ class Category {
 
   static Map<String, Category> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Category>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Category.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi/lib/model/order.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/order.dart
@@ -72,7 +72,7 @@ class Order {
 
   static Map<String, Order> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Order>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Order.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/pet.dart
@@ -72,7 +72,7 @@ class Pet {
 
   static Map<String, Pet> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Pet>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Pet.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/tag.dart
@@ -39,7 +39,7 @@ class Tag {
 
   static Map<String, Tag> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, Tag>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new Tag.fromJson(value));
     }
     return map;

--- a/samples/client/petstore/dart2/openapi/lib/model/user.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/user.dart
@@ -87,7 +87,7 @@ class User {
 
   static Map<String, User> mapFromJson(Map<String, dynamic> json) {
     var map = new Map<String, User>();
-    if (json != null && json.length > 0) {
+    if (json != null && json.isNotEmpty) {
       json.forEach((String key, dynamic value) => map[key] = new User.fromJson(value));
     }
     return map;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

@ircecho @swipesight @jaumard

The dart2 linter presently complains about a couple of items in the generated client. Namely:

- [The use of 'length > 0' to test for non-emptiness](https://dart-lang.github.io/linter/lints/prefer_is_empty.html); and
- [Using : notation for default value assignment](https://dart-lang.github.io/linter/lints/prefer_equal_for_default_values.html)

This PR updates the relevant mustache templates to obey these constraints, resulting in generated client code that successfully passes through the linter.

