### PR TITLE
[Elm] Bugfix .encode in modelTypeDiscriminator

### DIFF
--- a/modules/openapi-generator/src/main/resources/elm/modelTypeDiscriminator.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/modelTypeDiscriminator.mustache
@@ -27,6 +27,6 @@ encode model =
     case model of
 {{#mappedModels}}
         {{modelName}}Type subModel ->
-            {{modelName}}.encoder "{{mappingName}}" subModel
+            {{modelName}}.encode "{{mappingName}}" subModel
 
 {{/mappedModels}}


### PR DESCRIPTION
The function is called `encode`. This fixed the call.

See https://github.com/OpenAPITools/openapi-generator/blob/dfa7e616c0f311f3ebf58c04287f200c8e491f08/modules/openapi-generator/src/main/resources/elm/modelTypeArray.mustache#L11

I have encountered this issue, and this is probably an easy fix.
@eriktim Can you have a short look? 

