### PR TITLE
[ASP.NET Core]Switch registry to MCR for dotnet images

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Dockerfile.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore-build:2.0 AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.0 AS build-env
 WORKDIR /app
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
@@ -12,7 +12,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # build runtime image
-FROM microsoft/aspnetcore:2.0
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "{{packageName}}.dll"]

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Dockerfile.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.0 AS build-env
+FROM microsoft/aspnetcore-build:2.0 AS build-env
 WORKDIR /app
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
@@ -12,7 +12,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # build runtime image
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.0
+FROM microsoft/aspnetcore:2.0
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "{{packageName}}.dll"]

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Dockerfile.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:{{aspnetCoreVersion}}-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:{{aspnetCoreVersion}} AS build-env
 WORKDIR /app
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
@@ -12,7 +12,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # build runtime image
-FROM microsoft/dotnet:{{aspnetCoreVersion}}-aspnetcore-runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:{{aspnetCoreVersion}}
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "{{packageName}}.dll"]

--- a/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Dockerfile
+++ b/samples/server/petstore/aspnetcore/src/Org.OpenAPITools/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build-env
 WORKDIR /app
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
@@ -12,7 +12,7 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # build runtime image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "Org.OpenAPITools.dll"]


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Switch dotnet image registry to MCR to pull latest sha for dotnet tags

Please see
https://github.com/dotnet/announcements/issues/101

https://devblogs.microsoft.com/dotnet/net-core-container-images-now-published-to-microsoft-container-registry/

@jimschubert @wing328 
