### PR TITLE
Use golang's provided method names (gin)

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-gin-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/routers.mustache
@@ -3,7 +3,6 @@ package {{packageName}}
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )

--- a/modules/openapi-generator/src/main/resources/go-gin-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/routers.mustache
@@ -28,13 +28,13 @@ func NewRouter() *gin.Engine {
 	router := gin.Default()
 	for _, route := range routes {
 		switch route.Method {
-		case "GET":
+		case http.MethodGet:
 			router.GET(route.Pattern, route.HandlerFunc)
-		case "POST":
+		case http.MethodPost:
 			router.POST(route.Pattern, route.HandlerFunc)
-		case "PUT":
+		case http.MethodPut:
 			router.PUT(route.Pattern, route.HandlerFunc)
-		case "DELETE":
+		case http.MethodDelete:
 			router.DELETE(route.Pattern, route.HandlerFunc)
 		}
 	}
@@ -50,14 +50,14 @@ func Index(c *gin.Context) {
 var routes = Routes{
 	{
 		"Index",
-		"GET",
+		http.MethodGet,
 		"{{{basePathWithoutHost}}}/",
 		Index,
 	},{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}
 
 	{
 		"{{operationId}}",
-		strings.ToUpper("{{httpMethod}}"),
+		http.Method{{httpMethod}},
 		"{{{basePathWithoutHost}}}{{{path}}}",
 		{{operationId}},
 	},{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/samples/server/petstore/go-gin-api-server/go/routers.go
+++ b/samples/server/petstore/go-gin-api-server/go/routers.go
@@ -11,7 +11,6 @@ package petstoreserver
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -36,13 +35,13 @@ func NewRouter() *gin.Engine {
 	router := gin.Default()
 	for _, route := range routes {
 		switch route.Method {
-		case "GET":
+		case http.MethodGet:
 			router.GET(route.Pattern, route.HandlerFunc)
-		case "POST":
+		case http.MethodPost:
 			router.POST(route.Pattern, route.HandlerFunc)
-		case "PUT":
+		case http.MethodPut:
 			router.PUT(route.Pattern, route.HandlerFunc)
-		case "DELETE":
+		case http.MethodDelete:
 			router.DELETE(route.Pattern, route.HandlerFunc)
 		}
 	}
@@ -58,147 +57,147 @@ func Index(c *gin.Context) {
 var routes = Routes{
 	{
 		"Index",
-		"GET",
+		http.MethodGet,
 		"/v2/",
 		Index,
 	},
 
 	{
 		"AddPet",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/pet",
 		AddPet,
 	},
 
 	{
 		"DeletePet",
-		strings.ToUpper("Delete"),
+		http.MethodDelete,
 		"/v2/pet/:petId",
 		DeletePet,
 	},
 
 	{
 		"FindPetsByStatus",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/pet/findByStatus",
 		FindPetsByStatus,
 	},
 
 	{
 		"FindPetsByTags",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/pet/findByTags",
 		FindPetsByTags,
 	},
 
 	{
 		"GetPetById",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/pet/:petId",
 		GetPetById,
 	},
 
 	{
 		"UpdatePet",
-		strings.ToUpper("Put"),
+		http.MethodPut,
 		"/v2/pet",
 		UpdatePet,
 	},
 
 	{
 		"UpdatePetWithForm",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/pet/:petId",
 		UpdatePetWithForm,
 	},
 
 	{
 		"UploadFile",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/pet/:petId/uploadImage",
 		UploadFile,
 	},
 
 	{
 		"DeleteOrder",
-		strings.ToUpper("Delete"),
+		http.MethodDelete,
 		"/v2/store/order/:orderId",
 		DeleteOrder,
 	},
 
 	{
 		"GetInventory",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/store/inventory",
 		GetInventory,
 	},
 
 	{
 		"GetOrderById",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/store/order/:orderId",
 		GetOrderById,
 	},
 
 	{
 		"PlaceOrder",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/store/order",
 		PlaceOrder,
 	},
 
 	{
 		"CreateUser",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/user",
 		CreateUser,
 	},
 
 	{
 		"CreateUsersWithArrayInput",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/user/createWithArray",
 		CreateUsersWithArrayInput,
 	},
 
 	{
 		"CreateUsersWithListInput",
-		strings.ToUpper("Post"),
+		http.MethodPost,
 		"/v2/user/createWithList",
 		CreateUsersWithListInput,
 	},
 
 	{
 		"DeleteUser",
-		strings.ToUpper("Delete"),
+		http.MethodDelete,
 		"/v2/user/:username",
 		DeleteUser,
 	},
 
 	{
 		"GetUserByName",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/user/:username",
 		GetUserByName,
 	},
 
 	{
 		"LoginUser",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/user/login",
 		LoginUser,
 	},
 
 	{
 		"LogoutUser",
-		strings.ToUpper("Get"),
+		http.MethodGet,
 		"/v2/user/logout",
 		LogoutUser,
 	},
 
 	{
 		"UpdateUser",
-		strings.ToUpper("Put"),
+		http.MethodPut,
 		"/v2/user/:username",
 		UpdateUser,
 	},


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This commit modifies the gin template for the router to leverage the http constants for method types as defined by RFC 7231 section 4.3. These are documented on:

https://golang.org/pkg/net/http/#pkg-constants

This removes the need for the `strings` dependency and does not require any new dependencies, as `net/http` is already imported.