### PR TITLE
[Typescript][Fetch] switch to vars from allVars

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -31,7 +31,7 @@ export interface {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 export function {{classname}}FromJSON(json: any): {{classname}} {
     {{#hasVars}}
     return {
-        {{#allVars}}
+        {{#vars}}
         {{#isPrimitiveType}}
         {{#isDate}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}new Date(json['{{baseName}}']),
@@ -58,7 +58,7 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
         {{/isFreeFormObject}}
         {{/isContainer}}
         {{/isPrimitiveType}}
-        {{/allVars}}
+        {{/vars}}
     };
     {{/hasVars}}
     {{^hasVars}}
@@ -72,7 +72,7 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
         return undefined;
     }
     return {
-        {{#allVars}}
+        {{#vars}}
         {{^isReadOnly}}
         {{#isPrimitiveType}}
         '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString().substr(0,10){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString(){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
@@ -91,7 +91,7 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
         {{/isContainer}}
         {{/isPrimitiveType}}
         {{/isReadOnly}}
-        {{/allVars}}
+        {{/vars}}
     };
     {{/hasVars}}
     {{^hasVars}}


### PR DESCRIPTION
Signed-off-by: Prateek Malhotra <someone1@gmail.com>

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Attempt to address #2739 - In a [previous PR,](https://github.com/OpenAPITools/openapi-generator/pull/1545) I switched to `allVars` in the typescript model templates as `vars` only included the defined properties for that model, not any properties from any (at that time) inherited classes. Since then, the inheritance/composition models changed internally and `vars` includes all properties for the model as the model composition is now flattened and no longer inherits from any base class.

This gets the code in a compilable state but there are some worries here:

- Why is `allVars` blank?
- There are "*AllOf.ts" models generated that seem erroneous - these shouldn't be generated.
- Can we get better testing in place? I suggest using a yaml spec that's more comprehensive and possibly has examples from previous issues found (I think this exists somewhere already in this project, I just can't find it again). I also suggest that for the typescript tests that `tsc` (or even `npm install`) is run on the generated code to ensure it compiles. This combination would have found these regressions during development.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

CC @wing328 