### PR TITLE
[templating] Load TemplatingEngineAdapter via Service Provider

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/AbstractTemplatingEngineAdapter.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/AbstractTemplatingEngineAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.api;
 
 import java.util.Locale;

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.api;
 
 import java.io.IOException;
@@ -7,6 +23,13 @@ import java.util.Map;
  * Each templating engine is called by an Adapter, selected at runtime
  */
 public interface TemplatingEngineAdapter{
+
+  /**
+   * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
+   *
+   * @return A string identifier.
+   */
+  String getIdentifier();
 
   /**
    * Compiles a template into a string

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingGenerator.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.api;
 
 /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/TemplatingEngineLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/TemplatingEngineLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen;
+
+import org.openapitools.codegen.api.TemplatingEngineAdapter;
+
+import java.util.Locale;
+import java.util.ServiceLoader;
+
+public class TemplatingEngineLoader {
+    public static TemplatingEngineAdapter byIdentifier(String id) {
+        ServiceLoader<TemplatingEngineAdapter> loader = ServiceLoader.load(TemplatingEngineAdapter.class, TemplatingEngineLoader.class.getClassLoader());
+
+        StringBuilder sb = new StringBuilder();
+        for (TemplatingEngineAdapter templatingEngineAdapter : loader) {
+            if (id.equals(templatingEngineAdapter.getIdentifier())) {
+                return templatingEngineAdapter;
+            }
+            sb.append(templatingEngineAdapter.getIdentifier()).append("\n");
+        }
+
+        try {
+            // Attempt to load skipping SPI
+            return (TemplatingEngineAdapter) Class.forName(id).getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(String.format(Locale.ROOT, "Couldn't load template engine adapter %s. Available options: \n%s", id, sb.toString()), e);
+        }
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -30,6 +30,7 @@ import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.Validate;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.api.TemplatingEngineAdapter;
 import org.openapitools.codegen.auth.AuthParser;
 import org.openapitools.codegen.languages.*;
 import org.openapitools.codegen.templating.HandlebarsEngineAdapter;
@@ -579,12 +580,15 @@ public class CodegenConfigurator implements Serializable {
             config.setLibrary(library);
         }
 
-        // Built-in templates are mustache, but allow users to use a simplified handlebars engine for their custom templates.
-        if (isEmpty(templatingEngineName) || templatingEngineName.equals("mustache")) {
-            config.setTemplatingEngine(new MustacheEngineAdapter());
-        } else if (templatingEngineName.equals("handlebars")) {
-            config.setTemplatingEngine(new HandlebarsEngineAdapter());
+        String templatingEngineId;
+        if (isEmpty(templatingEngineName)) {
+            // Built-in templates are mustache, but allow users to use a simplified handlebars engine for their custom templates.
+            templatingEngineId = "mustache";
         }
+        else { templatingEngineId = templatingEngineName; }
+
+        TemplatingEngineAdapter templatingEngine = TemplatingEngineLoader.byIdentifier(templatingEngineId);
+        config.setTemplatingEngine(templatingEngine);
 
         config.additionalProperties().putAll(additionalProperties);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/HandlebarsEngineAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.templating;
 
 import com.github.jknack.handlebars.Context;
@@ -26,6 +42,16 @@ import java.util.Map;
 public class HandlebarsEngineAdapter extends AbstractTemplatingEngineAdapter {
     static Logger LOGGER = LoggerFactory.getLogger(HandlebarsEngineAdapter.class);
     private final String[] extensions = new String[]{"handlebars", "hbs"};
+
+    /**
+     * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
+     *
+     * @return A string identifier.
+     */
+    @Override
+    public String getIdentifier() {
+        return "handlebars";
+    }
 
     public String compileTemplate(TemplatingGenerator generator,
                                   Map<String, Object> bundle, String templateFile) throws IOException {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openapitools.codegen.templating;
 
 import com.samskivert.mustache.Mustache;
@@ -12,6 +28,16 @@ import java.util.Map;
 
 
 public class MustacheEngineAdapter implements TemplatingEngineAdapter {
+
+    /**
+     * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
+     *
+     * @return A string identifier.
+     */
+    @Override
+    public String getIdentifier() {
+        return "mustache";
+    }
 
     public String[] extensions = new String[]{"mustache"};
     Mustache.Compiler compiler = Mustache.compiler();

--- a/modules/openapi-generator/src/main/resources/META-INF/services/org.openapitools.codegen.api.TemplatingEngineAdapter
+++ b/modules/openapi-generator/src/main/resources/META-INF/services/org.openapitools.codegen.api.TemplatingEngineAdapter
@@ -1,0 +1,2 @@
+org.openapitools.codegen.templating.MustacheEngineAdapter
+org.openapitools.codegen.templating.HandlebarsEngineAdapter


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Allows for loading templating engine via ServiceLoader. Allows for user customization.

@OpenAPITools/generator-core-team 
