### PR TITLE
[TypeScript Angular] update ngpackagr version

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -22,7 +22,6 @@ import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.SemVer;
-import org.openapitools.codegen.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -267,7 +266,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         // Specific ng-packagr configuration
         if (ngVersion.atLeast("7.0.0")) {
             // compatible versions with typescript version
-            additionalProperties.put("ngPackagrVersion", "4.4.5");
+            additionalProperties.put("ngPackagrVersion", "5.1.0");
             additionalProperties.put("tsickleVersion", "0.34.0");
         } else if (ngVersion.atLeast("6.0.0")) {
             // compatible versions with typescript version
@@ -568,19 +567,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         String name = classname.substring(0, classname.length() - serviceSuffix.length());
         return toApiFilename(name);
     }
-
-    /*
-    private String getModelnameFromModelFilename(String filename) {
-        String name = filename.substring((modelPackage() + "/").length());
-        // Remove the file suffix and add the class suffix.
-        // This is needed because the model file suffix might not be the same as
-        // the model suffix.
-        if (modelFileSuffix.length() > 0) {
-            name = name.substring(0, name.length() - modelFileSuffix.length());
-        }
-        return camelize(name) + modelSuffix;
-    }
-    */
 
     @Override
     public String toModelName(String name) {

--- a/modules/openapi-generator/src/main/resources/typescript-angular/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/package.mustache
@@ -31,20 +31,19 @@
     "rxjs": "^{{rxjsVersion}}"
   },
   "devDependencies": {
+    "@angular/common": "^{{ngVersion}}",
+    "@angular/compiler": "^{{ngVersion}}",
     "@angular/compiler-cli": "^{{ngVersion}}",
     "@angular/core": "^{{ngVersion}}",
     "@angular/http": "^{{ngVersion}}",
-    "@angular/common": "^{{ngVersion}}",
-    "@angular/compiler": "^{{ngVersion}}",
     "@angular/platform-browser": "^{{ngVersion}}",{{#useNgPackagr}}
-    "ng-packagr": "^{{ngPackagrVersion}}",{{#useOldNgPackagr}}{{/useOldNgPackagr}}{{^useOldNgPackagr}}
-    "tsickle": "^{{tsickleVersion}}",{{/useOldNgPackagr}}{{/useNgPackagr}}
+    "ng-packagr": "^{{ngPackagrVersion}}",{{/useNgPackagr}}
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^{{rxjsVersion}}",
-    "zone.js": "^{{zonejsVersion}}",
-    "typescript": "{{{tsVersion}}}"
-  }{{#npmRepository}},{{/npmRepository}}
-{{#npmRepository}}
+    "rxjs": "^{{rxjsVersion}}",{{#useNgPackagr}}{{^useOldNgPackagr}}
+    "tsickle": "^{{tsickleVersion}}",{{/useOldNgPackagr}}{{/useNgPackagr}}
+    "typescript": "{{{tsVersion}}}",
+    "zone.js": "^{{zonejsVersion}}"
+  }{{#npmRepository}},
   "publishConfig": {
     "registry": "{{{npmRepository}}}"
   }

--- a/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
@@ -13,22 +13,20 @@
   "license": "Unlicense",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
-  "scripts" : {
+  "scripts": {
     "build": "tsc --outDir dist/",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "axios": "^0.18.0"
   },
-  "peerDependencies": {    
-  },
   "devDependencies": {
     "@types/node": "^8.0.9",
     "typescript": "^2.4"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
-  "publishConfig":{
-    "registry":"{{npmRepository}}"
+  "publishConfig": {
+    "registry": "{{npmRepository}}"
   }
 {{/npmRepository}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
@@ -13,8 +13,8 @@
     "typescript": "^2.4"
   }{{#npmRepository}},{{/npmRepository}}
 {{#npmRepository}}
-  "publishConfig":{
-    "registry":"{{npmRepository}}"
+  "publishConfig": {
+    "registry": "{{npmRepository}}"
   }
 {{/npmRepository}}
 }

--- a/samples/client/petstore/typescript-angular-v2/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v2/npm/package.json
@@ -24,16 +24,16 @@
     "rxjs": "^5.4.0"
   },
   "devDependencies": {
+    "@angular/common": "^2.0.0",
+    "@angular/compiler": "^2.0.0",
     "@angular/compiler-cli": "^2.0.0",
     "@angular/core": "^2.0.0",
     "@angular/http": "^2.0.0",
-    "@angular/common": "^2.0.0",
-    "@angular/compiler": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6",
-    "typescript": ">=2.1.5 <2.8.0"
+    "typescript": ">=2.1.5 <2.8.0",
+    "zone.js": "^0.7.6"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v4.3/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/package.json
@@ -21,17 +21,17 @@
     "rxjs": "^5.4.0"
   },
   "devDependencies": {
+    "@angular/common": "^4.3.0",
+    "@angular/compiler": "^4.3.0",
     "@angular/compiler-cli": "^4.3.0",
     "@angular/core": "^4.3.0",
     "@angular/http": "^4.3.0",
-    "@angular/common": "^4.3.0",
-    "@angular/compiler": "^4.3.0",
     "@angular/platform-browser": "^4.3.0",
     "ng-packagr": "^1.6.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6",
-    "typescript": ">=2.1.5 <2.8.0"
+    "typescript": ">=2.1.5 <2.8.0",
+    "zone.js": "^0.7.6"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v4/npm/package.json
+++ b/samples/client/petstore/typescript-angular-v4/npm/package.json
@@ -21,17 +21,17 @@
     "rxjs": "^5.4.0"
   },
   "devDependencies": {
+    "@angular/common": "^4.0.0",
+    "@angular/compiler": "^4.0.0",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/core": "^4.0.0",
     "@angular/http": "^4.0.0",
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
     "@angular/platform-browser": "^4.0.0",
     "ng-packagr": "^1.6.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.4.0",
-    "zone.js": "^0.7.6",
-    "typescript": ">=2.1.5 <2.8.0"
+    "typescript": ">=2.1.5 <2.8.0",
+    "zone.js": "^0.7.6"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/package.json
@@ -21,18 +21,18 @@
     "rxjs": "^6.1.0"
   },
   "devDependencies": {
+    "@angular/common": "^6.0.0",
+    "@angular/compiler": "^6.0.0",
     "@angular/compiler-cli": "^6.0.0",
     "@angular/core": "^6.0.0",
     "@angular/http": "^6.0.0",
-    "@angular/common": "^6.0.0",
-    "@angular/compiler": "^6.0.0",
     "@angular/platform-browser": "^6.0.0",
     "ng-packagr": "^3.0.6",
-    "tsickle": "^0.32.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
-    "zone.js": "^0.8.26",
-    "typescript": ">=2.7.2 and <2.10.0"
+    "tsickle": "^0.32.1",
+    "typescript": ">=2.7.2 and <2.10.0",
+    "zone.js": "^0.8.26"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/package.json
@@ -21,18 +21,18 @@
     "rxjs": "^6.1.0"
   },
   "devDependencies": {
+    "@angular/common": "^6.0.0",
+    "@angular/compiler": "^6.0.0",
     "@angular/compiler-cli": "^6.0.0",
     "@angular/core": "^6.0.0",
     "@angular/http": "^6.0.0",
-    "@angular/common": "^6.0.0",
-    "@angular/compiler": "^6.0.0",
     "@angular/platform-browser": "^6.0.0",
     "ng-packagr": "^3.0.6",
-    "tsickle": "^0.32.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.1.0",
-    "zone.js": "^0.8.26",
-    "typescript": ">=2.7.2 and <2.10.0"
+    "tsickle": "^0.32.1",
+    "typescript": ">=2.7.2 and <2.10.0",
+    "zone.js": "^0.8.26"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/package.json
@@ -21,18 +21,18 @@
     "rxjs": "^6.3.0"
   },
   "devDependencies": {
+    "@angular/common": "^7.0.0",
+    "@angular/compiler": "^7.0.0",
     "@angular/compiler-cli": "^7.0.0",
     "@angular/core": "^7.0.0",
     "@angular/http": "^7.0.0",
-    "@angular/common": "^7.0.0",
-    "@angular/compiler": "^7.0.0",
     "@angular/platform-browser": "^7.0.0",
-    "ng-packagr": "^4.4.5",
-    "tsickle": "^0.34.0",
+    "ng-packagr": "^5.1.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.3.0",
-    "zone.js": "^0.8.26",
-    "typescript": ">=3.1.1 <3.2.0"
+    "tsickle": "^0.34.0",
+    "typescript": ">=3.1.1 <3.2.0",
+    "zone.js": "^0.8.26"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/package.json
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/package.json
@@ -21,18 +21,18 @@
     "rxjs": "^6.3.0"
   },
   "devDependencies": {
+    "@angular/common": "^7.0.0",
+    "@angular/compiler": "^7.0.0",
     "@angular/compiler-cli": "^7.0.0",
     "@angular/core": "^7.0.0",
     "@angular/http": "^7.0.0",
-    "@angular/common": "^7.0.0",
-    "@angular/compiler": "^7.0.0",
     "@angular/platform-browser": "^7.0.0",
-    "ng-packagr": "^4.4.5",
-    "tsickle": "^0.34.0",
+    "ng-packagr": "^5.1.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^6.3.0",
-    "zone.js": "^0.8.26",
-    "typescript": ">=3.1.1 <3.2.0"
+    "tsickle": "^0.34.0",
+    "typescript": ">=3.1.1 <3.2.0",
+    "zone.js": "^0.8.26"
   },
   "publishConfig": {
     "registry": "https://skimdb.npmjs.com/registry"

--- a/samples/client/petstore/typescript-axios/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/package.json
@@ -13,20 +13,18 @@
   "license": "Unlicense",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
-  "scripts" : {
+  "scripts": {
     "build": "tsc --outDir dist/",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "axios": "^0.18.0"
   },
-  "peerDependencies": {    
-  },
   "devDependencies": {
     "@types/node": "^8.0.9",
     "typescript": "^2.4"
   },
-  "publishConfig":{
-    "registry":"https://skimdb.npmjs.com/registry"
+  "publishConfig": {
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
@@ -13,20 +13,18 @@
   "license": "Unlicense",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
-  "scripts" : {
+  "scripts": {
     "build": "tsc --outDir dist/",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "axios": "^0.18.0"
   },
-  "peerDependencies": {    
-  },
   "devDependencies": {
     "@types/node": "^8.0.9",
     "typescript": "^2.4"
   },
-  "publishConfig":{
-    "registry":"https://skimdb.npmjs.com/registry"
+  "publishConfig": {
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
@@ -13,20 +13,18 @@
   "license": "Unlicense",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
-  "scripts" : {
+  "scripts": {
     "build": "tsc --outDir dist/",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "axios": "^0.18.0"
   },
-  "peerDependencies": {    
-  },
   "devDependencies": {
     "@types/node": "^8.0.9",
     "typescript": "^2.4"
   },
-  "publishConfig":{
-    "registry":"https://skimdb.npmjs.com/registry"
+  "publishConfig": {
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "typescript": "^2.4"
   },
-  "publishConfig":{
-    "registry":"https://skimdb.npmjs.com/registry"
+  "publishConfig": {
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "typescript": "^2.4"
   },
-  "publishConfig":{
-    "registry":"https://skimdb.npmjs.com/registry"
+  "publishConfig": {
+    "registry": "https://skimdb.npmjs.com/registry"
   }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)


### Description of the PR

- update ng-packagr for angular 7 who don't use node-sass anymore (dependency vulnerability issue)
```
                       === npm audit security report ===                        
                                                                                
# Run  npm install --save-dev ng-packagr@5.1.0  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
                                                                                
  High            Arbitrary File Overwrite                                      
                                                                                
  Package         tar                                                           
                                                                                
  Dependency of   ng-packagr [dev]                                              
                                                                                
  Path            ng-packagr > node-sass > node-gyp > tar                       
                                                                                
  More info       https://nodesecurity.io/advisories/803         

```
the install and build of sample work as expected with latest ng-packagr

- improve some format and dependency order in package.json
