### PR TITLE
[aspnetcore]: Preliminary support for ASP.NET 3.0 Core preview 5

### DIFF
--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -27,8 +27,8 @@ sidebar_label: aspnetcore
 |isLibrary|Is the build a library| |false|
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
-|newtonsoftVersion|Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+| |3.0.0-preview4-19216-03|
-|useDefaultRoutng|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
+|newtonsoftVersion|Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+| |3.0.0-preview5-19227-01|
+|useDefaultRouting|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|
 |buildTarget|Target to build an application or library| |program|

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -27,7 +27,7 @@ sidebar_label: aspnetcore
 |isLibrary|Is the build a library| |false|
 |isFramework|Are we using packagereference or framework| |false|
 |useNewtonsoft|Uses the Newtonsoft JSN library.| |true|
-|useEndpointRoutng|Uses the newend point routing JSN library.| |false|
+|useDefaultRoutng|Uses the newend point routing JSN library.| |true|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|
 |buildTarget|Target to build an application or library| |program|

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -26,7 +26,7 @@ sidebar_label: aspnetcore
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
 |isLibrary|Is the build a library| |false|
 |isFramework|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
-|useNewtonsoft|Uses the Newtonsoft JSN library.| |true|
+|useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
 |useDefaultRoutng|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -27,6 +27,7 @@ sidebar_label: aspnetcore
 |isLibrary|Is the build a library| |false|
 |useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
+|newtonsoftVersion|Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+| |3.0.0-preview4-19216-03|
 |useDefaultRoutng|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -18,12 +18,16 @@ sidebar_label: aspnetcore
 |sourceFolder|source folder for generated code| |src|
 |compatibilityVersion|ASP.Net Core CompatibilityVersion| |Version_2_1|
 |aspnetCoreVersion|ASP.NET Core version: 2.2 (default), 2.1, 2.0 (deprecated)| |2.2|
+|swashbuckleVersion|Swashbucke version: 3.0.0 (default), 4.0.0| |3.0.0|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
 |returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
 |isLibrary|Is the build a library| |false|
+|isFramework|Are we using packagereference or framework| |false|
+|useNewtonsoft|Uses the Newtonsoft JSN library.| |true|
+|useEndpointRoutng|Uses the newend point routing JSN library.| |false|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|
 |buildTarget|Target to build an application or library| |program|

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -17,15 +17,15 @@ sidebar_label: aspnetcore
 |packageGuid|The GUID that will be associated with the C# project| |null|
 |sourceFolder|source folder for generated code| |src|
 |compatibilityVersion|ASP.Net Core CompatibilityVersion| |Version_2_2|
-|aspnetCoreVersion|ASP.NET Core version: 3.0 (preview4 only), 2.2 (default), 2.1, 2.0 (deprecated)| |2.2|
-|swashbuckleVersion|Swashbucke version: 3.0.0 (default), 4.0.0| |3.0.0|
+|aspnetCoreVersion|ASP.NET Core version: 3.0 (preview4 only), 2.2, 2.1, 2.0 (deprecated)| |2.2|
+|swashbuckleVersion|Swashbucke version: 3.0.0, 4.0.0| |3.0.0|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
 |useCollection|Deserialize array types to Collection&lt;T&gt; instead of List&lt;T&gt;.| |false|
 |returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
 |isLibrary|Is the build a library| |false|
-|isFramework|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
+|useFrameworkReference|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
 |useDefaultRoutng|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
 |classModifier|Class Modifier can be empty, abstract| ||

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -16,8 +16,8 @@ sidebar_label: aspnetcore
 |packageVersion|C# package version.| |1.0.0|
 |packageGuid|The GUID that will be associated with the C# project| |null|
 |sourceFolder|source folder for generated code| |src|
