### PR TITLE
Remove `-XX:MaxPermSize`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,8 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\gradle-bin.zip", "C:\gradle")
       }
   - cmd: SET PATH=C:\maven\apache-maven-3.2.5\bin;C:\gradle\gradle-5.3.1\bin;%JAVA_HOME%\bin;%PATH%
-  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=2g -Xmx4g
-  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: SET MAVEN_OPTS=-Xmx4g
+  - cmd: SET JAVA_OPTS=-Xmx4g
   - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
   - cmd: java -version
   - cmd: gradle -v

--- a/bin/ada-petstore.sh
+++ b/bin/ada-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 model="modules/openapi-generator/src/test/resources/2_0/petstore.yaml"
 ags="generate --template-dir modules/openapi-generator/src/main/resources/Ada -g ada $@"
 ags="$ags -i $model -t modules/openapi-generator/src/main/resources/Ada -o samples/client/petstore/ada"

--- a/bin/android-petstore-httpclient.sh
+++ b/bin/android-petstore-httpclient.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/android -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g android -Dlibrary=httpclient -o samples/client/petstore/android/httpclient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/android-petstore-volley.sh
+++ b/bin/android-petstore-volley.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g android -c bin/android-petstore-volley.json -o samples/client/petstore/android/volley $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/apache2-petstore-config.sh
+++ b/bin/apache2-petstore-config.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -g apache2 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/config/petstore/apache2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/apex-petstore.sh
+++ b/bin/apex-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/apex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g apex -o samples/client/petstore/apex $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/aspnetcore-petstore-server.sh
+++ b/bin/aspnetcore-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -g aspnetcore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/aspnetcore --additional-properties packageGuid={3C799344-F285-4669-8FD5-7ED9B795D5C5} $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/bash-petstore.sh
+++ b/bin/bash-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 args="generate -t modules/openapi-generator/src/main/resources/bash -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g bash -o samples/client/petstore/bash -c modules/openapi-generator/src/test/resources/2_0/bash-config.json --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/clojure-petstore.sh
+++ b/bin/clojure-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g clojure -o samples/client/petstore/clojure $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cpp-pistache-server-petstore.sh
+++ b/bin/cpp-pistache-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -g cpp-pistache-server -t modules/openapi-generator/src/main/resources/cpp-pistache-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml --additional-properties addExternalLibs=true -o samples/server/petstore/cpp-pistache $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cpp-qt5-petstore.sh
+++ b/bin/cpp-qt5-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-qt5-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g cpp-qt5-client -o samples/client/petstore/cpp-qt5 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cpp-qt5-qhttpengine-server-petstore.sh
+++ b/bin/cpp-qt5-qhttpengine-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g cpp-qt5-qhttpengine-server -o samples/server/petstore/cpp-qt5-qhttpengine-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cpp-restbed-petstore-server.sh
+++ b/bin/cpp-restbed-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -g cpp-restbed-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -o samples/server/petstore/cpp-restbed $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cpp-restsdk-petstore.sh
+++ b/bin/cpp-restsdk-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-rest-sdk-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g cpp-restsdk -o samples/client/petstore/cpp-restsdk $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cpp-tizen-petstore.sh
+++ b/bin/cpp-tizen-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-tizen-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g cpp-tizen -o samples/client/petstore/cpp-tizen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-dotnet2-petstore.sh
+++ b/bin/csharp-dotnet2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g csharp-dotnet2 -o samples/client/petstore/csharp-dotnet2/OpenAPIClientTest/Lib/OpenAPIClient --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-netcore-petstore-netcore.sh
+++ b/bin/csharp-netcore-petstore-netcore.sh
@@ -27,7 +27,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/csharp-netcore/ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp-netcore -o ${outdir} --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C},useCompareNetObjects=true,targetFramework=netcoreapp2.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-netcore-petstore.sh
+++ b/bin/csharp-netcore-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/csharp-netcore/ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp-netcore -o samples/client/petstore/csharp-netcore/OpenAPIClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C},useCompareNetObjects=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-net-35.sh
+++ b/bin/csharp-petstore-net-35.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientNet35 --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-35.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-net-40.sh
+++ b/bin/csharp-petstore-net-40.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientNet40 --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-40.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-net-standard.sh
+++ b/bin/csharp-petstore-net-standard.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientNetStandard --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-standard.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore-netcore-project.sh
+++ b/bin/csharp-petstore-netcore-project.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientNetCoreProject --additional-properties packageGuid={67035b31-f8e5-41a4-9673-954035084f7d},netCoreProjectFile=true -c ./bin/csharp-petstore-net-standard.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-petstore.sh
+++ b/bin/csharp-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/csharp-property-changed-petstore.sh
+++ b/bin/csharp-property-changed-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientWithPropertyChanged --additional-properties generatePropertyChanged=true --additional-properties packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5} $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/cwiki-petstore.sh
+++ b/bin/cwiki-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/confluenceWikiDocs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g cwiki -o samples/documentation/cwiki $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/dart-flutter-petstore.sh
+++ b/bin/dart-flutter-petstore.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 ## Generate non-browserClient
 #ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart/swagger -DhideGenerationTimestamp=true -DbrowserClient=false $@"

--- a/bin/dart-jaguar-petstore.sh
+++ b/bin/dart-jaguar-petstore.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate client
 ags="$@ generate -t modules/openapi-generator/src/main/resources/dart-jaguar -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart-jaguar -o samples/client/petstore/dart-jaguar/openapi -DhideGenerationTimestamp=true -DpubName=openapi"

--- a/bin/dart-petstore.sh
+++ b/bin/dart-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate non-browserClient
 ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart/openapi -DhideGenerationTimestamp=true -DbrowserClient=false --additional-properties supportDart2=false $@"

--- a/bin/dart2-petstore.sh
+++ b/bin/dart2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate non-browserClient
 ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/openapi -DhideGenerationTimestamp=true -DbrowserClient=false  $@"

--- a/bin/dynamic-html.sh
+++ b/bin/dynamic-html.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dynamic-html  -o samples/documentation/dynamic-html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/eiffel-petstore.sh
+++ b/bin/eiffel-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 args="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g eiffel -o samples/client/petstore/eiffel/ $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/elixir-petstore.sh
+++ b/bin/elixir-petstore.sh
@@ -31,7 +31,7 @@ rm -Rf "samples/client/petstore/elixir/lib/swagger_petstore/model/"
 rm -Rf "samples/client/petstore/elixir/lib/swagger_petstore/lib/"
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 args="generate -t modules/openapi-generator/src/main/resources/elixir -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g elixir -o samples/client/petstore/elixir/ --additional-properties invokerPackage=OpenapiPetstore $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/elm-0.18-petstore.sh
+++ b/bin/elm-0.18-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g elm -t modules/openapi-generator/src/main/resources/elm -o samples/client/petstore/elm-0.18 --additional-properties elmVersion=0.18 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/elm-petstore.sh
+++ b/bin/elm-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g elm -t modules/openapi-generator/src/main/resources/elm -o samples/client/petstore/elm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/erlang-petstore-client.sh
+++ b/bin/erlang-petstore-client.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/erlang-client -DpackageName=petstore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g erlang-client -o samples/client/petstore/erlang-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/erlang-petstore-proper.sh
+++ b/bin/erlang-petstore-proper.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/erlang-proper -DpackageName=petstore -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g erlang-proper -o samples/client/petstore/erlang-proper $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/erlang-petstore-server.sh
+++ b/bin/erlang-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/erlang-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g erlang-server -o samples/server/petstore/erlang-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/finch-petstore-server.sh
+++ b/bin/finch-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/finch -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-finch -o samples/server/petstore/finch $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/flash-petstore.sh
+++ b/bin/flash-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/flash -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g flash -o samples/client/petstore/flash -c bin/flash-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/go-gin-petstore-server.sh
+++ b/bin/go-gin-petstore-server.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 ags="generate -t modules/openapi-generator/src/main/resources/go-gin-server -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstoreserver --additional-properties hideGenerationTimestamp=true -Dservice $@"
 

