### PR TITLE
fix allof in javascript generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -1006,6 +1006,27 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         return objs;
     }
 
+    @Override
+    public Map<String, Object> postProcessAllModels(Map<String, Object> objs) {
+        objs = super.postProcessAllModels(objs);
+        for (Map.Entry<String, Object> entry : objs.entrySet()) {
+            CodegenModel cm = ModelUtils.getModelByName(entry.getKey(), objs);
+            
+            if (supportsInheritance || supportsMixins) {
+                if (cm.interfaceModels != null) {
+                    for (CodegenModel cmInterface : cm.interfaceModels) {
+                        for (CodegenProperty var : cmInterface.allVars) {
+                            if (Boolean.TRUE.equals(var.required)) {
+                                ((List<CodegenProperty>) cm.vendorExtensions.get("x-all-required")).add(var);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return objs;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public Map<String, Object> postProcessModels(Map<String, Object> objs) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR


Required parameters from inherited schemas were not being included on the constructor of the resulting schema when using allOf. These were included on the body of the constructor by using the {{#interfaceModels}} tag.

Fix for https://github.com/OpenAPITools/openapi-generator/issues/2438
@CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)

