### PR TITLE
dart2: update to work with dart 2.3.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/pubspec.mustache
@@ -2,4 +2,4 @@ name: {{pubName}}
 version: {{pubVersion}}
 description: {{pubDescription}}
 dependencies:
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.1 <0.13.0'

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -4,4 +4,4 @@ description: {{pubDescription}}
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.1 <0.13.0'

--- a/samples/client/petstore/dart/flutter_petstore/openapi/pubspec.yaml
+++ b/samples/client/petstore/dart/flutter_petstore/openapi/pubspec.yaml
@@ -2,4 +2,4 @@ name: openapi
 version: 1.0.0
 description: OpenAPI API client
 dependencies:
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.1 <0.13.0'

--- a/samples/client/petstore/dart/openapi-browser-client/pubspec.yaml
+++ b/samples/client/petstore/dart/openapi-browser-client/pubspec.yaml
@@ -2,4 +2,4 @@ name: openapi
 version: 1.0.0
 description: OpenAPI API client
 dependencies:
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.1 <0.13.0'

--- a/samples/client/petstore/dart/openapi/pubspec.yaml
+++ b/samples/client/petstore/dart/openapi/pubspec.yaml
@@ -2,4 +2,4 @@ name: openapi
 version: 1.0.0
 description: OpenAPI API client
 dependencies:
-  http: '>=0.11.1 <0.12.0'
+  http: '>=0.11.1 <0.13.0'


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09)

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

Dart 2.3.0 no longer works with http 0.11.+