--- a/bin/go-petstore-server.sh
+++ b/bin/go-petstore-server.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 ags="generate -t modules/openapi-generator/src/main/resources/go-server -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstoreserver --additional-properties hideGenerationTimestamp=true -Dservice $@"
 

--- a/bin/go-petstore-withxml.sh
+++ b/bin/go-petstore-withxml.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/go -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstore,withXml=true,withGoCodegenComment=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/go-petstore.sh
+++ b/bin/go-petstore.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/go -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstore $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/groovy-petstore.sh
+++ b/bin/groovy-petstore.sh
@@ -26,6 +26,6 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g groovy -o samples/client/petstore/groovy -DhideGenerationTimestamp=true $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/haskell-http-client-petstore.sh
+++ b/bin/haskell-http-client-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 args="generate -t modules/openapi-generator/src/main/resources/haskell-http-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g haskell-http-client -o samples/client/petstore/haskell-http-client $@"
 

--- a/bin/haskell-servant-petstore.sh
+++ b/bin/haskell-servant-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/haskell-servant -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g haskell -o samples/server/petstore/haskell-servant $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/html-markdown.sh
+++ b/bin/html-markdown.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/markdown.yaml -g html  -o samples/documentation/html.md $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/html-petstore.sh
+++ b/bin/html-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/htmlDocs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g html  -o samples/documentation/html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/html2-petstore.sh
+++ b/bin/html2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g html2  -o samples/documentation/html2 --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-inflector-petstore-server.sh
+++ b/bin/java-inflector-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaInflector -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java-inflector -o samples/server/petstore/java-inflector -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-msf4j-petstore-server.sh
+++ b/bin/java-msf4j-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/MSF4J -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java-msf4j -o samples/server/petstore/java-msf4j/ -DhideGenerationTimestamp=true --additional-properties artifactId=java-msf4j-server $@"
 
 echo "Removing files and folders under samples/server/petstore/java-msf4j/src/main"

--- a/bin/java-petstore-feign-10x.sh
+++ b/bin/java-petstore-feign-10x.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/feign -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-feign-10x.json -o samples/client/petstore/java/feign10x -DhideGenerationTimestamp=true -DbooleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/feign10x/src/main"

--- a/bin/java-petstore-feign.sh
+++ b/bin/java-petstore-feign.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/feign -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-feign-9x.json -o samples/client/petstore/java/feign -DhideGenerationTimestamp=true -DbooleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/feign/src/main"

--- a/bin/java-petstore-google-api-client.sh
+++ b/bin/java-petstore-google-api-client.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/google-api-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-google-api-client.json -o samples/client/petstore/java/google-api-client -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/google-api-client/src/main"

--- a/bin/java-petstore-jersey1.sh
+++ b/bin/java-petstore-jersey1.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-java-client-jersey1 -t modules/openapi-generator/src/main/resources/Java -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -o samples/client/petstore/java/jersey1 -DhideGenerationTimestamp=true --library=jersey1 --additional-properties useNullForUnknownEnumValue=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey1/src/main"

--- a/bin/java-petstore-jersey2-java6.sh
+++ b/bin/java-petstore-jersey2-java6.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-jersey2-java6 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java6 -DhideGenerationTimestamp=true,supportJava6=true,booleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2-java6/src/main"

--- a/bin/java-petstore-jersey2.sh
+++ b/bin/java-petstore-jersey2.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-jersey2.json -o samples/client/petstore/java/jersey2 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2/src/main"

--- a/bin/java-petstore-okhttp-gson-parcelable.sh
+++ b/bin/java-petstore-okhttp-gson-parcelable.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-okhttp-gson-parcelableModel -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore/java/okhttp-gson-parcelableModel -DhideGenerationTimestamp=true,parcelableModel=true $@"
 
 rm -rf samples/client/petstore/java/okhttp-gson-parcelableModel/src/main

--- a/bin/java-petstore-okhttp-gson.sh
+++ b/bin/java-petstore-okhttp-gson.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-okhttp-gson.json -o samples/client/petstore/java/okhttp-gson -DhideGenerationTimestamp=true $@"
 
 rm -rf samples/client/petstore/java/okhttp-gson/src/main

--- a/bin/java-petstore-rest-assured.sh
+++ b/bin/java-petstore-rest-assured.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/rest-assured -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-rest-assured.json -o samples/client/petstore/java/rest-assured -DhideGenerationTimestamp=true --additional-properties booleanGetterPrefix=is $@"
 
 echo "Removing files and folders under samples/client/petstore/java/rest-assured/src/main"

--- a/bin/java-petstore-resteasy.sh
+++ b/bin/java-petstore-resteasy.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-resteasy.json -o samples/client/petstore/java/resteasy -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/resteasy/src/main"

--- a/bin/java-petstore-resttemplate-withxml.sh
+++ b/bin/java-petstore-resttemplate-withxml.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml --artifact-id pestore-resttemplate-withxml -g java -c bin/java-petstore-resttemplate.json -o samples/client/petstore/java/resttemplate-withXml -DhideGenerationTimestamp=true,withXml=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/resttemplate/src/main"

--- a/bin/java-petstore-resttemplate.sh
+++ b/bin/java-petstore-resttemplate.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-resttemplate.json -o samples/client/petstore/java/resttemplate -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/resttemplate/src/main"

--- a/bin/java-petstore-retrofit.sh
+++ b/bin/java-petstore-retrofit.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit.json -o samples/client/petstore/java/retrofit -DhideGenerationTimestamp=true,dateLibrary=joda $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit/src/main"

--- a/bin/java-petstore-retrofit2-play24.sh
+++ b/bin/java-petstore-retrofit2-play24.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-java-client-retrofit2-play24 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit2-play24.json -o samples/client/petstore/java/retrofit2-play24 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2-play24/src/main"

--- a/bin/java-petstore-retrofit2-play25.sh
+++ b/bin/java-petstore-retrofit2-play25.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-java-client-retrofit2-play25 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit2-play25.json -o samples/client/petstore/java/retrofit2-play25 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2-play25/src/main"

--- a/bin/java-petstore-retrofit2-play26.sh
+++ b/bin/java-petstore-retrofit2-play26.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-java-client-retrofit2-play26 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit2-play26.json -o samples/client/petstore/java/retrofit2-play26 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2-play26/src/main"

--- a/bin/java-petstore-retrofit2.sh
+++ b/bin/java-petstore-retrofit2.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit2.json -o samples/client/petstore/java/retrofit2 -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2/src/main"

--- a/bin/java-petstore-retrofit2rx.sh
+++ b/bin/java-petstore-retrofit2rx.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit2rx.json -o samples/client/petstore/java/retrofit2rx -DuseRxJava=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2rx/src/main"

--- a/bin/java-petstore-retrofit2rx2.sh
+++ b/bin/java-petstore-retrofit2rx2.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/retrofit2 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-retrofit2rx2.json -o samples/client/petstore/java/retrofit2rx2 -DuseRxJava2=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/retrofit2rx2/src/main"

--- a/bin/java-petstore-vertx.sh
+++ b/bin/java-petstore-vertx.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Java/libraries/vertx -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-vertx.json -o samples/client/petstore/java/vertx -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/vertx/src/main"

--- a/bin/java-petstore-webclient.sh
+++ b/bin/java-petstore-webclient.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java-petstore-webclient.json -o samples/client/petstore/java/webclient -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/client/petstore/java/webclient/src/main"

--- a/bin/java-pkmst-petstore-server.sh
+++ b/bin/java-pkmst-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/java-pkmst -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-pkmst -o samples/server/petstore/java-pkmst/ -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/java-pkmst/src/main"

