### PR TITLE
Add support for enums in Elm operations

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElmClientCodegen.java
@@ -567,44 +567,56 @@ public class ElmClientCodegen extends DefaultCodegen implements CodegenConfig {
         return "(Just " + value + ")";
     }
 
+    private Optional<String> paramToStringMapper(final String paramName, final CodegenProperty property) {
+        if (property.isEnum) {
+            return Optional.of(toVarName(paramName) + "ToString");
+        } else if (property.isString || property.isBinary || property.isByteArray) {
+            return Optional.empty();
+        } else if (property.isBoolean) {
+            return Optional.of("(\\val -> if val then \"true\" else \"false\")");
+        } else if (property.isDateTime) {
+            return Optional.of("DateTime.toString");
+        } else if (property.isDate) {
+            return Optional.of("DateOnly.toString");
+        } else if (property.isUuid) {
+            return Optional.of("Uuid.toString");
+        } else if (ElmVersion.ELM_018.equals(elmVersion)) {
+            return Optional.of("toString");
+        } else if (property.isInteger || property.isLong) {
+            return Optional.of("String.fromInt");
+        } else if (property.isFloat || property.isDouble) {
+            return Optional.of("String.fromFloat");
+        }
+        throw new RuntimeException("Parameter '" + paramName + "' cannot be converted to a string. Please report the issue.");
+    }
+
+    private CodegenProperty paramToProperty(final CodegenParameter parameter) {
+        final CodegenProperty property = new CodegenProperty();
+        property.isEnum = parameter.isEnum;
+        property.isString = parameter.isString;
+        property.isBinary = parameter.isBinary;
+        property.isByteArray = parameter.isByteArray;
+        property.isBoolean = parameter.isBoolean;
+        property.isDateTime = parameter.isDateTime;
+        property.isDate = parameter.isDate;
+        property.isUuid = parameter.isUuid;
+        property.isInteger = parameter.isInteger;
+        property.isLong = parameter.isLong;
+        property.isFloat = parameter.isFloat;
+        property.isDouble = parameter.isDouble;
+        return property;
+    }
+
     private String paramToString(final String prefix, final CodegenParameter param, final boolean useMaybe, final String maybeMapResult) {
         final String paramName = (ElmVersion.ELM_018.equals(elmVersion) ? "" : prefix + ".") + param.paramName;
         if (!useMaybe) {
             param.required = true;
         }
 
-        String mapFn = null;
-        if (param.isString || param.isBinary || param.isByteArray) {
-            mapFn = "";
-        } else if (param.isBoolean) {
-            mapFn = "(\\val -> if val then \"true\" else \"false\")";
-        } else if (param.isDateTime) {
-            mapFn = "DateTime.toString";
-        } else if (param.isDate) {
-            mapFn = "DateOnly.toString";
-        } else if (param.isUuid) {
-            mapFn = "Uuid.toString";
-        } else if (ElmVersion.ELM_018.equals(elmVersion)) {
-            mapFn = "toString";
-        } else if (param.isInteger || param.isLong) {
-            mapFn = "String.fromInt";
-        } else if (param.isFloat || param.isDouble) {
-            mapFn = "String.fromFloat";
-        } else if (param.isListContainer) {
-            // TODO duplicate ALL types from parameter to property...
-            if (param.items.isString || param.items.isUuid || param.items.isBinary || param.items.isByteArray) {
-                mapFn = "String.join \",\"";
-            }
-        }
-        if (mapFn == null) {
-            throw new RuntimeException("Parameter '" + param.paramName + "' cannot be converted to a string. Please report the issue.");
-        }
+        final String mapFn = param.isListContainer
+                ? "(String.join \",\"" + paramToStringMapper(param.paramName, param.items).map(mapper -> " << List.map " + mapper).orElse("") + ")"
+                : paramToStringMapper(param.paramName, paramToProperty(param)).orElse("");
 
-        if (param.isListContainer) {
-            if (!param.required) {
-                mapFn = "(" + mapFn + ")";
-            }
-        }
         String mapResult = "";
         if (maybeMapResult != null) {
             if ("".equals(mapFn)) {

--- a/modules/openapi-generator/src/main/resources/elm/api.mustache
+++ b/modules/openapi-generator/src/main/resources/elm/api.mustache
@@ -1,11 +1,34 @@
 {{>licenseInfo}}
 
-module Request.{{classname}} exposing ({{#operations}}{{#operation}}{{^-first}}, {{/-first}}{{operationId}}{{/operation}}{{/operations}})
+module Request.{{classname}} exposing ({{#operations}}{{#operation}}{{^-first}}, {{/-first}}{{operationId}}{{#allParams}}{{#isEnum}}, {{enumName}}(..){{/isEnum}}{{/allParams}}{{/operation}}{{/operations}})
 
 {{>imports}}import Dict
 import Http
 import Json.Decode as Decode
 import Url.Builder as Url
+
+
+{{#operations}}
+{{#operation}}
+{{#allParams}}
+{{#isEnum}}
+type {{enumName}}
+{{#allowableValues.enumVars}}    {{#-first}}= {{/-first}}{{^-first}}| {{/-first}}{{name}}
+{{/allowableValues.enumVars}}
+
+{{paramName}}ToString : {{enumName}} -> String
+{{paramName}}ToString value =
+    case value of
+{{#allowableValues.enumVars}}        {{name}} ->
+            {{{value}}}
+
+{{/allowableValues.enumVars}}
+
+
+{{/isEnum}}
+{{/allParams}}
+{{/operation}}
+{{/operations}}
 
 
 {{^enableCustomBasePaths}}basePath : String
@@ -29,8 +52,8 @@ basePath =
 {{#enableCustomBasePaths}}    , basePath : String{{/enableCustomBasePaths}}
 {{#enableHttpRequestTrackers}}    , tracker : Maybe String{{/enableHttpRequestTrackers}}
 {{#bodyParam}}    , body : {{^required}}Maybe {{/required}}{{dataType}}{{/bodyParam}}
-{{#pathParams}}    , {{paramName}} : {{#isListContainer}}List {{/isListContainer}}{{dataType}}{{/pathParams}}
-{{#queryParams}}    , {{paramName}} : {{^required}}Maybe ({{/required}}{{#isListContainer}}List {{/isListContainer}}{{dataType}}{{^required}}){{/required}}{{/queryParams}}
+{{#pathParams}}    , {{paramName}} : {{#isListContainer}}List {{/isListContainer}}{{#datatypeWithEnum}}{{datatypeWithEnum}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{dataType}}{{/datatypeWithEnum}}{{/pathParams}}
+{{#queryParams}}    , {{paramName}} : {{^required}}Maybe ({{/required}}{{#isListContainer}}List {{/isListContainer}}{{#datatypeWithEnum}}{{datatypeWithEnum}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{dataType}}{{/datatypeWithEnum}}{{^required}}){{/required}}{{/queryParams}}
     }
     -> Cmd msg
 {{operationId}} {{#headerParams.0}}headers {{/headerParams.0}}params =

--- a/samples/client/petstore/elm/src/Request/Pet.elm
+++ b/samples/client/petstore/elm/src/Request/Pet.elm
@@ -10,7 +10,7 @@
 -}
 
 
-module Request.Pet exposing (addPet, deletePet, findPetsByStatus, findPetsByTags, getPetById, updatePet, updatePetWithForm, uploadFile)
+module Request.Pet exposing (Status(..), addPet, deletePet, findPetsByStatus, findPetsByTags, getPetById, updatePet, updatePetWithForm, uploadFile)
 
 import Data.ApiResponse as ApiResponse exposing (ApiResponse)
 import Data.Pet as Pet exposing (Pet)
@@ -18,6 +18,25 @@ import Dict
 import Http
 import Json.Decode as Decode
 import Url.Builder as Url
+
+
+type Status
+    = Available
+    | Pending
+    | Sold
+
+
+statusToString : Status -> String
+statusToString value =
+    case value of
+        Available ->
+            "available"
+
+        Pending ->
+            "pending"
+
+        Sold ->
+            "sold"
 
 
 basePath : String
@@ -72,7 +91,7 @@ deletePet headers params =
 -}
 findPetsByStatus :
     { onSend : Result Http.Error (List Pet) -> msg
-    , status : List String
+    , status : List Status
     }
     -> Cmd msg
 findPetsByStatus params =
@@ -82,7 +101,7 @@ findPetsByStatus params =
         , url =
             Url.crossOrigin basePath
                 [ "pet", "findByStatus" ]
-                (List.filterMap identity [ Just (Url.string "status" <| String.join "," params.status) ])
+                (List.filterMap identity [ Just (Url.string "status" <| (String.join "," << List.map statusToString) params.status) ])
         , body = Http.emptyBody
         , expect = Http.expectJson params.onSend (Decode.list Pet.decoder)
         , timeout = Just 30000


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Enumerations are interpreted as strings in Elm operations. This PR fixes this.

Fixes #2585.