### PR TITLE
JS Client - Add support for empty enum in server object

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/ApiClient.mustache
@@ -137,6 +137,7 @@
     }
     var url = this.basePath + path;
 
+
     // use API (operation, path) base path if defined
     if (apiBasePath !== null && apiBasePath !== undefined) {
         url = apiBasePath + path;
@@ -664,7 +665,8 @@
         // go through variable and assign a value
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
-                if (server['variables'][variable_name]['enum_values'].includes(variables[variable_name])) {
+                let variable = server['variables'][variable_name];
+                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/ApiClient.mustache
@@ -645,7 +645,8 @@ class ApiClient {
         // go through variable and assign a value
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
-                if (server['variables'][variable_name]['enum_values'].includes(variables[variable_name])) {
+                let variable = server['variables'][variable_name];
+                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -576,7 +576,8 @@ class ApiClient {
         // go through variable and assign a value
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
-                if (server['variables'][variable_name]['enum_values'].includes(variables[variable_name])) {
+                let variable = server['variables'][variable_name];
+                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -575,7 +575,8 @@ class ApiClient {
         // go through variable and assign a value
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
-                if (server['variables'][variable_name]['enum_values'].includes(variables[variable_name])) {
+                let variable = server['variables'][variable_name];
+                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");

--- a/samples/client/petstore/javascript-promise/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise/src/ApiClient.js
@@ -136,6 +136,7 @@
     }
     var url = this.basePath + path;
 
+
     // use API (operation, path) base path if defined
     if (apiBasePath !== null && apiBasePath !== undefined) {
         url = apiBasePath + path;
@@ -611,7 +612,8 @@
         // go through variable and assign a value
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
-                if (server['variables'][variable_name]['enum_values'].includes(variables[variable_name])) {
+                let variable = server['variables'][variable_name];
+                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");

--- a/samples/client/petstore/javascript/src/ApiClient.js
+++ b/samples/client/petstore/javascript/src/ApiClient.js
@@ -136,6 +136,7 @@
     }
     var url = this.basePath + path;
 
+
     // use API (operation, path) base path if defined
     if (apiBasePath !== null && apiBasePath !== undefined) {
         url = apiBasePath + path;
@@ -622,7 +623,8 @@
         // go through variable and assign a value
         for (var variable_name in server['variables']) {
             if (variable_name in variables) {
-                if (server['variables'][variable_name]['enum_values'].includes(variables[variable_name])) {
+                let variable = server['variables'][variable_name];
+                if ( !('enum_values' in variable) || variable['enum_values'].includes(variables[variable_name]) ) {
                     url = url.replace("{" + variable_name + "}", variables[variable_name]);
                 } else {
                     throw new Error("The variable `" + variable_name + "` in the host URL has invalid value " + variables[variable_name] + ". Must be " + server['variables'][variable_name]['enum_values'] + ".");


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The `enum_values` check only happens when `enum_values` exist.

Related issue: #2852 

### Questions

Should I also add the modifications in resources/Javascript ?

@CodeNinjai
@frol
@cliffano 