--- a/bin/java-play-framework-petstore-server-api-package-override.sh
+++ b/bin/java-play-framework-petstore-server-api-package-override.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-api-package-override -DhideGenerationTimestamp=true,apiPackage=com.puppies.store.apis $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-async.sh
+++ b/bin/java-play-framework-petstore-server-async.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -c bin/java-play-framework-petstore-server-async.json -o samples/server/petstore/java-play-framework-async -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-controller-only.sh
+++ b/bin/java-play-framework-petstore-server-controller-only.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-controller-only -DhideGenerationTimestamp=true,controllerOnly=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-fake-endpoints.sh
+++ b/bin/java-play-framework-petstore-server-fake-endpoints.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-fake-endpoints -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-no-bean-validation.sh
+++ b/bin/java-play-framework-petstore-server-no-bean-validation.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-no-bean-validation -DhideGenerationTimestamp=true,useBeanValidation=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-no-exception-handling.sh
+++ b/bin/java-play-framework-petstore-server-no-exception-handling.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-no-exception-handling -DhideGenerationTimestamp=true,handleExceptions=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-no-interface.sh
+++ b/bin/java-play-framework-petstore-server-no-interface.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-no-interface -DhideGenerationTimestamp=true,useInterfaces=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-no-swagger-ui.sh
+++ b/bin/java-play-framework-petstore-server-no-swagger-ui.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-no-swagger-ui -DhideGenerationTimestamp=true,useSwaggerUI=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server-no-wrap-calls.sh
+++ b/bin/java-play-framework-petstore-server-no-wrap-calls.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework-no-wrap-calls -DhideGenerationTimestamp=true,wrapCalls=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-play-framework-petstore-server.sh
+++ b/bin/java-play-framework-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaPlayFramework -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-play-framework -o samples/server/petstore/java-play-framework -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-undertow-petstore-server.sh
+++ b/bin/java-undertow-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/undertow -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-undertow-server -o samples/server/petstore/undertow --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-vertx-async-petstore-server.sh
+++ b/bin/java-vertx-async-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-vertx -o samples/server/petstore/java-vertx/async -DvertxSwaggerRouterVersion=1.4.0 -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java-vertx-rx-petstore-server.sh
+++ b/bin/java-vertx-rx-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g java-vertx --artifact-id java-vertx-rx-server -o samples/server/petstore/java-vertx/rx -DvertxSwaggerRouterVersion=1.4.0,rxInterface=true -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/java8-petstore-jersey2.sh
+++ b/bin/java8-petstore-jersey2.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id petstore-jersey2-java8 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g java -c bin/java8-petstore-jersey2.json -o samples/client/petstore/java/jersey2-java8 -DhideGenerationTimestamp=true --additional-properties serverPort=8082 $@"
 
 echo "Removing files and folders under samples/client/petstore/java/jersey2-java8/src/main"

--- a/bin/javascript-closure-angular.sh
+++ b/bin/javascript-closure-angular.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g javascript-closure-angular -o samples/client/petstore/javascript-closure-angular $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/javascript-es6-petstore.sh
+++ b/bin/javascript-es6-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Javascript/es6 \
 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g javascript \
 -o samples/client/petstore/javascript-es6 $@"

--- a/bin/javascript-flowtyped-petstore.sh
+++ b/bin/javascript-flowtyped-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Javascript-Flowtyped -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g javascript-flowtyped -o samples/client/petstore/javascript-flowtyped -DappName=PetstoreClient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/javascript-petstore.sh
+++ b/bin/javascript-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Javascript -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g javascript -o samples/client/petstore/javascript  -DappName=PetstoreClient --additional-properties useES6=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/javascript-promise-es6-petstore.sh
+++ b/bin/javascript-promise-es6-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Javascript/es6 \
 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g javascript \
 -o samples/client/petstore/javascript-promise-es6 \

--- a/bin/javascript-promise-petstore.sh
+++ b/bin/javascript-promise-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate \
 -t modules/openapi-generator/src/main/resources/Javascript \
 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml \

--- a/bin/jaxrs-cxf-cdi-petstore-server.sh
+++ b/bin/jaxrs-cxf-cdi-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-cxf-cdi -o samples/server/petstore/jaxrs-cxf-cdi -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-client-petstore.sh
+++ b/bin/jaxrs-cxf-client-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id "jaxrs-cxf-petstore-client" -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/ -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-cxf-client -o samples/client/petstore/jaxrs-cxf-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server-annotated-base-path.sh
+++ b/bin/jaxrs-cxf-petstore-server-annotated-base-path.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id cxf-annotated-basepath -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-cxf -o samples/server/petstore/jaxrs-cxf-annotated-base-path -DhideGenerationTimestamp=true,useAnnotatedBasePath=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server-non-spring-application.sh
+++ b/bin/jaxrs-cxf-petstore-server-non-spring-application.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id cxf-server-non-spring -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-cxf -o samples/server/petstore/jaxrs-cxf-non-spring-app -DhideGenerationTimestamp=true,generateNonSpringApplication=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server-test-data.sh
+++ b/bin/jaxrs-cxf-petstore-server-test-data.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id cxf-test-data -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-cxf-extended -o samples/server/petstore/jaxrs-cxf-test-data -DhideGenerationTimestamp=true -DuseAnnotatedBasePath=true --generate-alias-as-model --additional-properties java8=true,generateSpringApplication=true,generateSpringBootApplication=true,generateOperationBody=true,loadTestDataFromFile=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-cxf-petstore-server.sh
+++ b/bin/jaxrs-cxf-petstore-server.sh
@@ -29,7 +29,7 @@ echo "Removing files and folders under samples/server/petstore/jaxrs-cxf"
 rm -rf samples/server/petstore/jaxrs-cxf
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-cxf -o samples/server/petstore/jaxrs-cxf -DhideGenerationTimestamp=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-jersey1-petstore-server.sh
+++ b/bin/jaxrs-jersey1-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1 -DhideGenerationTimestamp=true,serverPort=8082 --library=jersey1 --artifact-id=jaxrs-jersey1-server $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1/src/main"

--- a/bin/jaxrs-jersey1-usetags-petstore-server.sh
+++ b/bin/jaxrs-jersey1-usetags-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-jersey -o samples/server/petstore/jaxrs/jersey1-useTags -DhideGenerationTimestamp=true,serverPort=8082 --library=jersey1 --artifact-id=jaxrs-jersey1-useTags --additional-properties useTags=true $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey1-useTags/src/main"

--- a/bin/jaxrs-petstore-server-datelib-j8.sh
+++ b/bin/jaxrs-petstore-server-datelib-j8.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/ -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-jersey -o samples/server/petstore/jaxrs-datelib-j8/ -c ./bin/jaxrs-datelib-j8.json -DhideGenerationTimestamp=true --additional-properties serverPort=8082 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-petstore-server.sh
+++ b/bin/jaxrs-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-jersey-petstore-server -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2 -DhideGenerationTimestamp=true,serverPort=8082 $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2/src/main"

--- a/bin/jaxrs-resteasy-eap-java8-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-java8-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-resteasy-eap-java8-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-java8 -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-java8-petstore-server.json $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap-java8/src/main"

--- a/bin/jaxrs-resteasy-eap-joda-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-joda-petstore-server.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-resteasy-eap-joda-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap-joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-eap-joda-petstore-server.json $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap-joda/src/main"

--- a/bin/jaxrs-resteasy-eap-petstore-server.sh
+++ b/bin/jaxrs-resteasy-eap-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/eap -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-resteasy-eap -o samples/server/petstore/jaxrs-resteasy/eap -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs-resteasy/eap/src/main"

--- a/bin/jaxrs-resteasy-joda-petstore-server.sh
+++ b/bin/jaxrs-resteasy-joda-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-resteasy-joda-server -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-resteasy -o samples/server/petstore/jaxrs-resteasy/joda -DhideGenerationTimestamp=true -c ./bin/jaxrs-resteasy-joda-petstore-server.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-resteasy-petstore-server.sh
+++ b/bin/jaxrs-resteasy-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jaxrs-resteasy -o samples/server/petstore/jaxrs-resteasy/default -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/jaxrs-spec-petstore-server-interface-returning-response.sh
+++ b/bin/jaxrs-spec-petstore-server-interface-returning-response.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-spec-interface-response-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-spec -o samples/server/petstore/jaxrs-spec-interface-response
 -DhideGenerationTimestamp=true
 -DserializableModel=true

