### PR TITLE
Kotlin-Spring template fixes/improvements

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -70,8 +70,8 @@ class {{classname}}Controller({{#serviceInterface}}@Autowired(required = true) v
             value = ["{{#lambda.escapeDoubleQuote}}{{path}}{{/lambda.escapeDoubleQuote}}"],{{#singleContentTypes}}{{#hasProduces}}
             produces = "{{{vendorExtensions.x-accepts}}}", {{/hasProduces}}{{#hasConsumes}}
             consumes = "{{{vendorExtensions.x-contentType}}}",{{/hasConsumes}}{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}}
-            produces = [{{#produces}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/produces}}], {{/hasProduces}}{{#hasConsumes}}
-            consumes = [{{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}],{{/hasConsumes}}{{/singleContentTypes}}
+            produces = [{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}], {{/hasProduces}}{{#hasConsumes}}
+            consumes = [{{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}}],{{/hasConsumes}}{{/singleContentTypes}}
             method = [RequestMethod.{{httpMethod}}])
     fun {{operationId}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}): ResponseEntity<{{>returnTypes}}> {
         return {{>returnValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/returnValue.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/returnValue.mustache
@@ -1,1 +1,1 @@
-{{#serviceInterface}}ResponseEntity(service.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}), HttpStatus.OK){{/serviceInterface}}{{^serviceInterface}}ResponseEntity(HttpStatus.NOT_IMPLEMENTED){{/serviceInterface}}
+{{#serviceInterface}}ResponseEntity(service.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}), {{#responses}}{{#-first}}HttpStatus.valueOf({{code}}){{/-first}}{{/responses}}){{/serviceInterface}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/returnValue.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/returnValue.mustache
@@ -1,1 +1,1 @@
-{{#serviceInterface}}ResponseEntity(service.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}), {{#responses}}{{#-first}}HttpStatus.valueOf({{code}}){{/-first}}{{/responses}}){{/serviceInterface}}
+{{#serviceInterface}}ResponseEntity(service.{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}), {{#responses}}{{#-first}}HttpStatus.valueOf({{code}}){{/-first}}{{/responses}}){{/serviceInterface}}{{^serviceInterface}}ResponseEntity(HttpStatus.NOT_IMPLEMENTED){{/serviceInterface}}

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -55,7 +55,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             method = [RequestMethod.POST])
     fun addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true ) @Valid @RequestBody body: Pet
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.addPet(body), HttpStatus.OK)
+        return ResponseEntity(service.addPet(body), HttpStatus.valueOf(405))
     }
 
     @ApiOperation(
@@ -71,7 +71,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
     fun deletePet(@ApiParam(value = "Pet id to delete", required=true) @PathVariable("petId") petId: Long
 ,@ApiParam(value = "" ) @RequestHeader(value="api_key", required=false) apiKey: String?
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.deletePet(petId, apiKey), HttpStatus.OK)
+        return ResponseEntity(service.deletePet(petId, apiKey), HttpStatus.valueOf(400))
     }
 
     @ApiOperation(
@@ -89,7 +89,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             method = [RequestMethod.GET])
     fun findPetsByStatus(@NotNull @ApiParam(value = "Status values that need to be considered for filter", required = true, allowableValues = "available, pending, sold") @Valid @RequestParam(value = "status", required = true) status: List<String>
 ): ResponseEntity<List<Pet>> {
-        return ResponseEntity(service.findPetsByStatus(status), HttpStatus.OK)
+        return ResponseEntity(service.findPetsByStatus(status), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -107,7 +107,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             method = [RequestMethod.GET])
     fun findPetsByTags(@NotNull @ApiParam(value = "Tags to filter by", required = true) @Valid @RequestParam(value = "tags", required = true) tags: List<String>
 ): ResponseEntity<List<Pet>> {
-        return ResponseEntity(service.findPetsByTags(tags), HttpStatus.OK)
+        return ResponseEntity(service.findPetsByTags(tags), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -124,7 +124,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             method = [RequestMethod.GET])
     fun getPetById(@ApiParam(value = "ID of pet to return", required=true) @PathVariable("petId") petId: Long
 ): ResponseEntity<Pet> {
-        return ResponseEntity(service.getPetById(petId), HttpStatus.OK)
+        return ResponseEntity(service.getPetById(petId), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -140,7 +140,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
             method = [RequestMethod.PUT])
     fun updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true ) @Valid @RequestBody body: Pet
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.updatePet(body), HttpStatus.OK)
+        return ResponseEntity(service.updatePet(body), HttpStatus.valueOf(400))
     }
 
     @ApiOperation(
@@ -158,7 +158,7 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
 ,@ApiParam(value = "Updated name of the pet") @RequestParam(value="name", required=false) name: String? 
 ,@ApiParam(value = "Updated status of the pet") @RequestParam(value="status", required=false) status: String? 
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.updatePetWithForm(petId, name, status), HttpStatus.OK)
+        return ResponseEntity(service.updatePetWithForm(petId, name, status), HttpStatus.valueOf(405))
     }
 
     @ApiOperation(
@@ -178,6 +178,6 @@ class PetApiController(@Autowired(required = true) val service: PetApiService) {
 ,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false) additionalMetadata: String? 
 ,@ApiParam(value = "file detail") @Valid @RequestPart("file") file: org.springframework.core.io.Resource?
 ): ResponseEntity<ModelApiResponse> {
-        return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.OK)
+        return ResponseEntity(service.uploadFile(petId, additionalMetadata, file), HttpStatus.valueOf(200))
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -52,7 +52,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             method = [RequestMethod.DELETE])
     fun deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required=true) @PathVariable("orderId") orderId: String
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.deleteOrder(orderId), HttpStatus.OK)
+        return ResponseEntity(service.deleteOrder(orderId), HttpStatus.valueOf(400))
     }
 
     @ApiOperation(
@@ -69,7 +69,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             produces = ["application/json"], 
             method = [RequestMethod.GET])
     fun getInventory(): ResponseEntity<Map<String, Int>> {
-        return ResponseEntity(service.getInventory(), HttpStatus.OK)
+        return ResponseEntity(service.getInventory(), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -85,7 +85,7 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             method = [RequestMethod.GET])
     fun getOrderById(@Min(1L) @Max(5L) @ApiParam(value = "ID of pet that needs to be fetched", required=true) @PathVariable("orderId") orderId: Long
 ): ResponseEntity<Order> {
-        return ResponseEntity(service.getOrderById(orderId), HttpStatus.OK)
+        return ResponseEntity(service.getOrderById(orderId), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -101,6 +101,6 @@ class StoreApiController(@Autowired(required = true) val service: StoreApiServic
             method = [RequestMethod.POST])
     fun placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true ) @Valid @RequestBody body: Order
 ): ResponseEntity<Order> {
-        return ResponseEntity(service.placeOrder(body), HttpStatus.OK)
+        return ResponseEntity(service.placeOrder(body), HttpStatus.valueOf(200))
     }
 }

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -52,7 +52,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             method = [RequestMethod.POST])
     fun createUser(@ApiParam(value = "Created user object" ,required=true ) @Valid @RequestBody body: User
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.createUser(body), HttpStatus.OK)
+        return ResponseEntity(service.createUser(body), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -66,7 +66,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             method = [RequestMethod.POST])
     fun createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody body: List<User>
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.createUsersWithArrayInput(body), HttpStatus.OK)
+        return ResponseEntity(service.createUsersWithArrayInput(body), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -80,7 +80,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             method = [RequestMethod.POST])
     fun createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true ) @Valid @RequestBody body: List<User>
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.createUsersWithListInput(body), HttpStatus.OK)
+        return ResponseEntity(service.createUsersWithListInput(body), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -94,7 +94,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             method = [RequestMethod.DELETE])
     fun deleteUser(@ApiParam(value = "The name that needs to be deleted", required=true) @PathVariable("username") username: String
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.deleteUser(username), HttpStatus.OK)
+        return ResponseEntity(service.deleteUser(username), HttpStatus.valueOf(400))
     }
 
     @ApiOperation(
@@ -110,7 +110,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             method = [RequestMethod.GET])
     fun getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required=true) @PathVariable("username") username: String
 ): ResponseEntity<User> {
-        return ResponseEntity(service.getUserByName(username), HttpStatus.OK)
+        return ResponseEntity(service.getUserByName(username), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -127,7 +127,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     fun loginUser(@NotNull @ApiParam(value = "The user name for login", required = true) @Valid @RequestParam(value = "username", required = true) username: String
 ,@NotNull @ApiParam(value = "The password for login in clear text", required = true) @Valid @RequestParam(value = "password", required = true) password: String
 ): ResponseEntity<String> {
-        return ResponseEntity(service.loginUser(username, password), HttpStatus.OK)
+        return ResponseEntity(service.loginUser(username, password), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -140,7 +140,7 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
             value = ["/user/logout"],
             method = [RequestMethod.GET])
     fun logoutUser(): ResponseEntity<Unit> {
-        return ResponseEntity(service.logoutUser(), HttpStatus.OK)
+        return ResponseEntity(service.logoutUser(), HttpStatus.valueOf(200))
     }
 
     @ApiOperation(
@@ -155,6 +155,6 @@ class UserApiController(@Autowired(required = true) val service: UserApiService)
     fun updateUser(@ApiParam(value = "name that need to be deleted", required=true) @PathVariable("username") username: String
 ,@ApiParam(value = "Updated user object" ,required=true ) @Valid @RequestBody body: User
 ): ResponseEntity<Unit> {
-        return ResponseEntity(service.updateUser(username, body), HttpStatus.OK)
+        return ResponseEntity(service.updateUser(username, body), HttpStatus.valueOf(400))
     }
 }


### PR DESCRIPTION
### Description of the PR

Fixed consumes/produces comma placement.
Sometimes following happened: produces = ["application/json", ],
- a comma was placed after last element. I susupect that an empty consumes/produces element is somehow added to the list. 


Changed default response code in interface returnValue from HttpStatus.OK to first response code in definition. Allowing other responses, like created, accepted ...

