### PR TITLE
[core] Support case where composed schema is single type definition

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1385,6 +1385,12 @@ public class DefaultCodegen implements CodegenConfig {
             ComposedSchema cs = (ComposedSchema) schema;
             List<Schema> schemas = ModelUtils.getInterfaces(cs);
 
+            // Special case: interfaces is a single type definition
+            // e.g. "allOf": [{"type": "string"}]
+            if (schemas.size() == 1 && schemas.get(0).get$ref() == null && schemas.get(0).getType() != null) {
+                return getSingleSchemaType(schemas.get(0));
+            }
+
             List<String> names = new ArrayList<>();
             for (Schema s : schemas) {
                 names.add(getSingleSchemaType(s));
@@ -1808,28 +1814,28 @@ public class DefaultCodegen implements CodegenConfig {
 
             // end of code block for composed schema
         } else {
-            m.dataType = getSchemaType(schema);
-            if (schema.getEnum() != null && !schema.getEnum().isEmpty()) {
-                m.isEnum = true;
-                // comment out below as allowableValues is not set in post processing model enum
-                m.allowableValues = new HashMap<String, Object>();
-                m.allowableValues.put("values", schema.getEnum());
-            }
-            if (ModelUtils.isMapSchema(schema)) {
-                addAdditionPropertiesToCodeGenModel(m, schema);
-                m.isMapModel = true;
-            }
-            if (ModelUtils.isIntegerSchema(schema)) { // integer type
-                if (!ModelUtils.isLongSchema(schema)) { // long type is not integer
-                    m.isInteger = Boolean.TRUE;
-                }
-            }
-            if (ModelUtils.isStringSchema(schema)) {
-                m.isString = Boolean.TRUE;
-            }
-
             // passing null to allProperties and allRequired as there's no parent
             addVars(m, unaliasPropertySchema(schema.getProperties()), schema.getRequired(), null, null);
+        }
+
+        m.dataType = getSchemaType(schema);
+        if (schema.getEnum() != null && !schema.getEnum().isEmpty()) {
+            m.isEnum = true;
+            // comment out below as allowableValues is not set in post processing model enum
+            m.allowableValues = new HashMap<String, Object>();
+            m.allowableValues.put("values", schema.getEnum());
+        }
+        if (ModelUtils.isMapSchema(schema)) {
+            addAdditionPropertiesToCodeGenModel(m, schema);
+            m.isMapModel = true;
+        }
+        if (ModelUtils.isIntegerSchema(schema)) { // integer type
+            if (!ModelUtils.isLongSchema(schema)) { // long type is not integer
+                m.isInteger = Boolean.TRUE;
+            }
+        }
+        if (ModelUtils.isStringSchema(schema)) {
+            m.isString = Boolean.TRUE;
         }
 
         // remove duplicated properties


### PR DESCRIPTION
### Description of the PR

Fix for https://github.com/OpenAPITools/openapi-generator/issues/2164

The general fix is to handle the case where a composed schema is a single element defining a type.

For example:
```yaml
allOf/anyOf/oneOf:
  type: string
```

^ this case is not really model composition but rather defining the type of the model which is equivalent to `type: <>`

Input:
```yaml
components:
  schemas:
    RatType:
      anyOf:
      - type: string
      enum:
        - NR
        - EUTRA
        - WLAN
        - VIRTUAL
      type: string

```

Output for Go model_rat_type.go:
```go
package openapi
type RatType string

// List of RatType
const (
	NR RatType = "NR"
	EUTRA RatType = "EUTRA"
	WLAN RatType = "WLAN"
	VIRTUAL RatType = "VIRTUAL"
)
```

@wing328 can you review this if you get a moment as it is a core change? I've tested Go and regenerated the sample files and there are no changes for Go at least, not sure about other languages.

cc: @mroland91 and @goyalnikhil 