### PR TITLE
[all] Adds strict spec option

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ SYNOPSIS
                 [--remove-operation-id-prefix]
                 [--reserved-words-mappings <reserved word mappings>...]
                 [(-s | --skip-overwrite)] [--skip-validate-spec]
+                [--strict-spec <true/false strict behavior>]
                 [(-t <template directory> | --template-dir <template directory>)]
                 [--type-mappings <type mappings>...] [(-v | --verbose)]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -239,7 +239,9 @@ SYNOPSIS
                 [--api-package <api package>] [--artifact-id <artifact id>]
                 [--artifact-version <artifact version>]
                 [(-c <configuration file> | --config <configuration file>)]
-                [-D <system properties>...] [--enable-post-process-file]
+                [-D <system properties>...]
+                [(-e <templating engine> | --engine <templating engine>)]
+                [--enable-post-process-file]
                 [(-g <generator name> | --generator-name <generator name>)]
                 [--generate-alias-as-model] [--git-repo-id <git repo id>]
                 [--git-user-id <git user id>] [--group-id <group id>]
@@ -259,6 +261,7 @@ SYNOPSIS
                 [--remove-operation-id-prefix]
                 [--reserved-words-mappings <reserved word mappings>...]
                 [(-s | --skip-overwrite)] [--skip-validate-spec]
+                [--strict-spec <true/false strict behavior>]
                 [(-t <template directory> | --template-dir <template directory>)]
                 [--type-mappings <type mappings>...] [(-v | --verbose)]
 
@@ -289,9 +292,11 @@ OPTIONS
             artifact version in generated pom.xml
 
         -c <configuration file>, --config <configuration file>
-            Path to json configuration file. File content should be in a json
-            format {"optionKey":"optionValue", "optionKey1":"optionValue1"...}
-            Supported options can be different for each language. Run
+            Path to configuration file configuration file. It can be json or
+            yaml.If file is json, the content should have the format
+            {"optionKey":"optionValue", "optionKey1":"optionValue1"...}.If file
+            is yaml, the content should have the format optionKey:
+            optionValueSupported options can be different for each language. Run
             config-help -g {generator name} command for language specific config
             options.
 
@@ -299,11 +304,17 @@ OPTIONS
             sets specified system properties in the format of
             name=value,name=value (or multiple options, each with name=value)
 
+        -e <templating engine>, --engine <templating engine>
+            templating engine: "mustache" (default) or "handlebars" (beta)
+
         --enable-post-process-file
             enablePostProcessFile
 
         -g <generator name>, --generator-name <generator name>
-            generator to use (see langs command for list)
+            generator to use (see list command for list)
+
+        --generate-alias-as-model
+            Generate alias to map, array as models
 
         --git-repo-id <git repo id>
             Git repo ID, e.g. openapi-generator.
@@ -354,6 +365,9 @@ OPTIONS
             piping the JSON output of debug options (e.g. `-DdebugOperations`)
             to an external parser directly while testing a generator.
 
+        --minimal-update
+            Only write output files that have changed.
+
         --model-name-prefix <model name prefix>
             Prefix that will be prepended to all model names. Default is the
             empty string.
@@ -367,6 +381,9 @@ OPTIONS
 
         -o <output directory>, --output <output directory>
             where to write the generated files (current dir by default)
+
+        --package-name <package name>
+            package for generated classes (where supported)
 
         --release-note <release note>
             Release note, default to 'Minor update'.
@@ -386,12 +403,17 @@ OPTIONS
         --skip-validate-spec
             Skips the default behavior of validating an input specification.
 
+        --strict-spec <true/false strict behavior>
+            'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to.
+            e.g. when false, no fixes will be applied to documents which pass
+            validation but don't follow the spec.
+
         -t <template directory>, --template-dir <template directory>
             folder containing the template files
 
         --type-mappings <type mappings>
             sets mappings between OpenAPI spec types and generated code types in
