### PR TITLE
[JAVA] fix artifactVersion is not taken from specification 

### DIFF
--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -45,5 +45,5 @@ sidebar_label: java-msf4j
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |library|library template (sub-template)|<dl><dt>**jersey1**</dt><dd>Jersey core 1.x</dd><dt>**jersey2**</dt><dd>Jersey core 2.x</dd><dl>|jersey2|

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -45,7 +45,7 @@ sidebar_label: jaxrs-cxf-cdi
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |library|library template (sub-template)|<dl><dt>**&lt;default&gt;**</dt><dd>JAXRS</dd><dl>|&lt;default&gt;|
 |generatePom|Whether to generate pom.xml if the file does not already exist.| |true|
 |interfaceOnly|Whether to generate only API interface stubs without the server files.| |false|

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -45,7 +45,7 @@ sidebar_label: jaxrs-cxf-extended
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |generateSpringApplication|Generate Spring application| |false|
 |useSpringAnnotationConfig|Use Spring Annotation Config| |false|
 |useSwaggerFeature|Use Swagger Feature| |false|

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -45,7 +45,7 @@ sidebar_label: jaxrs-cxf
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |generateSpringApplication|Generate Spring application| |false|
 |useSpringAnnotationConfig|Use Spring Annotation Config| |false|
 |useSwaggerFeature|Use Swagger Feature| |false|

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -45,7 +45,7 @@ sidebar_label: jaxrs-jersey
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |library|library template (sub-template)|<dl><dt>**jersey1**</dt><dd>Jersey core 1.x</dd><dt>**jersey2**</dt><dd>Jersey core 2.x</dd><dl>|jersey2|
 |supportJava6|Whether to support Java6 with the Jersey1/2 library.| |false|
 |useTags|use tags for creating interface and controller classnames| |false|

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -45,7 +45,7 @@ sidebar_label: jaxrs-resteasy-eap
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |generateJbossDeploymentDescriptor|Generate Jboss Deployment Descriptor| |true|
 |useSwaggerFeature|Use dynamic Swagger generator| |false|

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -45,5 +45,5 @@ sidebar_label: jaxrs-resteasy
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |generateJbossDeploymentDescriptor|Generate Jboss Deployment Descriptor| |false|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -45,7 +45,7 @@ sidebar_label: jaxrs-spec
 |implFolder|folder for generated implementation code| |src/main/java|
 |title|a title describing the application| |OpenAPI Server|
 |useBeanValidation|Use BeanValidation API annotations| |true|
-|serverPort|The port on which the server should be started| |null|
+|serverPort|The port on which the server should be started| |8080|
 |library|library template (sub-template)|<dl><dt>**&lt;default&gt;**</dt><dd>JAXRS</dd><dl>|&lt;default&gt;|
 |generatePom|Whether to generate pom.xml if the file does not already exist.| |true|
 |interfaceOnly|Whether to generate only API interface stubs without the server files.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1019,8 +1019,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         List<Map<String, String>> imports = (List<Map<String, String>>) objs.get("imports");
         Pattern pattern = Pattern.compile("java\\.util\\.(List|ArrayList|Map|HashMap)");
         for (Iterator<Map<String, String>> itr = imports.iterator(); itr.hasNext(); ) {
-            String _import = itr.next().get("import");
-            if (pattern.matcher(_import).matches()) {
+            String itrImport = itr.next().get("import");
+            if (pattern.matcher(itrImport).matches()) {
                 itr.remove();
             }
         }
@@ -1042,7 +1042,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                     LOGGER.info("Processing operation " + operation.getOperationId());
                     if (hasBodyParameter(openAPI, operation) || hasFormParameter(openAPI, operation)) {
                         String defaultContentType = hasFormParameter(openAPI, operation) ? "application/x-www-form-urlencoded" : "application/json";
-                        List<String> consumes = new ArrayList<String>(getConsumesInfo(openAPI, operation));
+                        List<String> consumes = new ArrayList<>(getConsumesInfo(openAPI, operation));
                         String contentType = consumes == null || consumes.isEmpty() ? defaultContentType : consumes.get(0);
                         operation.addExtension("x-contentType", contentType);
                     }
@@ -1067,7 +1067,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     }
 
