### PR TITLE
[elm] Fix repetitive enum prefixes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -694,7 +694,10 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
         final String prefix = toEnumName(property);
         for (Map<String, Object> enumVar : enumVars) {
-            enumVar.put("name", prefix + enumVar.get("name"));
+            if (!enumVar.containsKey("_isPrefixed")) {
+                enumVar.put("name", prefix + enumVar.get("name"));
+                enumVar.put("_isPrefixed", true);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #2759.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

For arrays of enums, the elm prefix is added four times, instead of once.

cc @wing328 