### PR TITLE
[gradle] Reworking publishing pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ after_success:
         echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository";
         popd;
       fi;
-      if [ -n $TRAVIS_TAG ] && [[ "$TRAVIS_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      if [ -n $TRAVIS_TAG ] && [[ "$TRAVIS_TAG" =~ ^[v][0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Publishing the gradle plugin to Gradle Portal on tag $TRAVIS_TAG (only)";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,8 +136,8 @@ after_success:
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository --no-daemon;
-        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository";
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeRepository --no-daemon;
+        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeRepository";
         popd;
       elif ([[ "$TRAVIS_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]) ; then
         mvn clean deploy --settings CI/settings.xml;
@@ -146,8 +146,8 @@ after_success:
         cd modules/openapi-generator-gradle-plugin;
         ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" publishPlugins -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET --no-daemon;
         echo "Finished ./gradlew publishPlugins (plugin portal)";
-        ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeRepository --no-daemon;
-        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeRepository";
+        ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository --no-daemon;
+        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository";
         popd;
       fi;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,8 +146,8 @@ after_success:
         cd modules/openapi-generator-gradle-plugin;
         ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" publishPlugins -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET --no-daemon;
         echo "Finished ./gradlew publishPlugins (plugin portal)";
-        ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
-        echo "Finished ./gradlew uploadArchives";
+        ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeRepository --no-daemon;
+        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeRepository";
         popd;
       fi;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,24 +130,32 @@ script:
   - mvn --quiet --batch-mode --show-version verify -Psamples
 after_success:
   # push to maven repo
-  - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      if [ "$TRAVIS_BRANCH" = "master" ]; then
+  - if [ $SONATYPE_USERNAME ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      if [ "$TRAVIS_BRANCH" = "master" ] && [ -z $TRAVIS_TAG ]; then
+        echo "Publishing from branch $TRAVIS_BRANCH";
         mvn clean deploy -DskipTests=true -B -U -P release --settings CI/settings.xml;
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeRepository --no-daemon;
-        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeRepository";
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository --no-daemon;
+        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository";
         popd;
-      elif ([[ "$TRAVIS_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]) ; then
+      elif [ -z $TRAVIS_TAG ] && [[ "$TRAVIS_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]; then
+        echo "Publishing from branch $TRAVIS_BRANCH";
         mvn clean deploy --settings CI/settings.xml;
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" publishPlugins -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET --no-daemon;
-        echo "Finished ./gradlew publishPlugins (plugin portal)";
         ./gradlew -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository --no-daemon;
         echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository closeAndReleaseRepository";
+        popd;
+      fi;
+      if [ -n $TRAVIS_TAG ] && [[ "$TRAVIS_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Publishing the gradle plugin to Gradle Portal on tag $TRAVIS_TAG (only)";
+        pushd .;
+        cd modules/openapi-generator-gradle-plugin;
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" publishPlugins -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET --no-daemon;
+        echo "Finished ./gradlew publishPlugins (plugin portal)";
         popd;
       fi;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,8 +136,8 @@ after_success:
         echo "Finished mvn clean deploy for $TRAVIS_BRANCH";
         pushd .;
         cd modules/openapi-generator-gradle-plugin;
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" uploadArchives --no-daemon;
-        echo "Finished ./gradlew uploadArchives";
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/sec.gpg" -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" publishPluginMavenPublicationToNexusRepository --no-daemon;
+        echo "Finished ./gradlew publishPluginMavenPublicationToNexusRepository";
         popd;
       elif ([[ "$TRAVIS_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]]) ; then
         mvn clean deploy --settings CI/settings.xml;

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -200,4 +200,13 @@ javadoc {
     }
 }
 
+tasks {
+    closeRepository {
+        onlyIf { nexusPublishing.useStaging.get() }
+    }
+    releaseRepository{
+        onlyIf { nexusPublishing.useStaging.get() }
+    }
+}
+
 publishToNexus.dependsOn 'check'

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.2.61'
     repositories {
         mavenCentral()
         maven {
@@ -11,14 +11,13 @@ buildscript {
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots/"
         }
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins:1.0-rc-3"
         classpath "com.gradle.publish:plugin-publish-plugin:0.10.1"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.20.0"
+        classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.2.0"
     }
 }
 
@@ -35,10 +34,11 @@ ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'java-gradle-plugin'
-apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'kotlin'
 apply plugin: "org.gradle.kotlin.kotlin-dsl"
+apply plugin: 'io.codearte.nexus-staging'
+apply plugin: "de.marcphilipp.nexus-publish"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -87,6 +87,54 @@ test {
     }
 }
 
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            pom {
+                name = 'OpenAPI-Generator Contributors'
+                description = project.description
+                url = 'https://openapi-generator.tech'
+                organization {
+                    name = 'org.openapitools'
+                    url = 'https://github.com/OpenAPITools'
+                }
+                licenses {
+                    license {
+                        name = "The Apache Software License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution = "repo"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "openapitools"
+                        name = "OpenAPI-Generator Contributors"
+                        email = "team@openapitools.org"
+                    }
+                }
+                scm {
+                    url = 'https://github.com/OpenAPITools/openapi-generator'
+                    connection = 'scm:git:git://github.com/OpenAPITools/openapi-generator.git'
+                    developerConnection = 'scm:git:ssh://git@github.com:OpenAPITools/openapi-generator.git'
+                }
+                issueManagement {
+                    system = 'GitHub'
+                    url = 'https://github.com/OpenAPITools/openapi-generator/issues'
+                }
+            }
+        }
+    }
+}
+
+nexusPublishing {
+    username = ossrhUsername
+    password = ossrhPassword
+    stagingProfileId = "org.openapitools"
+    packageGroup = "org.openapitools"
+}
+
 gradlePlugin {
     plugins {
         openApiGenerator {
@@ -109,6 +157,7 @@ pluginBundle {
             displayName = 'OpenAPI Generator Gradle Plugin'
             tags = ['openapi-3.0', 'openapi-2.0', 'openapi', 'swagger', 'codegen', 'sdk']
             version = "$openApiGeneratorVersion"
+            group = "org.openapitools"
         }
     }
 }
@@ -119,79 +168,7 @@ pluginBundle {
 // or stored as key=value pairs in ~/.gradle/gradle.properties
 // You can also apply them in CI via environment variables. See Gradle's docs for details.
 signing {
-    required { isReleaseVersion && gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
-}
-
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-
-task sourcesJar(type: Jar) {
-    from sourceSets.main.allSource
-    classifier = 'sources'
-}
-
-artifacts {
-    archives javadocJar, sourcesJar
-}
-
-def pomConfig = {
-    description project.description
-    name 'OpenAPI-Generator Contributors'
-    url 'https://openapi-generator.tech'
-    organization {
-        name 'org.openapitools'
-        url 'https://github.com/OpenAPITools'
-    }
-    licenses {
-        license {
-            name "The Apache Software License, Version 2.0"
-            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
-            distribution "repo"
-        }
-    }
-    developers {
-        developer {
-            id "openapitools"
-            name "OpenAPI-Generator Contributors"
-            email "team@openapitools.org"
-        }
-    }
-    scm {
-        url 'https://github.com/OpenAPITools/openapi-generator'
-        connection 'scm:git:git://github.com/OpenAPITools/openapi-generator.git'
-        developerConnection 'scm:git:ssh://git@github.com:OpenAPITools/openapi-generator.git'
-    }
-    issueManagement {
-        system 'GitHub'
-        url 'https://github.com/OpenAPITools/openapi-generator/issues'
-    }
-}
-
-uploadArchives {
-    repositories {
-
-        // credentials here would need to be passed along with the gradle command:
-        //   ./gradlew -P ossrhUsername=yourUser
-        // or stored in ~/.gradle/gradle.properties as key=value pairs
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            pom.withXml {
-                def root = asNode()
-                root.appendNode('description', project.description)
-                root.children().last() + pomConfig
-            }
-        }
-    }
+    sign publishing.publications
 }
 
 compileKotlin {
@@ -205,4 +182,4 @@ compileTestKotlin {
     }
 }
 
-uploadArchives.dependsOn 'check'
+publishToNexus.dependsOn 'check'

--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -87,11 +87,22 @@ test {
     }
 }
 
+task javadocJar(type: Jar) {
+    from javadoc
+    classifier = 'javadoc'
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
 
 publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+            artifact sourcesJar
+            artifact javadocJar
             pom {
                 name = 'OpenAPI-Generator Contributors'
                 description = project.description
@@ -168,7 +179,8 @@ pluginBundle {
 // or stored as key=value pairs in ~/.gradle/gradle.properties
 // You can also apply them in CI via environment variables. See Gradle's docs for details.
 signing {
-    sign publishing.publications
+    required { isReleaseVersion && (gradle.taskGraph.hasTask("publishPluginMavenPublicationToNexusRepository") ) }
+    sign publishing.publications.mavenJava
 }
 
 compileKotlin {
@@ -179,6 +191,12 @@ compileKotlin {
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+}
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
     }
 }
 

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -72,7 +72,7 @@
                                 <!-- calls "clean assemble install" -->
                                 <task>clean</task>
                                 <task>assemble</task>
-                                <task>install</task>
+                                <task>publishToMavenLocal</task>
                             </tasks>
                         </configuration>
                     </execution>

--- a/modules/openapi-generator-gradle-plugin/settings.gradle
+++ b/modules/openapi-generator-gradle-plugin/settings.gradle
@@ -1,2 +1,3 @@
 rootProject.name = 'openapi-generator-gradle-plugin'
+enableFeaturePreview('STABLE_PUBLISHING')
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`~~, `3.4.x`, `4.0.x`~~. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

TravisCI proxies separate external requests with different orginating IP
addresses, while Sonatype associates artifacts for auto-generated
repositories by IP address. This leads to many gradle deploys from CI
resulting in "split" staging repositories with no way to combine in
Sonatype Nexus.

This introduces a workflow which should resolve this issue on the next
revision release. Specifically, nexus-publish-plugin is included to
create singular staging repositories from TravisCI and
gradle-nexus-staging-plugin is included to auto-release and promote
this repository.

NOTE:
We need to publish via `publishPluginMavenPublicationToNexusRepository`,
because `publishToNexus` will publish _all_ publish-related tasks,
including the one intended only for the Gradle Plugin Portal.

Tested in standalone open source Nexus Repo Manager, which doesn't
support the staging plugin. So, only SNAPSHOT workflow has been
validated locally.

The `enableFeaturePreview('STABLE_PUBLISHING')` option in settings.gradle is a warning presented by the new nexus-publish-plugin:

> As part of making the publishing plugins stable, the 'deferred configurable' behavior of the 'publishing {}' block has been deprecated. In Gradle 5.0 the 'enableFeaturePreview('STABLE_PUBLISHING')' flag will be removed and the new behavior will become the default. Please add 'enableFeaturePreview('STABLE_PUBLISHING')' to your settings file and do a test run by publishing to a local repository. If all artifacts are published as expected, there is nothing else to do. If the published artifacts change unexpectedly, please see the migration guide for more details: https://docs.gradle.org/4.10.2/userguide/publishing_maven.html#publishing_maven:deferred_configuration.

This PR is an attempt at resolving #411
cc @OpenAPITools/generator-core-team 

