### PR TITLE
[JAVA][KOTLIN] fix var Naming for all uppercase with Numbers

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -607,7 +607,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
 
         // if it's all uppper case, do nothing
-        if (name.matches("^[A-Z_]*$")) {
+        if (name.matches("^[A-Z0-9_]*$")) {
             return name;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -717,7 +717,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         }
 
         // if it's all uppper case, do nothing
-        if (name.matches("^[A-Z_]*$")) {
+        if (name.matches("^[A-Z0-9_]*$")) {
             return name;
         }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -68,20 +68,24 @@ public class AbstractJavaCodegenTest {
 
     @Test
     public void convertVarName() throws Exception {
-       Assert.assertEquals(fakeJavaCodegen.toVarName("name"), "name");
-       Assert.assertEquals(fakeJavaCodegen.toVarName("$name"), "$name");
-       Assert.assertEquals(fakeJavaCodegen.toVarName("nam$$e"), "nam$$e");
-       Assert.assertEquals(fakeJavaCodegen.toVarName("user-name"), "userName");
-       Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");
-       Assert.assertEquals(fakeJavaCodegen.toVarName("user|name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("name"), "name");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("$name"), "$name");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("nam$$e"), "nam$$e");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("user-name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("user_name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("user|name"), "userName");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("uSername"), "uSername");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("USERname"), "usERname");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("USERNAME"), "USERNAME");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("USER123NAME"), "USER123NAME");
    }
 
    @Test
    public void convertModelName() throws Exception {
-       Assert.assertEquals(fakeJavaCodegen.toModelName("name"), "Name");
-       Assert.assertEquals(fakeJavaCodegen.toModelName("$name"), "Name");
-       Assert.assertEquals(fakeJavaCodegen.toModelName("nam#e"), "Name");
-       Assert.assertEquals(fakeJavaCodegen.toModelName("$another-fake?"), "AnotherFake");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("name"), "Name");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("$name"), "Name");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("nam#e"), "Name");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("$another-fake?"), "AnotherFake");
    }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -448,6 +448,34 @@ public class JavaModelTest {
         Assert.assertFalse(property.isContainer);
     }
 
+    @Test(description = "convert a model with upper-case property names and Numbers")
+    public void upperCaseNamesNumbersTest() {
+        final Schema schema = new Schema()
+                .description("a model with upper-case property names and numbers")
+                .addProperties("NAME1", new StringSchema())
+                .addRequiredItem("NAME1");
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("sample", schema);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel("sample", schema);
+
+        Assert.assertEquals(cm.name, "sample");
+        Assert.assertEquals(cm.classname, "Sample");
+        Assert.assertEquals(cm.vars.size(), 1);
+
+        final CodegenProperty property = cm.vars.get(0);
+        Assert.assertEquals(property.baseName, "NAME1");
+        Assert.assertEquals(property.getter, "getNAME1");
+        Assert.assertEquals(property.setter, "setNAME1");
+        Assert.assertEquals(property.dataType, "String");
+        Assert.assertEquals(property.name, "NAME1");
+        Assert.assertEquals(property.defaultValue, null);
+        Assert.assertEquals(property.baseType, "String");
+        Assert.assertFalse(property.hasMore);
+        Assert.assertTrue(property.required);
+        Assert.assertFalse(property.isContainer);
+    }
+
     @Test(description = "convert a model with a 2nd char upper-case property names")
     public void secondCharUpperCaseNamesTest() {
         final Schema schema = new Schema()

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -117,6 +117,10 @@ public class AbstractKotlinCodegenTest {
         assertEquals(codegen.toVarName("Pony?"), "ponyQuestionMark");
         assertEquals(codegen.toVarName("nam#e"), "namHashE");
         assertEquals(codegen.toVarName("Pony>=>="), "ponyGreaterThanEqualGreaterThanEqual");
+        assertEquals(codegen.toVarName("uSername"), "uSername");
+        assertEquals(codegen.toVarName("USERname"), "usERname");
+        assertEquals(codegen.toVarName("USERNAME"), "USERNAME");
+        assertEquals(codegen.toVarName("USER123NAME"), "USER123NAME");
     }
 
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@jimschubert (2017/09), @dr4ke616 (2018/08)  @Zomzog (2019/04)

### Description of the PR

a var with all upper case and numbers (e.g `USER123NAME`)  is incorrectly converted to (e.g `usER123NAME`) and the getter/setter generated is wrong (e.g `getUsER123NAME()`)

with the fix (following the all upper case var rule) :
`USER123NAME` stay `USER123NAME` and the getter is `getUSER123NAME()`


thanks to @JorgeMorata to detect this issue