### PR TITLE
[TS][Inversify] Rename map to GlobalImportOperators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptInversifyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptInversifyClientCodegen.java
@@ -52,8 +52,6 @@ public class TypeScriptInversifyClientCodegen extends AbstractTypeScriptClientCo
         apiPackage = "api";
         modelPackage = "model";
 
-        this.reservedWords.add("map");
-
         this.cliOptions.add(new CliOption(NPM_REPOSITORY,
                 "Use this property to set an url your private npmRepo in the package.json"));
         this.cliOptions.add(new CliOption(WITH_INTERFACES,

--- a/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/api.service.mustache
@@ -8,7 +8,7 @@ import { Observable } from "rxjs/Observable";
 import { Observable } from "rxjs";
 {{/useRxJS6}}
 
-import { map } from "rxjs/operators";
+import { GlobalImportOperators } from "rxjs/operators";
 import IHttpClient from "../IHttpClient";
 import { inject, injectable } from "inversify";
 import { IAPIConfiguration } from "../IAPIConfiguration";
@@ -177,7 +177,7 @@ export class {{classname}} {
         const response: Observable<HttpResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>> = this.httpClient.{{httpMethod}}(`${this.basePath}{{{path}}}{{#hasQueryParams}}?${queryParameters.join('&')}{{/hasQueryParams}}`{{#bodyParam}}, {{paramName}} {{/bodyParam}}{{#hasFormParams}}, body{{/hasFormParams}}, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>(httpResponse.response))
                ){{#usePromise}}.toPromise(){{/usePromise}};
         }
         return response{{#usePromise}}.toPromise(){{/usePromise}};

--- a/samples/client/petstore/typescript-inversify/api/pet.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/pet.service.ts
@@ -13,7 +13,7 @@
 
 import { Observable } from "rxjs/Observable";
 
-import { map } from "rxjs/operators";
+import { GlobalImportOperators } from "rxjs/operators";
 import IHttpClient from "../IHttpClient";
 import { inject, injectable } from "inversify";
 import { IAPIConfiguration } from "../IAPIConfiguration";
@@ -63,7 +63,7 @@ export class PetService {
         const response: Observable<HttpResponse<any>> = this.httpClient.post(`${this.basePath}/pet`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -100,7 +100,7 @@ export class PetService {
         const response: Observable<HttpResponse<any>> = this.httpClient.delete(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -137,7 +137,7 @@ export class PetService {
         const response: Observable<HttpResponse<Array<Pet>>> = this.httpClient.get(`${this.basePath}/pet/findByStatus?${queryParameters.join('&')}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <Array<Pet>>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <Array<Pet>>(httpResponse.response))
                );
         }
         return response;
@@ -174,7 +174,7 @@ export class PetService {
         const response: Observable<HttpResponse<Array<Pet>>> = this.httpClient.get(`${this.basePath}/pet/findByTags?${queryParameters.join('&')}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <Array<Pet>>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <Array<Pet>>(httpResponse.response))
                );
         }
         return response;
@@ -203,7 +203,7 @@ export class PetService {
         const response: Observable<HttpResponse<Pet>> = this.httpClient.get(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <Pet>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <Pet>(httpResponse.response))
                );
         }
         return response;
@@ -236,7 +236,7 @@ export class PetService {
         const response: Observable<HttpResponse<any>> = this.httpClient.put(`${this.basePath}/pet`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -279,7 +279,7 @@ export class PetService {
         const response: Observable<HttpResponse<any>> = this.httpClient.post(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`, body, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -322,7 +322,7 @@ export class PetService {
         const response: Observable<HttpResponse<ApiResponse>> = this.httpClient.post(`${this.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`, body, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <ApiResponse>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <ApiResponse>(httpResponse.response))
                );
         }
         return response;

--- a/samples/client/petstore/typescript-inversify/api/store.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/store.service.ts
@@ -13,7 +13,7 @@
 
 import { Observable } from "rxjs/Observable";
 
-import { map } from "rxjs/operators";
+import { GlobalImportOperators } from "rxjs/operators";
 import IHttpClient from "../IHttpClient";
 import { inject, injectable } from "inversify";
 import { IAPIConfiguration } from "../IAPIConfiguration";
@@ -54,7 +54,7 @@ export class StoreService {
         const response: Observable<HttpResponse<any>> = this.httpClient.delete(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -78,7 +78,7 @@ export class StoreService {
         const response: Observable<HttpResponse<{ [key: string]: number; }>> = this.httpClient.get(`${this.basePath}/store/inventory`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <{ [key: string]: number; }>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <{ [key: string]: number; }>(httpResponse.response))
                );
         }
         return response;
@@ -103,7 +103,7 @@ export class StoreService {
         const response: Observable<HttpResponse<Order>> = this.httpClient.get(`${this.basePath}/store/order/${encodeURIComponent(String(orderId))}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <Order>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <Order>(httpResponse.response))
                );
         }
         return response;
@@ -129,7 +129,7 @@ export class StoreService {
         const response: Observable<HttpResponse<Order>> = this.httpClient.post(`${this.basePath}/store/order`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <Order>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <Order>(httpResponse.response))
                );
         }
         return response;

--- a/samples/client/petstore/typescript-inversify/api/user.service.ts
+++ b/samples/client/petstore/typescript-inversify/api/user.service.ts
@@ -13,7 +13,7 @@
 
 import { Observable } from "rxjs/Observable";
 
-import { map } from "rxjs/operators";
+import { GlobalImportOperators } from "rxjs/operators";
 import IHttpClient from "../IHttpClient";
 import { inject, injectable } from "inversify";
 import { IAPIConfiguration } from "../IAPIConfiguration";
@@ -55,7 +55,7 @@ export class UserService {
         const response: Observable<HttpResponse<any>> = this.httpClient.post(`${this.basePath}/user`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -81,7 +81,7 @@ export class UserService {
         const response: Observable<HttpResponse<any>> = this.httpClient.post(`${this.basePath}/user/createWithArray`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -107,7 +107,7 @@ export class UserService {
         const response: Observable<HttpResponse<any>> = this.httpClient.post(`${this.basePath}/user/createWithList`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -132,7 +132,7 @@ export class UserService {
         const response: Observable<HttpResponse<any>> = this.httpClient.delete(`${this.basePath}/user/${encodeURIComponent(String(username))}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -157,7 +157,7 @@ export class UserService {
         const response: Observable<HttpResponse<User>> = this.httpClient.get(`${this.basePath}/user/${encodeURIComponent(String(username))}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <User>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <User>(httpResponse.response))
                );
         }
         return response;
@@ -195,7 +195,7 @@ export class UserService {
         const response: Observable<HttpResponse<string>> = this.httpClient.get(`${this.basePath}/user/login?${queryParameters.join('&')}`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <string>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <string>(httpResponse.response))
                );
         }
         return response;
@@ -215,7 +215,7 @@ export class UserService {
         const response: Observable<HttpResponse<any>> = this.httpClient.get(`${this.basePath}/user/logout`, headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;
@@ -246,7 +246,7 @@ export class UserService {
         const response: Observable<HttpResponse<any>> = this.httpClient.put(`${this.basePath}/user/${encodeURIComponent(String(username))}`, body , headers);
         if (observe == 'body') {
                return response.pipe(
-                   map(httpResponse => <any>(httpResponse.response))
+                   GlobalImportOperators(httpResponse => <any>(httpResponse.response))
                );
         }
         return response;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Rename map to GlobalImportOperators so that `map` doesn't need to be a reserved word.

cc @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)


