### PR TITLE
[TypeScript-axios] fix using withSeparateModelsAndApi and withoutPrefixEnums with additional-properties option

### DIFF
--- a/docs/generators/typescript-axios.md
+++ b/docs/generators/typescript-axios.md
@@ -15,8 +15,8 @@ sidebar_label: typescript-axios
 |supportsES6|Generate code that conforms to ES6.| |false|
 |npmName|The name under which you want to publish generated npm package| |null|
 |npmVersion|The version of your npm package| |null|
-|npmRepository|Use this property to set an url your private npmRepo in the package.json| |null|
+|npmRepository|Use this property to set an url of your private npmRepo in the package.json| |null|
 |snapshot|When setting this property to true the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm| |false|
 |withInterfaces|Setting this property to true will generate interfaces next to the default class implementations.| |false|
 |withSeparateModelsAndApi|Put the model and api in separate folders and in separate classes| |false|
-|withoutPrefixEnums|Dont prefix enum names with class names| |false|
+|withoutPrefixEnums|Don't prefix enum names with class names| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -59,11 +59,11 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
 
         this.cliOptions.add(new CliOption(NPM_NAME, "The name under which you want to publish generated npm package"));
         this.cliOptions.add(new CliOption(NPM_VERSION, "The version of your npm package"));
-        this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url your private npmRepo in the package.json"));
+        this.cliOptions.add(new CliOption(NPM_REPOSITORY, "Use this property to set an url of your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(SNAPSHOT, "When setting this property to true the version will be suffixed with -SNAPSHOT.yyyyMMddHHmm", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(WITH_INTERFACES, "Setting this property to true will generate interfaces next to the default class implementations.", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
         this.cliOptions.add(new CliOption(SEPARATE_MODELS_AND_API, "Put the model and api in separate folders and in separate classes", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
-        this.cliOptions.add(new CliOption(WITHOUT_PREFIX_ENUMS, "Dont prefix enum names with class names", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
+        this.cliOptions.add(new CliOption(WITHOUT_PREFIX_ENUMS, "Don't prefix enum names with class names", SchemaTypeUtil.BOOLEAN_TYPE).defaultValue(Boolean.FALSE.toString()));
     }
 
     @Override
@@ -135,22 +135,22 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
 
-        boolean separateModelsAndApi = (boolean)additionalProperties.getOrDefault(SEPARATE_MODELS_AND_API, false);
-
-        if (separateModelsAndApi) {
-            modelTemplateFiles.put("model.mustache", ".ts");
-            apiTemplateFiles.put("apiInner.mustache", ".ts");
-            supportingFiles.add(new SupportingFile("modelIndex.mustache", tsModelPackage, "index.ts"));
+        if (additionalProperties.containsKey(SEPARATE_MODELS_AND_API)) {
+            boolean separateModelsAndApi = Boolean.parseBoolean(additionalProperties.get(SEPARATE_MODELS_AND_API).toString());
+            if (separateModelsAndApi) {
+                if (StringUtils.isAnyBlank(modelPackage, apiPackage)) {
+                    throw new RuntimeException("apiPackage and modelPackage must be defined");
+                }
+                modelTemplateFiles.put("model.mustache", ".ts");
+                apiTemplateFiles.put("apiInner.mustache", ".ts");
+                supportingFiles.add(new SupportingFile("modelIndex.mustache", tsModelPackage, "index.ts"));
+            }
         }
 
         if (additionalProperties.containsKey(NPM_NAME)) {
             addNpmPackageGeneration();
         }
 
-        boolean emptyModelOrApi = separateModelsAndApi && StringUtils.isAnyBlank(modelPackage, apiPackage);
-        if (emptyModelOrApi) {
-            throw new RuntimeException("apiPackage and modelPackage must be defined");
-        }
     }
 
     @Override
@@ -180,7 +180,10 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {
         List<Object> models = (List<Object>) postProcessModelsEnum(objs).get("models");
 
-        boolean withoutPrefixEnums = (boolean)additionalProperties.getOrDefault(WITHOUT_PREFIX_ENUMS, false);
+        boolean withoutPrefixEnums = false;
+        if (additionalProperties.containsKey(WITHOUT_PREFIX_ENUMS)) {
+            withoutPrefixEnums = Boolean.parseBoolean(additionalProperties.get(WITHOUT_PREFIX_ENUMS).toString());
+        }
 
         for (Object _mo  : models) {
             Map<String, Object> mo = (Map<String, Object>) _mo;


### PR DESCRIPTION

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### Description of the PR

- fix using withSeparateModelsAndApi and withoutPrefixEnums in cli with additional-properties option reach a ClassCastException (fix #2709)
- fix typos in specific properties description

