### PR TITLE
[Kotlin] Fix parse error when using custom field names with @Json

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -1,6 +1,7 @@
 package {{packageName}}.infrastructure
 
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import okhttp3.OkHttpClient
@@ -69,6 +70,7 @@ open class ApiClient(val baseUrl: String) {
                     fun fromJson(s: String) = UUID.fromString(s)
                 })
                 .add(ByteArrayAdapter())
+                .add(KotlinJsonAdapterFactory())
                 .build().adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -58,7 +58,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         val bodyContent = body.string()
-        if (bodyContent.length == 0) {
+        if (bodyContent.isEmpty()) {
             return null
         }
         return when(mediaType) {

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,6 +1,7 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import okhttp3.OkHttpClient
@@ -58,7 +59,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         val bodyContent = body.string()
-        if (bodyContent.length == 0) {
+        if (bodyContent.isEmpty()) {
             return null
         }
         return when(mediaType) {
@@ -69,6 +70,7 @@ open class ApiClient(val baseUrl: String) {
                     fun fromJson(s: String) = UUID.fromString(s)
                 })
                 .add(ByteArrayAdapter())
+                .add(KotlinJsonAdapterFactory())
                 .build().adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,6 +1,7 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import okhttp3.OkHttpClient
@@ -58,7 +59,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         val bodyContent = body.string()
-        if (bodyContent.length == 0) {
+        if (bodyContent.isEmpty()) {
             return null
         }
         return when(mediaType) {
@@ -69,6 +70,7 @@ open class ApiClient(val baseUrl: String) {
                     fun fromJson(s: String) = UUID.fromString(s)
                 })
                 .add(ByteArrayAdapter())
+                .add(KotlinJsonAdapterFactory())
                 .build().adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,6 +1,7 @@
 package org.openapitools.client.infrastructure
 
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import okhttp3.OkHttpClient
@@ -58,7 +59,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         val bodyContent = body.string()
-        if (bodyContent.length == 0) {
+        if (bodyContent.isEmpty()) {
             return null
         }
         return when(mediaType) {
@@ -69,6 +70,7 @@ open class ApiClient(val baseUrl: String) {
                     fun fromJson(s: String) = UUID.fromString(s)
                 })
                 .add(ByteArrayAdapter())
+                .add(KotlinJsonAdapterFactory())
                 .build().adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
To parse a model using custom fields, KotlinJsonAdapterFactory needs to be added to moshi's Adapter. 
- Fix parse error when using custom field names with @Json
- Fix to use isEmpty method for string length verification

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

