### PR TITLE
[C++][Qt5 Server] Process server port

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5QHttpEngineServerCodegen.java
@@ -17,11 +17,16 @@
 
 package org.openapitools.codegen.languages;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+
 import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
+import org.openapitools.codegen.utils.URLPathUtils;
 
 import java.io.File;
+import java.net.URL;
 
 import static org.openapitools.codegen.utils.StringUtils.*;
 
@@ -188,7 +193,14 @@ public class CppQt5QHttpEngineServerCodegen extends CppQt5AbstractCodegen implem
         }
         return result;
     }
-
+    
+    @Override
+    public void preprocessOpenAPI(OpenAPI openAPI) {
+        URL url = URLPathUtils.getServerURL(openAPI);
+        String port = URLPathUtils.getPort(url, "8080");
+        this.additionalProperties.put("serverPort", port);
+    }
+    
     @Override
     public String toApiFilename(String name) {
         return modelNamePrefix + sanitizeName(camelize(name)) + "ApiHandler";

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/README.md.mustache
@@ -53,6 +53,17 @@ To run the server
 ./build/src/cpp-qt5-qhttpengine-server &
 ```
 
+To override the default port via the command line, provide the parameters `port` and `address` like below
+
+```shell
+cpp-qt5-qhttpengine-server --port 9080 --address 127.17.0.1
+```
+or
+
+```shell
+cpp-qt5-qhttpengine-server -p 9080 -a 127.17.0.1
+```
+
 #### Invoke an API
 
 ```shell

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/main.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-qhttpengine-server/main.cpp.mustache
@@ -58,7 +58,7 @@ int main(int argc, char * argv[])
         QStringList() << "p" << "port",
         "port to listen on",
         "port",
-        "8080"
+        "{{serverPort}}"
     );
     parser.addOption(portOption);
     parser.addHelpOption();


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Add listening of the socket on the server port defined in spec

`cc`
@stkrwork  @MartinDelille  @ravinikam  @fvarose 

