### PR TITLE
Added support for patterns on model properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/model.mustache
@@ -26,6 +26,9 @@ namespace {{modelPackage}}
         {{#required}}
         [Required]
         {{/required}}
+        {{#pattern}}
+        [RegularExpression("{{{pattern}}}")]
+        {{/pattern}}
         [DataMember(Name="{{baseName}}", EmitDefaultValue={{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}})]
         {{#isEnum}}
         public {{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} { get; set; }


### PR DESCRIPTION
ASPNET Core uses the attribute RegularExpression to validate the model state. This is supported in OpenAPI spec with the 'pattern' property.
This PR adds the reg-ex attribute to the model codegen.