--- a/bin/jaxrs-spec-petstore-server-interface.sh
+++ b/bin/jaxrs-spec-petstore-server-interface.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-spec-interface-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-spec -o samples/server/petstore/jaxrs-spec-interface
 -DhideGenerationTimestamp=true
 -DserializableModel=true

--- a/bin/jaxrs-spec-petstore-server.sh
+++ b/bin/jaxrs-spec-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id jaxrs-spec-petstore-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-spec -o samples/server/petstore/jaxrs-spec
 -DhideGenerationTimestamp=true
 -DserializableModel=true $@"

--- a/bin/jaxrs-usetags-petstore-server.sh
+++ b/bin/jaxrs-usetags-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaJaxRS -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-jersey -o samples/server/petstore/jaxrs/jersey2-useTags -DhideGenerationTimestamp=true,serverPort=8082 --artifact-id=jaxrs-jersey2-useTags --additional-properties useTags=true $@"
 
 echo "Removing files and folders under samples/server/petstore/jaxrs/jersey2-useTags/src/main"

--- a/bin/jmeter-petstore.sh
+++ b/bin/jmeter-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g jmeter -o samples/client/petstore/jmeter/ $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/kotlin-client-petstore.sh
+++ b/bin/kotlin-client-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/kotlin-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g kotlin --artifact-id kotlin-petstore-client -D dateLibrary=java8 -o samples/client/petstore/kotlin $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/bin/kotlin-client-string.sh
+++ b/bin/kotlin-client-string.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/kotlin-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g kotlin --artifact-id kotlin-petstore-string -D dateLibrary=string -o samples/client/petstore/kotlin-string $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/bin/kotlin-client-threetenbp.sh
+++ b/bin/kotlin-client-threetenbp.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/kotlin-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g kotlin --artifact-id kotlin-petstore-threetenbp -D dateLibrary=threetenbp -o samples/client/petstore/kotlin-threetenbp $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/bin/kotlin-server-petstore.sh
+++ b/bin/kotlin-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-server -g kotlin-server --library=ktor -o samples/server/petstore/kotlin-server/ktor -DhideGenerationTimestamp=true $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/bin/kotlin-springboot-petstore-server.sh
+++ b/bin/kotlin-springboot-petstore-server.sh
@@ -25,7 +25,7 @@ then
   mvn clean package
 fi
 
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-spring -g kotlin-spring -o samples/server/petstore/kotlin-springboot --additional-properties=library=spring-boot,beanValidations=true,swaggerAnnotations=true,serviceImplementation=true"
 
 echo "Cleaning previously generated files if any from samples/server/petstore/kotlin-springboot"

--- a/bin/lua-petstore.sh
+++ b/bin/lua-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties $@"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties $@"
 ags="generate -t modules/openapi-generator/src/main/resources/lua -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g lua -o samples/client/petstore/lua -DpackageName=petstore $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/meta-codegen.sh
+++ b/bin/meta-codegen.sh
@@ -25,7 +25,7 @@ then
   mvn -B clean package
 fi
 
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="meta -n myClientCodegen -t DOCUMENTATION -p com.my.company.codegen -o samples/meta-codegen/lib $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nancyfx-petstore-server-async.sh
+++ b/bin/nancyfx-petstore-server-async.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/csharp-nancyfx -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g csharp-nancyfx -o samples/server/petstore/nancyfx-async --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4},asyncServer=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nancyfx-petstore-server.sh
+++ b/bin/nancyfx-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/csharp-nancyfx -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g csharp-nancyfx -o samples/server/petstore/nancyfx --additional-properties packageGuid={768B8DC6-54EE-4D40-9B20-7857E1D742A4},asyncServer=false $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nodejs-petstore-google-cloud-functions.sh
+++ b/bin/nodejs-petstore-google-cloud-functions.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/nodejs-petstore-server.sh
+++ b/bin/nodejs-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/nodejs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g nodejs-server -o samples/server/petstore/nodejs -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/objc-petstore-coredata.sh
+++ b/bin/objc-petstore-coredata.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -c bin/objc-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/objc-petstore.sh
+++ b/bin/objc-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g objc -o samples/client/petstore/objc/default -c ./bin/objc-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/android-petstore-httpclient.sh
+++ b/bin/openapi3/android-petstore-httpclient.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/android -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g android -Dlibrary=httpclient -o samples/client/petstore/android/httpclient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/android-petstore-volley.sh
+++ b/bin/openapi3/android-petstore-volley.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g android -c bin/android-petstore-volley.json -o samples/client/petstore/android/volley $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/bash-petstore.sh
+++ b/bin/openapi3/bash-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 args="generate -t modules/openapi-generator/src/main/resources/bash -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g bash -o samples/client/petstore/bash -c modules/openapi-generator/src/test/resources/3_0/bash-config.json --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/openapi3/clojure-petstore.sh
+++ b/bin/openapi3/clojure-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.json -g clojure -o samples/client/petstore/clojure $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/cpp-pistache-server-petstore.sh
+++ b/bin/openapi3/cpp-pistache-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -g cpp-pistache-server -t modules/openapi-generator/src/main/resources/cpp-pistache-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o samples/server/petstore/cpp-pistache $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/cpp-qt5-petstore.sh
+++ b/bin/openapi3/cpp-qt5-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-qt5-client -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g cpp-qt5-client -o samples/client/petstore/cpp-qt5 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/cpp-qt5-qhttpengine-server-petstore.sh
+++ b/bin/openapi3/cpp-qt5-qhttpengine-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g cpp-qt5-qhttpengine-server -o samples/client/petstore/cpp-qt5-qhttpengine-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/cpp-restbed-petstore-server.sh
+++ b/bin/openapi3/cpp-restbed-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -g cpp-restbed-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o samples/server/petstore/cpp-restbed $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/cpp-tizen-petstore.sh
+++ b/bin/openapi3/cpp-tizen-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/cpp-tizen-client -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g cpp-tizen -o samples/client/petstore/cpp-tizen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/csharp-dotnet2-petstore.sh
+++ b/bin/openapi3/csharp-dotnet2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g csharp-dotnet2 -o samples/client/petstore/csharp-dotnet2/OpenAPIClientTest/Lib/OpenAPIClient --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/csharp-petstore-net-standard.sh
+++ b/bin/openapi3/csharp-petstore-net-standard.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate $@ -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientNetStandard --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C} -c ./bin/csharp-petstore-net-standard.json"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/csharp-petstore.sh
+++ b/bin/openapi3/csharp-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate $@ -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/openapi3/client/petstore/csharp/OpenAPIClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/csharp-property-changed-petstore.sh
+++ b/bin/openapi3/csharp-property-changed-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate $@ -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples/client/petstore/csharp/OpenAPIClientWithPropertyChanged --additional-properties generatePropertyChanged=true --additional-properties packageGuid={5CD900DE-8266-412F-A758-28E1F9C623D5}"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/dart-petstore.sh
+++ b/bin/openapi3/dart-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate non-browserClient
 ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g dart -o samples/client/petstore/dart/openapi -DhideGenerationTimestamp=true -DbrowserClient=false $@"

--- a/bin/openapi3/dynamic-html.sh
+++ b/bin/openapi3/dynamic-html.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g dynamic-html  -o samples/dynamic-html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/elixir-petstore.sh
+++ b/bin/openapi3/elixir-petstore.sh
@@ -31,7 +31,7 @@ rm -Rf "samples/client/petstore/elixir/lib/swagger_petstore/model/"
 rm -Rf "samples/client/petstore/elixir/lib/swagger_petstore/lib/"
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 args="generate -t modules/openapi-generator/src/main/resources/elixir -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g elixir -o samples/client/petstore/elixir/ $@"
 
 java $JAVA_OPTS -jar $executable $args

