### PR TITLE
Update perl test with correct body parameter

### DIFF
--- a/samples/client/petstore/perl/README.md
+++ b/samples/client/petstore/perl/README.md
@@ -222,7 +222,6 @@ Each of these calls returns a hashref with various useful pieces of information.
 To load the API packages:
 ```perl
 use WWW::OpenAPIClient::AnotherFakeApi;
-use WWW::OpenAPIClient::DefaultApi;
 use WWW::OpenAPIClient::FakeApi;
 use WWW::OpenAPIClient::FakeClassnameTags123Api;
 use WWW::OpenAPIClient::PetApi;
@@ -233,7 +232,14 @@ use WWW::OpenAPIClient::UserApi;
 
 To load the models:
 ```perl
+use WWW::OpenAPIClient::Object::AdditionalPropertiesAnyType;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesArray;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesBoolean;
 use WWW::OpenAPIClient::Object::AdditionalPropertiesClass;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesInteger;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesNumber;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesObject;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesString;
 use WWW::OpenAPIClient::Object::Animal;
 use WWW::OpenAPIClient::Object::ApiResponse;
 use WWW::OpenAPIClient::Object::ArrayOfArrayOfNumberOnly;
@@ -250,36 +256,26 @@ use WWW::OpenAPIClient::Object::EnumClass;
 use WWW::OpenAPIClient::Object::EnumTest;
 use WWW::OpenAPIClient::Object::File;
 use WWW::OpenAPIClient::Object::FileSchemaTestClass;
-use WWW::OpenAPIClient::Object::Foo;
 use WWW::OpenAPIClient::Object::FormatTest;
 use WWW::OpenAPIClient::Object::HasOnlyReadOnly;
-use WWW::OpenAPIClient::Object::HealthCheckResult;
-use WWW::OpenAPIClient::Object::InlineObject;
-use WWW::OpenAPIClient::Object::InlineObject1;
-use WWW::OpenAPIClient::Object::InlineObject2;
-use WWW::OpenAPIClient::Object::InlineObject3;
-use WWW::OpenAPIClient::Object::InlineObject4;
-use WWW::OpenAPIClient::Object::InlineObject5;
-use WWW::OpenAPIClient::Object::InlineResponseDefault;
 use WWW::OpenAPIClient::Object::List;
 use WWW::OpenAPIClient::Object::MapTest;
 use WWW::OpenAPIClient::Object::MixedPropertiesAndAdditionalPropertiesClass;
 use WWW::OpenAPIClient::Object::Model200Response;
 use WWW::OpenAPIClient::Object::ModelReturn;
 use WWW::OpenAPIClient::Object::Name;
-use WWW::OpenAPIClient::Object::NullableClass;
 use WWW::OpenAPIClient::Object::NumberOnly;
 use WWW::OpenAPIClient::Object::Order;
 use WWW::OpenAPIClient::Object::OuterComposite;
 use WWW::OpenAPIClient::Object::OuterEnum;
-use WWW::OpenAPIClient::Object::OuterEnumDefaultValue;
-use WWW::OpenAPIClient::Object::OuterEnumInteger;
-use WWW::OpenAPIClient::Object::OuterEnumIntegerDefaultValue;
 use WWW::OpenAPIClient::Object::Pet;
 use WWW::OpenAPIClient::Object::ReadOnlyFirst;
 use WWW::OpenAPIClient::Object::SpecialModelName;
 use WWW::OpenAPIClient::Object::Tag;
+use WWW::OpenAPIClient::Object::TypeHolderDefault;
+use WWW::OpenAPIClient::Object::TypeHolderExample;
 use WWW::OpenAPIClient::Object::User;
+use WWW::OpenAPIClient::Object::XmlItem;
 
 ````
 
@@ -292,7 +288,6 @@ use strict;
 use warnings;
 # load the API package
 use WWW::OpenAPIClient::AnotherFakeApi;
-use WWW::OpenAPIClient::DefaultApi;
 use WWW::OpenAPIClient::FakeApi;
 use WWW::OpenAPIClient::FakeClassnameTags123Api;
 use WWW::OpenAPIClient::PetApi;
@@ -300,7 +295,14 @@ use WWW::OpenAPIClient::StoreApi;
 use WWW::OpenAPIClient::UserApi;
 
 # load the models
+use WWW::OpenAPIClient::Object::AdditionalPropertiesAnyType;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesArray;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesBoolean;
 use WWW::OpenAPIClient::Object::AdditionalPropertiesClass;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesInteger;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesNumber;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesObject;
+use WWW::OpenAPIClient::Object::AdditionalPropertiesString;
 use WWW::OpenAPIClient::Object::Animal;
 use WWW::OpenAPIClient::Object::ApiResponse;
 use WWW::OpenAPIClient::Object::ArrayOfArrayOfNumberOnly;
@@ -317,36 +319,26 @@ use WWW::OpenAPIClient::Object::EnumClass;
 use WWW::OpenAPIClient::Object::EnumTest;
 use WWW::OpenAPIClient::Object::File;
 use WWW::OpenAPIClient::Object::FileSchemaTestClass;
-use WWW::OpenAPIClient::Object::Foo;
 use WWW::OpenAPIClient::Object::FormatTest;
 use WWW::OpenAPIClient::Object::HasOnlyReadOnly;
-use WWW::OpenAPIClient::Object::HealthCheckResult;
-use WWW::OpenAPIClient::Object::InlineObject;
-use WWW::OpenAPIClient::Object::InlineObject1;
-use WWW::OpenAPIClient::Object::InlineObject2;
-use WWW::OpenAPIClient::Object::InlineObject3;
-use WWW::OpenAPIClient::Object::InlineObject4;
-use WWW::OpenAPIClient::Object::InlineObject5;
-use WWW::OpenAPIClient::Object::InlineResponseDefault;
 use WWW::OpenAPIClient::Object::List;
 use WWW::OpenAPIClient::Object::MapTest;
 use WWW::OpenAPIClient::Object::MixedPropertiesAndAdditionalPropertiesClass;
 use WWW::OpenAPIClient::Object::Model200Response;
 use WWW::OpenAPIClient::Object::ModelReturn;
 use WWW::OpenAPIClient::Object::Name;
-use WWW::OpenAPIClient::Object::NullableClass;
 use WWW::OpenAPIClient::Object::NumberOnly;
 use WWW::OpenAPIClient::Object::Order;
 use WWW::OpenAPIClient::Object::OuterComposite;
 use WWW::OpenAPIClient::Object::OuterEnum;
-use WWW::OpenAPIClient::Object::OuterEnumDefaultValue;
-use WWW::OpenAPIClient::Object::OuterEnumInteger;
-use WWW::OpenAPIClient::Object::OuterEnumIntegerDefaultValue;
 use WWW::OpenAPIClient::Object::Pet;
 use WWW::OpenAPIClient::Object::ReadOnlyFirst;
 use WWW::OpenAPIClient::Object::SpecialModelName;
 use WWW::OpenAPIClient::Object::Tag;
