### PR TITLE
[typescript-fetch] Double ampersand in query string with empty nested object

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -198,6 +198,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
+        .filter(part => part.length > 0)
         .join('&');
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -209,6 +209,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
+        .filter(part => part.length > 0)
         .join('&');
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -209,6 +209,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
+        .filter(part => part.length > 0)
         .join('&');
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -209,6 +209,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
+        .filter(part => part.length > 0)
         .join('&');
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -209,6 +209,7 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
             }
             return `${encodeURIComponent(fullKey)}=${encodeURIComponent(String(value))}`;
         })
+        .filter(part => part.length > 0)
         .join('&');
 }
 


### PR DESCRIPTION
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

My previous pull request #2234 that introduced support for nested objects in query strings contains a bug where an empty nested object will lead to two ampersands (`&`) in a row.

This patch adds a filter to remove empty parts before joining them with ampersands.