### PR TITLE
Pass opts argument to api client in ruby-client

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -126,7 +126,7 @@ module {{moduleName}}
       local_var_path = '{{{path}}}'{{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       {{#queryParams}}
       {{#required}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
@@ -139,7 +139,7 @@ module {{moduleName}}
       {{/queryParams}}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       {{#hasProduces}}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept([{{#produces}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/produces}}])
@@ -160,7 +160,7 @@ module {{moduleName}}
       {{/headerParams}}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       {{#formParams}}
       {{#required}}
       form_params['{{baseName}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
@@ -173,20 +173,24 @@ module {{moduleName}}
       {{/formParams}}
 
       # http body (model)
-      {{^bodyParam}}
-      post_body = nil
-      {{/bodyParam}}
-      {{#bodyParam}}
-      post_body = @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}})
-      {{/bodyParam}}
-      auth_names = [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
-      data, status_code, headers = @api_client.call_api(:{{httpMethod}}, local_var_path,
+      post_body = opts[:body] {{#bodyParam}}|| @api_client.object_to_http_body({{#required}}{{{paramName}}}{{/required}}{{^required}}opts[:'{{{paramName}}}']{{/required}}) {{/bodyParam}}
+
+      # return_type
+      return_type = opts[:return_type] {{#returnType}}|| '{{{returnType}}}' {{/returnType}}
+
+      # auth_names
+      auth_names = opts[:auth_names] || [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names{{#returnType}},
-        :return_type => '{{{returnType}}}'{{/returnType}})
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:{{httpMethod}}, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: {{classname}}#{{operationId}}\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -181,7 +181,7 @@ module {{moduleName}}
       # auth_names
       auth_names = opts[:auth_names] || [{{#authMethods}}'{{name}}'{{#hasMore}}, {{/hasMore}}{{/authMethods}}]
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -190,7 +190,7 @@ module {{moduleName}}
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:{{httpMethod}}, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:{{httpMethod}}, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: {{classname}}#{{operationId}}\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -46,28 +46,37 @@ module Petstore
       local_var_path = '/another-fake/dummy'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Client' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Client')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: AnotherFakeApi#call_123_test_special_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -67,7 +67,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -76,7 +76,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: AnotherFakeApi#call_123_test_special_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -65,7 +65,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -74,7 +74,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#create_xml_item\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -121,7 +121,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -130,7 +130,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_boolean_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -177,7 +177,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -186,7 +186,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_composite_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -233,7 +233,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -242,7 +242,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_number_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -289,7 +289,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -298,7 +298,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_string_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -349,7 +349,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -358,7 +358,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_file_schema\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -414,7 +414,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -423,7 +423,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_query_params\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -478,7 +478,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -487,7 +487,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_client_model\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -646,7 +646,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['http_basic_test']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -655,7 +655,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_endpoint_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -758,7 +758,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -767,7 +767,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_enum_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -842,7 +842,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -851,7 +851,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_group_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -902,7 +902,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -911,7 +911,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_inline_additional_properties\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -970,7 +970,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -979,7 +979,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_json_form_data\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -46,25 +46,35 @@ module Petstore
       local_var_path = '/fake/create_xml_item'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/xml', 'application/xml; charset=utf-8', 'application/xml; charset=utf-16', 'text/xml', 'text/xml; charset=utf-8', 'text/xml; charset=utf-16'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(xml_item)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(xml_item) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#create_xml_item\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -92,26 +102,35 @@ module Petstore
       local_var_path = '/fake/outer/boolean'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Boolean' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Boolean')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_boolean_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -139,26 +158,35 @@ module Petstore
       local_var_path = '/fake/outer/composite'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'OuterComposite' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'OuterComposite')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_composite_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -186,26 +214,35 @@ module Petstore
       local_var_path = '/fake/outer/number'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Float' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Float')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_number_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -233,26 +270,35 @@ module Petstore
       local_var_path = '/fake/outer/string'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'String' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_string_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -284,25 +330,35 @@ module Petstore
       local_var_path = '/fake/body-with-file-schema'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_file_schema\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -338,26 +394,36 @@ module Petstore
       local_var_path = '/fake/body-with-query-params'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'query'] = query
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_query_params\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -391,28 +457,37 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Client' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Client')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_client_model\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -538,15 +613,15 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['number'] = number
       form_params['double'] = double
       form_params['pattern_without_delimiter'] = pattern_without_delimiter
@@ -563,14 +638,24 @@ module Petstore
       form_params['callback'] = opts[:'callback'] if !opts[:'callback'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['http_basic_test']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['http_basic_test']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_endpoint_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -646,33 +731,43 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'enum_query_string_array'] = @api_client.build_collection_param(opts[:'enum_query_string_array'], :csv) if !opts[:'enum_query_string_array'].nil?
       query_params[:'enum_query_string'] = opts[:'enum_query_string'] if !opts[:'enum_query_string'].nil?
       query_params[:'enum_query_integer'] = opts[:'enum_query_integer'] if !opts[:'enum_query_integer'].nil?
       query_params[:'enum_query_double'] = opts[:'enum_query_double'] if !opts[:'enum_query_double'].nil?
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       header_params[:'enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
       header_params[:'enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['enum_form_string_array'] = @api_client.build_collection_param(opts[:'enum_form_string_array'], :csv) if !opts[:'enum_form_string_array'].nil?
       form_params['enum_form_string'] = opts[:'enum_form_string'] if !opts[:'enum_form_string'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_enum_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -724,29 +819,39 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'required_string_group'] = required_string_group
       query_params[:'required_int64_group'] = required_int64_group
       query_params[:'string_group'] = opts[:'string_group'] if !opts[:'string_group'].nil?
       query_params[:'int64_group'] = opts[:'int64_group'] if !opts[:'int64_group'].nil?
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       header_params[:'required_boolean_group'] = required_boolean_group
       header_params[:'boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_group_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -778,25 +883,35 @@ module Petstore
       local_var_path = '/fake/inline-additionalProperties'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(param)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(param) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_inline_additional_properties\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -834,27 +949,37 @@ module Petstore
       local_var_path = '/fake/jsonFormData'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['param'] = param
       form_params['param2'] = param2
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_json_form_data\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -67,7 +67,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['api_key_query']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -76,7 +76,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeClassnameTags123Api#test_classname\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -46,28 +46,37 @@ module Petstore
       local_var_path = '/fake_classname_test'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = ['api_key_query']
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Client' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['api_key_query']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Client')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeClassnameTags123Api#test_classname\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -63,7 +63,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -72,7 +72,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -124,7 +124,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -133,7 +133,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -187,7 +187,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -196,7 +196,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -250,7 +250,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -259,7 +259,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -312,7 +312,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['api_key']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -321,7 +321,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -372,7 +372,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -381,7 +381,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -438,7 +438,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -447,7 +447,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -506,7 +506,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -515,7 +515,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -578,7 +578,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -587,7 +587,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file_with_required_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -44,25 +44,35 @@ module Petstore
       local_var_path = '/pet'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', 'application/xml'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -96,24 +106,34 @@ module Petstore
       local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       header_params[:'api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -147,27 +167,36 @@ module Petstore
       local_var_path = '/pet/findByStatus'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'status'] = @api_client.build_collection_param(status, :csv)
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Array<Pet>' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Array<Pet>')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -201,27 +230,36 @@ module Petstore
       local_var_path = '/pet/findByTags'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'tags'] = @api_client.build_collection_param(tags, :csv)
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Array<Pet>' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Array<Pet>')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -255,26 +293,35 @@ module Petstore
       local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['api_key']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Pet' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['api_key']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Pet')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -306,25 +353,35 @@ module Petstore
       local_var_path = '/pet'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', 'application/xml'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -360,27 +417,37 @@ module Petstore
       local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['name'] = opts[:'name'] if !opts[:'name'].nil?
       form_params['status'] = opts[:'status'] if !opts[:'status'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -416,30 +483,39 @@ module Petstore
       local_var_path = '/pet/{petId}/uploadImage'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['multipart/form-data'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
       form_params['file'] = opts[:'file'] if !opts[:'file'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'ApiResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'ApiResponse')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -479,30 +555,39 @@ module Petstore
       local_var_path = '/fake/{petId}/uploadImageWithRequiredFile'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['multipart/form-data'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['requiredFile'] = required_file
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'ApiResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'ApiResponse')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file_with_required_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -46,23 +46,33 @@ module Petstore
       local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -90,26 +100,35 @@ module Petstore
       local_var_path = '/store/inventory'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['api_key']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Hash<String, Integer>' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['api_key']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Hash<String, Integer>')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -151,26 +170,35 @@ module Petstore
       local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Order' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Order')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -202,26 +230,35 @@ module Petstore
       local_var_path = '/store/order'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Order' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Order')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -63,7 +63,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -72,7 +72,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -119,7 +119,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['api_key']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -128,7 +128,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -189,7 +189,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -198,7 +198,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -249,7 +249,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -258,7 +258,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -63,7 +63,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -72,7 +72,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -121,7 +121,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -130,7 +130,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -179,7 +179,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -188,7 +188,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -239,7 +239,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -248,7 +248,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -299,7 +299,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -308,7 +308,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -367,7 +367,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -376,7 +376,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -419,7 +419,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -428,7 +428,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -485,7 +485,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -494,7 +494,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -46,23 +46,33 @@ module Petstore
       local_var_path = '/user'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -94,23 +104,33 @@ module Petstore
       local_var_path = '/user/createWithArray'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -142,23 +162,33 @@ module Petstore
       local_var_path = '/user/createWithList'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -192,23 +222,33 @@ module Petstore
       local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -240,26 +280,35 @@ module Petstore
       local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'User' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'User')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -297,28 +346,37 @@ module Petstore
       local_var_path = '/user/login'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'username'] = username
       query_params[:'password'] = password
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'String' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -344,23 +402,33 @@ module Petstore
       local_var_path = '/user/logout'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -400,23 +468,33 @@ module Petstore
       local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -46,28 +46,37 @@ module Petstore
       local_var_path = '/another-fake/dummy'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(client)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Client' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Client')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: AnotherFakeApi#call_123_test_special_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -67,7 +67,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -76,7 +76,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: AnotherFakeApi#call_123_test_special_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -36,26 +36,35 @@ module Petstore
       local_var_path = '/foo'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'InlineResponseDefault' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'InlineResponseDefault')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: DefaultApi#foo_get\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -55,7 +55,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -64,7 +64,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: DefaultApi#foo_get\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -57,7 +57,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -66,7 +66,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_health_get\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -115,7 +115,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -124,7 +124,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_boolean_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -173,7 +173,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -182,7 +182,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_composite_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -231,7 +231,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -240,7 +240,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_number_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -289,7 +289,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -298,7 +298,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_string_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -349,7 +349,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -358,7 +358,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_file_schema\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -414,7 +414,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -423,7 +423,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_query_params\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -478,7 +478,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -487,7 +487,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_client_model\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -646,7 +646,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['http_basic_test']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -655,7 +655,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_endpoint_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -758,7 +758,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -767,7 +767,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_enum_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -842,7 +842,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['bearer_test']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -851,7 +851,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_group_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -902,7 +902,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -911,7 +911,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_inline_additional_properties\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -970,7 +970,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -979,7 +979,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_json_form_data\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -38,26 +38,35 @@ module Petstore
       local_var_path = '/fake/health'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'HealthCheckResult' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'HealthCheckResult')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_health_get\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -85,28 +94,37 @@ module Petstore
       local_var_path = '/fake/outer/boolean'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Boolean' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Boolean')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_boolean_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -134,28 +152,37 @@ module Petstore
       local_var_path = '/fake/outer/composite'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'outer_composite'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'outer_composite']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'OuterComposite' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'OuterComposite')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_composite_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -183,28 +210,37 @@ module Petstore
       local_var_path = '/fake/outer/number'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Float' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Float')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_number_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -232,28 +268,37 @@ module Petstore
       local_var_path = '/fake/outer/string'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['*/*'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(opts[:'body'])
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(opts[:'body']) 
+
+      # return_type
+      return_type = opts[:return_type] || 'String' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#fake_outer_string_serialize\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -285,25 +330,35 @@ module Petstore
       local_var_path = '/fake/body-with-file-schema'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(file_schema_test_class)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(file_schema_test_class) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_file_schema\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -339,26 +394,36 @@ module Petstore
       local_var_path = '/fake/body-with-query-params'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'query'] = query
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(user)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_body_with_query_params\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -392,28 +457,37 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(client)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Client' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Client')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_client_model\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -539,15 +613,15 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['number'] = number
       form_params['double'] = double
       form_params['pattern_without_delimiter'] = pattern_without_delimiter
@@ -564,14 +638,24 @@ module Petstore
       form_params['callback'] = opts[:'callback'] if !opts[:'callback'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['http_basic_test']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['http_basic_test']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_endpoint_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -647,33 +731,43 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'enum_query_string_array'] = @api_client.build_collection_param(opts[:'enum_query_string_array'], :multi) if !opts[:'enum_query_string_array'].nil?
       query_params[:'enum_query_string'] = opts[:'enum_query_string'] if !opts[:'enum_query_string'].nil?
       query_params[:'enum_query_integer'] = opts[:'enum_query_integer'] if !opts[:'enum_query_integer'].nil?
       query_params[:'enum_query_double'] = opts[:'enum_query_double'] if !opts[:'enum_query_double'].nil?
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
       header_params[:'enum_header_string_array'] = @api_client.build_collection_param(opts[:'enum_header_string_array'], :csv) if !opts[:'enum_header_string_array'].nil?
       header_params[:'enum_header_string'] = opts[:'enum_header_string'] if !opts[:'enum_header_string'].nil?
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['enum_form_string_array'] = @api_client.build_collection_param(opts[:'enum_form_string_array'], :csv) if !opts[:'enum_form_string_array'].nil?
       form_params['enum_form_string'] = opts[:'enum_form_string'] if !opts[:'enum_form_string'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_enum_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -725,29 +819,39 @@ module Petstore
       local_var_path = '/fake'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'required_string_group'] = required_string_group
       query_params[:'required_int64_group'] = required_int64_group
       query_params[:'string_group'] = opts[:'string_group'] if !opts[:'string_group'].nil?
       query_params[:'int64_group'] = opts[:'int64_group'] if !opts[:'int64_group'].nil?
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       header_params[:'required_boolean_group'] = required_boolean_group
       header_params[:'boolean_group'] = opts[:'boolean_group'] if !opts[:'boolean_group'].nil?
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['bearer_test']
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['bearer_test']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_group_parameters\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -779,25 +883,35 @@ module Petstore
       local_var_path = '/fake/inline-additionalProperties'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(request_body)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(request_body) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_inline_additional_properties\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -835,27 +949,37 @@ module Petstore
       local_var_path = '/fake/jsonFormData'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['param'] = param
       form_params['param2'] = param2
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeApi#test_json_form_data\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -46,28 +46,37 @@ module Petstore
       local_var_path = '/fake_classname_test'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(client)
-      auth_names = ['api_key_query']
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(client) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Client' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['api_key_query']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Client')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeClassnameTags123Api#test_classname\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -67,7 +67,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['api_key_query']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -76,7 +76,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PATCH, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: FakeClassnameTags123Api#test_classname\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -44,25 +44,35 @@ module Petstore
       local_var_path = '/pet'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', 'application/xml'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(pet)
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -96,24 +106,34 @@ module Petstore
       local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       header_params[:'api_key'] = opts[:'api_key'] if !opts[:'api_key'].nil?
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -147,27 +167,36 @@ module Petstore
       local_var_path = '/pet/findByStatus'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'status'] = @api_client.build_collection_param(status, :csv)
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Array<Pet>' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Array<Pet>')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -201,27 +230,36 @@ module Petstore
       local_var_path = '/pet/findByTags'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'tags'] = @api_client.build_collection_param(tags, :csv)
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Array<Pet>' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Array<Pet>')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -255,26 +293,35 @@ module Petstore
       local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['api_key']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Pet' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['api_key']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Pet')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -306,25 +353,35 @@ module Petstore
       local_var_path = '/pet'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', 'application/xml'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(pet)
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(pet) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -360,27 +417,37 @@ module Petstore
       local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/x-www-form-urlencoded'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['name'] = opts[:'name'] if !opts[:'name'].nil?
       form_params['status'] = opts[:'status'] if !opts[:'status'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -416,30 +483,39 @@ module Petstore
       local_var_path = '/pet/{petId}/uploadImage'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['multipart/form-data'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
       form_params['file'] = opts[:'file'] if !opts[:'file'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'ApiResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'ApiResponse')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -479,30 +555,39 @@ module Petstore
       local_var_path = '/fake/{petId}/uploadImageWithRequiredFile'.sub('{' + 'petId' + '}', pet_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['multipart/form-data'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
       form_params['requiredFile'] = required_file
       form_params['additionalMetadata'] = opts[:'additional_metadata'] if !opts[:'additional_metadata'].nil?
 
       # http body (model)
-      post_body = nil
-      auth_names = ['petstore_auth']
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'ApiResponse' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['petstore_auth']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'ApiResponse')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file_with_required_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -63,7 +63,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -72,7 +72,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#add_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -124,7 +124,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -133,7 +133,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#delete_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -187,7 +187,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -196,7 +196,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_status\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -250,7 +250,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -259,7 +259,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#find_pets_by_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -312,7 +312,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['api_key']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -321,7 +321,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#get_pet_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -372,7 +372,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -381,7 +381,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -438,7 +438,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -447,7 +447,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#update_pet_with_form\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -506,7 +506,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -515,7 +515,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -578,7 +578,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['petstore_auth']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -587,7 +587,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: PetApi#upload_file_with_required_file\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -63,7 +63,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -72,7 +72,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -119,7 +119,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || ['api_key']
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -128,7 +128,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -189,7 +189,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -198,7 +198,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -251,7 +251,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -260,7 +260,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -46,23 +46,33 @@ module Petstore
       local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#delete_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -90,26 +100,35 @@ module Petstore
       local_var_path = '/store/inventory'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = ['api_key']
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Hash<String, Integer>' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || ['api_key']
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Hash<String, Integer>')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_inventory\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -151,26 +170,35 @@ module Petstore
       local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'Order' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Order')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#get_order_by_id\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -202,28 +230,37 @@ module Petstore
       local_var_path = '/store/order'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(order)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(order) 
+
+      # return_type
+      return_type = opts[:return_type] || 'Order' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'Order')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: StoreApi#place_order\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -65,7 +65,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -74,7 +74,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -125,7 +125,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -134,7 +134,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -185,7 +185,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -194,7 +194,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -245,7 +245,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -254,7 +254,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -305,7 +305,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -314,7 +314,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -373,7 +373,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -382,7 +382,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -425,7 +425,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -434,7 +434,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -493,7 +493,7 @@ module Petstore
       # auth_names
       auth_names = opts[:auth_names] || []
 
-      new_optios = opts.merge(
+      new_options = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -502,7 +502,7 @@ module Petstore
         :return_type => return_type
       )
 
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -46,25 +46,35 @@ module Petstore
       local_var_path = '/user'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(user)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -96,25 +106,35 @@ module Petstore
       local_var_path = '/user/createWithArray'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(user)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_array_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -146,25 +166,35 @@ module Petstore
       local_var_path = '/user/createWithList'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(user)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#create_users_with_list_input\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -198,23 +228,33 @@ module Petstore
       local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:DELETE, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#delete_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -246,26 +286,35 @@ module Petstore
       local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'User' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'User')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#get_user_by_name\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -303,28 +352,37 @@ module Petstore
       local_var_path = '/user/login'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
       query_params[:'username'] = username
       query_params[:'password'] = password
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/xml', 'application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] || 'String' 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
         :auth_names => auth_names,
-        :return_type => 'String')
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#login_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -350,23 +408,33 @@ module Petstore
       local_var_path = '/user/logout'
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = nil
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:GET, local_var_path,
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#logout_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
@@ -406,25 +474,35 @@ module Petstore
       local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
 
       # query parameters
-      query_params = {}
+      query_params = opts[:query_params] || {}
 
       # header parameters
-      header_params = {}
+      header_params = opts[:header_params] || {}
       # HTTP header 'Content-Type'
       header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
 
       # form parameters
-      form_params = {}
+      form_params = opts[:form_params] || {}
 
       # http body (model)
-      post_body = @api_client.object_to_http_body(user)
-      auth_names = []
-      data, status_code, headers = @api_client.call_api(:PUT, local_var_path,
+      post_body = opts[:body] || @api_client.object_to_http_body(user) 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_optios = opts.merge(
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
         :body => post_body,
-        :auth_names => auth_names)
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_optios)
       if @api_client.config.debugging
         @api_client.config.logger.debug "API called: UserApi#update_user\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

### Description of the PR

We want to change the option when debugging, changing timeout to specific api, etc...
So we want to merge and pass options to api client.
