### PR TITLE
[C++][Pistache] Allow socket address reuse option

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/main-api-server.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/main-api-server.mustache
@@ -12,7 +12,8 @@
 {{#apiInfo}}{{#apis}}{{#operations}}
 #include "{{classname}}Impl.h"{{/operations}}{{/apis}}{{/apiInfo}}
 
-#define PISTACHE_SERVER_THREADS 2
+#define PISTACHE_SERVER_THREADS     2
+#define PISTACHE_SERVER_MAX_PAYLOAD 32768
 
 static Pistache::Http::Endpoint *httpEndpoint;
 #ifdef __linux__
@@ -59,6 +60,8 @@ int main() {
 
     auto opts = Pistache::Http::Endpoint::options()
         .threads(PISTACHE_SERVER_THREADS);
+    opts.flags(Pistache::Tcp::Options::ReuseAddr);
+    opts.maxPayload(PISTACHE_SERVER_MAX_PAYLOAD);
     httpEndpoint->init(opts);
 
     {{#apiInfo}}{{#apis}}{{#operations}}

--- a/samples/server/petstore/cpp-pistache/main-api-server.cpp
+++ b/samples/server/petstore/cpp-pistache/main-api-server.cpp
@@ -24,7 +24,8 @@
 #include "StoreApiImpl.h"
 #include "UserApiImpl.h"
 
-#define PISTACHE_SERVER_THREADS 2
+#define PISTACHE_SERVER_THREADS     2
+#define PISTACHE_SERVER_MAX_PAYLOAD 32768
 
 static Pistache::Http::Endpoint *httpEndpoint;
 #ifdef __linux__
@@ -71,6 +72,8 @@ int main() {
 
     auto opts = Pistache::Http::Endpoint::options()
         .threads(PISTACHE_SERVER_THREADS);
+    opts.flags(Pistache::Tcp::Options::ReuseAddr);
+    opts.maxPayload(PISTACHE_SERVER_MAX_PAYLOAD);
     httpEndpoint->init(opts);
 
     


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fixes #2771
- Allow socket payload size override
- Set socket address reuse option

@stkrwork @MartinDelille @ravinikam @fvarose 

