### PR TITLE
[BUG][cpp-qt5-client] Header params in api-body operations use param name instead of value

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -101,7 +101,7 @@ void
     {{/isContainer}}{{/bodyParams}}
     {{#headerParams}}
     if ({{paramName}} != nullptr) {
-        input.headers.insert("{{baseName}}", "{{paramName}}");
+        input.headers.insert("{{baseName}}", {{paramName}});
     }
     {{/headerParams}}
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Header parameters are broken in the `cpp-qt5-client` due to quotation of the `{{paramName}}` value -- the name of the parameter is used instead of the value. Remove quotation marks.

Fixes issue [2726](https://github.com/OpenAPITools/openapi-generator/issues/2726).