-|compatibilityVersion|ASP.Net Core CompatibilityVersion| |Version_2_1|
-|aspnetCoreVersion|ASP.NET Core version: 2.2 (default), 2.1, 2.0 (deprecated)| |2.2|
+|compatibilityVersion|ASP.Net Core CompatibilityVersion| |Version_2_2|
+|aspnetCoreVersion|ASP.NET Core version: 3.0 (preview4 only), 2.2 (default), 2.1, 2.0 (deprecated)| |2.2|
 |swashbuckleVersion|Swashbucke version: 3.0.0 (default), 4.0.0| |3.0.0|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |useDateTimeOffset|Use DateTimeOffset to model date-time properties| |false|
@@ -25,9 +25,9 @@ sidebar_label: aspnetcore
 |returnICollection|Return ICollection&lt;T&gt; instead of the concrete type.| |false|
 |useSwashbuckle|Uses the Swashbuckle.AspNetCore NuGet package for documentation.| |true|
 |isLibrary|Is the build a library| |false|
-|isFramework|Are we using packagereference or framework| |false|
+|isFramework|Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.| |false|
 |useNewtonsoft|Uses the Newtonsoft JSN library.| |true|
-|useDefaultRoutng|Uses the newend point routing JSN library.| |true|
+|useDefaultRoutng|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|
 |buildTarget|Target to build an application or library| |program|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -54,7 +54,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String IS_LIBRARY = "isLibrary";
     public static final String USE_FRAMEWORK_REFERENCE = "useFrameworkReference";
     public static final String USE_NEWTONSOFT = "useNewtonsoft";
-    public static final String USE_DEFAULT_ROUTING = "useDefaultRoutng";
+    public static final String USE_DEFAULT_ROUTING = "useDefaultRouting";
     public static final String NEWTONSOFT_VERSION = "newtonsoftVersion";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
@@ -80,7 +80,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean isLibrary = false;
     private boolean useFrameworkReference = false;
     private boolean useNewtonsoft = true;
-    private boolean useDefaultRoutng = true;
+    private boolean useDefaultRouting = true;
     private String newtonsoftVersion = "3.0.0-preview5-19227-01";
 
     public AspNetCoreServerCodegen() {
@@ -162,6 +162,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
         swashbuckleVersion.addEnum("3.0.0", "Swashbuckle 3.0.0");
         swashbuckleVersion.addEnum("4.0.0", "Swashbuckle 4.0.0");
+        swashbuckleVersion.addEnum("5.0.0", "Swashbuckle 5.0.0");
         swashbuckleVersion.setDefault("3.0.0");
         swashbuckleVersion.setOptValue(swashbuckleVersion.getDefault());
         addOption(swashbuckleVersion.getOpt(), swashbuckleVersion.getDescription(), swashbuckleVersion.getOptValue());
@@ -206,7 +207,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
         addSwitch(USE_DEFAULT_ROUTING,
                 "Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.",
-                useDefaultRoutng);
+                useDefaultRouting);
 
         classModifier.addEnum("", "Keep class default with no modifier");
         classModifier.addEnum("abstract", "Make class abstract");
@@ -558,13 +559,13 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private void setUseEndpointRouting() {
         if (aspnetCoreVersion.getOptValue().startsWith("3.")) {
             LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so switching to old style endpoint routing.");
-            useDefaultRoutng = false;
-            additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
+            useDefaultRouting = false;
+            additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRouting);
         } else {
             if (additionalProperties.containsKey(USE_DEFAULT_ROUTING)) {
-                useDefaultRoutng = convertPropertyToBooleanAndWriteBack(USE_DEFAULT_ROUTING);
+                useDefaultRouting = convertPropertyToBooleanAndWriteBack(USE_DEFAULT_ROUTING);
             } else {
-                additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
+                additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRouting);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -55,6 +55,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String USE_FRAMEWORK_REFERENCE = "useFrameworkReference";
     public static final String USE_NEWTONSOFT = "useNewtonsoft";
     public static final String USE_DEFAULT_ROUTING = "useDefaultRoutng";
+    public static final String NEWTONSOFT_VERSION = "newtonsoftVersion";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
 
@@ -80,6 +81,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean useFrameworkReference = false;
     private boolean useNewtonsoft = true;
     private boolean useDefaultRoutng = true;
+    private String newtonsoftVersion = "3.0.0-preview4-19216-03";
 
     public AspNetCoreServerCodegen() {
         super();
@@ -197,6 +199,11 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 "Uses the Newtonsoft JSON library.",
                 useNewtonsoft);
 
+        addOption(NEWTONSOFT_VERSION,
+                "Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+",
+                newtonsoftVersion);
+
+
         addSwitch(USE_DEFAULT_ROUTING,
                 "Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.",
                 useDefaultRoutng);
@@ -272,6 +279,11 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         }
         additionalProperties.put("packageGuid", packageGuid);
 
