### PR TITLE
Feature/typescript fetch/map templating

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,4 +1,4 @@
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 {{#hasImports}}
 import {
     {{#imports}}
@@ -46,17 +46,22 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
         {{/isDate}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        {{#isContainer}}
+        {{#isListContainer}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON),
-        {{/isContainer}}
-        {{^isContainer}}
+        {{/isListContainer}}
+        {{#isMapContainer}}
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON),
+        {{/isMapContainer}}
+        {{^isListContainer}}
+        {{^isMapContainer}}
         {{^isFreeFormObject}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
         '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
         {{/isFreeFormObject}}
-        {{/isContainer}}
+        {{/isMapContainer}}
+        {{/isListContainer}}
         {{/isPrimitiveType}}
         {{/allVars}}
     };
@@ -78,17 +83,22 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
         '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString().substr(0,10){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}value.{{name}}.toISOString(){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
-        {{#isContainer}}
+        {{#isListContainer}}
         '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}(value.{{name}} as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON),
-        {{/isContainer}}
-        {{^isContainer}}
+        {{/isListContainer}}
+        {{#isMapContainer}}
+        '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}mapValues(value.{{name}}, {{#items}}{{datatype}}{{/items}}ToJSON),
+        {{/isMapContainer}}
+        {{^isListContainer}}
+        {{^isMapContainer}}
         {{^isFreeFormObject}}
         '{{baseName}}': {{datatype}}ToJSON(value.{{name}}),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
         '{{baseName}}': value.{{name}},
         {{/isFreeFormObject}}
-        {{/isContainer}}
+        {{/isMapContainer}}
+        {{/isListContainer}}        
         {{/isPrimitiveType}}
         {{/isReadOnly}}
         {{/allVars}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -202,6 +202,13 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
 export interface RequestContext {
     fetch: FetchAPI;
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 import {
     Category,
     CategoryFromJSON,

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -213,6 +213,13 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
 export interface RequestContext {
     fetch: FetchAPI;
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/Category.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/ModelApiResponse.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/Order.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 import {
     Category,
     CategoryFromJSON,

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/Tag.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/models/User.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -213,6 +213,13 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
 export interface RequestContext {
     fetch: FetchAPI;
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 import {
     Category,
     CategoryFromJSON,

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -213,6 +213,13 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
 export interface RequestContext {
     fetch: FetchAPI;
     url: string;

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Category.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/ModelApiResponse.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Order.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Pet.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 import {
     Category,
     CategoryFromJSON,

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/Tag.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/models/User.ts
@@ -11,7 +11,7 @@
  * Do not edit the class manually.
  */
 
-import { exists } from '../runtime';
+import { exists, mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -213,6 +213,13 @@ export function querystring(params: HTTPQuery, prefix: string = ''): string {
         .join('&');
 }
 
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
 export interface RequestContext {
     fetch: FetchAPI;
     url: string;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


cc. @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce

### Description of the PR
- Add support for openapi maps/dictionaries to be generated as typescript map.
- Fix is `.mustache` files only.
- Reason for PR: consumption of openapi api with [map collections](https://swagger.io/docs/specification/data-models/dictionaries/). The typescript-fetch generator failed to create working code by mapping it as an array.
- related previous issue: #1878 


