### PR TITLE
[gradle] Display non-Stable generator stability in parens on openApiG…

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GeneratorsTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GeneratorsTask.kt
@@ -22,6 +22,8 @@ import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.openapitools.codegen.CodegenConfigLoader
 import org.openapitools.codegen.CodegenType
+import org.openapitools.codegen.meta.GeneratorMetadata
+import org.openapitools.codegen.meta.Stability
 
 /**
  * A task which lists out the generators available in OpenAPI Generator
@@ -55,8 +57,18 @@ open class GeneratorsTask : DefaultTask() {
                 generators.filter { it.tag == type }
                         .sortedBy { it.name }
                         .forEach({ generator ->
+
+                            val meta: GeneratorMetadata? = generator.generatorMetadata
+
                             append("    - ")
                             append(generator.name)
+
+                            meta?.stability?.let {
+                                if (it != Stability.STABLE) {
+                                    append(" (${it.value()})")
+                                }
+                            }
+
                             append(System.lineSeparator())
                         })
 


### PR DESCRIPTION
…enerators task

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Related to #2816, this appends any non-Stable value for the stability option of a generator. It wasn't included in #2816 because the gradle plugin is "built" alongside the maven project, but this doesn't allow the gradle plugin to reference the 4.0.0-SNAPSHOT version of code which was currently in-progress during build. We have another issue tracking the rework of how we do gradle builds, so rather than looking into that I've just done the work iteratively.

To evaluate locally, build the project as normally:

* `mvn clean install`
* `cd modules/openapi-generator-gradle-plugin/`
* `./gradlew install`
* `cd samples/cd local-spec/`
* `gradle -q openApiGenerators -PopenApiGeneratorVersion=4.0.0-SNAPSHOT`

Sample:

```
CLIENT generators:
    - ada
    - android
    - apex
    - bash
    - c
    - clojure
    - cpp-qt5-client
    - cpp-restsdk
    - cpp-tizen
    - csharp
    - csharp-dotnet2 (deprecated)
    …
    - scala-httpclient-deprecated (deprecated)
    - swift2-deprecated (deprecated)
    - swift3-deprecated (deprecated)
```