### PR TITLE
[JavaScript] Remove default parameters syntax, as it's an ES6 feature

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -650,7 +650,8 @@
       ];
     };
 
-    exports.getBasePathFromSettings = function(index, variables={}) {
+    exports.getBasePathFromSettings = function(index, variables) {
+        var variables = variables || {};
         var servers = this.hostSettings();
 
         // check array index out of bound

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -597,7 +597,8 @@
       ];
     };
 
-    exports.getBasePathFromSettings = function(index, variables={}) {
+    exports.getBasePathFromSettings = function(index, variables) {
+        var variables = variables || {};
         var servers = this.hostSettings();
 
         // check array index out of bound

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -608,7 +608,8 @@
       ];
     };
 
-    exports.getBasePathFromSettings = function(index, variables={}) {
+    exports.getBasePathFromSettings = function(index, variables) {
+        var variables = variables || {};
         var servers = this.hostSettings();
 
         // check array index out of bound


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This removes some syntax for "default parameters" from the JavaScript client. The reason is that it's a ES6 feature that [doesn't work on IE11](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#Browser_compatibility)

cc @CodeNinjai @frol @cliffano 

