### PR TITLE
[C#] Enabling XML documentation in the C# client

### DIFF
--- a/bin/windows/csharp-petstore.bat
+++ b/bin/windows/csharp-petstore.bat
@@ -5,7 +5,7 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\openapi-generator\src\test/resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples\client\petstore\csharp\SwaggerClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C}
+set ags=generate -i modules\openapi-generator\src\test/resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -g csharp -o samples\client\petstore\csharp\OpenAPIClient --additional-properties packageGuid={321C8C3F-0156-40C1-AE42-D59761FB9B6C}
 
 java %JAVA_OPTS% -jar %executable% %ags%
 

--- a/modules/openapi-generator/src/main/resources/csharp/Project.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/Project.mustache
@@ -46,6 +46,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\{{packageName}}.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -54,6 +55,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\{{packageName}}.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     {{^netStandard}}

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -28,6 +28,7 @@ The version of the OpenAPI document: 1.0.0
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Org.OpenAPITools.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +37,7 @@ The version of the OpenAPI document: 1.0.0
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Org.OpenAPITools.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

#2952 

@mandrean @jimschubert