--- a/bin/openapi3/elm-petstore.sh
+++ b/bin/openapi3/elm-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g elm -t modules/openapi-generator/src/main/resources/elm -o samples/openapi3/client/petstore/elm --additional-properties elmPrefixCustomTypeVariants=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/erlang-petstore-client.sh
+++ b/bin/openapi3/erlang-petstore-client.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/erlang-client -DpackageName=petstore -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g erlang-client -o samples/client/petstore/erlang-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/erlang-petstore-server.sh
+++ b/bin/openapi3/erlang-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/erlang-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g erlang-server -o samples/server/petstore/erlang-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/finch-petstore-server.sh
+++ b/bin/openapi3/finch-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate $@ -t modules/openapi-generator/src/main/resources/finch -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g scala-finch -o samples/server/petstore/finch"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/flash-petstore.sh
+++ b/bin/openapi3/flash-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/flash -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g flash -o samples/client/petstore/flash -c bin/flash-petstore.json $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/go-gin-petstore-server.sh
+++ b/bin/openapi3/go-gin-petstore-server.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 ags="generate -t modules/openapi-generator/src/main/resources/go-gin-server -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstoreserver --additional-properties hideGenerationTimestamp=true -Dservice $@"
 

--- a/bin/openapi3/go-petstore-server.sh
+++ b/bin/openapi3/go-petstore-server.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 ags="generate -t modules/openapi-generator/src/main/resources/go-server -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstoreserver --additional-properties hideGenerationTimestamp=true -Dservice $@"
 

--- a/bin/openapi3/go-petstore.sh
+++ b/bin/openapi3/go-petstore.sh
@@ -33,7 +33,7 @@ echo "Removing files and folders under $STUB_DIR"
 rm -rf $STUB_DIR
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/go -i $SPEC -g $GENERATOR -o $STUB_DIR -DpackageName=petstore $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/groovy-petstore.sh
+++ b/bin/openapi3/groovy-petstore.sh
@@ -26,6 +26,6 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g groovy -o samples/client/petstore/groovy -DhideGenerationTimestamp=true $@"
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/haskell-http-client-petstore.sh
+++ b/bin/openapi3/haskell-http-client-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 args="generate -t modules/openapi-generator/src/main/resources/haskell-http-client -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g haskell-http-client -o samples/client/petstore/haskell-http-client $@"
 

--- a/bin/openapi3/haskell-servant-petstore.sh
+++ b/bin/openapi3/haskell-servant-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/haskell-servant -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g haskell -o samples/server/petstore/haskell-servant $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/html-petstore.sh
+++ b/bin/openapi3/html-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g html  -o samples/html $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/html2-petstore.sh
+++ b/bin/openapi3/html2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g html2  -o samples/html2 --additional-properties hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/javascript-closure-angular.sh
+++ b/bin/openapi3/javascript-closure-angular.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g javascript-closure-angular -o samples/client/petstore/javascript-closure-angular $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/javascript-es6-petstore.sh
+++ b/bin/openapi3/javascript-es6-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/Javascript/es6 \
 -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g javascript \
 -o samples/openapi3/client/petstore/javascript-es6 $@"

--- a/bin/openapi3/jaxrs-cxf-client-petstore.sh
+++ b/bin/openapi3/jaxrs-cxf-client-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id "jaxrs-cxf-petstore-client" -t modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/ -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g jaxrs-cxf-client -o samples/client/petstore/jaxrs-cxf-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/jaxrs-jersey-petstore.sh
+++ b/bin/openapi3/jaxrs-jersey-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id "openapiv3-jaxrs-jersey-petstore-server" -t modules/openapi-generator/src/main/resources/JavaJaxRS/ -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g jaxrs-jersey -o samples/server/petstore/jaxrs-jersey -DhideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/kotlin-client-petstore.sh
+++ b/bin/openapi3/kotlin-client-petstore.sh
@@ -25,7 +25,7 @@ then
   mvn clean package
 fi
 
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -t modules/openapi-generator/src/main/resources/kotlin-client -g kotlin --artifact-id kotlin-petstore-client -D dateLibrary=java8 -o samples/openapi3/client/petstore/kotlin $@"
 
 echo "Cleaning previously generated files if any from samples/openapi3/client/petstore/kotlin"

--- a/bin/openapi3/kotlin-springboot-petstore-server.sh
+++ b/bin/openapi3/kotlin-springboot-petstore-server.sh
@@ -25,7 +25,7 @@ then
   mvn clean package
 fi
 
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="$@ generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -t modules/openapi-generator/src/main/resources/kotlin-spring -g kotlin-spring -o samples/server/openapi3/petstore/kotlin-springboot --additional-properties=library=spring-boot,beanValidations=true,swaggerAnnotations=true,serviceImplementation=true"
 
 echo "Cleaning previously generated files if any from samples/server/openapi3/petstore/kotlin-springboot"

--- a/bin/openapi3/lua-petstore.sh
+++ b/bin/openapi3/lua-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/lua -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g lua -o samples/client/petstore/lua -DpackageName=petstore $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/nodejs-petstore-google-cloud-functions.sh
+++ b/bin/openapi3/nodejs-petstore-google-cloud-functions.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g nodejs-server --additional-properties=googleCloudFunctions=true -o samples/server/petstore/nodejs-google-cloud-functions -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/nodejs-petstore-server.sh
+++ b/bin/openapi3/nodejs-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/nodejs -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g nodejs-server -o samples/server/petstore/nodejs -Dservice $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/objc-petstore-coredata.sh
+++ b/bin/openapi3/objc-petstore-coredata.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/3_0/petstore.json -g objc -D apiDocs=false -D modelDocs=false -o samples/client/petstore/objc/core-data --additional-properties coreData=true -D appName=PetstoreClient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/objc-petstore.sh
+++ b/bin/openapi3/objc-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/objc -i modules/openapi-generator/src/test/resources/3_0/petstore.json -g objc -o samples/client/petstore/objc/default -D appName=PetstoreClient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/perl-petstore.sh
+++ b/bin/openapi3/perl-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
 ags="generate -t modules/openapi-generator/src/main/resources/perl -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml  -g perl -o samples/client/petstore/perl -DhideGenerationTimestamp=true $@"
 

