### PR TITLE
typescript-fetch: Remove superfluous closing parenthsesis which resul…

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -94,7 +94,7 @@ export class {{classname}} extends runtime.BaseAPI {
         {{#headerParams}}
         {{#isListContainer}}
         if (requestParameters.{{paramName}}) {
-            headerParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
+            headerParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
         }
 
         {{/isListContainer}}


### PR DESCRIPTION

[x]  successfully ran `bin/typescript-fetch-petstore-all.sh`

There is an obvious syntax error in the template for the `typescript-fetch` language: The second closing parenthesis is superfluous and has no matching counterpart. This results in a syntax error when compiling with the typescript compiler and breaks the generated code.

You can use any editor that highlights matching parenthisis to see there is no counterpart in that line, block, or elsewhere.

Highlighting typescript-fetch technical comittee:
@TiFu  @taxpon  @sebastianhaas @kenisteward @Vrolijkx  @macjohnny  @nicokoenig @topce 
