### PR TITLE
Update DefaultCodeGen to allow additional primitive types

### DIFF
--- a/bin/windows/android-petstore-httpclient.bat
+++ b/bin/windows/android-petstore-httpclient.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M -DloggerPath=conf/log4j.properties
-set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g android -o samples\client\petstore\android\httpclient-Dlibrary=httpclient
+set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore.yaml -g android -o samples\client\petstore\android\httpclient -Dlibrary=httpclient
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1411,7 +1411,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param schema
      * @return type
      */
-    private static String getPrimitiveType(Schema schema) {
+    private String getPrimitiveType(Schema schema) {
         if (schema == null) {
             throw new RuntimeException("schema cannot be null in getPrimitiveType");
         } else if (ModelUtils.isStringSchema(schema) && "number".equals(schema.getFormat())) {
@@ -1452,6 +1452,13 @@ public class DefaultCodegen implements CodegenConfig {
         } else if (ModelUtils.isUUIDSchema(schema)) {
             return "UUID";
         } else if (ModelUtils.isStringSchema(schema)) {
+            if(typeMapping.containsKey(schema.getFormat())) {
+                // If the format matches a typeMapping (supplied with the --typeMappings flag)
+                // then treat the format as a primitive type.
+                // This allows the typeMapping flag to add a new custom type which can then
+                // be used in the format field.   
+                return schema.getFormat();
+            }
             return "string";
         } else if (ModelUtils.isFreeFormObject(schema)) {
             return "object";
@@ -3548,7 +3555,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @param schemas The complete set of model definitions (schemas).
      * @return A mapping from model name to type alias
      */
-    static Map<String, String> getAllAliases(Map<String, Schema> schemas) {
+    Map<String, String> getAllAliases(Map<String, Schema> schemas) {
         if (schemas == null || schemas.isEmpty()) {
             return new HashMap<>();
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -182,6 +182,7 @@ public class DefaultCodegenTest {
 
     @Test
     public void testArraySchemaIsNotIncluedInAliases() throws Exception {
+        final DefaultCodegen codegen = new DefaultCodegen();
         Map<String, Schema> schemas = new HashMap<String, Schema>() {
             {
                 put("ArraySchemaTest", new ArraySchema());
@@ -189,7 +190,7 @@ public class DefaultCodegenTest {
 
         };
 
-        Map<String, String> aliases = DefaultCodegen.getAllAliases(schemas);
+        Map<String, String> aliases = codegen.getAllAliases(schemas);
 
         Assert.assertEquals(aliases.size(), 0);
     }


### PR DESCRIPTION
If a string field is specified with a format which is also defined using --typeMappings, it will be treated as a primitive type

For example, if you run the following command:

`java -jar openapi-generator-cli.jar generate [options] --type-mappings dateorcutlabel=CutLabel`

The generated code will assume there is a class `CutLabel` and use it for any parameter which has a specific similiar to this:

> {
>   "name": "effectiveAt",
>   "in": "query",
>   "description": "Optional. The effective date of the data",
>   "required": false,
>   "type": "string",
>   "format": "**dateorcutlabel**"
> }

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