--- a/bin/openapi3/php-laravel-petstore.sh
+++ b/bin/openapi3/php-laravel-petstore.sh
@@ -36,7 +36,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t $SCRIPT_DIR/../../modules/openapi-generator/src/main/resources/php-laravel -i $SCRIPT_DIR/../../modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-laravel -o $TARGET_DIR $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-lumen-petstore-server.sh
+++ b/bin/openapi3/php-lumen-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-lumen -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php-lumen -o samples/server/petstore/php-lumen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-petstore.sh
+++ b/bin/openapi3/php-petstore.sh
@@ -32,7 +32,7 @@ if [ -d $TEST_DIR ]; then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php -o samples/openapi3/client/petstore/php/OpenAPIClient-php $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-silex-petstore-server.sh
+++ b/bin/openapi3/php-silex-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-silex -o samples/server/petstore/php-silex/OpenAPIServer $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-slim-server-petstore.sh
+++ b/bin/openapi3/php-slim-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-slim-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-slim -o samples/server/petstore/php-slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-symfony-petstore.sh
+++ b/bin/openapi3/php-symfony-petstore.sh
@@ -36,7 +36,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t $SCRIPT_DIR/../../modules/openapi-generator/src/main/resources/php-symfony -i $SCRIPT_DIR/../../modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-symfony -o $TARGET_DIR $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/php-ze-ph-petstore-server.sh
+++ b/bin/openapi3/php-ze-ph-petstore-server.sh
@@ -30,7 +30,7 @@ out_folder=samples/server/openapi3/petstore/php-ze-ph
 resources=modules/openapi-generator/src/main/resources/ze-ph
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t $resources -i $input -g php-ze-ph -o $out_folder $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/powershell-petstore.sh
+++ b/bin/openapi3/powershell-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/powershell -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g powershell -o samples/client/petstore/powershell --additional-properties packageGuid=a27b908d-2a20-467f-bc32-af6f3a654ac5,csharpClientPath=\$ScriptDir\..\..\petstore\csharp\OpenAPIClient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/python-petstore.sh
+++ b/bin/openapi3/python-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g python -o samples/openapi3/client/petstore/python/ -DpackageName=petstore_api $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/r-petstore.sh
+++ b/bin/openapi3/r-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/r -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g r -o samples/client/petstore/R -DpackageName=petstore $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/ruby-client-petstore.sh
+++ b/bin/openapi3/ruby-client-petstore.sh
@@ -37,7 +37,7 @@ find samples/openapi3/client/petstore/ruby/spec -type d -not -name spec -not -na
 find samples/openapi3/client/petstore/ruby/spec -type f -not -name petstore_helper.rb -not -iwholename '*/spec/custom/*' | xargs rm -Rf
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-client -i modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml -g ruby -c bin/ruby-petstore.json -o samples/openapi3/client/petstore/ruby -DskipFormModel=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/ruby-on-rails-server-petstore.sh
+++ b/bin/openapi3/ruby-on-rails-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-on-rails-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g ruby-on-rails -o samples/server/petstore/ruby-on-rails $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/ruby-sinatra-server-petstore.sh
+++ b/bin/openapi3/ruby-sinatra-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-sinatra-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g ruby-sinatra -o samples/server/petstore/ruby-sinatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/rust-petstore.sh
+++ b/bin/openapi3/rust-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/rust -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g rust -o samples/client/petstore/rust -DpackageName=petstore_client $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/bin/openapi3/scala-akka-petstore.sh
+++ b/bin/openapi3/scala-akka-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id "scala-akka-petstore-client" -t modules/openapi-generator/src/main/resources/scala-akka-client -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g akka-scala -o samples/client/petstore/scala-akka $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/scala-httpclient-petstore.sh
+++ b/bin/openapi3/scala-httpclient-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scala-httpclient -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g scala -o samples/client/petstore/scala-httpclient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/scalatra-petstore-server.sh
+++ b/bin/openapi3/scalatra-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scalatra -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g scalatra -o samples/server/petstore/scalatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/scalaz-petstore.sh
+++ b/bin/openapi3/scalaz-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scalaz -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g scalaz -o samples/client/petstore/scalaz $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-petstore-all.sh
+++ b/bin/openapi3/typescript-angular-petstore-all.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript Petstore API client (default)"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v2/default --additional-properties ngVersion=2 $@"

--- a/bin/openapi3/typescript-angular-v2-petstore-interfaces.sh
+++ b/bin/openapi3/typescript-angular-v2-petstore-interfaces.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v2-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-angular-v2-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v2-petstore.sh
+++ b/bin/openapi3/typescript-angular-v2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v2/default --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v4-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-angular-v4-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angular-v4.3-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-angular-v4.3-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-angularjs-petstore.sh
+++ b/bin/openapi3/typescript-angularjs-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-angularjs -o samples/client/petstore/typescript-angularjs $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-aurelia-petstore.sh
+++ b/bin/openapi3/typescript-aurelia-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-aurelia -o samples/client/petstore/typescript-aurelia/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore-interfaces.sh
+++ b/bin/openapi3/typescript-fetch-petstore-interfaces.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-fetch -o samples/client/petstore/typescript-fetch/builds/with-interfaces -D withInterfaces=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore-target-es6.sh
+++ b/bin/openapi3/typescript-fetch-petstore-target-es6.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-fetch -c bin/typescript-fetch-petstore-target-es6.json -o samples/client/petstore/typescript-fetch/builds/es6-target $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore-with-npm-version.sh
+++ b/bin/openapi3/typescript-fetch-petstore-with-npm-version.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-fetch -c bin/typescript-fetch-petstore-with-npm-version.json -o samples/client/petstore/typescript-fetch/builds/with-npm-version $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-fetch-petstore.sh
+++ b/bin/openapi3/typescript-fetch-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-inversify-petstore.sh
+++ b/bin/openapi3/typescript-inversify-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-inversify -o samples/client/petstore/typescript-inversify $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-jquery-petstore-all.sh
+++ b/bin/openapi3/typescript-jquery-petstore-all.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript Petstore API client (default)"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-jquery -o samples/client/petstore/typescript-jquery/default $@"

--- a/bin/openapi3/typescript-jquery-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-jquery-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-jquery-petstore.sh
+++ b/bin/openapi3/typescript-jquery-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-jquery -o samples/client/petstore/typescript-jquery/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-node-petstore-all.sh
+++ b/bin/openapi3/typescript-node-petstore-all.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 echo "Typescript node Petstore API client (default setting)"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-node -o samples/client/petstore/typescript-node/default $@"

--- a/bin/openapi3/typescript-node-petstore-with-npm.sh
+++ b/bin/openapi3/typescript-node-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-node -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-node/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/openapi3/typescript-node-petstore.sh
+++ b/bin/openapi3/typescript-node-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g typescript-node -o samples/client/petstore/typescript-node/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/perl-deep-module-petstore.sh
+++ b/bin/perl-deep-module-petstore.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml  -g perl -o samples/client/petstore/perl/deep_module_test -DhideGenerationTimestamp=true $@"
 

--- a/bin/perl-petstore.sh
+++ b/bin/perl-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 # complex module name used for testing
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml  -g perl -o samples/client/petstore/perl -DhideGenerationTimestamp=true $@"
 

--- a/bin/php-laravel-petstore-server.sh
+++ b/bin/php-laravel-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-laravel -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php-laravel -o samples/server/petstore/php-laravel $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-lumen-petstore-server.sh
+++ b/bin/php-lumen-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-lumen -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php-lumen -o samples/server/petstore/php-lumen $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-petstore.sh
+++ b/bin/php-petstore.sh
@@ -32,7 +32,7 @@ if [ -d $TEST_DIR ]; then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php -o samples/client/petstore/php/OpenAPIClient-php $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-silex-petstore-server.sh
+++ b/bin/php-silex-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-silex -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g php-silex -o samples/server/petstore/php-silex/OpenAPIServer $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-slim-server-petstore.sh
+++ b/bin/php-slim-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/php-slim-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php-slim -o samples/server/petstore/php-slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-symfony-petstore.sh
+++ b/bin/php-symfony-petstore.sh
@@ -36,7 +36,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t $SCRIPT_DIR/../modules/openapi-generator/src/main/resources/php-symfony -i $SCRIPT_DIR/../modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g php-symfony -o $TARGET_DIR $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-ze-ph-petstore-server.sh
+++ b/bin/php-ze-ph-petstore-server.sh
@@ -30,7 +30,7 @@ out_folder=samples/server/petstore/php-ze-ph
 resources=modules/openapi-generator/src/main/resources/ze-ph
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t $resources -i $input -g php-ze-ph -o $out_folder $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/powershell-petstore.sh
+++ b/bin/powershell-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/powershell -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g powershell -o samples/client/petstore/powershell --additional-properties packageGuid=a27b908d-2a20-467f-bc32-af6f3a654ac5,csharpClientPath=\$ScriptDir\..\..\petstore\csharp\OpenAPIClient $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}