+        if (!additionalProperties.containsKey(NEWTONSOFT_VERSION)) {
+            additionalProperties.put(NEWTONSOFT_VERSION, newtonsoftVersion);
+        } else {
+            newtonsoftVersion = (String)additionalProperties.get(NEWTONSOFT_VERSION);
+        }
 
         // CHeck for the modifiers etc.
         // The order of the checks is important.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -52,7 +52,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String SDK_LIB = "Microsoft.NET.Sdk";
     public static final String COMPATIBILITY_VERSION = "compatibilityVersion";
     public static final String IS_LIBRARY = "isLibrary";
-    public static final String IS_FRAMEWORK = "isFramework";
+    public static final String USE_FRAMEWORK_REFERENCE = "useFrameworkReference";
     public static final String USE_NEWTONSOFT = "useNewtonsoft";
     public static final String USE_DEFAULT_ROUTING = "useDefaultRoutng";
 
@@ -64,9 +64,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean useSwashbuckle = true;
     protected int serverPort = 8080;
     protected String serverHost = "0.0.0.0";
-    protected CliOption swashbuckleVersion = new CliOption(SWASHBUCKLE_VERSION, "Swashbucke version: 3.0.0 (default), 4.0.0");
+    protected CliOption swashbuckleVersion = new CliOption(SWASHBUCKLE_VERSION, "Swashbucke version: 3.0.0, 4.0.0");
     ; // default to 2.1
-    protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 3.0 (preview4 only), 2.2 (default), 2.1, 2.0 (deprecated)");
+    protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 3.0 (preview4 only), 2.2, 2.1, 2.0 (deprecated)");
     private CliOption classModifier = new CliOption(CLASS_MODIFIER, "Class Modifier can be empty, abstract");
     private CliOption operationModifier = new CliOption(OPERATION_MODIFIER, "Operation Modifier can be virtual, abstract or partial");
     private CliOption modelClassModifier = new CliOption(MODEL_CLASS_MODIFIER, "Model Class Modifier can be nothing or partial");
@@ -77,7 +77,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean operationIsAsync = false;
     private boolean operationResultTask = false;
     private boolean isLibrary = false;
-    private boolean isFramework = false;
+    private boolean useFrameworkReference = false;
     private boolean useNewtonsoft = true;
     private boolean useDefaultRoutng = true;
 
@@ -189,9 +189,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 "Is the build a library",
                 isLibrary);
 
