### PR TITLE
[typescript-rxjs] fix samples and invalid package.json

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/package.mustache
@@ -10,10 +10,10 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
-    "typescript": "^2.4"
+    "typescript": "^3.0.1"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
   "publishConfig":{

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/package.json
@@ -10,10 +10,10 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
-    "typescript": "^2.4"
+    "typescript": "^3.0.1"
   },
   "publishConfig":{
     "registry":"https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/package.json
@@ -5,17 +5,17 @@
   "author": "OpenAPI-Generator",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
-  "scripts" : {
+  "scripts": {
     "build": "tsc --outDir dist/",
     "prepare": "npm run build"
   },
   "dependencies": {
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
-    "typescript": "^2.4"
+    "typescript": "^3.0.1"
   },
-  "publishConfig":{
-    "registry":"https://skimdb.npmjs.com/registry"
+  "publishConfig": {
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fixes #2667 by increasing the min version of typescript to `^3.0.1` to be in sync with rxjs (https://github.com/ReactiveX/rxjs/blob/master/package.json#L241) and fixing invalid `package.json`.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)
