### PR TITLE
[java-okhttp]: Make example snippets code compilable

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
@@ -88,7 +88,7 @@ import {{{package}}}.{{{classname}}};
 public class Example {
   public static void main(String[] args) {
     ApiClient defaultClient = Configuration.getDefaultApiClient();
-    defaultClient.setBasePath("{{basePath}}");
+    defaultClient.setBasePath("{{{basePath}}}");
     {{#hasAuthMethods}}
     {{#authMethods}}{{#isBasic}}
     // Configure HTTP basic authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
@@ -77,48 +77,52 @@ Please follow the [installation](#installation) instruction and execute the foll
 
 ```java
 {{#apiInfo}}{{#apis}}{{#-first}}{{#operations}}{{#operation}}{{#-first}}
-import {{{invokerPackage}}}.*;
-import {{{invokerPackage}}}.auth.*;
-import {{{modelPackage}}}.*;
+// Import classes:
+import {{{invokerPackage}}}.ApiClient;
+import {{{invokerPackage}}}.ApiException;
+import {{{invokerPackage}}}.Configuration;{{#hasAuthMethods}}
+import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
+import {{{invokerPackage}}}.models.*;
 import {{{package}}}.{{{classname}}};
 
-import java.io.File;
-import java.util.*;
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("{{basePath}}");
+    {{#hasAuthMethods}}
+    {{#authMethods}}{{#isBasic}}
+    // Configure HTTP basic authorization: {{{name}}}
+    HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setUsername("YOUR USERNAME");
+    {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+    // Configure API key authorization: {{{name}}}
+    ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+    // Configure OAuth2 access token for authorization: {{{name}}}
+    OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
 
-public class {{{classname}}}Example {
-
-    public static void main(String[] args) {
-        {{#hasAuthMethods}}ApiClient defaultClient = Configuration.getDefaultApiClient();
-        {{#authMethods}}{{#isBasic}}
-        // Configure HTTP basic authorization: {{{name}}}
-        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setUsername("YOUR USERNAME");
-        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
-        // Configure API key authorization: {{{name}}}
-        ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
-        // Configure OAuth2 access token for authorization: {{{name}}}
-        OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
-        {{/authMethods}}
-        {{/hasAuthMethods}}
-
-        {{{classname}}} apiInstance = new {{{classname}}}();
-        {{#allParams}}
-        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
-        {{/allParams}}
-        try {
-            {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}{{^vendorExtensions.x-group-parameters}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}({{#requiredParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}){{#optionalParams}}
-                    .{{{paramName}}}({{{paramName}}}){{/optionalParams}}
-                    .execute();{{/vendorExtensions.x-group-parameters}}{{#returnType}}
-            System.out.println(result);{{/returnType}}
-        } catch (ApiException e) {
-            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
-            e.printStackTrace();
-        }
+    {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
+    {{#allParams}}
+    {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+    {{/allParams}}
+    try {
+      {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}{{^vendorExtensions.x-group-parameters}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}({{#requiredParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}){{#optionalParams}}
+            .{{{paramName}}}({{{paramName}}}){{/optionalParams}}
+            .execute();{{/vendorExtensions.x-group-parameters}}{{#returnType}}
+      System.out.println(result);{{/returnType}}
+    } catch (ApiException e) {
+      System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
     }
+  }
 }
 {{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}
 ```

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
@@ -32,7 +32,7 @@ import {{{package}}}.{{{classname}}};
 public class Example {
   public static void main(String[] args) {
     ApiClient defaultClient = Configuration.getDefaultApiClient();
-    defaultClient.setBasePath("{{basePath}}");
+    defaultClient.setBasePath("{{{basePath}}}");
     {{#hasAuthMethods}}
     {{#authMethods}}{{#isBasic}}
     // Configure HTTP basic authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
@@ -21,44 +21,52 @@ Method | HTTP request | Description
 
 ### Example
 ```java
-// Import classes:{{#hasAuthMethods}}
-//import {{{invokerPackage}}}.ApiClient;{{/hasAuthMethods}}
-//import {{{invokerPackage}}}.ApiException;{{#hasAuthMethods}}
-//import {{{invokerPackage}}}.Configuration;
-//import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
-//import {{{package}}}.{{{classname}}};
+// Import classes:
+import {{{invokerPackage}}}.ApiClient;
+import {{{invokerPackage}}}.ApiException;
+import {{{invokerPackage}}}.Configuration;{{#hasAuthMethods}}
+import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
+import {{{invokerPackage}}}.models.*;
+import {{{package}}}.{{{classname}}};
 
-{{#hasAuthMethods}}
-ApiClient defaultClient = Configuration.getDefaultApiClient();
-defaultClient.setBasePath("{{basePath}}");
-{{#authMethods}}{{#isBasic}}
-// Configure HTTP basic authorization: {{{name}}}
-HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
-{{{name}}}.setUsername("YOUR USERNAME");
-{{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
-// Configure API key authorization: {{{name}}}
-ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
-{{{name}}}.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
-// Configure OAuth2 access token for authorization: {{{name}}}
-OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
-{{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
-{{/authMethods}}
-{{/hasAuthMethods}}
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("{{basePath}}");
+    {{#hasAuthMethods}}
+    {{#authMethods}}{{#isBasic}}
+    // Configure HTTP basic authorization: {{{name}}}
+    HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setUsername("YOUR USERNAME");
+    {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+    // Configure API key authorization: {{{name}}}
+    ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+    // Configure OAuth2 access token for authorization: {{{name}}}
+    OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
+    {{/authMethods}}
+    {{/hasAuthMethods}}
 
-{{{classname}}} apiInstance = new {{{classname}}}({{#hasAuthMethods}}defaultClient{{/hasAuthMethods}});
-{{#allParams}}
-{{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
-{{/allParams}}
-try {
-    {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}{{^vendorExtensions.x-group-parameters}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}({{#requiredParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}){{#optionalParams}}
+    {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
+    {{#allParams}}
+    {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+    {{/allParams}}
+    try {
+      {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}{{^vendorExtensions.x-group-parameters}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}({{#requiredParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/requiredParams}}){{#optionalParams}}
             .{{{paramName}}}({{{paramName}}}){{/optionalParams}}
             .execute();{{/vendorExtensions.x-group-parameters}}{{#returnType}}
-    System.out.println(result);{{/returnType}}
-} catch (ApiException e) {
-    System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
-    e.printStackTrace();
+      System.out.println(result);{{/returnType}}
+    } catch (ApiException e) {
+      System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
@@ -30,6 +30,7 @@ Method | HTTP request | Description
 
 {{#hasAuthMethods}}
 ApiClient defaultClient = Configuration.getDefaultApiClient();
+defaultClient.setBasePath("{{basePath}}");
 {{#authMethods}}{{#isBasic}}
 // Configure HTTP basic authorization: {{{name}}}
 HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
@@ -46,7 +47,7 @@ OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
 {{/authMethods}}
 {{/hasAuthMethods}}
 
-{{{classname}}} apiInstance = new {{{classname}}}();
+{{{classname}}} apiInstance = new {{{classname}}}({{#hasAuthMethods}}defaultClient{{/hasAuthMethods}});
 {{#allParams}}
 {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
 {{/allParams}}

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/AnotherFakeApi.md
@@ -18,18 +18,30 @@ To test special tags and operation ID starting with number
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+    AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+    Client body = new Client(); // Client | client model
+    try {
+      Client result = apiInstance.call123testSpecialTags(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -30,17 +30,29 @@ this route creates an XmlItem
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+    try {
+      apiInstance.createXmlItem(xmlItem);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#createXmlItem");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -74,18 +86,30 @@ Test serialization of outer boolean types
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Boolean body = true; // Boolean | Input boolean as post body
+    try {
+      Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -119,18 +143,30 @@ Test serialization of object with outer number type
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+    try {
+      OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -164,18 +200,30 @@ Test serialization of outer number types
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+    try {
+      BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -209,18 +257,30 @@ Test serialization of outer string types
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    String body = "body_example"; // String | Input string as post body
+    try {
+      String result = apiInstance.fakeOuterStringSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -254,17 +314,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+    try {
+      apiInstance.testBodyWithFileSchema(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -296,18 +368,30 @@ No authorization required
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    String query = "query_example"; // String | 
+    User body = new User(); // User | 
+    try {
+      apiInstance.testBodyWithQueryParams(query, body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -342,18 +426,30 @@ To test \&quot;client\&quot; model
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Client body = new Client(); // Client | client model
+    try {
+      Client result = apiInstance.testClientModel(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testClientModel");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -387,39 +483,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure HTTP basic authorization: http_basic_test
+    HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+    http_basic_test.setUsername("YOUR USERNAME");
+    http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    BigDecimal number = new BigDecimal(); // BigDecimal | None
+    Double _double = 3.4D; // Double | None
+    String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+    byte[] _byte = null; // byte[] | None
+    Integer integer = 56; // Integer | None
+    Integer int32 = 56; // Integer | None
+    Long int64 = 56L; // Long | None
+    Float _float = 3.4F; // Float | None
+    String string = "string_example"; // String | None
+    File binary = new File("/path/to/file"); // File | None
+    LocalDate date = new LocalDate(); // LocalDate | None
+    OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+    String password = "password_example"; // String | None
+    String paramCallback = "paramCallback_example"; // String | None
+    try {
+      apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testEndpointParameters");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -466,24 +571,36 @@ To test enum parameters
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+    String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+    List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+    String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+    Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+    Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+    List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+    String enumFormString = "-efg"; // String | Form parameter enum test (string)
+    try {
+      apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testEnumParameters");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -524,26 +641,38 @@ Fake endpoint to test group parameters (optional)
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group)
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+    Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+    Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+    Integer stringGroup = 56; // Integer | String in group parameters
+    Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+    Long int64Group = 56L; // Long | Integer in group parameters
+    try {
+      apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group)
             .stringGroup(stringGroup)
             .booleanGroup(booleanGroup)
             .int64Group(int64Group)
             .execute();
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testGroupParameters");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -580,17 +709,29 @@ test inline additionalProperties
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Map<String, String> param = new HashMap(); // Map<String, String> | request body
+    try {
+      apiInstance.testInlineAdditionalProperties(param);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -622,18 +763,30 @@ test json serialization of form data
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    String param = "param_example"; // String | field1
+    String param2 = "param2_example"; // String | field2
+    try {
+      apiInstance.testJsonFormData(param, param2);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testJsonFormData");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeClassnameTags123Api.md
@@ -18,28 +18,37 @@ To test class name in snake case
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure API key authorization: api_key_query
+    ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+    api_key_query.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+    FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+    Client body = new Client(); // Client | client model
+    try {
+      Client result = apiInstance.testClassname(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/PetApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/PetApi.md
@@ -24,25 +24,34 @@ Add a new pet to the store
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+    try {
+      apiInstance.addPet(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#addPet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -74,26 +83,35 @@ Deletes a pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | Pet id to delete
+    String apiKey = "apiKey_example"; // String | 
+    try {
+      apiInstance.deletePet(petId, apiKey);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#deletePet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -128,26 +146,35 @@ Multiple status values can be provided with comma separated strings
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+    try {
+      List<Pet> result = apiInstance.findPetsByStatus(status);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#findPetsByStatus");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -181,26 +208,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+    try {
+      List<Pet> result = apiInstance.findPetsByTags(tags);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#findPetsByTags");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -234,28 +270,37 @@ Returns a single pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure API key authorization: api_key
+    ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+    api_key.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet to return
+    try {
+      Pet result = apiInstance.getPetById(petId);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#getPetById");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -287,25 +332,34 @@ Update an existing pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+    try {
+      apiInstance.updatePet(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#updatePet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -337,27 +391,36 @@ Updates a pet in the store with form data
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet that needs to be updated
+    String name = "name_example"; // String | Updated name of the pet
+    String status = "status_example"; // String | Updated status of the pet
+    try {
+      apiInstance.updatePetWithForm(petId, name, status);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#updatePetWithForm");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -391,28 +454,37 @@ uploads an image
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet to update
+    String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+    File file = new File("/path/to/file"); // File | file to upload
+    try {
+      ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#uploadFile");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -446,28 +518,37 @@ uploads an image (required)
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet to update
+    File requiredFile = new File("/path/to/file"); // File | file to upload
+    String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+    try {
+      ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/StoreApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/StoreApi.md
@@ -21,17 +21,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+    try {
+      apiInstance.deleteOrder(orderId);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#deleteOrder");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -65,27 +77,36 @@ Returns a map of status codes to quantities
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure API key authorization: api_key
+    ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+    api_key.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    try {
+      Map<String, Integer> result = apiInstance.getInventory();
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#getInventory");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -116,18 +137,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    Long orderId = 56L; // Long | ID of pet that needs to be fetched
+    try {
+      Order result = apiInstance.getOrderById(orderId);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#getOrderById");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -159,18 +192,30 @@ Place an order for a pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    Order body = new Order(); // Order | order placed for purchasing the pet
+    try {
+      Order result = apiInstance.placeOrder(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#placeOrder");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/UserApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/UserApi.md
@@ -25,17 +25,29 @@ This can only be done by the logged in user.
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    User body = new User(); // User | Created user object
+    try {
+      apiInstance.createUser(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#createUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -67,17 +79,29 @@ Creates list of users with given input array
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    try {
+      apiInstance.createUsersWithArrayInput(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -109,17 +133,29 @@ Creates list of users with given input array
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    try {
+      apiInstance.createUsersWithListInput(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#createUsersWithListInput");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -153,17 +189,29 @@ This can only be done by the logged in user.
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | The name that needs to be deleted
+    try {
+      apiInstance.deleteUser(username);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#deleteUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -195,18 +243,30 @@ Get user by user name
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+    try {
+      User result = apiInstance.getUserByName(username);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#getUserByName");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -238,19 +298,31 @@ Logs user into the system
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | The user name for login
+    String password = "password_example"; // String | The password for login in clear text
+    try {
+      String result = apiInstance.loginUser(username, password);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#loginUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -283,16 +355,28 @@ Logs out current logged in user session
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    try {
+      apiInstance.logoutUser();
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#logoutUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -323,18 +407,30 @@ This can only be done by the logged in user.
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | name that need to be deleted
+    User body = new User(); // User | Updated user object
+    try {
+      apiInstance.updateUser(username, body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#updateUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/AnotherFakeApi.md
@@ -18,18 +18,30 @@ To test special tags and operation ID starting with number
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+    AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+    Client body = new Client(); // Client | client model
+    try {
+      Client result = apiInstance.call123testSpecialTags(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -30,17 +30,29 @@ this route creates an XmlItem
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+    try {
+      apiInstance.createXmlItem(xmlItem);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#createXmlItem");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -74,18 +86,30 @@ Test serialization of outer boolean types
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Boolean body = true; // Boolean | Input boolean as post body
+    try {
+      Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -119,18 +143,30 @@ Test serialization of object with outer number type
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+    try {
+      OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -164,18 +200,30 @@ Test serialization of outer number types
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+    try {
+      BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -209,18 +257,30 @@ Test serialization of outer string types
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    String body = "body_example"; // String | Input string as post body
+    try {
+      String result = apiInstance.fakeOuterStringSerialize(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -254,17 +314,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+    try {
+      apiInstance.testBodyWithFileSchema(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -296,18 +368,30 @@ No authorization required
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    String query = "query_example"; // String | 
+    User body = new User(); // User | 
+    try {
+      apiInstance.testBodyWithQueryParams(query, body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -342,18 +426,30 @@ To test \&quot;client\&quot; model
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Client body = new Client(); // Client | client model
+    try {
+      Client result = apiInstance.testClientModel(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testClientModel");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -387,39 +483,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure HTTP basic authorization: http_basic_test
+    HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+    http_basic_test.setUsername("YOUR USERNAME");
+    http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    BigDecimal number = new BigDecimal(); // BigDecimal | None
+    Double _double = 3.4D; // Double | None
+    String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+    byte[] _byte = null; // byte[] | None
+    Integer integer = 56; // Integer | None
+    Integer int32 = 56; // Integer | None
+    Long int64 = 56L; // Long | None
+    Float _float = 3.4F; // Float | None
+    String string = "string_example"; // String | None
+    File binary = new File("/path/to/file"); // File | None
+    LocalDate date = new LocalDate(); // LocalDate | None
+    OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+    String password = "password_example"; // String | None
+    String paramCallback = "paramCallback_example"; // String | None
+    try {
+      apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testEndpointParameters");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -466,24 +571,36 @@ To test enum parameters
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+    String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+    List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+    String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+    Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+    Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+    List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+    String enumFormString = "-efg"; // String | Form parameter enum test (string)
+    try {
+      apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testEnumParameters");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -524,26 +641,38 @@ Fake endpoint to test group parameters (optional)
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group)
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+    Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+    Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+    Integer stringGroup = 56; // Integer | String in group parameters
+    Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+    Long int64Group = 56L; // Long | Integer in group parameters
+    try {
+      apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group)
             .stringGroup(stringGroup)
             .booleanGroup(booleanGroup)
             .int64Group(int64Group)
             .execute();
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testGroupParameters");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -580,17 +709,29 @@ test inline additionalProperties
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    Map<String, String> param = new HashMap(); // Map<String, String> | request body
+    try {
+      apiInstance.testInlineAdditionalProperties(param);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -622,18 +763,30 @@ test json serialization of form data
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    String param = "param_example"; // String | field1
+    String param2 = "param2_example"; // String | field2
+    try {
+      apiInstance.testJsonFormData(param, param2);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testJsonFormData");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeClassnameTags123Api.md
@@ -18,28 +18,37 @@ To test class name in snake case
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure API key authorization: api_key_query
+    ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+    api_key_query.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+    FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+    Client body = new Client(); // Client | client model
+    try {
+      Client result = apiInstance.testClassname(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson/docs/PetApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/PetApi.md
@@ -24,25 +24,34 @@ Add a new pet to the store
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+    try {
+      apiInstance.addPet(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#addPet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -74,26 +83,35 @@ Deletes a pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | Pet id to delete
+    String apiKey = "apiKey_example"; // String | 
+    try {
+      apiInstance.deletePet(petId, apiKey);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#deletePet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -128,26 +146,35 @@ Multiple status values can be provided with comma separated strings
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+    try {
+      List<Pet> result = apiInstance.findPetsByStatus(status);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#findPetsByStatus");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -181,26 +208,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+    try {
+      List<Pet> result = apiInstance.findPetsByTags(tags);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#findPetsByTags");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -234,28 +270,37 @@ Returns a single pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure API key authorization: api_key
+    ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+    api_key.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet to return
+    try {
+      Pet result = apiInstance.getPetById(petId);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#getPetById");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -287,25 +332,34 @@ Update an existing pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+    try {
+      apiInstance.updatePet(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#updatePet");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -337,27 +391,36 @@ Updates a pet in the store with form data
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet that needs to be updated
+    String name = "name_example"; // String | Updated name of the pet
+    String status = "status_example"; // String | Updated status of the pet
+    try {
+      apiInstance.updatePetWithForm(petId, name, status);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#updatePetWithForm");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -391,28 +454,37 @@ uploads an image
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet to update
+    String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+    File file = new File("/path/to/file"); // File | file to upload
+    try {
+      ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#uploadFile");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -446,28 +518,37 @@ uploads an image (required)
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure OAuth2 access token for authorization: petstore_auth
+    OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+    petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+    PetApi apiInstance = new PetApi(defaultClient);
+    Long petId = 56L; // Long | ID of pet to update
+    File requiredFile = new File("/path/to/file"); // File | file to upload
+    String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+    try {
+      ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson/docs/StoreApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/StoreApi.md
@@ -21,17 +21,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+    try {
+      apiInstance.deleteOrder(orderId);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#deleteOrder");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -65,27 +77,36 @@ Returns a map of status codes to quantities
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+    
+    // Configure API key authorization: api_key
+    ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+    api_key.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    try {
+      Map<String, Integer> result = apiInstance.getInventory();
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#getInventory");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -116,18 +137,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    Long orderId = 56L; // Long | ID of pet that needs to be fetched
+    try {
+      Order result = apiInstance.getOrderById(orderId);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#getOrderById");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -159,18 +192,30 @@ Place an order for a pet
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+    StoreApi apiInstance = new StoreApi(defaultClient);
+    Order body = new Order(); // Order | order placed for purchasing the pet
+    try {
+      Order result = apiInstance.placeOrder(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling StoreApi#placeOrder");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 

--- a/samples/client/petstore/java/okhttp-gson/docs/UserApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/UserApi.md
@@ -25,17 +25,29 @@ This can only be done by the logged in user.
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    User body = new User(); // User | Created user object
+    try {
+      apiInstance.createUser(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#createUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -67,17 +79,29 @@ Creates list of users with given input array
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    try {
+      apiInstance.createUsersWithArrayInput(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -109,17 +133,29 @@ Creates list of users with given input array
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    try {
+      apiInstance.createUsersWithListInput(body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#createUsersWithListInput");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -153,17 +189,29 @@ This can only be done by the logged in user.
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | The name that needs to be deleted
+    try {
+      apiInstance.deleteUser(username);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#deleteUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -195,18 +243,30 @@ Get user by user name
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+    try {
+      User result = apiInstance.getUserByName(username);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#getUserByName");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -238,19 +298,31 @@ Logs user into the system
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | The user name for login
+    String password = "password_example"; // String | The password for login in clear text
+    try {
+      String result = apiInstance.loginUser(username, password);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#loginUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -283,16 +355,28 @@ Logs out current logged in user session
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    try {
+      apiInstance.logoutUser();
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#logoutUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 
@@ -323,18 +407,30 @@ This can only be done by the logged in user.
 ### Example
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+    UserApi apiInstance = new UserApi(defaultClient);
+    String username = "username_example"; // String | name that need to be deleted
+    User body = new User(); // User | Updated user object
+    try {
+      apiInstance.updateUser(username, body);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling UserApi#updateUser");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

#3017  

Make example snippets code compilable. Also, specify how to access response message and headers in case of request failure.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)