### PR TITLE
[KOTLIN client] fix Moshi (Serializer/Deserializer)  duplicated

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -30,9 +30,11 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.5.0"
-    compile "com.squareup.moshi:moshi-adapters:1.5.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.0"
+    compile "com.squareup.moshi:moshi-kotlin:1.8.0"
+    compile "com.squareup.moshi:moshi-adapters:1.8.0"
+    compile "com.squareup.okhttp3:okhttp:3.14.2"
+    {{#threetenbp}}
     compile "org.threeten:threetenbp:1.3.8"
+    {{/threetenbp}}
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -1,8 +1,5 @@
 package {{packageName}}.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.MediaType
@@ -11,7 +8,6 @@ import okhttp3.HttpUrl
 import okhttp3.ResponseBody
 import okhttp3.Request
 import java.io.File
-import java.util.Date
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -62,14 +58,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         return when(mediaType) {
-            JsonMediaType -> Moshi.Builder()
-                .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
-                .add(LocalDateTimeAdapter())
-                .add(LocalDateAdapter())
-                .add(UUIDAdapter())
-                .add(ByteArrayAdapter())
-                .add(KotlinJsonAdapterFactory())
-                .build().adapter(T::class.java).fromJson(bodyContent)
+            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }
     }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/Serializer.kt.mustache
@@ -1,8 +1,8 @@
 package {{packageName}}.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
 
 object Serializer {

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -30,9 +30,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.5.0"
-    compile "com.squareup.moshi:moshi-adapters:1.5.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.0"
-    compile "org.threeten:threetenbp:1.3.8"
+    compile "com.squareup.moshi:moshi-kotlin:1.8.0"
+    compile "com.squareup.moshi:moshi-adapters:1.8.0"
+    compile "com.squareup.okhttp3:okhttp:3.14.2"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,8 +1,5 @@
 package org.openapitools.client.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.MediaType
@@ -11,7 +8,6 @@ import okhttp3.HttpUrl
 import okhttp3.ResponseBody
 import okhttp3.Request
 import java.io.File
-import java.util.Date
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -62,14 +58,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         return when(mediaType) {
-            JsonMediaType -> Moshi.Builder()
-                .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
-                .add(LocalDateTimeAdapter())
-                .add(LocalDateAdapter())
-                .add(UUIDAdapter())
-                .add(ByteArrayAdapter())
-                .add(KotlinJsonAdapterFactory())
-                .build().adapter(T::class.java).fromJson(bodyContent)
+            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }
     }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,8 @@
 package org.openapitools.client.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
 
 object Serializer {

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -30,9 +30,9 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.5.0"
-    compile "com.squareup.moshi:moshi-adapters:1.5.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.0"
+    compile "com.squareup.moshi:moshi-kotlin:1.8.0"
+    compile "com.squareup.moshi:moshi-adapters:1.8.0"
+    compile "com.squareup.okhttp3:okhttp:3.14.2"
     compile "org.threeten:threetenbp:1.3.8"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,8 +1,5 @@
 package org.openapitools.client.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.MediaType
@@ -11,7 +8,6 @@ import okhttp3.HttpUrl
 import okhttp3.ResponseBody
 import okhttp3.Request
 import java.io.File
-import java.util.Date
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -62,14 +58,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         return when(mediaType) {
-            JsonMediaType -> Moshi.Builder()
-                .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
-                .add(LocalDateTimeAdapter())
-                .add(LocalDateAdapter())
-                .add(UUIDAdapter())
-                .add(ByteArrayAdapter())
-                .add(KotlinJsonAdapterFactory())
-                .build().adapter(T::class.java).fromJson(bodyContent)
+            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }
     }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,8 @@
 package org.openapitools.client.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
 
 object Serializer {

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -30,9 +30,8 @@ test {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    compile "com.squareup.moshi:moshi-kotlin:1.5.0"
-    compile "com.squareup.moshi:moshi-adapters:1.5.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.0"
-    compile "org.threeten:threetenbp:1.3.8"
+    compile "com.squareup.moshi:moshi-kotlin:1.8.0"
+    compile "com.squareup.moshi:moshi-adapters:1.8.0"
+    compile "com.squareup.okhttp3:okhttp:3.14.2"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -1,8 +1,5 @@
 package org.openapitools.client.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
 import okhttp3.MediaType
@@ -11,7 +8,6 @@ import okhttp3.HttpUrl
 import okhttp3.ResponseBody
 import okhttp3.Request
 import java.io.File
-import java.util.Date
 
 open class ApiClient(val baseUrl: String) {
     companion object {
@@ -62,14 +58,7 @@ open class ApiClient(val baseUrl: String) {
             return null
         }
         return when(mediaType) {
-            JsonMediaType -> Moshi.Builder()
-                .add(Date::class.java, Rfc3339DateJsonAdapter().nullSafe())
-                .add(LocalDateTimeAdapter())
-                .add(LocalDateAdapter())
-                .add(UUIDAdapter())
-                .add(ByteArrayAdapter())
-                .add(KotlinJsonAdapterFactory())
-                .build().adapter(T::class.java).fromJson(bodyContent)
+            JsonMediaType -> Serializer.moshi.adapter(T::class.java).fromJson(bodyContent)
             else ->  TODO("responseBody currently only supports JSON body.")
         }
     }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -1,8 +1,8 @@
 package org.openapitools.client.infrastructure
 
-import com.squareup.moshi.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Rfc3339DateJsonAdapter
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import java.util.Date
 
 object Serializer {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @Zomzog (2019/04)

cc @lemoinem 

### Description of the PR

- fix Moshi (Serializer/Deserializer)  duplicated  (fix #3004)
- update Moshi / okhttp version to latest