-        addSwitch(IS_FRAMEWORK,
+        addSwitch(USE_FRAMEWORK_REFERENCE,
                 "Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.",
-                isFramework);
+                useFrameworkReference);
 
         addSwitch(USE_NEWTONSOFT,
                 "Uses the Newtonsoft JSON library.",
@@ -476,16 +476,16 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
     private void setAspnetCoreVersion(String packageFolder) {
         setCliOption(aspnetCoreVersion);
-            if ("2.0".equals(aspnetCoreVersion.getOptValue())) {
-                embeddedTemplateDir = templateDir = "aspnetcore/2.0";
-                supportingFiles.add(new SupportingFile("web.config", packageFolder, "web.config"));
-                LOGGER.info("ASP.NET core version: 2.0");
-                compatibilityVersion = null;
-            } else {
-                // default, do nothing
-                LOGGER.info("ASP.NET core version: " + aspnetCoreVersion.getOptValue());
-                compatibilityVersion = "Version_" + aspnetCoreVersion.getOptValue().replace(".", "_");
-            }
+        if ("2.0".equals(aspnetCoreVersion.getOptValue())) {
+            embeddedTemplateDir = templateDir = "aspnetcore/2.0";
+            supportingFiles.add(new SupportingFile("web.config", packageFolder, "web.config"));
+            LOGGER.info("ASP.NET core version: 2.0");
+            compatibilityVersion = null;
+        } else {
+            // default, do nothing
+            LOGGER.info("ASP.NET core version: " + aspnetCoreVersion.getOptValue());
+            compatibilityVersion = "Version_" + aspnetCoreVersion.getOptValue().replace(".", "_");
+        }
         additionalProperties.put(COMPATIBILITY_VERSION, compatibilityVersion);
     }
 
@@ -507,7 +507,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         if (isLibrary) {
             operationIsAsync = false;
             additionalProperties.put(OPERATION_IS_ASYNC, operationIsAsync);
-        } else  if (additionalProperties.containsKey(OPERATION_IS_ASYNC)) {
+        } else if (additionalProperties.containsKey(OPERATION_IS_ASYNC)) {
             operationIsAsync = convertPropertyToBooleanAndWriteBack(OPERATION_IS_ASYNC);
         } else {
             additionalProperties.put(OPERATION_IS_ASYNC, operationIsAsync);
@@ -515,16 +515,15 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     }
 
     private void setIsFramework() {
-        if (aspnetCoreVersion.getOptValue().startsWith("3.")) {
-            // default, do nothing
+        if (aspnetCoreVersion.getOptValue().startsWith("3.")) {// default, do nothing
             LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so changing  to use frameworkReference instead of packageReference ");
-            isFramework = true;
-            additionalProperties.put(IS_FRAMEWORK, isFramework);
+            useFrameworkReference = true;
+            additionalProperties.put(USE_FRAMEWORK_REFERENCE, useFrameworkReference);
         } else {
-            if (additionalProperties.containsKey(IS_FRAMEWORK)) {
-                isFramework = convertPropertyToBooleanAndWriteBack(IS_FRAMEWORK);
+            if (additionalProperties.containsKey(USE_FRAMEWORK_REFERENCE)) {
+                useFrameworkReference = convertPropertyToBooleanAndWriteBack(USE_FRAMEWORK_REFERENCE);
             } else {
-                additionalProperties.put(IS_FRAMEWORK, isFramework);
+                additionalProperties.put(USE_FRAMEWORK_REFERENCE, useFrameworkReference);
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -54,7 +54,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String IS_LIBRARY = "isLibrary";
     public static final String IS_FRAMEWORK = "isFramework";
     public static final String USE_NEWtONSOFT = "useNewtonsoft";
-    public static final String USE_ENDPOINT_ROUTING = "useEndpointRoutng";
+    public static final String USE_DEFAULT_ROUTING = "useDefaultRoutng";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
 
@@ -79,7 +79,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean isLibrary = false;
     private boolean isFramework = false;
     private boolean useNewtonsoft = true;
-    private boolean useEndpointRouting = false;
+    private boolean useDefaultRoutng = true;
 
     public AspNetCoreServerCodegen() {
         super();
@@ -197,9 +197,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 "Uses the Newtonsoft JSN library.",
                 useNewtonsoft);
 
-        addSwitch(USE_ENDPOINT_ROUTING,
+        addSwitch(USE_DEFAULT_ROUTING,
                 "Uses the newend point routing JSN library.",
-                useEndpointRouting);
+                useDefaultRoutng);
 
         classModifier.addEnum("", "Keep class default with no modifier");
         classModifier.addEnum("abstract", "Make class abstract");
@@ -547,13 +547,13 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private void setUseEndpointRouting() {
         if (aspnetCoreVersion.getOptValue().startsWith("2.")) {
             LOGGER.warn("buildTarget is " + buildTarget.getOptValue() + " so changing default endpoint routing  to false");
-            useNewtonsoft = false;
-            additionalProperties.put(USE_ENDPOINT_ROUTING, useEndpointRouting);
+            useDefaultRoutng = true;
+            additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
         } else {
             if (additionalProperties.containsKey(USE_NEWtONSOFT)) {
-                useEndpointRouting = convertPropertyToBooleanAndWriteBack(USE_ENDPOINT_ROUTING);
+                useDefaultRoutng = convertPropertyToBooleanAndWriteBack(USE_DEFAULT_ROUTING);
             } else {
-                additionalProperties.put(USE_ENDPOINT_ROUTING, useEndpointRouting);
+                additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
             }
         }
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -66,14 +66,14 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     protected String serverHost = "0.0.0.0";
     protected CliOption swashbuckleVersion = new CliOption(SWASHBUCKLE_VERSION, "Swashbucke version: 3.0.0 (default), 4.0.0");
     ; // default to 2.1
-    protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 2.2 (default), 2.1, 2.0 (deprecated)");
+    protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 3.0 (preview4 only), 2.2 (default), 2.1, 2.0 (deprecated)");
     private CliOption classModifier = new CliOption(CLASS_MODIFIER, "Class Modifier can be empty, abstract");
     private CliOption operationModifier = new CliOption(OPERATION_MODIFIER, "Operation Modifier can be virtual, abstract or partial");
     private CliOption modelClassModifier = new CliOption(MODEL_CLASS_MODIFIER, "Model Class Modifier can be nothing or partial");
     private boolean generateBody = true;
     private CliOption buildTarget = new CliOption("buildTarget", "Target to build an application or library");
     private String projectSdk = SDK_WEB;
-    private String compatibilityVersion = "Version_2_1";
+    private String compatibilityVersion = "Version_2_2";
     private boolean operationIsAsync = false;
     private boolean operationResultTask = false;
     private boolean isLibrary = false;
@@ -190,7 +190,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 isLibrary);
 
         addSwitch(IS_FRAMEWORK,
-                "Are we using packagereference or framework",
+                "Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.",
                 isFramework);
 
         addSwitch(USE_NEWtONSOFT,
@@ -198,7 +198,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 useNewtonsoft);
 
         addSwitch(USE_DEFAULT_ROUTING,
-                "Uses the newend point routing JSN library.",
+                "Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.",
                 useDefaultRoutng);
 
         classModifier.addEnum("", "Keep class default with no modifier");
@@ -532,7 +532,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
     private void setUseNewtonsoft() {
         if (aspnetCoreVersion.getOptValue().startsWith("2.")) {
-            LOGGER.warn("buildTarget is " + buildTarget.getOptValue() + " so changing default json library to Newtonsoft ");
+            LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so staying on default json library.");
             useNewtonsoft = false;
             additionalProperties.put(USE_NEWtONSOFT, useNewtonsoft);
         } else {
@@ -546,7 +546,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
     private void setUseEndpointRouting() {
         if (aspnetCoreVersion.getOptValue().startsWith("2.")) {
-            LOGGER.warn("buildTarget is " + buildTarget.getOptValue() + " so changing default endpoint routing  to false");
+            LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so staying on default endpoint routing.");
             useDefaultRoutng = true;
             additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
         } else {
@@ -562,7 +562,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         setCliOption(swashbuckleVersion);
 
         if (aspnetCoreVersion.getOptValue().startsWith("3.")) {
-            LOGGER.warn("buildTarget is " + buildTarget.getOptValue() + " so changing default Swashbuckle version to 4.0.0");
+            LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so changing default Swashbuckle version to 4.0.0.");
             swashbuckleVersion.setOptValue("4.0.0");
             additionalProperties.put(SWASHBUCKLE_VERSION, swashbuckleVersion.getOptValue());
         } else {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -545,12 +545,12 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     }
 
     private void setUseEndpointRouting() {
-        if (aspnetCoreVersion.getOptValue().startsWith("2.")) {
-            LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so staying on default endpoint routing.");
-            useDefaultRoutng = true;
+        if (aspnetCoreVersion.getOptValue().startsWith("3.")) {
+            LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so switching to old style endpoint routing.");
+            useDefaultRoutng = false;
             additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
         } else {
-            if (additionalProperties.containsKey(USE_NEWTONSOFT)) {
+            if (additionalProperties.containsKey(USE_DEFAULT_ROUTING)) {
                 useDefaultRoutng = convertPropertyToBooleanAndWriteBack(USE_DEFAULT_ROUTING);
             } else {
                 additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -81,7 +81,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean useFrameworkReference = false;
     private boolean useNewtonsoft = true;
     private boolean useDefaultRoutng = true;
-    private String newtonsoftVersion = "3.0.0-preview4-19216-03";
+    private String newtonsoftVersion = "3.0.0-preview5-19227-01";
 
     public AspNetCoreServerCodegen() {
         super();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -53,7 +53,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String COMPATIBILITY_VERSION = "compatibilityVersion";
     public static final String IS_LIBRARY = "isLibrary";
     public static final String IS_FRAMEWORK = "isFramework";
-    public static final String USE_NEWtONSOFT = "useNewtonsoft";
+    public static final String USE_NEWTONSOFT = "useNewtonsoft";
     public static final String USE_DEFAULT_ROUTING = "useDefaultRoutng";
 
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
@@ -193,8 +193,8 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 "Use frameworkReference for ASP.NET Core 3.0+ and  PackageReference  ASP.NET Core 2.2 or earlier.",
                 isFramework);
 
-        addSwitch(USE_NEWtONSOFT,
-                "Uses the Newtonsoft JSN library.",
+        addSwitch(USE_NEWTONSOFT,
+                "Uses the Newtonsoft JSON library.",
                 useNewtonsoft);
 
         addSwitch(USE_DEFAULT_ROUTING,
@@ -534,12 +534,12 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         if (aspnetCoreVersion.getOptValue().startsWith("2.")) {
             LOGGER.warn("ASP.NET core version is " + aspnetCoreVersion.getOptValue() + " so staying on default json library.");
             useNewtonsoft = false;
-            additionalProperties.put(USE_NEWtONSOFT, useNewtonsoft);
+            additionalProperties.put(USE_NEWTONSOFT, useNewtonsoft);
         } else {
-            if (additionalProperties.containsKey(USE_NEWtONSOFT)) {
-                useNewtonsoft = convertPropertyToBooleanAndWriteBack(USE_NEWtONSOFT);
+            if (additionalProperties.containsKey(USE_NEWTONSOFT)) {
+                useNewtonsoft = convertPropertyToBooleanAndWriteBack(USE_NEWTONSOFT);
             } else {
-                additionalProperties.put(USE_NEWtONSOFT, useNewtonsoft);
+                additionalProperties.put(USE_NEWTONSOFT, useNewtonsoft);
             }
         }
     }
@@ -550,7 +550,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             useDefaultRoutng = true;
             additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);
         } else {
-            if (additionalProperties.containsKey(USE_NEWtONSOFT)) {
+            if (additionalProperties.containsKey(USE_NEWTONSOFT)) {
                 useDefaultRoutng = convertPropertyToBooleanAndWriteBack(USE_DEFAULT_ROUTING);
             } else {
                 additionalProperties.put(USE_DEFAULT_ROUTING, useDefaultRoutng);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -38,6 +38,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
     public static final String USE_SWASHBUCKLE = "useSwashbuckle";
     public static final String ASPNET_CORE_VERSION = "aspnetCoreVersion";
+    public static final String SWASHBUCKLE_VERSION = "swashbuckleVersion";
     public static final String CLASS_MODIFIER = "classModifier";
     public static final String OPERATION_MODIFIER = "operationModifier";
     public static final String OPERATION_IS_ASYNC = "operationIsAsync";
@@ -63,8 +64,9 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     private boolean useSwashbuckle = true;
     protected int serverPort = 8080;
     protected String serverHost = "0.0.0.0";
-    protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 2.2 (default), 2.1, 2.0 (deprecated)");
+    protected CliOption swashbuckleVersion = new CliOption(SWASHBUCKLE_VERSION, "Swashbucke version: 3.0.0 (default), 4.0.0");
     ; // default to 2.1
+    protected CliOption aspnetCoreVersion = new CliOption(ASPNET_CORE_VERSION, "ASP.NET Core version: 2.2 (default), 2.1, 2.0 (deprecated)");
     private CliOption classModifier = new CliOption(CLASS_MODIFIER, "Class Modifier can be empty, abstract");
     private CliOption operationModifier = new CliOption(OPERATION_MODIFIER, "Operation Modifier can be virtual, abstract or partial");
     private CliOption modelClassModifier = new CliOption(MODEL_CLASS_MODIFIER, "Model Class Modifier can be nothing or partial");
@@ -155,6 +157,12 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         aspnetCoreVersion.setDefault("2.2");
         aspnetCoreVersion.setOptValue(aspnetCoreVersion.getDefault());
         addOption(aspnetCoreVersion.getOpt(), aspnetCoreVersion.getDescription(), aspnetCoreVersion.getOptValue());
+
+        swashbuckleVersion.addEnum("3.0.0", "Swashbuckle 3.0.0");
+        swashbuckleVersion.addEnum("4.0.0", "Swashbuckle 4.0.0");
+        swashbuckleVersion.setDefault("3.0.0");
+        swashbuckleVersion.setOptValue(swashbuckleVersion.getDefault());
+        addOption(swashbuckleVersion.getOpt(), swashbuckleVersion.getDescription(), swashbuckleVersion.getOptValue());
 
         // CLI Switches
         addSwitch(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG,
@@ -293,6 +301,7 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
         // determine the ASP.NET core version setting
         setAspnetCoreVersion(packageFolder);
+        setSwashbuckleVersion();
         setIsFramework();
         setUseNewtonsoft();
         setUseEndpointRouting();
@@ -546,6 +555,19 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
             } else {
                 additionalProperties.put(USE_ENDPOINT_ROUTING, useEndpointRouting);
             }
+        }
+    }
+
+    private void setSwashbuckleVersion() {
+        setCliOption(swashbuckleVersion);
+
+        if (aspnetCoreVersion.getOptValue().startsWith("3.")) {
+            LOGGER.warn("buildTarget is " + buildTarget.getOptValue() + " so changing default Swashbuckle version to 4.0.0");
+            swashbuckleVersion.setOptValue("4.0.0");
+            additionalProperties.put(SWASHBUCKLE_VERSION, swashbuckleVersion.getOptValue());
+        } else {
+            // default, do nothing
+            LOGGER.info("Swashbuckle version: " + swashbuckleVersion.getOptValue());
         }
     }
 }

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
@@ -12,14 +12,14 @@
     <PackageId>{{packageName}}</PackageId>
   </PropertyGroup>
   <ItemGroup>
-{{#isFramework}}
+{{#useFrameworkReference}}
 {{#isLibrary}}
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 {{/isLibrary}}
-{{/isFramework}}
-{{^isFramework}}
+{{/useFrameworkReference}}
+{{^useFrameworkReference}}
     <PackageReference Include="Microsoft.AspNetCore.App" />
-{{/isFramework}}
+{{/useFrameworkReference}}
 {{#useNewtonsoft}}
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview4-19216-03" />
 {{/useNewtonsoft}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
@@ -12,7 +12,17 @@
     <PackageId>{{packageName}}</PackageId>
   </PropertyGroup>
   <ItemGroup>
+{{#isFramework}}
+{{#isLibrary}}
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+{{/isLibrary}}
+{{/isFramework}}
+{{^isFramework}}
     <PackageReference Include="Microsoft.AspNetCore.App" />
+{{/isFramework}}
+{{#useNewtonsoft}}
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview4-19216-03" />
+{{/useNewtonsoft}}
 {{#useSwashbuckle}}
     <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0"/>
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="3.0.0" />

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
 {{/useFrameworkReference}}
 {{#useNewtonsoft}}
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview4-19216-03" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="{{newtonsoftVersion}}" />
 {{/useNewtonsoft}}
 {{#useSwashbuckle}}
     <PackageReference Include="Swashbuckle.AspNetCore" Version="{{swashbuckleVersion}}"/>

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Project.csproj.mustache
@@ -24,8 +24,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview4-19216-03" />
 {{/useNewtonsoft}}
 {{#useSwashbuckle}}
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="3.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="{{swashbuckleVersion}}"/>
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="{{swashbuckleVersion}}" />
 {{/useSwashbuckle}}
   </ItemGroup>
   <ItemGroup>

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
@@ -110,9 +110,8 @@ namespace {{packageName}}
                     //TODO: Or alternatively use the original Swagger contract that's included in the static files
                     // c.SwaggerEndpoint("/openapi-original.json", "{{#appName}}{{{appName}}}{{/appName}}{{^appName}}{{packageName}}{{/appName}} Original");
                 }){{/useSwashbuckle}};{{^useDefaultRoutng}}
-            	app.UseHttpsRedirection();
-	            app.UseRouting();
-	            app.UseEndpoints(endpoints =>
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
 	            {
 	    	        endpoints.MapControllers();
 	            });{{/useDefaultRoutng}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
@@ -51,7 +51,7 @@ namespace {{packageName}}
                     opts.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
                     opts.SerializerSettings.Converters.Add(new StringEnumConverter
                     {
-                        CamelCaseText = true
+                        {{#useNewtonsoft}}NamingStrategy = new CamelCaseNamingStrategy(){{/useNewtonsoft}}{{^useNewtonsoft}}CamelCaseText = true{{/useNewtonsoft}}
                     });
                 });
             {{#useSwashbuckle}}
@@ -109,7 +109,13 @@ namespace {{packageName}}
 
                     //TODO: Or alternatively use the original Swagger contract that's included in the static files
                     // c.SwaggerEndpoint("/openapi-original.json", "{{#appName}}{{{appName}}}{{/appName}}{{^appName}}{{packageName}}{{/appName}} Original");
-                }){{/useSwashbuckle}};
+                }){{/useSwashbuckle}};{{^useDefaultRoutng}}
+            	app.UseHttpsRedirection();
+	            app.UseRouting();
+	            app.UseEndpoints(endpoints =>
+	            {
+	    	        endpoints.MapControllers();
+	            });{{/useDefaultRoutng}}
 
             if (env.IsDevelopment())
             {

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
@@ -42,11 +42,11 @@ namespace {{packageName}}
         {
             // Add framework services.
             services
-                .AddMvc()
+                .AddMvc({{^useEndpointRouting}}opts => opts.EnableEndpointRouting = false{{/useEndpointRouting}})
                 {{#compatibilityVersion}}
                 .SetCompatibilityVersion(CompatibilityVersion.{{compatibilityVersion}})
                 {{/compatibilityVersion}}
-                .AddJsonOptions(opts =>
+                .{{#useNewtonsoft}}AddNewtonsoftJson{{/useNewtonsoft}}{{^useNewtonsoft}}AddJsonOptions{{/useNewtonsoft}}(opts =>
                 {
                     opts.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
                     opts.SerializerSettings.Converters.Add(new StringEnumConverter

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/Startup.mustache
@@ -42,7 +42,7 @@ namespace {{packageName}}
         {
             // Add framework services.
             services
-                .AddMvc({{^useEndpointRouting}}opts => opts.EnableEndpointRouting = false{{/useEndpointRouting}})
+                .AddMvc({{^useDefaultRoutng}}opts => opts.EnableEndpointRouting = false{{/useDefaultRoutng}})
                 {{#compatibilityVersion}}
                 .SetCompatibilityVersion(CompatibilityVersion.{{compatibilityVersion}})
                 {{/compatibilityVersion}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Preliminary support for ASP.NET Core 3.0 (preview 4). See issue #2350

No support for the new style routing or new Json library (still uses Newtonsoft).