--- a/bin/python-asyncio-petstore.sh
+++ b/bin/python-asyncio-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g python -o samples/client/petstore/python-asyncio -DpackageName=petstore_api --library asyncio $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/python-petstore.sh
+++ b/bin/python-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g python -o samples/client/petstore/python -DpackageName=petstore_api $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/python-tornado-petstore.sh
+++ b/bin/python-tornado-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g python -o samples/client/petstore/python-tornado -DpackageName=petstore_api --library tornado $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/r-petstore.sh
+++ b/bin/r-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/r -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g r -o samples/client/petstore/R -DpackageName=petstore $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/ruby-client-petstore.sh
+++ b/bin/ruby-client-petstore.sh
@@ -31,7 +31,7 @@ rm -Rf samples/client/petstore/ruby/docs
 rm -Rf samples/client/petstore/ruby/spec
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-client -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g ruby -c bin/ruby-petstore.json -o samples/client/petstore/ruby $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/ruby-on-rails-server-petstore.sh
+++ b/bin/ruby-on-rails-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-on-rails-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g ruby-on-rails -o samples/server/petstore/ruby-on-rails $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/ruby-sinatra-server-petstore.sh
+++ b/bin/ruby-sinatra-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/ruby-sinatra-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g ruby-sinatra -o samples/server/petstore/ruby-sinatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/rust-server-petstore.sh
+++ b/bin/rust-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 for spec_path in modules/openapi-generator/src/test/resources/*/rust-server/* ; do
-  export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+  export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
   spec=$(basename "$spec_path" | sed 's/.yaml//')
   args="generate --template-dir modules/openapi-generator/src/main/resources/rust-server
                  --input-spec $spec_path

--- a/bin/scala-akka-petstore.sh
+++ b/bin/scala-akka-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id "scala-akka-petstore-client" -t modules/openapi-generator/src/main/resources/scala-akka-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-akka -o samples/client/petstore/scala-akka $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-gatling-petstore.sh
+++ b/bin/scala-gatling-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scala-gatling -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-gatling -o samples/client/petstore/scala-gatling $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-httpclient-petstore.sh
+++ b/bin/scala-httpclient-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scala-httpclient -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-httpclient-deprecated -o samples/client/petstore/scala-httpclient $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-lagom-server-petstore.sh
+++ b/bin/scala-lagom-server-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scala-lagom-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-lagom-server -o samples/server/petstore/scala-lagom-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scala-play-framework-petstore.sh
+++ b/bin/scala-play-framework-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scala-play-server -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scala-play-server -o samples/server/petstore/scala-play-server $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scalatra-petstore-server.sh
+++ b/bin/scalatra-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scalatra -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scalatra -o samples/server/petstore/scalatra $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/scalaz-petstore.sh
+++ b/bin/scalaz-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/scalaz -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g scalaz -o samples/client/petstore/scalaz $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-cloud-feign-petstore.sh
+++ b/bin/spring-cloud-feign-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g spring -c bin/spring-cloud-feign-petstore.json -o samples/client/petstore/spring-cloud -DhideGenerationTimestamp=true,responseWrapper=HystrixCommand $@"
 
 echo "Removing files and folders under samples/client/petstore/spring-cloud/src/main"

--- a/bin/spring-delegate-j8.sh
+++ b/bin/spring-delegate-j8.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id springboot-delegate-j8 -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-delegate-j8 -DdelegatePattern=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-delegate-j8/src/main"

--- a/bin/spring-delegate.sh
+++ b/bin/spring-delegate.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id springboot-delegate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-delegate -DdelegatePattern=true,hideGenerationTimestamp=true,java8=false $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-delegate/src/main"

--- a/bin/spring-mvc-petstore-j8-async-server.sh
+++ b/bin/spring-mvc-petstore-j8-async-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/spring-mvc-j8-async -c bin/spring-mvc-petstore-j8-async.json -DhideGenerationTimestamp=true,async=true --additional-properties serverPort=8002 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-mvc-petstore-j8-localdatetime.sh
+++ b/bin/spring-mvc-petstore-j8-localdatetime.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/spring-mvc-petstore-j8-localdatetime.json -o samples/server/petstore/spring-mvc-j8-localdatetime -DhideGenerationTimestamp=true -DbooleanGetterPrefix=get --additional-properties serverPort=8002 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-mvc-petstore-server.sh
+++ b/bin/spring-mvc-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/spring-mvc-petstore-server.json -o samples/server/petstore/spring-mvc -DhideGenerationTimestamp=true,java8=false --additional-properties serverPort=8002 --additional-properties booleanGetterPrefix=get $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/spring-stubs.sh
+++ b/bin/spring-stubs.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id spring-stubs -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g spring -o samples/client/petstore/spring-stubs -DinterfaceOnly=true,singleContentTypes=true,hideGenerationTimestamp=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/springboot-petstore-server-beanvalidation.sh
+++ b/bin/springboot-petstore-server-beanvalidation.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-beanvalidation -c bin/springboot-petstore-server-beanvalidation.json -DhideGenerationTimestamp=true,java8=false $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-beanvalidation/src/main"

--- a/bin/springboot-petstore-server-implicitHeaders.sh
+++ b/bin/springboot-petstore-server-implicitHeaders.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id springboot-implicitHeaders -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/springboot-petstore-server-implicitHeaders.json -o samples/server/petstore/springboot-implicitHeaders -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-implicitHeaders/src/main"

--- a/bin/springboot-petstore-server-reactive.sh
+++ b/bin/springboot-petstore-server-reactive.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id springboot-reactive -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-reactive -Dreactive=true,delegatePattern=true,hideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-reactive/src/main"

--- a/bin/springboot-petstore-server-useOptional.sh
+++ b/bin/springboot-petstore-server-useOptional.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -c bin/springboot-petstore-server-useOptional.json -o samples/server/petstore/springboot-useoptional -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-useoptional/src/main"

--- a/bin/springboot-petstore-server.sh
+++ b/bin/springboot-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id springboot -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot/src/main"

--- a/bin/springboot-virtualan-petstore-server.sh
+++ b/bin/springboot-virtualan-petstore-server.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate --artifact-id springboot-virtualan -t modules/openapi-generator/src/main/resources/JavaSpring -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g spring -o samples/server/petstore/springboot-virtualan -c bin/springboot-virtualan-petstore-server.json -DhideGenerationTimestamp=true $@"
 
 echo "Removing files and folders under samples/server/petstore/springboot-virtualan/src/main"

--- a/bin/swift-petstore-promisekit.sh
+++ b/bin/swift-petstore-promisekit.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g swift2-deprecated -c ./bin/swift-petstore-promisekit.json -o samples/client/petstore/swift/promisekit $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift-petstore-rxswift.sh
+++ b/bin/swift-petstore-rxswift.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g swift2-deprecated -c ./bin/swift-petstore-rxswift.json -o samples/client/petstore/swift/rxswift $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift-petstore.sh
+++ b/bin/swift-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift -i modules/openapi-generator/src/test/resources/2_0/petstore.json -g swift2-deprecated -c ./bin/swift-petstore.json -o samples/client/petstore/swift/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift3-petstore-objcCompatible.sh
+++ b/bin/swift3-petstore-objcCompatible.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift3-deprecated -c ./bin/swift3-petstore-objcCompatible.json -o samples/client/petstore/swift3/objcCompatible $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift3-petstore-promisekit.sh
+++ b/bin/swift3-petstore-promisekit.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift3-deprecated -c ./bin/swift3-petstore-promisekit.json -o samples/client/petstore/swift3/promisekit $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift3-petstore-rxswift.sh
+++ b/bin/swift3-petstore-rxswift.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift3-deprecated -c ./bin/swift3-petstore-rxswift.json -o samples/client/petstore/swift3/rxswift $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift3-petstore-unwraprequired.sh
+++ b/bin/swift3-petstore-unwraprequired.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift3-deprecated -c ./bin/swift3-petstore-unwraprequired.json -o samples/client/petstore/swift3/unwraprequired $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift3-petstore.sh
+++ b/bin/swift3-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift3 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift3-deprecated -c ./bin/swift3-petstore.json -o samples/client/petstore/swift3/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-objcCompatible.sh
+++ b/bin/swift4-petstore-objcCompatible.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g swift4 -c ./bin/swift4-petstore-objcCompatible.json -o samples/client/petstore/swift4/objcCompatible $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-promisekit.sh
+++ b/bin/swift4-petstore-promisekit.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift4 -c ./bin/swift4-petstore-promisekit.json -o samples/client/petstore/swift4/promisekit --generate-alias-as-model  $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-rxswift.sh
+++ b/bin/swift4-petstore-rxswift.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift4 -c ./bin/swift4-petstore-rxswift.json -o samples/client/petstore/swift4/rxswift --generate-alias-as-model $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore-unwrapRequired.sh
+++ b/bin/swift4-petstore-unwrapRequired.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift4 -c ./bin/swift4-petstore-unwrapRequired.json -o samples/client/petstore/swift4/unwrapRequired --generate-alias-as-model $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-petstore.sh
+++ b/bin/swift4-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml -g swift4 -c ./bin/swift4-petstore.json -o samples/client/petstore/swift4/default --generate-alias-as-model $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/swift4-test.sh
+++ b/bin/swift4-test.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/swift4 -i modules/openapi-generator/src/test/resources/2_0/swift4Test.json -g swift4 -c ./bin/swift4-test.json -o samples/client/test/swift4/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/tests/test-debug-supporting-files.sh
+++ b/bin/tests/test-debug-supporting-files.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -t modules/openapi-generator/src/main/resources/python -i modules/openapi-generator/src/test/resources/3_0/issue_241.yaml -g python -o /tmp/test-debug-supporting-files/ -DpackageName=petstore_api -DdebugSupportingFiles=true $@"
 
 if [[ $(java $JAVA_OPTS -jar $executable $ags 2>&1 | grep "StackOverflowError") ]]; then

--- a/bin/typescript-angular-v2-petstore-interfaces.sh
+++ b/bin/typescript-angular-v2-petstore-interfaces.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v2/with-interfaces -D withInterfaces=true --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v2-petstore-with-npm.sh
+++ b/bin/typescript-angular-v2-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v2/npm --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v2-petstore.sh
+++ b/bin/typescript-angular-v2-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v2/default --additional-properties ngVersion=2 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v4-petstore-with-npm.sh
+++ b/bin/typescript-angular-v4-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4/npm --additional-properties ngVersion=4 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v4.3-petstore-with-npm.sh
+++ b/bin/typescript-angular-v4.3-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-petstore-npm.json -o samples/client/petstore/typescript-angular-v4.3/npm --additional-properties ngVersion=4.3 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.sh
+++ b/bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-angular-v6-petstore-not-provided-in-root-with-npm.json -o samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm -D providedInRoot=false --additional-properties ngVersion=6.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v6-petstore-not-provided-in-root.sh
+++ b/bin/typescript-angular-v6-petstore-not-provided-in-root.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default -D providedInRoot=false --additional-properties ngVersion=6.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v6-petstore-provided-in-root-with-npm.sh
+++ b/bin/typescript-angular-v6-petstore-provided-in-root-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-angular-v6-petstore-provided-in-root-with-npm.json -o samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm --additional-properties ngVersion=6.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v6-petstore-provided-in-root.sh
+++ b/bin/typescript-angular-v6-petstore-provided-in-root.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default --additional-properties ngVersion=6.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v7-petstore-not-provided-in-root-with-npm.sh
+++ b/bin/typescript-angular-v7-petstore-not-provided-in-root-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-angular-v7-petstore-not-provided-in-root-with-npm.json -o samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm -D providedInRoot=false --additional-properties ngVersion=7.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v7-petstore-not-provided-in-root.sh
+++ b/bin/typescript-angular-v7-petstore-not-provided-in-root.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default -D providedInRoot=false --additional-properties ngVersion=7.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v7-petstore-provided-in-root-with-npm.sh
+++ b/bin/typescript-angular-v7-petstore-provided-in-root-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -c bin/typescript-angular-v7-petstore-provided-in-root-with-npm.json -o samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm --additional-properties ngVersion=7.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angular-v7-petstore-provided-in-root.sh
+++ b/bin/typescript-angular-v7-petstore-provided-in-root.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angular -o samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default --additional-properties ngVersion=7.0.0 $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-angularjs-petstore.sh
+++ b/bin/typescript-angularjs-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-angularjs -o samples/client/petstore/typescript-angularjs $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-aurelia-petstore.sh
+++ b/bin/typescript-aurelia-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-aurelia -o samples/client/petstore/typescript-aurelia/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-axios-petstore-interfaces.sh
+++ b/bin/typescript-axios-petstore-interfaces.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-axios -o samples/client/petstore/typescript-axios/builds/with-interfaces -D withInterfaces=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-axios-petstore-target-es6.sh
+++ b/bin/typescript-axios-petstore-target-es6.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-axios -c bin/typescript-axios-petstore-target-es6.json -o samples/client/petstore/typescript-axios/builds/es6-target $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-axios-petstore-with-npm-version-and-separate-models-and-api.sh
+++ b/bin/typescript-axios-petstore-with-npm-version-and-separate-models-and-api.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-axios -c bin/typescript-axios-petstore-with-npm-version-and-separate-models-and-api.json -o samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-axios-petstore-with-npm-version.sh
+++ b/bin/typescript-axios-petstore-with-npm-version.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-axios -c bin/typescript-axios-petstore-with-npm-version.json -o samples/client/petstore/typescript-axios/builds/with-npm-version $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-axios-petstore.sh
+++ b/bin/typescript-axios-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-axios -o samples/client/petstore/typescript-axios/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore-interfaces.sh
+++ b/bin/typescript-fetch-petstore-interfaces.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-fetch -o samples/client/petstore/typescript-fetch/builds/with-interfaces -D withInterfaces=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore-target-es6.sh
+++ b/bin/typescript-fetch-petstore-target-es6.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-fetch -c bin/typescript-fetch-petstore-target-es6.json -o samples/client/petstore/typescript-fetch/builds/es6-target $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore-with-npm-version.sh
+++ b/bin/typescript-fetch-petstore-with-npm-version.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-fetch -c bin/typescript-fetch-petstore-with-npm-version.json -o samples/client/petstore/typescript-fetch/builds/with-npm-version $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-fetch-petstore.sh
+++ b/bin/typescript-fetch-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-fetch -o samples/client/petstore/typescript-fetch/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-inversify-petstore.sh
+++ b/bin/typescript-inversify-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-inversify -o samples/client/petstore/typescript-inversify $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-jquery-petstore-with-npm.sh
+++ b/bin/typescript-jquery-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-jquery -c bin/typescript-jquery-petstore-npm.json -o samples/client/petstore/typescript-jquery/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-jquery-petstore.sh
+++ b/bin/typescript-jquery-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-jquery -o samples/client/petstore/typescript-jquery/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-node-petstore-with-npm.sh
+++ b/bin/typescript-node-petstore-with-npm.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-node -c bin/typescript-node-petstore-npm.json -o samples/client/petstore/typescript-node/npm $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-node-petstore.sh
+++ b/bin/typescript-node-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-node -o samples/client/petstore/typescript-node/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-rxjs-petstore-interfaces.sh
+++ b/bin/typescript-rxjs-petstore-interfaces.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-rxjs -o samples/client/petstore/typescript-rxjs/builds/with-interfaces -D withInterfaces=true $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-rxjs-petstore-target-es6.sh
+++ b/bin/typescript-rxjs-petstore-target-es6.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-rxjs -c bin/typescript-rxjs-petstore-target-es6.json -o samples/client/petstore/typescript-rxjs/builds/es6-target $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-rxjs-petstore-with-npm-version.sh
+++ b/bin/typescript-rxjs-petstore-with-npm-version.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-rxjs -c bin/typescript-rxjs-petstore-with-npm-version.json -o samples/client/petstore/typescript-rxjs/builds/with-npm-version $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript-rxjs-petstore.sh
+++ b/bin/typescript-rxjs-petstore.sh
@@ -26,7 +26,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript-rxjs -o samples/client/petstore/typescript-rxjs/builds/default $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/new.sh
+++ b/new.sh
@@ -248,7 +248,7 @@ then
 fi
 
 # if you've executed sbt assembly previously it will use that instead.
-export JAVA_OPTS="\${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
+export JAVA_OPTS="\${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 ags="\$@ generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g ${gen_name_camel} -o samples/${gen_type}/petstore/${gen_name_camel_path}"
 
 java \${JAVA_OPTS} -jar \${executable} \${ags}


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

`-XX:MaxPermSize` was removed and produces a warning in JDK 8.

Given OpenAPI Generator only supports Java 8 and above, and given Java 7 is EOL, we should be fine to just remove this.