+use WWW::OpenAPIClient::Object::TypeHolderDefault;
+use WWW::OpenAPIClient::Object::TypeHolderExample;
 use WWW::OpenAPIClient::Object::User;
+use WWW::OpenAPIClient::Object::XmlItem;
 
 # for displaying the API response data
 use Data::Dumper;
@@ -355,10 +347,10 @@ use WWW::OpenAPIClient::;
 my $api_instance = WWW::OpenAPIClient::->new(
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval {
-    my $result = $api_instance->call_123_test_special_tags(client => $client);
+    my $result = $api_instance->call_123_test_special_tags(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -374,8 +366,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
-*DefaultApi* | [**foo_get**](docs/DefaultApi.md#foo_get) | **GET** /foo | 
-*FakeApi* | [**fake_health_get**](docs/FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+*FakeApi* | [**create_xml_item**](docs/FakeApi.md#create_xml_item) | **POST** /fake/create_xml_item | creates an XmlItem
 *FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 *FakeApi* | [**fake_outer_number_serialize**](docs/FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -413,7 +404,14 @@ Class | Method | HTTP request | Description
 
 
 # DOCUMENTATION FOR MODELS
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesAnyType](docs/AdditionalPropertiesAnyType.md)
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesArray](docs/AdditionalPropertiesArray.md)
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesBoolean](docs/AdditionalPropertiesBoolean.md)
  - [WWW::OpenAPIClient::Object::AdditionalPropertiesClass](docs/AdditionalPropertiesClass.md)
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesInteger](docs/AdditionalPropertiesInteger.md)
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesNumber](docs/AdditionalPropertiesNumber.md)
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesObject](docs/AdditionalPropertiesObject.md)
+ - [WWW::OpenAPIClient::Object::AdditionalPropertiesString](docs/AdditionalPropertiesString.md)
  - [WWW::OpenAPIClient::Object::Animal](docs/Animal.md)
  - [WWW::OpenAPIClient::Object::ApiResponse](docs/ApiResponse.md)
  - [WWW::OpenAPIClient::Object::ArrayOfArrayOfNumberOnly](docs/ArrayOfArrayOfNumberOnly.md)
@@ -430,36 +428,26 @@ Class | Method | HTTP request | Description
  - [WWW::OpenAPIClient::Object::EnumTest](docs/EnumTest.md)
  - [WWW::OpenAPIClient::Object::File](docs/File.md)
  - [WWW::OpenAPIClient::Object::FileSchemaTestClass](docs/FileSchemaTestClass.md)
- - [WWW::OpenAPIClient::Object::Foo](docs/Foo.md)
  - [WWW::OpenAPIClient::Object::FormatTest](docs/FormatTest.md)
  - [WWW::OpenAPIClient::Object::HasOnlyReadOnly](docs/HasOnlyReadOnly.md)
- - [WWW::OpenAPIClient::Object::HealthCheckResult](docs/HealthCheckResult.md)
- - [WWW::OpenAPIClient::Object::InlineObject](docs/InlineObject.md)
- - [WWW::OpenAPIClient::Object::InlineObject1](docs/InlineObject1.md)
- - [WWW::OpenAPIClient::Object::InlineObject2](docs/InlineObject2.md)
- - [WWW::OpenAPIClient::Object::InlineObject3](docs/InlineObject3.md)
- - [WWW::OpenAPIClient::Object::InlineObject4](docs/InlineObject4.md)
- - [WWW::OpenAPIClient::Object::InlineObject5](docs/InlineObject5.md)
- - [WWW::OpenAPIClient::Object::InlineResponseDefault](docs/InlineResponseDefault.md)
  - [WWW::OpenAPIClient::Object::List](docs/List.md)
  - [WWW::OpenAPIClient::Object::MapTest](docs/MapTest.md)
  - [WWW::OpenAPIClient::Object::MixedPropertiesAndAdditionalPropertiesClass](docs/MixedPropertiesAndAdditionalPropertiesClass.md)
  - [WWW::OpenAPIClient::Object::Model200Response](docs/Model200Response.md)
  - [WWW::OpenAPIClient::Object::ModelReturn](docs/ModelReturn.md)
  - [WWW::OpenAPIClient::Object::Name](docs/Name.md)
- - [WWW::OpenAPIClient::Object::NullableClass](docs/NullableClass.md)
  - [WWW::OpenAPIClient::Object::NumberOnly](docs/NumberOnly.md)
  - [WWW::OpenAPIClient::Object::Order](docs/Order.md)
  - [WWW::OpenAPIClient::Object::OuterComposite](docs/OuterComposite.md)
  - [WWW::OpenAPIClient::Object::OuterEnum](docs/OuterEnum.md)
- - [WWW::OpenAPIClient::Object::OuterEnumDefaultValue](docs/OuterEnumDefaultValue.md)
- - [WWW::OpenAPIClient::Object::OuterEnumInteger](docs/OuterEnumInteger.md)
- - [WWW::OpenAPIClient::Object::OuterEnumIntegerDefaultValue](docs/OuterEnumIntegerDefaultValue.md)
  - [WWW::OpenAPIClient::Object::Pet](docs/Pet.md)
  - [WWW::OpenAPIClient::Object::ReadOnlyFirst](docs/ReadOnlyFirst.md)
  - [WWW::OpenAPIClient::Object::SpecialModelName](docs/SpecialModelName.md)
  - [WWW::OpenAPIClient::Object::Tag](docs/Tag.md)
+ - [WWW::OpenAPIClient::Object::TypeHolderDefault](docs/TypeHolderDefault.md)
+ - [WWW::OpenAPIClient::Object::TypeHolderExample](docs/TypeHolderExample.md)
  - [WWW::OpenAPIClient::Object::User](docs/User.md)
+ - [WWW::OpenAPIClient::Object::XmlItem](docs/XmlItem.md)
 
 
 # DOCUMENTATION FOR AUTHORIZATION
@@ -475,10 +463,6 @@ Class | Method | HTTP request | Description
 - **Type**: API key
 - **API key parameter name**: api_key_query
 - **Location**: URL query string
-
-## bearer_test
-
-- **Type**: HTTP basic authentication
 
 ## http_basic_test
 

--- a/samples/client/petstore/perl/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/perl/docs/AdditionalPropertiesClass.md
@@ -8,8 +8,17 @@ use WWW::OpenAPIClient::Object::AdditionalPropertiesClass;
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**map_property** | **HASH[string,string]** |  | [optional] 
-**map_of_map_property** | **HASH[string,HASH[string,string]]** |  | [optional] 
+**map_string** | **HASH[string,string]** |  | [optional] 
+**map_number** | **HASH[string,double]** |  | [optional] 
+**map_integer** | **HASH[string,int]** |  | [optional] 
+**map_boolean** | **HASH[string,boolean]** |  | [optional] 
+**map_array_integer** | **HASH[string,ARRAY[int]]** |  | [optional] 
+**map_array_anytype** | **HASH[string,ARRAY[object]]** |  | [optional] 
+**map_map_string** | **HASH[string,HASH[string,string]]** |  | [optional] 
+**map_map_anytype** | **HASH[string,HASH[string,object]]** |  | [optional] 
+**anytype_1** | [**object**](.md) |  | [optional] 
+**anytype_2** | [**object**](.md) |  | [optional] 
+**anytype_3** | [**object**](.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/perl/docs/AnotherfakeApi.md
+++ b/samples/client/petstore/perl/docs/AnotherfakeApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 
 # **call_123_test_special_tags**
-> Client call_123_test_special_tags(client => $client)
+> Client call_123_test_special_tags(body => $body)
 
 To test special tags
 
@@ -26,10 +26,10 @@ use WWW::OpenAPIClient::AnotherFakeApi;
 my $api_instance = WWW::OpenAPIClient::AnotherFakeApi->new(
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval { 
-    my $result = $api_instance->call_123_test_special_tags(client => $client);
+    my $result = $api_instance->call_123_test_special_tags(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -41,7 +41,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/EnumTest.md
+++ b/samples/client/petstore/perl/docs/EnumTest.md
@@ -13,9 +13,6 @@ Name | Type | Description | Notes
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **double** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
-**outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
-**outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 
-**outer_enum_integer_default_value** | [**OuterEnumIntegerDefaultValue**](OuterEnumIntegerDefaultValue.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -9,7 +9,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
+[**create_xml_item**](FakeApi.md#create_xml_item) | **POST** /fake/create_xml_item | creates an XmlItem
 [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
 [**fake_outer_number_serialize**](FakeApi.md#fake_outer_number_serialize) | **POST** /fake/outer/number | 
@@ -24,10 +24,12 @@ Method | HTTP request | Description
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
 
 
-# **fake_health_get**
-> HealthCheckResult fake_health_get()
+# **create_xml_item**
+> create_xml_item(xml_item => $xml_item)
 
-Health check endpoint
+creates an XmlItem
+
+this route creates an XmlItem
 
 ### Example 
 ```perl
@@ -36,22 +38,25 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
+my $xml_item = WWW::OpenAPIClient::Object::XmlItem->new(); # XmlItem | XmlItem Body
 
 eval { 
-    my $result = $api_instance->fake_health_get();
-    print Dumper($result);
+    $api_instance->create_xml_item(xml_item => $xml_item);
 };
 if ($@) {
-    warn "Exception when calling FakeApi->fake_health_get: $@\n";
+    warn "Exception when calling FakeApi->create_xml_item: $@\n";
 }
 ```
 
 ### Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **xml_item** | [**XmlItem**](XmlItem.md)| XmlItem Body | 
 
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+void (empty response body)
 
 ### Authorization
 
@@ -59,8 +64,8 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: Not defined
- - **Accept**: application/json
+ - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -105,13 +110,13 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **fake_outer_composite_serialize**
-> OuterComposite fake_outer_composite_serialize(outer_composite => $outer_composite)
+> OuterComposite fake_outer_composite_serialize(body => $body)
 
 
 
@@ -124,10 +129,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $outer_composite = WWW::OpenAPIClient::Object::OuterComposite->new(); # OuterComposite | Input composite as post body
+my $body = WWW::OpenAPIClient::Object::OuterComposite->new(); # OuterComposite | Input composite as post body
 
 eval { 
-    my $result = $api_instance->fake_outer_composite_serialize(outer_composite => $outer_composite);
+    my $result = $api_instance->fake_outer_composite_serialize(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -139,7 +144,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **outer_composite** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
+ **body** | [**OuterComposite**](OuterComposite.md)| Input composite as post body | [optional] 
 
 ### Return type
 
@@ -151,7 +156,7 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
@@ -197,7 +202,7 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
@@ -243,13 +248,13 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: */*
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_body_with_file_schema**
-> test_body_with_file_schema(file_schema_test_class => $file_schema_test_class)
+> test_body_with_file_schema(body => $body)
 
 
 
@@ -262,10 +267,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $file_schema_test_class = WWW::OpenAPIClient::Object::FileSchemaTestClass->new(); # FileSchemaTestClass | 
+my $body = WWW::OpenAPIClient::Object::FileSchemaTestClass->new(); # FileSchemaTestClass | 
 
 eval { 
-    $api_instance->test_body_with_file_schema(file_schema_test_class => $file_schema_test_class);
+    $api_instance->test_body_with_file_schema(body => $body);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_body_with_file_schema: $@\n";
@@ -276,7 +281,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **file_schema_test_class** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
+ **body** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
 
 ### Return type
 
@@ -294,7 +299,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_body_with_query_params**
-> test_body_with_query_params(query => $query, user => $user)
+> test_body_with_query_params(query => $query, body => $body)
 
 
 
@@ -306,10 +311,10 @@ my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
 my $query = "query_example"; # string | 
-my $user = WWW::OpenAPIClient::Object::User->new(); # User | 
+my $body = WWW::OpenAPIClient::Object::User->new(); # User | 
 
 eval { 
-    $api_instance->test_body_with_query_params(query => $query, user => $user);
+    $api_instance->test_body_with_query_params(query => $query, body => $body);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_body_with_query_params: $@\n";
@@ -321,7 +326,7 @@ if ($@) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **query** | **string**|  | 
- **user** | [**User**](User.md)|  | 
+ **body** | [**User**](User.md)|  | 
 
 ### Return type
 
@@ -339,7 +344,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_client_model**
-> Client test_client_model(client => $client)
+> Client test_client_model(body => $body)
 
 To test \"client\" model
 
@@ -352,10 +357,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval { 
-    my $result = $api_instance->test_client_model(client => $client);
+    my $result = $api_instance->test_client_model(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -367,7 +372,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
 
@@ -530,10 +535,6 @@ Fake endpoint to test group parameters (optional)
 use Data::Dumper;
 use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
-
-    # Configure HTTP basic authorization: bearer_test
-    username => 'YOUR_USERNAME',
-    password => 'YOUR_PASSWORD',
 );
 
 my $required_string_group = 56; # int | Required String in group parameters
@@ -568,7 +569,7 @@ void (empty response body)
 
 ### Authorization
 
-[bearer_test](../README.md#bearer_test)
+No authorization required
 
 ### HTTP request headers
 
@@ -578,7 +579,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **test_inline_additional_properties**
-> test_inline_additional_properties(request_body => $request_body)
+> test_inline_additional_properties(param => $param)
 
 test inline additionalProperties
 
@@ -589,10 +590,10 @@ use WWW::OpenAPIClient::FakeApi;
 my $api_instance = WWW::OpenAPIClient::FakeApi->new(
 );
 
-my $request_body = WWW::OpenAPIClient::Object::HASH[string,string]->new(); # HASH[string,string] | request body
+my $param = WWW::OpenAPIClient::Object::HASH[string,string]->new(); # HASH[string,string] | request body
 
 eval { 
-    $api_instance->test_inline_additional_properties(request_body => $request_body);
+    $api_instance->test_inline_additional_properties(param => $param);
 };
 if ($@) {
     warn "Exception when calling FakeApi->test_inline_additional_properties: $@\n";
@@ -603,7 +604,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **request_body** | [**HASH[string,string]**](string.md)| request body | 
+ **param** | [**HASH[string,string]**](string.md)| request body | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/perl/docs/FakeClassnameTags123Api.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 
 # **test_classname**
-> Client test_classname(client => $client)
+> Client test_classname(body => $body)
 
 To test class name in snake case
 
@@ -31,10 +31,10 @@ my $api_instance = WWW::OpenAPIClient::FakeClassnameTags123Api->new(
     #api_key_prefix => {'api_key_query' => 'Bearer'},
 );
 
-my $client = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
+my $body = WWW::OpenAPIClient::Object::Client->new(); # Client | client model
 
 eval { 
-    my $result = $api_instance->test_classname(client => $client);
+    my $result = $api_instance->test_classname(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -46,7 +46,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **client** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md)| client model | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/FormatTest.md
+++ b/samples/client/petstore/perl/docs/FormatTest.md
@@ -21,8 +21,6 @@ Name | Type | Description | Notes
 **date_time** | **DateTime** |  | [optional] 
 **uuid** | **string** |  | [optional] 
 **password** | **string** |  | 
-**pattern_with_digits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
-**pattern_with_digits_and_delimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/perl/docs/PetApi.md
+++ b/samples/client/petstore/perl/docs/PetApi.md
@@ -21,7 +21,7 @@ Method | HTTP request | Description
 
 
 # **add_pet**
-> add_pet(pet => $pet)
+> add_pet(body => $body)
 
 Add a new pet to the store
 
@@ -35,10 +35,10 @@ my $api_instance = WWW::OpenAPIClient::PetApi->new(
     access_token => 'YOUR_ACCESS_TOKEN',
 );
 
-my $pet = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
+my $body = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
 
 eval { 
-    $api_instance->add_pet(pet => $pet);
+    $api_instance->add_pet(body => $body);
 };
 if ($@) {
     warn "Exception when calling PetApi->add_pet: $@\n";
@@ -49,7 +49,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
 
@@ -264,7 +264,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update_pet**
-> update_pet(pet => $pet)
+> update_pet(body => $body)
 
 Update an existing pet
 
@@ -278,10 +278,10 @@ my $api_instance = WWW::OpenAPIClient::PetApi->new(
     access_token => 'YOUR_ACCESS_TOKEN',
 );
 
-my $pet = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
+my $body = WWW::OpenAPIClient::Object::Pet->new(); # Pet | Pet object that needs to be added to the store
 
 eval { 
-    $api_instance->update_pet(pet => $pet);
+    $api_instance->update_pet(body => $body);
 };
 if ($@) {
     warn "Exception when calling PetApi->update_pet: $@\n";
@@ -292,7 +292,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
 
 ### Return type
 

--- a/samples/client/petstore/perl/docs/StoreApi.md
+++ b/samples/client/petstore/perl/docs/StoreApi.md
@@ -154,7 +154,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **place_order**
-> Order place_order(order => $order)
+> Order place_order(body => $body)
 
 Place an order for a pet
 
@@ -165,10 +165,10 @@ use WWW::OpenAPIClient::StoreApi;
 my $api_instance = WWW::OpenAPIClient::StoreApi->new(
 );
 
-my $order = WWW::OpenAPIClient::Object::Order->new(); # Order | order placed for purchasing the pet
+my $body = WWW::OpenAPIClient::Object::Order->new(); # Order | order placed for purchasing the pet
 
 eval { 
-    my $result = $api_instance->place_order(order => $order);
+    my $result = $api_instance->place_order(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -180,7 +180,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+ **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
 
 ### Return type
 
@@ -192,7 +192,7 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: application/xml, application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/perl/docs/UserApi.md
+++ b/samples/client/petstore/perl/docs/UserApi.md
@@ -20,7 +20,7 @@ Method | HTTP request | Description
 
 
 # **create_user**
-> create_user(user => $user)
+> create_user(body => $body)
 
 Create user
 
@@ -33,10 +33,10 @@ use WWW::OpenAPIClient::UserApi;
 my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
-my $user = WWW::OpenAPIClient::Object::User->new(); # User | Created user object
+my $body = WWW::OpenAPIClient::Object::User->new(); # User | Created user object
 
 eval { 
-    $api_instance->create_user(user => $user);
+    $api_instance->create_user(body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->create_user: $@\n";
@@ -47,7 +47,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**User**](User.md)| Created user object | 
+ **body** | [**User**](User.md)| Created user object | 
 
 ### Return type
 
@@ -59,13 +59,13 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **create_users_with_array_input**
-> create_users_with_array_input(user => $user)
+> create_users_with_array_input(body => $body)
 
 Creates list of users with given input array
 
@@ -76,10 +76,10 @@ use WWW::OpenAPIClient::UserApi;
 my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
-my $user = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
+my $body = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
 
 eval { 
-    $api_instance->create_users_with_array_input(user => $user);
+    $api_instance->create_users_with_array_input(body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->create_users_with_array_input: $@\n";
@@ -90,7 +90,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
+ **body** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
 
 ### Return type
 
@@ -102,13 +102,13 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **create_users_with_list_input**
-> create_users_with_list_input(user => $user)
+> create_users_with_list_input(body => $body)
 
 Creates list of users with given input array
 
@@ -119,10 +119,10 @@ use WWW::OpenAPIClient::UserApi;
 my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
-my $user = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
+my $body = [WWW::OpenAPIClient::Object::ARRAY[User]->new()]; # ARRAY[User] | List of user object
 
 eval { 
-    $api_instance->create_users_with_list_input(user => $user);
+    $api_instance->create_users_with_list_input(body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->create_users_with_list_input: $@\n";
@@ -133,7 +133,7 @@ if ($@) {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **user** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
+ **body** | [**ARRAY[User]**](ARRAY.md)| List of user object | 
 
 ### Return type
 
@@ -145,7 +145,7 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
@@ -325,7 +325,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update_user**
-> update_user(username => $username, user => $user)
+> update_user(username => $username, body => $body)
 
 Updated user
 
@@ -339,10 +339,10 @@ my $api_instance = WWW::OpenAPIClient::UserApi->new(
 );
 
 my $username = "username_example"; # string | name that need to be deleted
-my $user = WWW::OpenAPIClient::Object::User->new(); # User | Updated user object
+my $body = WWW::OpenAPIClient::Object::User->new(); # User | Updated user object
 
 eval { 
-    $api_instance->update_user(username => $username, user => $user);
+    $api_instance->update_user(username => $username, body => $body);
 };
 if ($@) {
     warn "Exception when calling UserApi->update_user: $@\n";
@@ -354,7 +354,7 @@ if ($@) {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **username** | **string**| name that need to be deleted | 
- **user** | [**User**](User.md)| Updated user object | 
+ **body** | [**User**](User.md)| Updated user object | 
 
 ### Return type
 
@@ -366,7 +366,7 @@ No authorization required
 
 ### HTTP request headers
 
- - **Content-Type**: application/json
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/AnotherFakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/AnotherFakeApi.pm
@@ -53,10 +53,10 @@ sub new {
 #
 # To test special tags
 # 
-# @param Client $client client model (required)
+# @param Client $body client model (required)
 {
     my $params = {
-    'client' => {
+    'body' => {
         data_type => 'Client',
         description => 'client model',
         required => '1',
@@ -73,9 +73,9 @@ sub new {
 sub call_123_test_special_tags {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'client' is set
-    unless (exists $args{'client'}) {
-      croak("Missing the required parameter 'client' when calling call_123_test_special_tags");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling call_123_test_special_tags");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub call_123_test_special_tags {
 
     my $_body_data;
     # body params
-    if ( exists $args{'client'}) {
-        $_body_data = $args{'client'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiClient.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/ApiClient.pm
@@ -348,11 +348,6 @@ sub update_params_for_auth {
                 $query_params->{'api_key_query'} = $api_key;
             }
         }
-        elsif ($auth eq 'bearer_test') {
-            if ($self->{config}{username} || $self->{config}{password}) {
-                $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});
-            }
-        }
         elsif ($auth eq 'http_basic_test') {
             if ($self->{config}{username} || $self->{config}{password}) {
                 $header_params->{'Authorization'} = 'Basic ' . encode_base64($self->{config}{username} . ":" . $self->{config}{password});

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
@@ -49,52 +49,64 @@ sub new {
 
 
 #
-# fake_health_get
+# create_xml_item
 #
-# Health check endpoint
+# creates an XmlItem
 # 
+# @param XmlItem $xml_item XmlItem Body (required)
 {
     my $params = {
+    'xml_item' => {
+        data_type => 'XmlItem',
+        description => 'XmlItem Body',
+        required => '1',
+    },
     };
-    __PACKAGE__->method_documentation->{ 'fake_health_get' } = { 
-        summary => 'Health check endpoint',
+    __PACKAGE__->method_documentation->{ 'create_xml_item' } = { 
+        summary => 'creates an XmlItem',
         params => $params,
-        returns => 'HealthCheckResult',
+        returns => undef,
         };
 }
-# @return HealthCheckResult
+# @return void
 #
-sub fake_health_get {
+sub create_xml_item {
     my ($self, %args) = @_;
 
-    # parse inputs
-    my $_resource_path = '/fake/health';
+    # verify the required parameter 'xml_item' is set
+    unless (exists $args{'xml_item'}) {
+      croak("Missing the required parameter 'xml_item' when calling create_xml_item");
+    }
 
-    my $_method = 'GET';
+    # parse inputs
+    my $_resource_path = '/fake/create_xml_item';
+
+    my $_method = 'POST';
     my $query_params = {};
     my $header_params = {};
     my $form_params = {};
 
     # 'Accept' and 'Content-Type' header
-    my $_header_accept = $self->{api_client}->select_header_accept('application/json');
+    my $_header_accept = $self->{api_client}->select_header_accept();
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16');
 
     my $_body_data;
+    # body params
+    if ( exists $args{'xml_item'}) {
+        $_body_data = $args{'xml_item'};
+    }
+
     # authentication setting, if any
     my $auth_settings = [qw()];
 
     # make the API Call
-    my $response = $self->{api_client}->call_api($_resource_path, $_method,
+    $self->{api_client}->call_api($_resource_path, $_method,
                                            $query_params, $form_params,
                                            $header_params, $_body_data, $auth_settings);
-    if (!$response) {
-        return;
-    }
-    my $_response_object = $self->{api_client}->deserialize('HealthCheckResult', $response);
-    return $_response_object;
+    return;
 }
 
 #
@@ -135,7 +147,7 @@ sub fake_outer_boolean_serialize {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
@@ -162,10 +174,10 @@ sub fake_outer_boolean_serialize {
 #
 # 
 # 
-# @param OuterComposite $outer_composite Input composite as post body (optional)
+# @param OuterComposite $body Input composite as post body (optional)
 {
     my $params = {
-    'outer_composite' => {
+    'body' => {
         data_type => 'OuterComposite',
         description => 'Input composite as post body',
         required => '0',
@@ -195,12 +207,12 @@ sub fake_outer_composite_serialize {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
-    if ( exists $args{'outer_composite'}) {
-        $_body_data = $args{'outer_composite'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -255,7 +267,7 @@ sub fake_outer_number_serialize {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
@@ -315,7 +327,7 @@ sub fake_outer_string_serialize {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
@@ -342,10 +354,10 @@ sub fake_outer_string_serialize {
 #
 # 
 # 
-# @param FileSchemaTestClass $file_schema_test_class  (required)
+# @param FileSchemaTestClass $body  (required)
 {
     my $params = {
-    'file_schema_test_class' => {
+    'body' => {
         data_type => 'FileSchemaTestClass',
         description => '',
         required => '1',
@@ -362,9 +374,9 @@ sub fake_outer_string_serialize {
 sub test_body_with_file_schema {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'file_schema_test_class' is set
-    unless (exists $args{'file_schema_test_class'}) {
-      croak("Missing the required parameter 'file_schema_test_class' when calling test_body_with_file_schema");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_body_with_file_schema");
     }
 
     # parse inputs
@@ -384,8 +396,8 @@ sub test_body_with_file_schema {
 
     my $_body_data;
     # body params
-    if ( exists $args{'file_schema_test_class'}) {
-        $_body_data = $args{'file_schema_test_class'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -404,7 +416,7 @@ sub test_body_with_file_schema {
 # 
 # 
 # @param string $query  (required)
-# @param User $user  (required)
+# @param User $body  (required)
 {
     my $params = {
     'query' => {
@@ -412,7 +424,7 @@ sub test_body_with_file_schema {
         description => '',
         required => '1',
     },
-    'user' => {
+    'body' => {
         data_type => 'User',
         description => '',
         required => '1',
@@ -434,9 +446,9 @@ sub test_body_with_query_params {
       croak("Missing the required parameter 'query' when calling test_body_with_query_params");
     }
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling test_body_with_query_params");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_body_with_query_params");
     }
 
     # parse inputs
@@ -461,8 +473,8 @@ sub test_body_with_query_params {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -480,10 +492,10 @@ sub test_body_with_query_params {
 #
 # To test \"client\" model
 # 
-# @param Client $client client model (required)
+# @param Client $body client model (required)
 {
     my $params = {
-    'client' => {
+    'body' => {
         data_type => 'Client',
         description => 'client model',
         required => '1',
@@ -500,9 +512,9 @@ sub test_body_with_query_params {
 sub test_client_model {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'client' is set
-    unless (exists $args{'client'}) {
-      croak("Missing the required parameter 'client' when calling test_client_model");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_client_model");
     }
 
     # parse inputs
@@ -522,8 +534,8 @@ sub test_client_model {
 
     my $_body_data;
     # body params
-    if ( exists $args{'client'}) {
-        $_body_data = $args{'client'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -1010,7 +1022,7 @@ sub test_group_parameters {
 
     my $_body_data;
     # authentication setting, if any
-    my $auth_settings = [qw(bearer_test )];
+    my $auth_settings = [qw()];
 
     # make the API Call
     $self->{api_client}->call_api($_resource_path, $_method,
@@ -1024,10 +1036,10 @@ sub test_group_parameters {
 #
 # test inline additionalProperties
 # 
-# @param HASH[string,string] $request_body request body (required)
+# @param HASH[string,string] $param request body (required)
 {
     my $params = {
-    'request_body' => {
+    'param' => {
         data_type => 'HASH[string,string]',
         description => 'request body',
         required => '1',
@@ -1044,9 +1056,9 @@ sub test_group_parameters {
 sub test_inline_additional_properties {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'request_body' is set
-    unless (exists $args{'request_body'}) {
-      croak("Missing the required parameter 'request_body' when calling test_inline_additional_properties");
+    # verify the required parameter 'param' is set
+    unless (exists $args{'param'}) {
+      croak("Missing the required parameter 'param' when calling test_inline_additional_properties");
     }
 
     # parse inputs
@@ -1066,8 +1078,8 @@ sub test_inline_additional_properties {
 
     my $_body_data;
     # body params
-    if ( exists $args{'request_body'}) {
-        $_body_data = $args{'request_body'};
+    if ( exists $args{'param'}) {
+        $_body_data = $args{'param'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeClassnameTags123Api.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeClassnameTags123Api.pm
@@ -53,10 +53,10 @@ sub new {
 #
 # To test class name in snake case
 # 
-# @param Client $client client model (required)
+# @param Client $body client model (required)
 {
     my $params = {
-    'client' => {
+    'body' => {
         data_type => 'Client',
         description => 'client model',
         required => '1',
@@ -73,9 +73,9 @@ sub new {
 sub test_classname {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'client' is set
-    unless (exists $args{'client'}) {
-      croak("Missing the required parameter 'client' when calling test_classname");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling test_classname");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub test_classname {
 
     my $_body_data;
     # body params
-    if ( exists $args{'client'}) {
-        $_body_data = $args{'client'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesAnyType.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesAnyType.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesArray.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesArray.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesBoolean.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesBoolean.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesClass.pm
@@ -161,16 +161,79 @@ __PACKAGE__->class_documentation({description => '',
 }                                 );
 
 __PACKAGE__->method_documentation({
-    'map_property' => {
+    'map_string' => {
         datatype => 'HASH[string,string]',
-        base_name => 'map_property',
+        base_name => 'map_string',
         description => '',
         format => '',
         read_only => '',
             },
-    'map_of_map_property' => {
+    'map_number' => {
+        datatype => 'HASH[string,double]',
+        base_name => 'map_number',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'map_integer' => {
+        datatype => 'HASH[string,int]',
+        base_name => 'map_integer',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'map_boolean' => {
+        datatype => 'HASH[string,boolean]',
+        base_name => 'map_boolean',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'map_array_integer' => {
+        datatype => 'HASH[string,ARRAY[int]]',
+        base_name => 'map_array_integer',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'map_array_anytype' => {
+        datatype => 'HASH[string,ARRAY[object]]',
+        base_name => 'map_array_anytype',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'map_map_string' => {
         datatype => 'HASH[string,HASH[string,string]]',
-        base_name => 'map_of_map_property',
+        base_name => 'map_map_string',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'map_map_anytype' => {
+        datatype => 'HASH[string,HASH[string,object]]',
+        base_name => 'map_map_anytype',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'anytype_1' => {
+        datatype => 'object',
+        base_name => 'anytype_1',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'anytype_2' => {
+        datatype => 'object',
+        base_name => 'anytype_2',
+        description => '',
+        format => '',
+        read_only => '',
+            },
+    'anytype_3' => {
+        datatype => 'object',
+        base_name => 'anytype_3',
         description => '',
         format => '',
         read_only => '',
@@ -178,13 +241,31 @@ __PACKAGE__->method_documentation({
 });
 
 __PACKAGE__->openapi_types( {
-    'map_property' => 'HASH[string,string]',
-    'map_of_map_property' => 'HASH[string,HASH[string,string]]'
+    'map_string' => 'HASH[string,string]',
+    'map_number' => 'HASH[string,double]',
+    'map_integer' => 'HASH[string,int]',
+    'map_boolean' => 'HASH[string,boolean]',
+    'map_array_integer' => 'HASH[string,ARRAY[int]]',
+    'map_array_anytype' => 'HASH[string,ARRAY[object]]',
+    'map_map_string' => 'HASH[string,HASH[string,string]]',
+    'map_map_anytype' => 'HASH[string,HASH[string,object]]',
+    'anytype_1' => 'object',
+    'anytype_2' => 'object',
+    'anytype_3' => 'object'
 } );
 
 __PACKAGE__->attribute_map( {
-    'map_property' => 'map_property',
-    'map_of_map_property' => 'map_of_map_property'
+    'map_string' => 'map_string',
+    'map_number' => 'map_number',
+    'map_integer' => 'map_integer',
+    'map_boolean' => 'map_boolean',
+    'map_array_integer' => 'map_array_integer',
+    'map_array_anytype' => 'map_array_anytype',
+    'map_map_string' => 'map_map_string',
+    'map_map_anytype' => 'map_map_anytype',
+    'anytype_1' => 'anytype_1',
+    'anytype_2' => 'anytype_2',
+    'anytype_3' => 'anytype_3'
 } );
 
 __PACKAGE__->mk_accessors(keys %{__PACKAGE__->attribute_map});

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesInteger.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesInteger.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesNumber.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesNumber.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesObject.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesObject.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesString.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/AdditionalPropertiesString.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/EnumTest.pm
@@ -31,9 +31,6 @@ use Date::Parse;
 use DateTime;
 
 use WWW::OpenAPIClient::Object::OuterEnum;
-use WWW::OpenAPIClient::Object::OuterEnumDefaultValue;
-use WWW::OpenAPIClient::Object::OuterEnumInteger;
-use WWW::OpenAPIClient::Object::OuterEnumIntegerDefaultValue;
 
 use base ("Class::Accessor", "Class::Data::Inheritable");
 
@@ -200,27 +197,6 @@ __PACKAGE__->method_documentation({
         format => '',
         read_only => '',
             },
-    'outer_enum_integer' => {
-        datatype => 'OuterEnumInteger',
-        base_name => 'outerEnumInteger',
-        description => '',
-        format => '',
-        read_only => '',
-            },
-    'outer_enum_default_value' => {
-        datatype => 'OuterEnumDefaultValue',
-        base_name => 'outerEnumDefaultValue',
-        description => '',
-        format => '',
-        read_only => '',
-            },
-    'outer_enum_integer_default_value' => {
-        datatype => 'OuterEnumIntegerDefaultValue',
-        base_name => 'outerEnumIntegerDefaultValue',
-        description => '',
-        format => '',
-        read_only => '',
-            },
 });
 
 __PACKAGE__->openapi_types( {
@@ -228,10 +204,7 @@ __PACKAGE__->openapi_types( {
     'enum_string_required' => 'string',
     'enum_integer' => 'int',
     'enum_number' => 'double',
-    'outer_enum' => 'OuterEnum',
-    'outer_enum_integer' => 'OuterEnumInteger',
-    'outer_enum_default_value' => 'OuterEnumDefaultValue',
-    'outer_enum_integer_default_value' => 'OuterEnumIntegerDefaultValue'
+    'outer_enum' => 'OuterEnum'
 } );
 
 __PACKAGE__->attribute_map( {
@@ -239,10 +212,7 @@ __PACKAGE__->attribute_map( {
     'enum_string_required' => 'enum_string_required',
     'enum_integer' => 'enum_integer',
     'enum_number' => 'enum_number',
-    'outer_enum' => 'outerEnum',
-    'outer_enum_integer' => 'outerEnumInteger',
-    'outer_enum_default_value' => 'outerEnumDefaultValue',
-    'outer_enum_integer_default_value' => 'outerEnumIntegerDefaultValue'
+    'outer_enum' => 'outerEnum'
 } );
 
 __PACKAGE__->mk_accessors(keys %{__PACKAGE__->attribute_map});

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
@@ -252,20 +252,6 @@ __PACKAGE__->method_documentation({
         format => '',
         read_only => '',
             },
-    'pattern_with_digits' => {
-        datatype => 'string',
-        base_name => 'pattern_with_digits',
-        description => 'A string that is a 10 digit number. Can have leading zeros.',
-        format => '',
-        read_only => '',
-            },
-    'pattern_with_digits_and_delimiter' => {
-        datatype => 'string',
-        base_name => 'pattern_with_digits_and_delimiter',
-        description => 'A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.',
-        format => '',
-        read_only => '',
-            },
 });
 
 __PACKAGE__->openapi_types( {
@@ -281,9 +267,7 @@ __PACKAGE__->openapi_types( {
     'date' => 'DateTime',
     'date_time' => 'DateTime',
     'uuid' => 'string',
-    'password' => 'string',
-    'pattern_with_digits' => 'string',
-    'pattern_with_digits_and_delimiter' => 'string'
+    'password' => 'string'
 } );
 
 __PACKAGE__->attribute_map( {
@@ -299,9 +283,7 @@ __PACKAGE__->attribute_map( {
     'date' => 'date',
     'date_time' => 'dateTime',
     'uuid' => 'uuid',
-    'password' => 'password',
-    'pattern_with_digits' => 'pattern_with_digits',
-    'pattern_with_digits_and_delimiter' => 'pattern_with_digits_and_delimiter'
+    'password' => 'password'
 } );
 
 __PACKAGE__->mk_accessors(keys %{__PACKAGE__->attribute_map});

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/TypeHolderDefault.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/TypeHolderDefault.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/TypeHolderExample.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/TypeHolderExample.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/XmlItem.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/XmlItem.pm
@@ -114,13 +114,20 @@ sub from_hash {
     # loop through attributes and use openapi_types to deserialize the data
     while ( my ($_key, $_type) = each %{$self->openapi_types} ) {
         my $_json_attribute = $self->attribute_map->{$_key}; 
-        if ($_type =~ /^array\[/i) { # array
-            my $_subclass = substr($_type, 6, -1);
+        if ($_type =~ /^array\[(.+)\]$/i) { # array
+            my $_subclass = $1;
             my @_array = ();
             foreach my $_element (@{$hash->{$_json_attribute}}) {
                 push @_array, $self->_deserialize($_subclass, $_element);
             }
             $self->{$_key} = \@_array;
+        } elsif ($_type =~ /^hash\[string,(.+)\]$/i) { # hash
+            my $_subclass = $1;
+            my %_hash = ();
+            while (my($_key, $_element) = each %{$hash->{$_json_attribute}}) {
+                $_hash{$_key} = $self->_deserialize($_subclass, $_element);
+            }
+            $self->{$_key} = \%_hash;
         } elsif (exists $hash->{$_json_attribute}) { #hash(model), primitive, datetime
             $self->{$_key} = $self->_deserialize($_type, $hash->{$_json_attribute});
         } else {
@@ -135,10 +142,10 @@ sub from_hash {
 sub _deserialize {
     my ($self, $type, $data) = @_;
     $log->debugf("deserializing %s with %s",Dumper($data), $type);
-        
+
     if ($type eq 'DateTime') {
         return DateTime->from_epoch(epoch => str2time($data));
-    } elsif ( grep {$type=~/^(ARRAY\[|HASH\[string,)?$_(\])?$/} ('int', 'double', 'string', 'boolean') ) {
+    } elsif ( grep( /^$type$/, ('int', 'double', 'string', 'boolean'))) {
         return $data;
     } else { # hash(model)
         my $_instance = eval "WWW::OpenAPIClient::Object::$type->new()";

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/PetApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/PetApi.pm
@@ -53,10 +53,10 @@ sub new {
 #
 # Add a new pet to the store
 # 
-# @param Pet $pet Pet object that needs to be added to the store (required)
+# @param Pet $body Pet object that needs to be added to the store (required)
 {
     my $params = {
-    'pet' => {
+    'body' => {
         data_type => 'Pet',
         description => 'Pet object that needs to be added to the store',
         required => '1',
@@ -73,9 +73,9 @@ sub new {
 sub add_pet {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'pet' is set
-    unless (exists $args{'pet'}) {
-      croak("Missing the required parameter 'pet' when calling add_pet");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling add_pet");
     }
 
     # parse inputs
@@ -95,8 +95,8 @@ sub add_pet {
 
     my $_body_data;
     # body params
-    if ( exists $args{'pet'}) {
-        $_body_data = $args{'pet'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -385,10 +385,10 @@ sub get_pet_by_id {
 #
 # Update an existing pet
 # 
-# @param Pet $pet Pet object that needs to be added to the store (required)
+# @param Pet $body Pet object that needs to be added to the store (required)
 {
     my $params = {
-    'pet' => {
+    'body' => {
         data_type => 'Pet',
         description => 'Pet object that needs to be added to the store',
         required => '1',
@@ -405,9 +405,9 @@ sub get_pet_by_id {
 sub update_pet {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'pet' is set
-    unless (exists $args{'pet'}) {
-      croak("Missing the required parameter 'pet' when calling update_pet");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling update_pet");
     }
 
     # parse inputs
@@ -427,8 +427,8 @@ sub update_pet {
 
     my $_body_data;
     # body params
-    if ( exists $args{'pet'}) {
-        $_body_data = $args{'pet'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/StoreApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/StoreApi.pm
@@ -232,10 +232,10 @@ sub get_order_by_id {
 #
 # Place an order for a pet
 # 
-# @param Order $order order placed for purchasing the pet (required)
+# @param Order $body order placed for purchasing the pet (required)
 {
     my $params = {
-    'order' => {
+    'body' => {
         data_type => 'Order',
         description => 'order placed for purchasing the pet',
         required => '1',
@@ -252,9 +252,9 @@ sub get_order_by_id {
 sub place_order {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'order' is set
-    unless (exists $args{'order'}) {
-      croak("Missing the required parameter 'order' when calling place_order");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling place_order");
     }
 
     # parse inputs
@@ -270,12 +270,12 @@ sub place_order {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
-    if ( exists $args{'order'}) {
-        $_body_data = $args{'order'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/UserApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/UserApi.pm
@@ -53,10 +53,10 @@ sub new {
 #
 # Create user
 # 
-# @param User $user Created user object (required)
+# @param User $body Created user object (required)
 {
     my $params = {
-    'user' => {
+    'body' => {
         data_type => 'User',
         description => 'Created user object',
         required => '1',
@@ -73,9 +73,9 @@ sub new {
 sub create_user {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling create_user");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling create_user");
     }
 
     # parse inputs
@@ -91,12 +91,12 @@ sub create_user {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -114,10 +114,10 @@ sub create_user {
 #
 # Creates list of users with given input array
 # 
-# @param ARRAY[User] $user List of user object (required)
+# @param ARRAY[User] $body List of user object (required)
 {
     my $params = {
-    'user' => {
+    'body' => {
         data_type => 'ARRAY[User]',
         description => 'List of user object',
         required => '1',
@@ -134,9 +134,9 @@ sub create_user {
 sub create_users_with_array_input {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling create_users_with_array_input");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling create_users_with_array_input");
     }
 
     # parse inputs
@@ -152,12 +152,12 @@ sub create_users_with_array_input {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -175,10 +175,10 @@ sub create_users_with_array_input {
 #
 # Creates list of users with given input array
 # 
-# @param ARRAY[User] $user List of user object (required)
+# @param ARRAY[User] $body List of user object (required)
 {
     my $params = {
-    'user' => {
+    'body' => {
         data_type => 'ARRAY[User]',
         description => 'List of user object',
         required => '1',
@@ -195,9 +195,9 @@ sub create_users_with_array_input {
 sub create_users_with_list_input {
     my ($self, %args) = @_;
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling create_users_with_list_input");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling create_users_with_list_input");
     }
 
     # parse inputs
@@ -213,12 +213,12 @@ sub create_users_with_list_input {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any
@@ -493,7 +493,7 @@ sub logout_user {
 # Updated user
 # 
 # @param string $username name that need to be deleted (required)
-# @param User $user Updated user object (required)
+# @param User $body Updated user object (required)
 {
     my $params = {
     'username' => {
@@ -501,7 +501,7 @@ sub logout_user {
         description => 'name that need to be deleted',
         required => '1',
     },
-    'user' => {
+    'body' => {
         data_type => 'User',
         description => 'Updated user object',
         required => '1',
@@ -523,9 +523,9 @@ sub update_user {
       croak("Missing the required parameter 'username' when calling update_user");
     }
 
-    # verify the required parameter 'user' is set
-    unless (exists $args{'user'}) {
-      croak("Missing the required parameter 'user' when calling update_user");
+    # verify the required parameter 'body' is set
+    unless (exists $args{'body'}) {
+      croak("Missing the required parameter 'body' when calling update_user");
     }
 
     # parse inputs
@@ -541,7 +541,7 @@ sub update_user {
     if ($_header_accept) {
         $header_params->{'Accept'} = $_header_accept;
     }
-    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type('application/json');
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
 
     # path params
     if ( exists $args{'username'}) {
@@ -552,8 +552,8 @@ sub update_user {
 
     my $_body_data;
     # body params
-    if ( exists $args{'user'}) {
-        $_body_data = $args{'user'};
+    if ( exists $args{'body'}) {
+        $_body_data = $args{'body'};
     }
 
     # authentication setting, if any

--- a/samples/client/petstore/perl/tests/01_pet_api.t
+++ b/samples/client/petstore/perl/tests/01_pet_api.t
@@ -50,7 +50,7 @@ is $pet_hash->{category}->{name}, 'perl', 'get the proper category name';
 is $pet_hash->{tags}[0]->{name}, 'just kidding', 'get the proper tag name';
 is $pet_hash->{tags}[0]->{id}, '11', 'get the proper tag id';
 
-my $add_pet = $api->add_pet(pet => $pet);
+my $add_pet = $api->add_pet(body => $pet);
 
 my $get_pet = $api->get_pet_by_id(pet_id => $pet_id);
 my $get_pet_hash = $get_pet->to_hash;

--- a/samples/client/petstore/perl/tests/03_api_factory.t
+++ b/samples/client/petstore/perl/tests/03_api_factory.t
@@ -37,7 +37,7 @@ is $pet->tags->[0]->name, 'just kidding', 'got the proper tag name';
 is $pet->tags->[0]->id, '11', 'got the proper tag id';
 
 
-my $add_pet = $pet_api->add_pet(pet => $pet);
+my $add_pet = $pet_api->add_pet(body => $pet);
 my $get_pet = $pet_api->get_pet_by_id(pet_id => $pet_id);
 
 is $get_pet->id, '10008', 'stored and retrieved: got the proper pet id';

--- a/samples/client/petstore/perl/tests/04_role.t
+++ b/samples/client/petstore/perl/tests/04_role.t
@@ -36,7 +36,7 @@ is $pet->tags->[0]->name, 'just kidding', 'got the proper tag name';
 is $pet->tags->[0]->id, '11', 'got the proper tag id';
 
 
-my $add_pet = $api->add_pet(pet => $pet);
+my $add_pet = $api->add_pet(body => $pet);
 my $get_pet = $api->get_pet_by_id(pet_id => $pet_id);
 
 is $get_pet->id, '10008', 'stored and retrieved: got the proper pet id';


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use body instead of the model name as the parser can now retain the body name in OAS v2
