### PR TITLE
dart2: Do not add non-nullable fields to model json

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/class.mustache
@@ -60,21 +60,24 @@ class {{classname}} {
   }
 
   Map<String, dynamic> toJson() {
-    return {
+    Map <String, dynamic> json = {};
     {{#vars}}
-      {{#isDateTime}}
-      '{{baseName}}': {{name}} == null ? '' : {{name}}.toUtc().toIso8601String(){{^-last}},{{/-last}}
+        {{^isNullable}}
+    if ({{name}} != null)
+        {{/isNullable}}
+        {{#isDateTime}}
+      json['{{baseName}}'] = {{name}} == null ? null : {{name}}.toUtc().toIso8601String();
       {{/isDateTime}}
       {{#isDate}}
-      '{{baseName}}': {{name}} == null ? '' : {{name}}.toUtc().toIso8601String(){{^-last}},{{/-last}}
+      json['{{baseName}}'] = {{name}} == null ? null : {{name}}.toUtc().toIso8601String();
       {{/isDate}}
       {{^isDateTime}}
       {{^isDate}}
-      '{{baseName}}': {{name}}{{^-last}},{{/-last}}
+      json['{{baseName}}'] = {{name}};
       {{/isDate}}
       {{/isDateTime}}
     {{/vars}}
-    };
+    return json;
   }
 
   static List<{{classname}}> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api_client.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/api_client.dart
@@ -18,7 +18,7 @@ class ApiClient {
   final _regList = RegExp(r'^List<(.*)>$');
   final _regMap = RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
+  ApiClient({this.basePath = "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
     _authentications['api_key'] = ApiKeyAuth("header", "api_key");
     _authentications['petstore_auth'] = OAuth();

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/api_response.dart
@@ -34,11 +34,14 @@ class ApiResponse {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'code': code,
-      'type': type,
-      'message': message
-    };
+    Map <String, dynamic> json = {};
+    if (code != null)
+      json['code'] = code;
+    if (type != null)
+      json['type'] = type;
+    if (message != null)
+      json['message'] = message;
+    return json;
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/category.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/category.dart
@@ -27,10 +27,12 @@ class Category {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (name != null)
+      json['name'] = name;
+    return json;
   }
 
   static List<Category> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/order.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/order.dart
@@ -56,14 +56,20 @@ class Order {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'petId': petId,
-      'quantity': quantity,
-      'shipDate': shipDate == null ? '' : shipDate.toUtc().toIso8601String(),
-      'status': status,
-      'complete': complete
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (petId != null)
+      json['petId'] = petId;
+    if (quantity != null)
+      json['quantity'] = quantity;
+    if (shipDate != null)
+      json['shipDate'] = shipDate == null ? null : shipDate.toUtc().toIso8601String();
+    if (status != null)
+      json['status'] = status;
+    if (complete != null)
+      json['complete'] = complete;
+    return json;
   }
 
   static List<Order> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/pet.dart
@@ -56,14 +56,20 @@ class Pet {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'category': category,
-      'name': name,
-      'photoUrls': photoUrls,
-      'tags': tags,
-      'status': status
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (category != null)
+      json['category'] = category;
+    if (name != null)
+      json['name'] = name;
+    if (photoUrls != null)
+      json['photoUrls'] = photoUrls;
+    if (tags != null)
+      json['tags'] = tags;
+    if (status != null)
+      json['status'] = status;
+    return json;
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/tag.dart
@@ -27,10 +27,12 @@ class Tag {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (name != null)
+      json['name'] = name;
+    return json;
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/user.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/user.dart
@@ -69,16 +69,24 @@ class User {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'username': username,
-      'firstName': firstName,
-      'lastName': lastName,
-      'email': email,
-      'password': password,
-      'phone': phone,
-      'userStatus': userStatus
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (username != null)
+      json['username'] = username;
+    if (firstName != null)
+      json['firstName'] = firstName;
+    if (lastName != null)
+      json['lastName'] = lastName;
+    if (email != null)
+      json['email'] = email;
+    if (password != null)
+      json['password'] = password;
+    if (phone != null)
+      json['phone'] = phone;
+    if (userStatus != null)
+      json['userStatus'] = userStatus;
+    return json;
   }
 
   static List<User> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/api_client.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/api_client.dart
@@ -18,7 +18,7 @@ class ApiClient {
   final _regList = RegExp(r'^List<(.*)>$');
   final _regMap = RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
+  ApiClient({this.basePath = "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
     _authentications['api_key'] = ApiKeyAuth("header", "api_key");
     _authentications['petstore_auth'] = OAuth();

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/api_response.dart
@@ -34,11 +34,14 @@ class ApiResponse {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'code': code,
-      'type': type,
-      'message': message
-    };
+    Map <String, dynamic> json = {};
+    if (code != null)
+      json['code'] = code;
+    if (type != null)
+      json['type'] = type;
+    if (message != null)
+      json['message'] = message;
+    return json;
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/category.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/category.dart
@@ -27,10 +27,12 @@ class Category {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (name != null)
+      json['name'] = name;
+    return json;
   }
 
   static List<Category> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/order.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/order.dart
@@ -56,14 +56,20 @@ class Order {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'petId': petId,
-      'quantity': quantity,
-      'shipDate': shipDate == null ? '' : shipDate.toUtc().toIso8601String(),
-      'status': status,
-      'complete': complete
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (petId != null)
+      json['petId'] = petId;
+    if (quantity != null)
+      json['quantity'] = quantity;
+    if (shipDate != null)
+      json['shipDate'] = shipDate == null ? null : shipDate.toUtc().toIso8601String();
+    if (status != null)
+      json['status'] = status;
+    if (complete != null)
+      json['complete'] = complete;
+    return json;
   }
 
   static List<Order> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/pet.dart
@@ -56,14 +56,20 @@ class Pet {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'category': category,
-      'name': name,
-      'photoUrls': photoUrls,
-      'tags': tags,
-      'status': status
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (category != null)
+      json['category'] = category;
+    if (name != null)
+      json['name'] = name;
+    if (photoUrls != null)
+      json['photoUrls'] = photoUrls;
+    if (tags != null)
+      json['tags'] = tags;
+    if (status != null)
+      json['status'] = status;
+    return json;
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/tag.dart
@@ -27,10 +27,12 @@ class Tag {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (name != null)
+      json['name'] = name;
+    return json;
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/user.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/user.dart
@@ -69,16 +69,24 @@ class User {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'username': username,
-      'firstName': firstName,
-      'lastName': lastName,
-      'email': email,
-      'password': password,
-      'phone': phone,
-      'userStatus': userStatus
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (username != null)
+      json['username'] = username;
+    if (firstName != null)
+      json['firstName'] = firstName;
+    if (lastName != null)
+      json['lastName'] = lastName;
+    if (email != null)
+      json['email'] = email;
+    if (password != null)
+      json['password'] = password;
+    if (phone != null)
+      json['phone'] = phone;
+    if (userStatus != null)
+      json['userStatus'] = userStatus;
+    return json;
   }
 
   static List<User> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi/lib/api_client.dart
+++ b/samples/client/petstore/dart2/openapi/lib/api_client.dart
@@ -18,7 +18,7 @@ class ApiClient {
   final _regList = RegExp(r'^List<(.*)>$');
   final _regMap = RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
+  ApiClient({this.basePath = "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
     _authentications['api_key'] = ApiKeyAuth("header", "api_key");
     _authentications['petstore_auth'] = OAuth();

--- a/samples/client/petstore/dart2/openapi/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/api_response.dart
@@ -34,11 +34,14 @@ class ApiResponse {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'code': code,
-      'type': type,
-      'message': message
-    };
+    Map <String, dynamic> json = {};
+    if (code != null)
+      json['code'] = code;
+    if (type != null)
+      json['type'] = type;
+    if (message != null)
+      json['message'] = message;
+    return json;
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi/lib/model/category.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/category.dart
@@ -27,10 +27,12 @@ class Category {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (name != null)
+      json['name'] = name;
+    return json;
   }
 
   static List<Category> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi/lib/model/order.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/order.dart
@@ -56,14 +56,20 @@ class Order {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'petId': petId,
-      'quantity': quantity,
-      'shipDate': shipDate == null ? '' : shipDate.toUtc().toIso8601String(),
-      'status': status,
-      'complete': complete
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (petId != null)
+      json['petId'] = petId;
+    if (quantity != null)
+      json['quantity'] = quantity;
+    if (shipDate != null)
+      json['shipDate'] = shipDate == null ? null : shipDate.toUtc().toIso8601String();
+    if (status != null)
+      json['status'] = status;
+    if (complete != null)
+      json['complete'] = complete;
+    return json;
   }
 
   static List<Order> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/pet.dart
@@ -56,14 +56,20 @@ class Pet {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'category': category,
-      'name': name,
-      'photoUrls': photoUrls,
-      'tags': tags,
-      'status': status
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (category != null)
+      json['category'] = category;
+    if (name != null)
+      json['name'] = name;
+    if (photoUrls != null)
+      json['photoUrls'] = photoUrls;
+    if (tags != null)
+      json['tags'] = tags;
+    if (status != null)
+      json['status'] = status;
+    return json;
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/tag.dart
@@ -27,10 +27,12 @@ class Tag {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (name != null)
+      json['name'] = name;
+    return json;
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {

--- a/samples/client/petstore/dart2/openapi/lib/model/user.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/user.dart
@@ -69,16 +69,24 @@ class User {
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'username': username,
-      'firstName': firstName,
-      'lastName': lastName,
-      'email': email,
-      'password': password,
-      'phone': phone,
-      'userStatus': userStatus
-    };
+    Map <String, dynamic> json = {};
+    if (id != null)
+      json['id'] = id;
+    if (username != null)
+      json['username'] = username;
+    if (firstName != null)
+      json['firstName'] = firstName;
+    if (lastName != null)
+      json['lastName'] = lastName;
+    if (email != null)
+      json['email'] = email;
+    if (password != null)
+      json['password'] = password;
+    if (phone != null)
+      json['phone'] = phone;
+    if (userStatus != null)
+      json['userStatus'] = userStatus;
+    return json;
   }
 
   static List<User> listFromJson(List<dynamic> json) {


### PR DESCRIPTION
This fix would avoid adding and sending fields that are not isNullable in the request.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This is the correct fix for the issue #2535 as discussed earlier. Self-explanatory in commit message.

@ircecho @swipesight  @jaumard  @wing328 