### PR TITLE
Fix ServiceLoader initialization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfigLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfigLoader.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import static java.util.ServiceLoader.load;
-
 public class CodegenConfigLoader {
     /**
      * Tries to load config class with SPI first, then with class name directly from classpath
@@ -31,7 +29,7 @@ public class CodegenConfigLoader {
      * @return config class
      */
     public static CodegenConfig forName(String name) {
-        ServiceLoader<CodegenConfig> loader = load(CodegenConfig.class);
+        ServiceLoader<CodegenConfig> loader = ServiceLoader.load(CodegenConfig.class, CodegenConfig.class.getClassLoader());
 
         StringBuilder availableConfigs = new StringBuilder();
 
@@ -52,7 +50,7 @@ public class CodegenConfigLoader {
     }
 
     public static List<CodegenConfig> getAll() {
-        ServiceLoader<CodegenConfig> loader = ServiceLoader.load(CodegenConfig.class);
+        ServiceLoader<CodegenConfig> loader = ServiceLoader.load(CodegenConfig.class, CodegenConfig.class.getClassLoader());
         List<CodegenConfig> output = new ArrayList<CodegenConfig>();
         for (CodegenConfig aLoader : loader) {
             output.add(aLoader);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR fixes the service loader initializations for `CodegenConfig` so that the correct class loader is used, regardless of the thread's context class loader.

This essentially fixes an issue that occurs when calling `CodegenConfigurator.toClientOptInput` from a thread that doesn't use the same class loader which is used to load `openapi-generator` module (e.g. build tool plugins), and as a result, generator names cannot be specified.

There's still an issue with code generation itself but that is related to the `swagger-parser` module; I'll file another PR there to fix that as well.