-    protected static String getAccept(OpenAPI openAPI, Operation operation) {
+    private static String getAccept(OpenAPI openAPI, Operation operation) {
         String accepts = null;
         String defaultContentType = "application/json";
         Set<String> producesInfo = getProducesInfo(openAPI, operation);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -102,6 +102,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
 
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
+        super.preprocessOpenAPI(openAPI);
         /* TODO there should be no need for the following logic
         if ("/".equals(swagger.getBasePath())) {
             swagger.setBasePath("");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -42,7 +42,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     protected String implFolder = "src/main/java";
     protected String testResourcesFolder = "src/test/resources";
     protected String title = "OpenAPI Server";
-
+    protected String serverPort = "8080";
     protected boolean useBeanValidation = true;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
@@ -71,7 +71,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         cliOptions.add(new CliOption(CodegenConstants.IMPL_FOLDER, CodegenConstants.IMPL_FOLDER_DESC).defaultValue(implFolder));
         cliOptions.add(new CliOption("title", "a title describing the application").defaultValue(title));
         cliOptions.add(CliOption.newBoolean(USE_BEANVALIDATION, "Use BeanValidation API annotations",useBeanValidation));
-        cliOptions.add(new CliOption(SERVER_PORT, "The port on which the server should be started"));
+        cliOptions.add(new CliOption(SERVER_PORT, "The port on which the server should be started").defaultValue(serverPort));
     }
 
 
@@ -112,7 +112,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         if (!this.additionalProperties.containsKey(SERVER_PORT)) {
             URL url = URLPathUtils.getServerURL(openAPI);
             // 8080 is the default value for a JEE Server:
-            this.additionalProperties.put(SERVER_PORT, URLPathUtils.getPort(url, 8080));
+            this.additionalProperties.put(SERVER_PORT, URLPathUtils.getPort(url, serverPort));
         }
 
         if (openAPI.getPaths() != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
@@ -221,11 +221,13 @@ public class JavaVertXServerCodegen extends AbstractJavaCodegen {
         this.additionalProperties.put("serverPort", URLPathUtils.getPort(url, 8080));
 
         // retrieve api version from swagger file, 1.0.0-SNAPSHOT by default
+        // set in super.preprocessOpenAPI
+        /*
         if (openAPI.getInfo() != null && openAPI.getInfo().getVersion() != null) {
             artifactVersion = apiVersion = openAPI.getInfo().getVersion();
         } else {
             artifactVersion = apiVersion;
-        }
+        }*/
 
         /*
          * manage operation & custom serviceId because operationId field is not

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -3,6 +3,7 @@ package org.openapitools.codegen;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
@@ -27,6 +28,7 @@ public class TestUtils {
     public static OpenAPI createOpenAPI() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
+        openAPI.setPaths(new Paths());
 
         final Info info = new Info();
         info.setDescription("API under test");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -55,15 +55,26 @@ public class AbstractJavaCodegenTest {
     public void toModelNameUsesPascalCase() throws Exception {
         Assert.assertEquals("JsonAnotherclass", fakeJavaCodegen.toModelName("json_anotherclass"));
     }
- 
+
     @Test
     public void testPreprocessOpenAPI() throws Exception {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
-        final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
 
         codegen.preprocessOpenAPI(openAPI);
 
+        Assert.assertEquals(codegen.getArtifactVersion(), openAPI.getInfo().getVersion());
         Assert.assertEquals(openAPI.getPaths().get("/pet").getPost().getExtensions().get("x-accepts"), "application/json");
+    }
+
+    @Test
+    public void testPreprocessOpenAPINumVersion() throws Exception {
+        final OpenAPI openAPIOtherNumVersion = TestUtils.parseSpec("src/test/resources/2_0/duplicateOperationIds.yaml");
+        final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+
+        codegen.preprocessOpenAPI(openAPIOtherNumVersion);
+
+        Assert.assertEquals(codegen.getArtifactVersion(), openAPIOtherNumVersion.getInfo().getVersion());
     }
 
     @Test
@@ -208,9 +219,8 @@ public class AbstractJavaCodegenTest {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
 
         OpenAPI api = TestUtils.createOpenAPI();
-        codegen.setOpenAPI(api);
-
         codegen.processOpts();
+        codegen.preprocessOpenAPI(api);
 
         Assert.assertEquals(codegen.getArtifactVersion(), "1.0.7");
     }
@@ -222,15 +232,14 @@ public class AbstractJavaCodegenTest {
         codegen.additionalProperties().put("artifactVersion", "1.1.1");
 
         OpenAPI api = TestUtils.createOpenAPI();
-        codegen.setOpenAPI(api);
-
         codegen.processOpts();
+        codegen.preprocessOpenAPI(api);
 
         Assert.assertEquals(codegen.getArtifactVersion(), "1.1.1");
     }
 
     @Test(description = "tests if default version is used when neither OpenAPI version nor artifactVersion additional property has been provided")
-    public void defautlVersionTest() {
+    public void defaultVersionTest() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
 
         codegen.processOpts();

--- a/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
@@ -46,6 +46,8 @@ paths:
       tags:
       - pet
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,6 +83,8 @@ paths:
       tags:
       - pet
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,6 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -170,6 +175,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -201,6 +207,7 @@ paths:
       summary: Deletes a pet
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
     get:
@@ -235,6 +242,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -269,6 +277,8 @@ paths:
       summary: Updates a pet in the store with form data
       tags:
       - pet
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}/uploadImage:
@@ -308,6 +318,8 @@ paths:
       summary: uploads an image
       tags:
       - pet
+      x-contentType: multipart/form-data
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /store/inventory:
@@ -329,6 +341,7 @@ paths:
       summary: Returns pet inventories by status
       tags:
       - store
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order:
@@ -358,6 +371,8 @@ paths:
       tags:
       - store
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -382,6 +397,7 @@ paths:
       summary: Delete purchase order by ID
       tags:
       - store
+      x-accepts: application/json
       x-tags:
       - tag: store
     get:
@@ -417,6 +433,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -438,6 +455,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/createWithArray:
@@ -460,6 +479,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/createWithList:
@@ -482,6 +503,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/login:
@@ -527,6 +550,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -539,6 +563,7 @@ paths:
       summary: Logs out current logged in user session
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/{username}:
@@ -562,6 +587,7 @@ paths:
       summary: Delete user
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
     get:
@@ -592,6 +618,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:
@@ -622,6 +649,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /fake_classname_test:
@@ -648,6 +677,8 @@ paths:
       tags:
       - fake_classname_tags 123#$%^
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake_classname_tags 123#$%^
   /fake:
@@ -698,6 +729,7 @@ paths:
       tags:
       - fake
       x-group-parameters: true
+      x-accepts: application/json
       x-tags:
       - tag: fake
     get:
@@ -800,6 +832,8 @@ paths:
       summary: To test enum parameters
       tags:
       - fake
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: fake
     patch:
@@ -823,6 +857,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
     post:
@@ -923,6 +959,8 @@ paths:
         가짜 엔드 포인트
       tags:
       - fake
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/outer/number:
@@ -946,6 +984,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/outer/string:
@@ -969,6 +1009,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/outer/boolean:
@@ -992,6 +1034,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/outer/composite:
@@ -1015,6 +1059,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/jsonFormData:
@@ -1042,6 +1088,8 @@ paths:
       summary: test json serialization of form data
       tags:
       - fake
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/inline-additionalProperties:
@@ -1064,6 +1112,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: param
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/body-with-query-params:
@@ -1088,6 +1138,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/create_xml_item:
@@ -1124,6 +1176,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: XmlItem
+      x-contentType: application/xml
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /another-fake/dummy:
@@ -1148,6 +1202,8 @@ paths:
       tags:
       - $another-fake?
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: $another-fake?
   /fake/body-with-file-schema:
@@ -1168,6 +1224,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
@@ -1210,6 +1268,8 @@ paths:
       summary: uploads an image (required)
       tags:
       - pet
+      x-contentType: multipart/form-data
+      x-accepts: application/json
       x-tags:
       - tag: pet
 components:

--- a/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
@@ -46,6 +46,8 @@ paths:
       tags:
       - pet
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,6 +83,8 @@ paths:
       tags:
       - pet
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,6 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -170,6 +175,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -201,6 +207,7 @@ paths:
       summary: Deletes a pet
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
     get:
@@ -235,6 +242,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -269,6 +277,8 @@ paths:
       summary: Updates a pet in the store with form data
       tags:
       - pet
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}/uploadImage:
@@ -308,6 +318,8 @@ paths:
       summary: uploads an image
       tags:
       - pet
+      x-contentType: multipart/form-data
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /store/inventory:
@@ -329,6 +341,7 @@ paths:
       summary: Returns pet inventories by status
       tags:
       - store
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order:
@@ -358,6 +371,8 @@ paths:
       tags:
       - store
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -382,6 +397,7 @@ paths:
       summary: Delete purchase order by ID
       tags:
       - store
+      x-accepts: application/json
       x-tags:
       - tag: store
     get:
@@ -417,6 +433,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -438,6 +455,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/createWithArray:
@@ -460,6 +479,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/createWithList:
@@ -482,6 +503,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/login:
@@ -527,6 +550,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -539,6 +563,7 @@ paths:
       summary: Logs out current logged in user session
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/{username}:
@@ -562,6 +587,7 @@ paths:
       summary: Delete user
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
     get:
@@ -592,6 +618,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:
@@ -622,6 +649,8 @@ paths:
       tags:
       - user
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: application/json
       x-tags:
       - tag: user
   /fake_classname_test:
@@ -648,6 +677,8 @@ paths:
       tags:
       - fake_classname_tags 123#$%^
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake_classname_tags 123#$%^
   /fake:
@@ -698,6 +729,7 @@ paths:
       tags:
       - fake
       x-group-parameters: true
+      x-accepts: application/json
       x-tags:
       - tag: fake
     get:
@@ -800,6 +832,8 @@ paths:
       summary: To test enum parameters
       tags:
       - fake
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: fake
     patch:
@@ -823,6 +857,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
     post:
@@ -923,6 +959,8 @@ paths:
         가짜 엔드 포인트
       tags:
       - fake
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/outer/number:
@@ -946,6 +984,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/outer/string:
@@ -969,6 +1009,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/outer/boolean:
@@ -992,6 +1034,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/outer/composite:
@@ -1015,6 +1059,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: '*/*'
+      x-accepts: '*/*'
       x-tags:
       - tag: fake
   /fake/jsonFormData:
@@ -1042,6 +1088,8 @@ paths:
       summary: test json serialization of form data
       tags:
       - fake
+      x-contentType: application/x-www-form-urlencoded
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/inline-additionalProperties:
@@ -1064,6 +1112,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: param
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/body-with-query-params:
@@ -1088,6 +1138,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/create_xml_item:
@@ -1124,6 +1176,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: XmlItem
+      x-contentType: application/xml
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /another-fake/dummy:
@@ -1148,6 +1202,8 @@ paths:
       tags:
       - $another-fake?
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: $another-fake?
   /fake/body-with-file-schema:
@@ -1168,6 +1224,8 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+      x-contentType: application/json
+      x-accepts: application/json
       x-tags:
       - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
@@ -1210,6 +1268,8 @@ paths:
       summary: uploads an image (required)
       tags:
       - pet
+      x-contentType: multipart/form-data
+      x-accepts: application/json
       x-tags:
       - tag: pet
 components:


### PR DESCRIPTION
when not provided by generator option

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @Zomzog (2019/04)


### Description of the PR

fix #1815 
fix #2033 PR feature :
- If no artifactVersion is provided in additional properties, version from API specification is used. If none of them is provided then fallbacks to default version (1.0.0)

