### PR TITLE
[Apex] Set namedCredential file name from the property

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ApexClientCodegen.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.SupportingFile;
@@ -46,7 +47,7 @@ public class ApexClientCodegen extends AbstractApexCodegen {
     private String classPrefix = "OAS";
     private String apiVersion = "42.0";
     private String buildMethod = "sfdx";
-    private String namedCredential = classPrefix;
+    private String namedCredential;
     private String srcPath = "force-app/main/default/";
     private String sfdxConfigPath = "config/";
     private HashMap<String, Object> primitiveDefaults = new HashMap<String, Object>();
@@ -161,8 +162,10 @@ public class ApexClientCodegen extends AbstractApexCodegen {
 
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
-        Info info = openAPI.getInfo();
-        String calloutLabel = info.getTitle();
+        String calloutLabel = openAPI.getInfo().getTitle();
+        if (StringUtils.isNotBlank(namedCredential)) {
+            calloutLabel = namedCredential;
+        }
         additionalProperties.put("calloutLabel", calloutLabel);
         String sanitized = sanitizeName(calloutLabel);
         additionalProperties.put("calloutName", sanitized);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

@asnelling It seems like you're the person to review this one.

This fixes #2904

The namedCredential property is intended to override the namedCredentials name, but it wasn't being used. Instead, the title from the openapi spec file was used in all cases, and the namedCredential property wasn't used anywhere.

If a namedCredential property is provided, it will be used instead of the default name. For backwards compatibility, the spec title is still used for the named credential by default.
