### PR TITLE
[build] Avoid caching openapitools* artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ jdk:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  # Avoid caching our built dependencies between runs.
+  - rm -fr $HOME/.m2/repository/org/openapitools/
+
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Limited reviewer request since this is a fairly simple change. #2388 introduced a somewhat cyclical dependency (`openapi-generator-cli` -> `openapi-generator` -> `openapi-generator-cli`). @jmini is working on an alternative method to enable better debugging during new generator development. As discussed in chat, we'd want this to fail in CI and the fix would be to avoid caching openapitools artifacts across builds.

This will likely fail until Jérémie's work is available and merged.