### PR TITLE
[C++][Pistache] Fixed checking for optional properties when converting from json.

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -37,7 +37,7 @@ void to_json(nlohmann::json& j, const {{classname}}& o)
 void from_json(const nlohmann::json& j, {{classname}}& o)
 {
     {{#vars}}
-    {{#required}}j.at("{{baseName}}").get_to(o.m_{{name}});{{/required}}{{^required}}if(!j.at("{{baseName}}").is_null())
+    {{#required}}j.at("{{baseName}}").get_to(o.m_{{name}});{{/required}}{{^required}}if(j.contains("{{baseName}}"))
     {
         j.at("{{baseName}}").get_to(o.m_{{name}});
         o.m_{{name}}IsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
+++ b/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
@@ -51,17 +51,17 @@ void to_json(nlohmann::json& j, const ApiResponse& o)
 
 void from_json(const nlohmann::json& j, ApiResponse& o)
 {
-    if(!j.at("code").is_null())
+    if(j.contains("code"))
     {
         j.at("code").get_to(o.m_Code);
         o.m_CodeIsSet = true;
     } 
-    if(!j.at("type").is_null())
+    if(j.contains("type"))
     {
         j.at("type").get_to(o.m_Type);
         o.m_TypeIsSet = true;
     } 
-    if(!j.at("message").is_null())
+    if(j.contains("message"))
     {
         j.at("message").get_to(o.m_Message);
         o.m_MessageIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Category.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Category.cpp
@@ -47,12 +47,12 @@ void to_json(nlohmann::json& j, const Category& o)
 
 void from_json(const nlohmann::json& j, Category& o)
 {
-    if(!j.at("id").is_null())
+    if(j.contains("id"))
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(!j.at("name").is_null())
+    if(j.contains("name"))
     {
         j.at("name").get_to(o.m_Name);
         o.m_NameIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Order.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Order.cpp
@@ -63,32 +63,32 @@ void to_json(nlohmann::json& j, const Order& o)
 
 void from_json(const nlohmann::json& j, Order& o)
 {
-    if(!j.at("id").is_null())
+    if(j.contains("id"))
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(!j.at("petId").is_null())
+    if(j.contains("petId"))
     {
         j.at("petId").get_to(o.m_PetId);
         o.m_PetIdIsSet = true;
     } 
-    if(!j.at("quantity").is_null())
+    if(j.contains("quantity"))
     {
         j.at("quantity").get_to(o.m_Quantity);
         o.m_QuantityIsSet = true;
     } 
-    if(!j.at("shipDate").is_null())
+    if(j.contains("shipDate"))
     {
         j.at("shipDate").get_to(o.m_ShipDate);
         o.m_ShipDateIsSet = true;
     } 
-    if(!j.at("status").is_null())
+    if(j.contains("status"))
     {
         j.at("status").get_to(o.m_Status);
         o.m_StatusIsSet = true;
     } 
-    if(!j.at("complete").is_null())
+    if(j.contains("complete"))
     {
         j.at("complete").get_to(o.m_Complete);
         o.m_CompleteIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Pet.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Pet.cpp
@@ -56,24 +56,24 @@ void to_json(nlohmann::json& j, const Pet& o)
 
 void from_json(const nlohmann::json& j, Pet& o)
 {
-    if(!j.at("id").is_null())
+    if(j.contains("id"))
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(!j.at("category").is_null())
+    if(j.contains("category"))
     {
         j.at("category").get_to(o.m_Category);
         o.m_CategoryIsSet = true;
     } 
     j.at("name").get_to(o.m_Name);
     j.at("photoUrls").get_to(o.m_PhotoUrls);
-    if(!j.at("tags").is_null())
+    if(j.contains("tags"))
     {
         j.at("tags").get_to(o.m_Tags);
         o.m_TagsIsSet = true;
     } 
-    if(!j.at("status").is_null())
+    if(j.contains("status"))
     {
         j.at("status").get_to(o.m_Status);
         o.m_StatusIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Tag.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Tag.cpp
@@ -47,12 +47,12 @@ void to_json(nlohmann::json& j, const Tag& o)
 
 void from_json(const nlohmann::json& j, Tag& o)
 {
-    if(!j.at("id").is_null())
+    if(j.contains("id"))
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(!j.at("name").is_null())
+    if(j.contains("name"))
     {
         j.at("name").get_to(o.m_Name);
         o.m_NameIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/User.cpp
+++ b/samples/server/petstore/cpp-pistache/model/User.cpp
@@ -71,42 +71,42 @@ void to_json(nlohmann::json& j, const User& o)
 
 void from_json(const nlohmann::json& j, User& o)
 {
-    if(!j.at("id").is_null())
+    if(j.contains("id"))
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(!j.at("username").is_null())
+    if(j.contains("username"))
     {
         j.at("username").get_to(o.m_Username);
         o.m_UsernameIsSet = true;
     } 
-    if(!j.at("firstName").is_null())
+    if(j.contains("firstName"))
     {
         j.at("firstName").get_to(o.m_FirstName);
         o.m_FirstNameIsSet = true;
     } 
-    if(!j.at("lastName").is_null())
+    if(j.contains("lastName"))
     {
         j.at("lastName").get_to(o.m_LastName);
         o.m_LastNameIsSet = true;
     } 
-    if(!j.at("email").is_null())
+    if(j.contains("email"))
     {
         j.at("email").get_to(o.m_Email);
         o.m_EmailIsSet = true;
     } 
-    if(!j.at("password").is_null())
+    if(j.contains("password"))
     {
         j.at("password").get_to(o.m_Password);
         o.m_PasswordIsSet = true;
     } 
-    if(!j.at("phone").is_null())
+    if(j.contains("phone"))
     {
         j.at("phone").get_to(o.m_Phone);
         o.m_PhoneIsSet = true;
     } 
-    if(!j.at("userStatus").is_null())
+    if(j.contains("userStatus"))
     {
         j.at("userStatus").get_to(o.m_UserStatus);
         o.m_UserStatusIsSet = true;


### PR DESCRIPTION
### PR checklist

- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@etherealjoy @stkrwork @ravinikam @MartinDelille @fvarose 

### Description of the PR

Fixed checking for optional properties when converting from json. Using 'at' on a key that doesn't exist throws an exception. Was replaced with 'contains'. This resolves issues #2734.

Fixes #2734