-            the format of OpenaAPIType=generatedType,OpenAPIType=generatedType.
+            the format of OpenAPIType=generatedType,OpenAPIType=generatedType.
             For example: array=List,map=Map,string=String. You can also have
             multiple occurrences of this option.
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -216,7 +216,7 @@ public class Generate implements Runnable {
 
     @Option(name = {"--strict-spec"},
             title = "true/false strict behavior",
-            description = "'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to, e.g. no fixes will be applied to documents which pass validation but don't follow the spec.",
+            description = "'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to. e.g. when false, no fixes will be applied to documents which pass validation but don't follow the spec.",
             arity = 1)
     private Boolean strictSpecBehavior;
 

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -214,6 +214,12 @@ public class Generate implements Runnable {
             description = "Skips the default behavior of validating an input specification.")
     private Boolean skipValidateSpec;
 
+    @Option(name = {"--strict-spec"},
+            title = "true/false strict behavior",
+            description = "'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to, e.g. no fixes will be applied to documents which pass validation but don't follow the spec.",
+            arity = 1)
+    private Boolean strictSpecBehavior;
+
     @Option(name = {"--log-to-stderr"},
             title = "Log to STDERR",
             description = "write all log messages (not just errors) to STDOUT."
@@ -368,8 +374,13 @@ public class Generate implements Runnable {
         if (generateAliasAsModel != null) {
             configurator.setGenerateAliasAsModel(generateAliasAsModel);
         }
+
         if (minimalUpdate != null) {
             configurator.setEnableMinimalUpdate(minimalUpdate);
+        }
+
+        if (strictSpecBehavior != null) {
+            configurator.setStrictSpecBehavior(strictSpecBehavior);
         }
 
         applySystemPropertiesKvpList(systemProperties, configurator);

--- a/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
+++ b/modules/openapi-generator-cli/src/test/java/org/openapitools/codegen/cmd/GenerateTest.java
@@ -278,6 +278,26 @@ public class GenerateTest {
     }
 
     @Test
+    public void testStrictSpec() throws Exception {
+
+        setupAndRunGenericTest("--strict-spec", "true");
+        new FullVerifications() {
+            {
+                configurator.setStrictSpecBehavior(true);
+                times = 1;
+            }
+        };
+
+        setupAndRunGenericTest("--strict-spec", "false");
+        new FullVerifications() {
+            {
+                configurator.setStrictSpecBehavior(false);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
     public void testPackageName() throws Exception {
         final String value = "io.foo.bar.baz";
         setupAndRunGenericTest("--package-name", value);

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -57,7 +57,7 @@ mvn clean compile
 - `logToStderr` - write all log messages (not just errors) to STDOUT
 - `enablePostProcessFile` - enable file post-processing hook
 - `skipValidateSpec` - Whether or not to skip validating the input spec prior to generation. By default, invalid specifications will result in an error.
-- `strictSpec` - Whether or not to treat an input document strictly against the spec. 'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to, e.g. no fixes will be applied to documents which pass validation but don't follow the spec.
+- `strictSpec` - Whether or not to treat an input document strictly against the spec. 'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to. e.g. when false, no fixes will be applied to documents which pass validation but don't follow the spec.
 - `generateAliasAsModel` - generate alias (array, map) as model
 - `generateApis` - generate the apis (`true` by default)
 - `generateApiTests` - generate the api tests (`true` by default. Only available if `generateApis` is `true`)

--- a/modules/openapi-generator-maven-plugin/README.md
+++ b/modules/openapi-generator-maven-plugin/README.md
@@ -57,6 +57,7 @@ mvn clean compile
 - `logToStderr` - write all log messages (not just errors) to STDOUT
 - `enablePostProcessFile` - enable file post-processing hook
 - `skipValidateSpec` - Whether or not to skip validating the input spec prior to generation. By default, invalid specifications will result in an error.
+- `strictSpec` - Whether or not to treat an input document strictly against the spec. 'MUST' and 'SHALL' wording in OpenAPI spec is strictly adhered to, e.g. no fixes will be applied to documents which pass validation but don't follow the spec.
 - `generateAliasAsModel` - generate alias (array, map) as model
 - `generateApis` - generate the apis (`true` by default)
 - `generateApiTests` - generate the api tests (`true` by default. Only available if `generateApis` is `true`)

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -236,6 +236,12 @@ public class CodeGenMojo extends AbstractMojo {
     private Boolean skipValidateSpec;
 
     /**
+     * To treat a document strictly against the spec.
+     */
+    @Parameter(name = "strictSpec", required = false)
+    private Boolean strictSpecBehavior;
+
+    /**
      * To generate alias (array, map) as model
      */
     @Parameter(name = "generateAliasAsModel", required = false)
@@ -457,6 +463,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (skipValidateSpec != null) {
                 configurator.setValidateSpec(!skipValidateSpec);
+            }
+
+            if (strictSpecBehavior != null) {
+                configurator.setStrictSpecBehavior(strictSpecBehavior);
             }
 
             if (logToStderr != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -270,4 +270,8 @@ public interface CodegenConfig {
     public boolean isEnableMinimalUpdate();
 
     public void setEnableMinimalUpdate(boolean isEnableMinimalUpdate);
+
+    boolean isStrictSpecBehavior();
+
+    void setStrictSpecBehavior(boolean strictSpecBehavior);
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -118,6 +118,9 @@ public class DefaultCodegen implements CodegenConfig {
     // flag to indicate whether to only update files whose contents have changed
     protected boolean enableMinimalUpdate = false;
 
+    // acts strictly upon a spec, potentially modifying it to have consistent behavior across generators.
+    protected boolean strictSpecBehavior = true;
+
     // make openapi available to all methods
     protected OpenAPI openAPI;
 
@@ -2387,11 +2390,13 @@ public class DefaultCodegen implements CodegenConfig {
         }
         operationId = removeNonNameElementToCamelCase(operationId);
 
-        if (path.startsWith("/")) {
-            op.path = path;
-        } else {
+        if (isStrictSpecBehavior() && !path.startsWith("/")) {
+            // modifies an operation.path to strictly conform to OpenAPI Spec
             op.path = "/" + path;
+        } else {
+            op.path = path;
         }
+
         op.operationId = toOperationId(operationId);
         op.summary = escapeText(operation.getSummary());
         op.unescapedNotes = operation.getDescription();
@@ -4900,4 +4905,24 @@ public class DefaultCodegen implements CodegenConfig {
         this.enableMinimalUpdate = enableMinimalUpdate;
     }
 
+    /**
+     * Indicates whether the codegen configuration should treat documents as strictly defined by the OpenAPI specification.
+     *
+     * @return true to act strictly upon spec documents, potentially modifying the spec to strictly fit the spec.
+     */
+    @Override
+    public boolean isStrictSpecBehavior() {
+        return this.strictSpecBehavior;
+    }
+
+    /**
+     * Sets the boolean valid indicating whether generation will work strictly against the specification, potentially making
+     * minor changes to the input document.
+     *
+     * @param strictSpecBehavior true if we will behave strictly, false to allow specification documents which pass validation to be loosely interpreted against the spec.
+     */
+    @Override
+    public void setStrictSpecBehavior(final boolean strictSpecBehavior) {
+        this.strictSpecBehavior = strictSpecBehavior;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -85,6 +85,7 @@ public class CodegenConfigurator implements Serializable {
     private boolean validateSpec;
     private boolean enablePostProcessFile;
     private boolean enableMinimalUpdate;
+    private boolean strictSpecBehavior;
     private String templateDir;
     private String templatingEngineName;
     private String auth;
@@ -117,6 +118,7 @@ public class CodegenConfigurator implements Serializable {
 
     public CodegenConfigurator() {
         this.validateSpec = true;
+        this.strictSpecBehavior = true;
         this.setOutputDir(".");
     }
 
@@ -249,6 +251,15 @@ public class CodegenConfigurator implements Serializable {
 
     public CodegenConfigurator setModelNameSuffix(String suffix) {
         this.modelNameSuffix = suffix;
+        return this;
+    }
+
+    public boolean isStrictSpecBehavior() {
+        return strictSpecBehavior;
+    }
+
+    public CodegenConfigurator setStrictSpecBehavior(boolean strictSpecBehavior) {
+        this.strictSpecBehavior = strictSpecBehavior;
         return this;
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -48,7 +48,35 @@ public class DefaultGeneratorTest {
         Assert.assertEquals(defaultList.get(3).path, "/path4");
         Assert.assertEquals(defaultList.get(3).allParams.size(), 1);
     }
-    
+
+
+    @Test
+    public void testNonStrictProcessPaths() throws Exception {
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.setPaths(new Paths());
+        openAPI.getPaths().addPathItem("path1/", new PathItem().get(new Operation().operationId("op1").responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+        openAPI.getPaths().addPathItem("path2/", new PathItem().get(new Operation().operationId("op2").addParametersItem(new QueryParameter().name("p1").schema(new StringSchema())).responses(new ApiResponses().addApiResponse("201", new ApiResponse().description("OK")))));
+
+        ClientOptInput opts = new ClientOptInput();
+        opts.setOpenAPI(openAPI);
+        CodegenConfig config = new DefaultCodegen();
+        config.setStrictSpecBehavior(false);
+        opts.setConfig(config);
+        opts.setOpts(new ClientOpts());
+
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(opts);
+        Map<String, List<CodegenOperation>> result = generator.processPaths(openAPI.getPaths());
+        Assert.assertEquals(result.size(), 1);
+        List<CodegenOperation> defaultList = result.get("Default");
+        Assert.assertEquals(defaultList.size(), 2);
+        Assert.assertEquals(defaultList.get(0).path, "path1/");
+        Assert.assertEquals(defaultList.get(0).allParams.size(), 0);
+        Assert.assertEquals(defaultList.get(1).path, "path2/");
+        Assert.assertEquals(defaultList.get(1).allParams.size(), 1);
+    }
+
+
     @Test
     public void minimalUpdateTest() throws IOException {
         OpenAPI openAPI = TestUtils.createOpenAPI();


### PR DESCRIPTION
Introduces an option to allow user customization of strict specification
behaviors. For instance, OpenAPI 3.x requires a path object name to be
prefixed with '/' so we append any missing '/', but this may not be
desirable to some users or generators. In this commit, this fix specifically is
the only modification affected.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adds an option which allows users to disable any strict specification behaviors applied during generation. For example, #1034 introduces a modification which prefixes all paths missing a beginning slash to better fit "MUST" definitions in the OpenAPI Specification 3.x. Ideally, this behavior would be rolled up into the parser (i.e. if we've validated via the parser, we shouldn't need to fix the spec document).

Such a switch is necessary because, as discussed in #2702, users may not want the input document to be modified to match strict behaviors against the specification.

Use of this option to disable strict behaviors, however, does mean that one or more generators may not work as expected. For example, if the url part of a document is: `http://localhost/api` and the path is `resource/{id}`, this may result in a generated URL such as `http://localhost/apiresource/{id}`.

Note that there seems to be a discrepancy or error in the OpenAPI 3.0.x specification. A server url object default is a server with relative url `/`. The url requirement is defined as:

> REQUIRED. A URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in {brackets}.

But, URLs with and without trailing `/` are both valid.

The field name for a paths object is defined as:

> A relative path to an individual endpoint. The field name MUST begin with a forward slash (/). The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. Path templating is allowed. When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts. Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical. In case of ambiguous matching, it's up to the tooling to decide which one to use.

So, strictly following the spec here, it seems that when `server.url = /` and `paths["/api"]` exist, the desired outcome (no relative URL resolution, appending path to URL) is `//api`, which obviously isn't correct as this means the protocol-relative hostname `api`.

This PR does not attempt to resolve any concerns with the above scenario; it is only provided as an example of why we follow strict behaviors by default and need to sometimes modify what a user provides (even when it successfully validates against the spec).

/cc @OpenAPITools/generator-core-team 

## TODO

Once merged, the option will need to be applied to the gradle plugin. It seems to always resolve against maven with greater precedence over mavenLocal, and I'm hesitant to shift repository settings around and introduce any issues with the build pipeline.