### PR TITLE
[jaxrs-spec] equals/hashCode methods in POJOs ignore parent variables

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -55,16 +55,17 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
-    }
-    {{classname}} {{classVarName}} = ({{classname}}) o;{{#hasVars}}
-    return {{#vars}}Objects.equals({{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{^hasMore}};{{/hasMore}}{{/vars}}{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+        {{/hasMore}}{{/vars}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}});
+    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(name, additionalPropertiesAnyType.name);
+    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -48,12 +48,13 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(name, additionalPropertiesArray.name);
+    return Objects.equals(this.name, additionalPropertiesArray.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(name, additionalPropertiesBoolean.name);
+    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -229,17 +229,17 @@ public class AdditionalPropertiesClass  implements Serializable {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(name, additionalPropertiesInteger.name);
+    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -48,12 +48,13 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(name, additionalPropertiesNumber.name);
+    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(name, additionalPropertiesObject.name);
+    return Objects.equals(this.name, additionalPropertiesObject.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(name, additionalPropertiesString.name);
+    return Objects.equals(this.name, additionalPropertiesString.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
@@ -66,8 +66,8 @@ public class Animal  implements Serializable {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(className, animal.className) &&
-        Objects.equals(color, animal.color);
+    return Objects.equals(this.className, animal.className) &&
+        Objects.equals(this.color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -48,7 +48,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -48,7 +48,7 @@ public class ArrayOfNumberOnly  implements Serializable {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -84,9 +84,9 @@ public class ArrayTest  implements Serializable {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
@@ -136,12 +136,12 @@ public class Capitalization  implements Serializable {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(smallCamel, capitalization.smallCamel) &&
-        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(smallSnake, capitalization.smallSnake) &&
-        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
+        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
+        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
@@ -46,12 +46,13 @@ public class Cat extends Animal implements Serializable {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(declawed, cat.declawed);
+    return Objects.equals(this.declawed, cat.declawed) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed);
+    return Objects.hash(declawed, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
@@ -64,8 +64,8 @@ public class Category  implements Serializable {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(id, category.id) &&
-        Objects.equals(name, category.name);
+    return Objects.equals(this.id, category.id) &&
+        Objects.equals(this.name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
@@ -47,7 +47,7 @@ public class ClassModel  implements Serializable {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(propertyClass, classModel.propertyClass);
+    return Objects.equals(this.propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
@@ -45,7 +45,7 @@ public class Client  implements Serializable {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(client, client.client);
+    return Objects.equals(this.client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
@@ -46,12 +46,13 @@ public class Dog extends Animal implements Serializable {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(breed, dog.breed);
+    return Objects.equals(this.breed, dog.breed) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed);
+    return Objects.hash(breed, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -131,8 +131,8 @@ public enum ArrayEnumEnum {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -251,11 +251,11 @@ public enum EnumNumberEnum {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(enumString, enumTest.enumString) &&
-        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(enumInteger, enumTest.enumInteger) &&
-        Objects.equals(enumNumber, enumTest.enumNumber) &&
-        Objects.equals(outerEnum, enumTest.outerEnum);
+    return Objects.equals(this.enumString, enumTest.enumString) &&
+        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
+        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
+        Objects.equals(this.outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -65,8 +65,8 @@ public class FileSchemaTestClass  implements Serializable {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(file, fileSchemaTestClass.file) &&
-        Objects.equals(files, fileSchemaTestClass.files);
+    return Objects.equals(this.file, fileSchemaTestClass.file) &&
+        Objects.equals(this.files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
@@ -280,19 +280,19 @@ public class FormatTest  implements Serializable {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(integer, formatTest.integer) &&
-        Objects.equals(int32, formatTest.int32) &&
-        Objects.equals(int64, formatTest.int64) &&
-        Objects.equals(number, formatTest.number) &&
-        Objects.equals(_float, formatTest._float) &&
-        Objects.equals(_double, formatTest._double) &&
-        Objects.equals(string, formatTest.string) &&
-        Objects.equals(_byte, formatTest._byte) &&
-        Objects.equals(binary, formatTest.binary) &&
-        Objects.equals(date, formatTest.date) &&
-        Objects.equals(dateTime, formatTest.dateTime) &&
-        Objects.equals(uuid, formatTest.uuid) &&
-        Objects.equals(password, formatTest.password);
+    return Objects.equals(this.integer, formatTest.integer) &&
+        Objects.equals(this.int32, formatTest.int32) &&
+        Objects.equals(this.int64, formatTest.int64) &&
+        Objects.equals(this.number, formatTest.number) &&
+        Objects.equals(this._float, formatTest._float) &&
+        Objects.equals(this._double, formatTest._double) &&
+        Objects.equals(this.string, formatTest.string) &&
+        Objects.equals(this._byte, formatTest._byte) &&
+        Objects.equals(this.binary, formatTest.binary) &&
+        Objects.equals(this.date, formatTest.date) &&
+        Objects.equals(this.dateTime, formatTest.dateTime) &&
+        Objects.equals(this.uuid, formatTest.uuid) &&
+        Objects.equals(this.password, formatTest.password);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -63,8 +63,8 @@ public class HasOnlyReadOnly  implements Serializable {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(foo, hasOnlyReadOnly.foo);
+    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(this.foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -135,10 +135,10 @@ public enum InnerEnum {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(directMap, mapTest.directMap) &&
-        Objects.equals(indirectMap, mapTest.indirectMap);
+    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(this.directMap, mapTest.directMap) &&
+        Objects.equals(this.indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -87,9 +87,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
@@ -65,8 +65,8 @@ public class Model200Response  implements Serializable {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(name, _200response.name) &&
-        Objects.equals(propertyClass, _200response.propertyClass);
+    return Objects.equals(this.name, _200response.name) &&
+        Objects.equals(this.propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -81,9 +81,9 @@ public class ModelApiResponse  implements Serializable {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(code, _apiResponse.code) &&
-        Objects.equals(type, _apiResponse.type) &&
-        Objects.equals(message, _apiResponse.message);
+    return Objects.equals(this.code, _apiResponse.code) &&
+        Objects.equals(this.type, _apiResponse.type) &&
+        Objects.equals(this.message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -47,7 +47,7 @@ public class ModelReturn  implements Serializable {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(_return, _return._return);
+    return Objects.equals(this._return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
@@ -102,10 +102,10 @@ public class Name  implements Serializable {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(name, name.name) &&
-        Objects.equals(snakeCase, name.snakeCase) &&
-        Objects.equals(property, name.property) &&
-        Objects.equals(_123number, name._123number);
+    return Objects.equals(this.name, name.name) &&
+        Objects.equals(this.snakeCase, name.snakeCase) &&
+        Objects.equals(this.property, name.property) &&
+        Objects.equals(this._123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -46,7 +46,7 @@ public class NumberOnly  implements Serializable {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(justNumber, numberOnly.justNumber);
+    return Objects.equals(this.justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -170,12 +170,12 @@ public enum StatusEnum {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(id, order.id) &&
-        Objects.equals(petId, order.petId) &&
-        Objects.equals(quantity, order.quantity) &&
-        Objects.equals(shipDate, order.shipDate) &&
-        Objects.equals(status, order.status) &&
-        Objects.equals(complete, order.complete);
+    return Objects.equals(this.id, order.id) &&
+        Objects.equals(this.petId, order.petId) &&
+        Objects.equals(this.quantity, order.quantity) &&
+        Objects.equals(this.shipDate, order.shipDate) &&
+        Objects.equals(this.status, order.status) &&
+        Objects.equals(this.complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -82,9 +82,9 @@ public class OuterComposite  implements Serializable {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(myNumber, outerComposite.myNumber) &&
-        Objects.equals(myString, outerComposite.myString) &&
-        Objects.equals(myBoolean, outerComposite.myBoolean);
+    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
+        Objects.equals(this.myString, outerComposite.myString) &&
+        Objects.equals(this.myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -175,12 +175,12 @@ public enum StatusEnum {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(id, pet.id) &&
-        Objects.equals(category, pet.category) &&
-        Objects.equals(name, pet.name) &&
-        Objects.equals(photoUrls, pet.photoUrls) &&
-        Objects.equals(tags, pet.tags) &&
-        Objects.equals(status, pet.status);
+    return Objects.equals(this.id, pet.id) &&
+        Objects.equals(this.category, pet.category) &&
+        Objects.equals(this.name, pet.name) &&
+        Objects.equals(this.photoUrls, pet.photoUrls) &&
+        Objects.equals(this.tags, pet.tags) &&
+        Objects.equals(this.status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -63,8 +63,8 @@ public class ReadOnlyFirst  implements Serializable {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(bar, readOnlyFirst.bar) &&
-        Objects.equals(baz, readOnlyFirst.baz);
+    return Objects.equals(this.bar, readOnlyFirst.bar) &&
+        Objects.equals(this.baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -45,7 +45,7 @@ public class SpecialModelName  implements Serializable {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
@@ -63,8 +63,8 @@ public class Tag  implements Serializable {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(id, tag.id) &&
-        Objects.equals(name, tag.name);
+    return Objects.equals(this.id, tag.id) &&
+        Objects.equals(this.name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -125,11 +125,11 @@ public class TypeHolderDefault  implements Serializable {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -125,11 +125,11 @@ public class TypeHolderExample  implements Serializable {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
@@ -172,14 +172,14 @@ public class User  implements Serializable {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(id, user.id) &&
-        Objects.equals(username, user.username) &&
-        Objects.equals(firstName, user.firstName) &&
-        Objects.equals(lastName, user.lastName) &&
-        Objects.equals(email, user.email) &&
-        Objects.equals(password, user.password) &&
-        Objects.equals(phone, user.phone) &&
-        Objects.equals(userStatus, user.userStatus);
+    return Objects.equals(this.id, user.id) &&
+        Objects.equals(this.username, user.username) &&
+        Objects.equals(this.firstName, user.firstName) &&
+        Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.email, user.email) &&
+        Objects.equals(this.password, user.password) &&
+        Objects.equals(this.phone, user.phone) &&
+        Objects.equals(this.userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
@@ -552,35 +552,35 @@ public class XmlItem  implements Serializable {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(attributeString, xmlItem.attributeString) &&
-        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(nameString, xmlItem.nameString) &&
-        Objects.equals(nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(nameArray, xmlItem.nameArray) &&
-        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(prefixString, xmlItem.prefixString) &&
-        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
+        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(this.nameString, xmlItem.nameString) &&
+        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(this.nameArray, xmlItem.nameArray) &&
+        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(this.prefixString, xmlItem.prefixString) &&
+        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(name, additionalPropertiesAnyType.name);
+    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -48,12 +48,13 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(name, additionalPropertiesArray.name);
+    return Objects.equals(this.name, additionalPropertiesArray.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(name, additionalPropertiesBoolean.name);
+    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -229,17 +229,17 @@ public class AdditionalPropertiesClass  implements Serializable {
       return false;
     }
     AdditionalPropertiesClass additionalPropertiesClass = (AdditionalPropertiesClass) o;
-    return Objects.equals(mapString, additionalPropertiesClass.mapString) &&
-        Objects.equals(mapNumber, additionalPropertiesClass.mapNumber) &&
-        Objects.equals(mapInteger, additionalPropertiesClass.mapInteger) &&
-        Objects.equals(mapBoolean, additionalPropertiesClass.mapBoolean) &&
-        Objects.equals(mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
-        Objects.equals(mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
-        Objects.equals(mapMapString, additionalPropertiesClass.mapMapString) &&
-        Objects.equals(mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
-        Objects.equals(anytype1, additionalPropertiesClass.anytype1) &&
-        Objects.equals(anytype2, additionalPropertiesClass.anytype2) &&
-        Objects.equals(anytype3, additionalPropertiesClass.anytype3);
+    return Objects.equals(this.mapString, additionalPropertiesClass.mapString) &&
+        Objects.equals(this.mapNumber, additionalPropertiesClass.mapNumber) &&
+        Objects.equals(this.mapInteger, additionalPropertiesClass.mapInteger) &&
+        Objects.equals(this.mapBoolean, additionalPropertiesClass.mapBoolean) &&
+        Objects.equals(this.mapArrayInteger, additionalPropertiesClass.mapArrayInteger) &&
+        Objects.equals(this.mapArrayAnytype, additionalPropertiesClass.mapArrayAnytype) &&
+        Objects.equals(this.mapMapString, additionalPropertiesClass.mapMapString) &&
+        Objects.equals(this.mapMapAnytype, additionalPropertiesClass.mapMapAnytype) &&
+        Objects.equals(this.anytype1, additionalPropertiesClass.anytype1) &&
+        Objects.equals(this.anytype2, additionalPropertiesClass.anytype2) &&
+        Objects.equals(this.anytype3, additionalPropertiesClass.anytype3);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(name, additionalPropertiesInteger.name);
+    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -48,12 +48,13 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(name, additionalPropertiesNumber.name);
+    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(name, additionalPropertiesObject.name);
+    return Objects.equals(this.name, additionalPropertiesObject.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -47,12 +47,13 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(name, additionalPropertiesString.name);
+    return Objects.equals(this.name, additionalPropertiesString.name) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(name, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
@@ -66,8 +66,8 @@ public class Animal  implements Serializable {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(className, animal.className) &&
-        Objects.equals(color, animal.color);
+    return Objects.equals(this.className, animal.className) &&
+        Objects.equals(this.color, animal.color);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -48,7 +48,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
       return false;
     }
     ArrayOfArrayOfNumberOnly arrayOfArrayOfNumberOnly = (ArrayOfArrayOfNumberOnly) o;
-    return Objects.equals(arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
+    return Objects.equals(this.arrayArrayNumber, arrayOfArrayOfNumberOnly.arrayArrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -48,7 +48,7 @@ public class ArrayOfNumberOnly  implements Serializable {
       return false;
     }
     ArrayOfNumberOnly arrayOfNumberOnly = (ArrayOfNumberOnly) o;
-    return Objects.equals(arrayNumber, arrayOfNumberOnly.arrayNumber);
+    return Objects.equals(this.arrayNumber, arrayOfNumberOnly.arrayNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -84,9 +84,9 @@ public class ArrayTest  implements Serializable {
       return false;
     }
     ArrayTest arrayTest = (ArrayTest) o;
-    return Objects.equals(arrayOfString, arrayTest.arrayOfString) &&
-        Objects.equals(arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
-        Objects.equals(arrayArrayOfModel, arrayTest.arrayArrayOfModel);
+    return Objects.equals(this.arrayOfString, arrayTest.arrayOfString) &&
+        Objects.equals(this.arrayArrayOfInteger, arrayTest.arrayArrayOfInteger) &&
+        Objects.equals(this.arrayArrayOfModel, arrayTest.arrayArrayOfModel);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
@@ -136,12 +136,12 @@ public class Capitalization  implements Serializable {
       return false;
     }
     Capitalization capitalization = (Capitalization) o;
-    return Objects.equals(smallCamel, capitalization.smallCamel) &&
-        Objects.equals(capitalCamel, capitalization.capitalCamel) &&
-        Objects.equals(smallSnake, capitalization.smallSnake) &&
-        Objects.equals(capitalSnake, capitalization.capitalSnake) &&
-        Objects.equals(scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
-        Objects.equals(ATT_NAME, capitalization.ATT_NAME);
+    return Objects.equals(this.smallCamel, capitalization.smallCamel) &&
+        Objects.equals(this.capitalCamel, capitalization.capitalCamel) &&
+        Objects.equals(this.smallSnake, capitalization.smallSnake) &&
+        Objects.equals(this.capitalSnake, capitalization.capitalSnake) &&
+        Objects.equals(this.scAETHFlowPoints, capitalization.scAETHFlowPoints) &&
+        Objects.equals(this.ATT_NAME, capitalization.ATT_NAME);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -46,12 +46,13 @@ public class Cat extends Animal implements Serializable {
       return false;
     }
     Cat cat = (Cat) o;
-    return Objects.equals(declawed, cat.declawed);
+    return Objects.equals(this.declawed, cat.declawed) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(declawed);
+    return Objects.hash(declawed, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
@@ -64,8 +64,8 @@ public class Category  implements Serializable {
       return false;
     }
     Category category = (Category) o;
-    return Objects.equals(id, category.id) &&
-        Objects.equals(name, category.name);
+    return Objects.equals(this.id, category.id) &&
+        Objects.equals(this.name, category.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
@@ -47,7 +47,7 @@ public class ClassModel  implements Serializable {
       return false;
     }
     ClassModel classModel = (ClassModel) o;
-    return Objects.equals(propertyClass, classModel.propertyClass);
+    return Objects.equals(this.propertyClass, classModel.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
@@ -45,7 +45,7 @@ public class Client  implements Serializable {
       return false;
     }
     Client client = (Client) o;
-    return Objects.equals(client, client.client);
+    return Objects.equals(this.client, client.client);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
@@ -46,12 +46,13 @@ public class Dog extends Animal implements Serializable {
       return false;
     }
     Dog dog = (Dog) o;
-    return Objects.equals(breed, dog.breed);
+    return Objects.equals(this.breed, dog.breed) &&
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(breed);
+    return Objects.hash(breed, super.hashCode());
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -131,8 +131,8 @@ public enum ArrayEnumEnum {
       return false;
     }
     EnumArrays enumArrays = (EnumArrays) o;
-    return Objects.equals(justSymbol, enumArrays.justSymbol) &&
-        Objects.equals(arrayEnum, enumArrays.arrayEnum);
+    return Objects.equals(this.justSymbol, enumArrays.justSymbol) &&
+        Objects.equals(this.arrayEnum, enumArrays.arrayEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -251,11 +251,11 @@ public enum EnumNumberEnum {
       return false;
     }
     EnumTest enumTest = (EnumTest) o;
-    return Objects.equals(enumString, enumTest.enumString) &&
-        Objects.equals(enumStringRequired, enumTest.enumStringRequired) &&
-        Objects.equals(enumInteger, enumTest.enumInteger) &&
-        Objects.equals(enumNumber, enumTest.enumNumber) &&
-        Objects.equals(outerEnum, enumTest.outerEnum);
+    return Objects.equals(this.enumString, enumTest.enumString) &&
+        Objects.equals(this.enumStringRequired, enumTest.enumStringRequired) &&
+        Objects.equals(this.enumInteger, enumTest.enumInteger) &&
+        Objects.equals(this.enumNumber, enumTest.enumNumber) &&
+        Objects.equals(this.outerEnum, enumTest.outerEnum);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -65,8 +65,8 @@ public class FileSchemaTestClass  implements Serializable {
       return false;
     }
     FileSchemaTestClass fileSchemaTestClass = (FileSchemaTestClass) o;
-    return Objects.equals(file, fileSchemaTestClass.file) &&
-        Objects.equals(files, fileSchemaTestClass.files);
+    return Objects.equals(this.file, fileSchemaTestClass.file) &&
+        Objects.equals(this.files, fileSchemaTestClass.files);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
@@ -280,19 +280,19 @@ public class FormatTest  implements Serializable {
       return false;
     }
     FormatTest formatTest = (FormatTest) o;
-    return Objects.equals(integer, formatTest.integer) &&
-        Objects.equals(int32, formatTest.int32) &&
-        Objects.equals(int64, formatTest.int64) &&
-        Objects.equals(number, formatTest.number) &&
-        Objects.equals(_float, formatTest._float) &&
-        Objects.equals(_double, formatTest._double) &&
-        Objects.equals(string, formatTest.string) &&
-        Objects.equals(_byte, formatTest._byte) &&
-        Objects.equals(binary, formatTest.binary) &&
-        Objects.equals(date, formatTest.date) &&
-        Objects.equals(dateTime, formatTest.dateTime) &&
-        Objects.equals(uuid, formatTest.uuid) &&
-        Objects.equals(password, formatTest.password);
+    return Objects.equals(this.integer, formatTest.integer) &&
+        Objects.equals(this.int32, formatTest.int32) &&
+        Objects.equals(this.int64, formatTest.int64) &&
+        Objects.equals(this.number, formatTest.number) &&
+        Objects.equals(this._float, formatTest._float) &&
+        Objects.equals(this._double, formatTest._double) &&
+        Objects.equals(this.string, formatTest.string) &&
+        Objects.equals(this._byte, formatTest._byte) &&
+        Objects.equals(this.binary, formatTest.binary) &&
+        Objects.equals(this.date, formatTest.date) &&
+        Objects.equals(this.dateTime, formatTest.dateTime) &&
+        Objects.equals(this.uuid, formatTest.uuid) &&
+        Objects.equals(this.password, formatTest.password);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -63,8 +63,8 @@ public class HasOnlyReadOnly  implements Serializable {
       return false;
     }
     HasOnlyReadOnly hasOnlyReadOnly = (HasOnlyReadOnly) o;
-    return Objects.equals(bar, hasOnlyReadOnly.bar) &&
-        Objects.equals(foo, hasOnlyReadOnly.foo);
+    return Objects.equals(this.bar, hasOnlyReadOnly.bar) &&
+        Objects.equals(this.foo, hasOnlyReadOnly.foo);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -135,10 +135,10 @@ public enum InnerEnum {
       return false;
     }
     MapTest mapTest = (MapTest) o;
-    return Objects.equals(mapMapOfString, mapTest.mapMapOfString) &&
-        Objects.equals(mapOfEnumString, mapTest.mapOfEnumString) &&
-        Objects.equals(directMap, mapTest.directMap) &&
-        Objects.equals(indirectMap, mapTest.indirectMap);
+    return Objects.equals(this.mapMapOfString, mapTest.mapMapOfString) &&
+        Objects.equals(this.mapOfEnumString, mapTest.mapOfEnumString) &&
+        Objects.equals(this.directMap, mapTest.directMap) &&
+        Objects.equals(this.indirectMap, mapTest.indirectMap);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -87,9 +87,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
       return false;
     }
     MixedPropertiesAndAdditionalPropertiesClass mixedPropertiesAndAdditionalPropertiesClass = (MixedPropertiesAndAdditionalPropertiesClass) o;
-    return Objects.equals(uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
-        Objects.equals(dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
-        Objects.equals(map, mixedPropertiesAndAdditionalPropertiesClass.map);
+    return Objects.equals(this.uuid, mixedPropertiesAndAdditionalPropertiesClass.uuid) &&
+        Objects.equals(this.dateTime, mixedPropertiesAndAdditionalPropertiesClass.dateTime) &&
+        Objects.equals(this.map, mixedPropertiesAndAdditionalPropertiesClass.map);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
@@ -65,8 +65,8 @@ public class Model200Response  implements Serializable {
       return false;
     }
     Model200Response _200response = (Model200Response) o;
-    return Objects.equals(name, _200response.name) &&
-        Objects.equals(propertyClass, _200response.propertyClass);
+    return Objects.equals(this.name, _200response.name) &&
+        Objects.equals(this.propertyClass, _200response.propertyClass);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -81,9 +81,9 @@ public class ModelApiResponse  implements Serializable {
       return false;
     }
     ModelApiResponse _apiResponse = (ModelApiResponse) o;
-    return Objects.equals(code, _apiResponse.code) &&
-        Objects.equals(type, _apiResponse.type) &&
-        Objects.equals(message, _apiResponse.message);
+    return Objects.equals(this.code, _apiResponse.code) &&
+        Objects.equals(this.type, _apiResponse.type) &&
+        Objects.equals(this.message, _apiResponse.message);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -47,7 +47,7 @@ public class ModelReturn  implements Serializable {
       return false;
     }
     ModelReturn _return = (ModelReturn) o;
-    return Objects.equals(_return, _return._return);
+    return Objects.equals(this._return, _return._return);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
@@ -102,10 +102,10 @@ public class Name  implements Serializable {
       return false;
     }
     Name name = (Name) o;
-    return Objects.equals(name, name.name) &&
-        Objects.equals(snakeCase, name.snakeCase) &&
-        Objects.equals(property, name.property) &&
-        Objects.equals(_123number, name._123number);
+    return Objects.equals(this.name, name.name) &&
+        Objects.equals(this.snakeCase, name.snakeCase) &&
+        Objects.equals(this.property, name.property) &&
+        Objects.equals(this._123number, name._123number);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -46,7 +46,7 @@ public class NumberOnly  implements Serializable {
       return false;
     }
     NumberOnly numberOnly = (NumberOnly) o;
-    return Objects.equals(justNumber, numberOnly.justNumber);
+    return Objects.equals(this.justNumber, numberOnly.justNumber);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -170,12 +170,12 @@ public enum StatusEnum {
       return false;
     }
     Order order = (Order) o;
-    return Objects.equals(id, order.id) &&
-        Objects.equals(petId, order.petId) &&
-        Objects.equals(quantity, order.quantity) &&
-        Objects.equals(shipDate, order.shipDate) &&
-        Objects.equals(status, order.status) &&
-        Objects.equals(complete, order.complete);
+    return Objects.equals(this.id, order.id) &&
+        Objects.equals(this.petId, order.petId) &&
+        Objects.equals(this.quantity, order.quantity) &&
+        Objects.equals(this.shipDate, order.shipDate) &&
+        Objects.equals(this.status, order.status) &&
+        Objects.equals(this.complete, order.complete);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -82,9 +82,9 @@ public class OuterComposite  implements Serializable {
       return false;
     }
     OuterComposite outerComposite = (OuterComposite) o;
-    return Objects.equals(myNumber, outerComposite.myNumber) &&
-        Objects.equals(myString, outerComposite.myString) &&
-        Objects.equals(myBoolean, outerComposite.myBoolean);
+    return Objects.equals(this.myNumber, outerComposite.myNumber) &&
+        Objects.equals(this.myString, outerComposite.myString) &&
+        Objects.equals(this.myBoolean, outerComposite.myBoolean);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -175,12 +175,12 @@ public enum StatusEnum {
       return false;
     }
     Pet pet = (Pet) o;
-    return Objects.equals(id, pet.id) &&
-        Objects.equals(category, pet.category) &&
-        Objects.equals(name, pet.name) &&
-        Objects.equals(photoUrls, pet.photoUrls) &&
-        Objects.equals(tags, pet.tags) &&
-        Objects.equals(status, pet.status);
+    return Objects.equals(this.id, pet.id) &&
+        Objects.equals(this.category, pet.category) &&
+        Objects.equals(this.name, pet.name) &&
+        Objects.equals(this.photoUrls, pet.photoUrls) &&
+        Objects.equals(this.tags, pet.tags) &&
+        Objects.equals(this.status, pet.status);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -63,8 +63,8 @@ public class ReadOnlyFirst  implements Serializable {
       return false;
     }
     ReadOnlyFirst readOnlyFirst = (ReadOnlyFirst) o;
-    return Objects.equals(bar, readOnlyFirst.bar) &&
-        Objects.equals(baz, readOnlyFirst.baz);
+    return Objects.equals(this.bar, readOnlyFirst.bar) &&
+        Objects.equals(this.baz, readOnlyFirst.baz);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -45,7 +45,7 @@ public class SpecialModelName  implements Serializable {
       return false;
     }
     SpecialModelName $specialModelName = (SpecialModelName) o;
-    return Objects.equals($specialPropertyName, $specialModelName.$specialPropertyName);
+    return Objects.equals(this.$specialPropertyName, $specialModelName.$specialPropertyName);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
@@ -63,8 +63,8 @@ public class Tag  implements Serializable {
       return false;
     }
     Tag tag = (Tag) o;
-    return Objects.equals(id, tag.id) &&
-        Objects.equals(name, tag.name);
+    return Objects.equals(this.id, tag.id) &&
+        Objects.equals(this.name, tag.name);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -125,11 +125,11 @@ public class TypeHolderDefault  implements Serializable {
       return false;
     }
     TypeHolderDefault typeHolderDefault = (TypeHolderDefault) o;
-    return Objects.equals(stringItem, typeHolderDefault.stringItem) &&
-        Objects.equals(numberItem, typeHolderDefault.numberItem) &&
-        Objects.equals(integerItem, typeHolderDefault.integerItem) &&
-        Objects.equals(boolItem, typeHolderDefault.boolItem) &&
-        Objects.equals(arrayItem, typeHolderDefault.arrayItem);
+    return Objects.equals(this.stringItem, typeHolderDefault.stringItem) &&
+        Objects.equals(this.numberItem, typeHolderDefault.numberItem) &&
+        Objects.equals(this.integerItem, typeHolderDefault.integerItem) &&
+        Objects.equals(this.boolItem, typeHolderDefault.boolItem) &&
+        Objects.equals(this.arrayItem, typeHolderDefault.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -125,11 +125,11 @@ public class TypeHolderExample  implements Serializable {
       return false;
     }
     TypeHolderExample typeHolderExample = (TypeHolderExample) o;
-    return Objects.equals(stringItem, typeHolderExample.stringItem) &&
-        Objects.equals(numberItem, typeHolderExample.numberItem) &&
-        Objects.equals(integerItem, typeHolderExample.integerItem) &&
-        Objects.equals(boolItem, typeHolderExample.boolItem) &&
-        Objects.equals(arrayItem, typeHolderExample.arrayItem);
+    return Objects.equals(this.stringItem, typeHolderExample.stringItem) &&
+        Objects.equals(this.numberItem, typeHolderExample.numberItem) &&
+        Objects.equals(this.integerItem, typeHolderExample.integerItem) &&
+        Objects.equals(this.boolItem, typeHolderExample.boolItem) &&
+        Objects.equals(this.arrayItem, typeHolderExample.arrayItem);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
@@ -172,14 +172,14 @@ public class User  implements Serializable {
       return false;
     }
     User user = (User) o;
-    return Objects.equals(id, user.id) &&
-        Objects.equals(username, user.username) &&
-        Objects.equals(firstName, user.firstName) &&
-        Objects.equals(lastName, user.lastName) &&
-        Objects.equals(email, user.email) &&
-        Objects.equals(password, user.password) &&
-        Objects.equals(phone, user.phone) &&
-        Objects.equals(userStatus, user.userStatus);
+    return Objects.equals(this.id, user.id) &&
+        Objects.equals(this.username, user.username) &&
+        Objects.equals(this.firstName, user.firstName) &&
+        Objects.equals(this.lastName, user.lastName) &&
+        Objects.equals(this.email, user.email) &&
+        Objects.equals(this.password, user.password) &&
+        Objects.equals(this.phone, user.phone) &&
+        Objects.equals(this.userStatus, user.userStatus);
   }
 
   @Override

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
@@ -552,35 +552,35 @@ public class XmlItem  implements Serializable {
       return false;
     }
     XmlItem xmlItem = (XmlItem) o;
-    return Objects.equals(attributeString, xmlItem.attributeString) &&
-        Objects.equals(attributeNumber, xmlItem.attributeNumber) &&
-        Objects.equals(attributeInteger, xmlItem.attributeInteger) &&
-        Objects.equals(attributeBoolean, xmlItem.attributeBoolean) &&
-        Objects.equals(wrappedArray, xmlItem.wrappedArray) &&
-        Objects.equals(nameString, xmlItem.nameString) &&
-        Objects.equals(nameNumber, xmlItem.nameNumber) &&
-        Objects.equals(nameInteger, xmlItem.nameInteger) &&
-        Objects.equals(nameBoolean, xmlItem.nameBoolean) &&
-        Objects.equals(nameArray, xmlItem.nameArray) &&
-        Objects.equals(nameWrappedArray, xmlItem.nameWrappedArray) &&
-        Objects.equals(prefixString, xmlItem.prefixString) &&
-        Objects.equals(prefixNumber, xmlItem.prefixNumber) &&
-        Objects.equals(prefixInteger, xmlItem.prefixInteger) &&
-        Objects.equals(prefixBoolean, xmlItem.prefixBoolean) &&
-        Objects.equals(prefixArray, xmlItem.prefixArray) &&
-        Objects.equals(prefixWrappedArray, xmlItem.prefixWrappedArray) &&
-        Objects.equals(namespaceString, xmlItem.namespaceString) &&
-        Objects.equals(namespaceNumber, xmlItem.namespaceNumber) &&
-        Objects.equals(namespaceInteger, xmlItem.namespaceInteger) &&
-        Objects.equals(namespaceBoolean, xmlItem.namespaceBoolean) &&
-        Objects.equals(namespaceArray, xmlItem.namespaceArray) &&
-        Objects.equals(namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
-        Objects.equals(prefixNsString, xmlItem.prefixNsString) &&
-        Objects.equals(prefixNsNumber, xmlItem.prefixNsNumber) &&
-        Objects.equals(prefixNsInteger, xmlItem.prefixNsInteger) &&
-        Objects.equals(prefixNsBoolean, xmlItem.prefixNsBoolean) &&
-        Objects.equals(prefixNsArray, xmlItem.prefixNsArray) &&
-        Objects.equals(prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
+    return Objects.equals(this.attributeString, xmlItem.attributeString) &&
+        Objects.equals(this.attributeNumber, xmlItem.attributeNumber) &&
+        Objects.equals(this.attributeInteger, xmlItem.attributeInteger) &&
+        Objects.equals(this.attributeBoolean, xmlItem.attributeBoolean) &&
+        Objects.equals(this.wrappedArray, xmlItem.wrappedArray) &&
+        Objects.equals(this.nameString, xmlItem.nameString) &&
+        Objects.equals(this.nameNumber, xmlItem.nameNumber) &&
+        Objects.equals(this.nameInteger, xmlItem.nameInteger) &&
+        Objects.equals(this.nameBoolean, xmlItem.nameBoolean) &&
+        Objects.equals(this.nameArray, xmlItem.nameArray) &&
+        Objects.equals(this.nameWrappedArray, xmlItem.nameWrappedArray) &&
+        Objects.equals(this.prefixString, xmlItem.prefixString) &&
+        Objects.equals(this.prefixNumber, xmlItem.prefixNumber) &&
+        Objects.equals(this.prefixInteger, xmlItem.prefixInteger) &&
+        Objects.equals(this.prefixBoolean, xmlItem.prefixBoolean) &&
+        Objects.equals(this.prefixArray, xmlItem.prefixArray) &&
+        Objects.equals(this.prefixWrappedArray, xmlItem.prefixWrappedArray) &&
+        Objects.equals(this.namespaceString, xmlItem.namespaceString) &&
+        Objects.equals(this.namespaceNumber, xmlItem.namespaceNumber) &&
+        Objects.equals(this.namespaceInteger, xmlItem.namespaceInteger) &&
+        Objects.equals(this.namespaceBoolean, xmlItem.namespaceBoolean) &&
+        Objects.equals(this.namespaceArray, xmlItem.namespaceArray) &&
+        Objects.equals(this.namespaceWrappedArray, xmlItem.namespaceWrappedArray) &&
+        Objects.equals(this.prefixNsString, xmlItem.prefixNsString) &&
+        Objects.equals(this.prefixNsNumber, xmlItem.prefixNsNumber) &&
+        Objects.equals(this.prefixNsInteger, xmlItem.prefixNsInteger) &&
+        Objects.equals(this.prefixNsBoolean, xmlItem.prefixNsBoolean) &&
+        Objects.equals(this.prefixNsArray, xmlItem.prefixNsArray) &&
+        Objects.equals(this.prefixNsWrappedArray, xmlItem.prefixNsWrappedArray);
   }
 
   @Override


### PR DESCRIPTION
### PR checklist
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
* fixed jaxrs-spec pojo template to include parent class properties in equals and hashCode methods
* fixes issue #2663 

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)