### PR TITLE
[PHP] Fix group parameters in WithHttpInfo method

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -178,7 +178,7 @@ use {{invokerPackage}}\ObjectSerializer;
      */
     public function {{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
     {
-        $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}{{#allParams}}$associative_array['{{paramName}}']{{#hasMore}}, {{/hasMore}}{{/allParams}}{{/vendorExtensions.x-group-parameters}});
+        $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
 
         try {
             $options = $this->createHttpClientOption();

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -2807,7 +2807,7 @@ class FakeApi
      */
     public function testGroupParametersWithHttpInfo($associative_array)
     {
-        $request = $this->testGroupParametersRequest($associative_array['required_string_group'], $associative_array['required_boolean_group'], $associative_array['required_int64_group'], $associative_array['string_group'], $associative_array['boolean_group'], $associative_array['int64_group']);
+        $request = $this->testGroupParametersRequest($associative_array);
 
         try {
             $options = $this->createHttpClientOption();

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -2841,7 +2841,7 @@ class FakeApi
      */
     public function testGroupParametersWithHttpInfo($associative_array)
     {
-        $request = $this->testGroupParametersRequest($associative_array['required_string_group'], $associative_array['required_boolean_group'], $associative_array['required_int64_group'], $associative_array['string_group'], $associative_array['boolean_group'], $associative_array['int64_group']);
+        $request = $this->testGroupParametersRequest($associative_array);
 
         try {
             $options = $this->createHttpClientOption();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

To fix #2945  