### PR TITLE
[Typescript Angular] Set ResponseType for HttpClient Call

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -1,24 +1,24 @@
 {{>licenseInfo}}
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 {{#useHttpClient}}
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 {{/useHttpClient}}
 {{^useHttpClient}}
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 {{/useHttpClient}}
 
 {{^useRxJS6}}
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 {{/useRxJS6}}
 {{^useHttpClient}}
 import '../rxjs-operators';
@@ -28,10 +28,10 @@ import '../rxjs-operators';
 import { {{classname}} } from '../{{filename}}';
 {{/imports}}
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 {{#withInterfaces}}
-import { {{classname}}Interface }                            from './{{classFilename}}Interface';
+import { {{classname}}Interface } from './{{classFilename}}Interface';
 {{/withInterfaces}}
 
 {{#operations}}
@@ -319,21 +319,24 @@ export class {{classname}} {
 
 {{/hasFormParams}}
 {{#useHttpClient}}
+        const httpOptions: Object = {
+            {{#hasQueryParams}}
+            params: queryParameters,
+            {{/hasQueryParams}}
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            {{^isResponseFile}}
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+            {{/isResponseFile}}
+            {{#isResponseFile}}
+            responseType: 'blob',
+            {{/isResponseFile}}
+        };
+
         return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.configuration.basePath}{{{path}}}`,{{#isBodyAllowed}}
-            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
-            {
-{{#hasQueryParams}}
-                params: queryParameters,
-{{/hasQueryParams}}
-{{#isResponseFile}}
-                responseType: "blob",
-{{/isResponseFile}}
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}} httpOptions);
 {{/useHttpClient}}
 {{^useHttpClient}}
         let requestOptions: RequestOptionsArgs = new RequestOptions({

--- a/modules/openapi-generator/src/main/resources/typescript-angular/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/apiInterface.mustache
@@ -1,16 +1,16 @@
 {{>licenseInfo}}
 {{#useHttpClient}}
-import { HttpHeaders }                                       from '@angular/common/http';
+import { HttpHeaders } from '@angular/common/http';
 {{/useHttpClient}}
 {{^useHttpClient}}
-import { Headers }                                           from '@angular/http';
+import { Headers } from '@angular/http';
 {{/useHttpClient}}
 
 {{^useRxJS6}}
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 {{/useRxJS6}}
 {{#useRxJS6}}
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 {{/useRxJS6}}
 
 {{#imports}}
@@ -18,7 +18,7 @@ import { {{classname}} } from '../{{filename}}';
 {{/imports}}
 
 
-import { Configuration }                                     from '../configuration';
+import { Configuration } from '../configuration';
 
 {{#operations}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -11,20 +11,20 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -11,19 +11,19 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -11,19 +11,19 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -11,20 +11,20 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -11,19 +11,19 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -11,19 +11,19 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -11,21 +11,21 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
-import { PetServiceInterface }                            from './pet.serviceInterface';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
+import { PetServiceInterface } from './pet.serviceInterface';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.serviceInterface.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.serviceInterface.ts
@@ -9,15 +9,15 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { Headers }                                           from '@angular/http';
+import { Headers } from '@angular/http';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
 
-import { Configuration }                                     from '../configuration';
+import { Configuration } from '../configuration';
 
 
 export interface PetServiceInterface {

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -11,20 +11,20 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
-import { StoreServiceInterface }                            from './store.serviceInterface';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
+import { StoreServiceInterface } from './store.serviceInterface';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.serviceInterface.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.serviceInterface.ts
@@ -9,14 +9,14 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { Headers }                                           from '@angular/http';
+import { Headers } from '@angular/http';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
 import { Order } from '../model/order';
 
 
-import { Configuration }                                     from '../configuration';
+import { Configuration } from '../configuration';
 
 
 export interface StoreServiceInterface {

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -11,20 +11,20 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
-import { UserServiceInterface }                            from './user.serviceInterface';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
+import { UserServiceInterface } from './user.serviceInterface';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.serviceInterface.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.serviceInterface.ts
@@ -9,14 +9,14 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import { Headers }                                           from '@angular/http';
+import { Headers } from '@angular/http';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
 import { User } from '../model/user';
 
 
-import { Configuration }                                     from '../configuration';
+import { Configuration } from '../configuration';
 
 
 export interface UserServiceInterface {

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -101,15 +101,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -153,14 +154,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -207,15 +209,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -262,15 +265,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -309,14 +313,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -362,15 +367,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -431,15 +437,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -504,15 +511,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -86,14 +86,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -127,14 +128,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -168,14 +170,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -213,15 +216,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -90,15 +90,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -134,15 +135,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -178,15 +180,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -218,14 +221,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -259,14 +263,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -312,15 +317,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -348,14 +354,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -395,15 +402,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -11,20 +11,20 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
@@ -11,19 +11,19 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
@@ -11,19 +11,19 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { Http, Headers, URLSearchParams } from '@angular/http';
 import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
-import { CustomQueryEncoderHelper }                          from '../encoder';
+import { Response, ResponseContentType } from '@angular/http';
+import { CustomQueryEncoderHelper } from '../encoder';
 
-import { Observable }                                        from 'rxjs/Observable';
+import { Observable } from 'rxjs/Observable';
 import '../rxjs-operators';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()

--- a/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -101,15 +101,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -153,14 +154,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -207,15 +209,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -262,15 +265,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -309,14 +313,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -362,15 +367,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -431,15 +437,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -504,15 +511,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -86,14 +86,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -127,14 +128,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -168,14 +170,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -213,15 +216,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -90,15 +90,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -134,15 +135,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -178,15 +180,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -218,14 +221,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -259,14 +263,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -312,15 +317,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -348,14 +354,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -395,15 +402,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -101,15 +101,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -153,14 +154,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -207,15 +209,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -262,15 +265,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -309,14 +313,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -362,15 +367,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -431,15 +437,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -504,15 +511,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -86,14 +86,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -127,14 +128,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -168,14 +170,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -213,15 +216,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -90,15 +90,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -134,15 +135,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -178,15 +180,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -218,14 +221,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -259,14 +263,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -312,15 +317,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -348,14 +354,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -395,15 +402,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -103,15 +103,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -155,14 +156,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -209,15 +211,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -264,15 +267,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -311,14 +315,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -364,15 +369,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -433,15 +439,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -506,15 +513,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -88,14 +88,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -129,14 +130,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -170,14 +172,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -215,15 +218,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -92,15 +92,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -136,15 +137,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -180,15 +182,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -220,14 +223,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -261,14 +265,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -314,15 +319,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -350,14 +356,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -397,15 +404,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -103,15 +103,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -155,14 +156,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -209,15 +211,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -264,15 +267,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -311,14 +315,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -364,15 +369,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -433,15 +439,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -506,15 +513,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -88,14 +88,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -129,14 +130,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -170,14 +172,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -215,15 +218,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -92,15 +92,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -136,15 +137,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -180,15 +182,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -220,14 +223,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -261,14 +265,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -314,15 +319,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -350,14 +356,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -397,15 +404,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -101,15 +101,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -153,14 +154,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -207,15 +209,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -262,15 +265,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -309,14 +313,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -362,15 +367,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -431,15 +437,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -504,15 +511,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -86,14 +86,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -127,14 +128,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -168,14 +170,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -213,15 +216,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -90,15 +90,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -134,15 +135,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -178,15 +180,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -218,14 +221,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -259,14 +263,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -312,15 +317,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -348,14 +354,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -395,15 +402,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -101,15 +101,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -153,14 +154,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -207,15 +209,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -262,15 +265,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -309,14 +313,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -362,15 +367,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -431,15 +437,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -504,15 +511,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -86,14 +86,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -127,14 +128,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -168,14 +170,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -213,15 +216,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable()
@@ -90,15 +90,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -134,15 +135,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -178,15 +180,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -218,14 +221,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -259,14 +263,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -312,15 +317,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -348,14 +354,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -395,15 +402,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -103,15 +103,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -155,14 +156,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -209,15 +211,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -264,15 +267,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -311,14 +315,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -364,15 +369,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -433,15 +439,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -506,15 +513,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -88,14 +88,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -129,14 +130,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -170,14 +172,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -215,15 +218,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -92,15 +92,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -136,15 +137,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -180,15 +182,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -220,14 +223,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -261,14 +265,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -314,15 +319,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -350,14 +356,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -397,15 +404,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -11,18 +11,18 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
 import { Pet } from '../model/pet';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -103,15 +103,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -155,14 +156,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -209,15 +211,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`, httpOptions);
     }
 
     /**
@@ -264,15 +267,16 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`, httpOptions);
     }
 
     /**
@@ -311,14 +315,15 @@ export class PetService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`, httpOptions);
     }
 
     /**
@@ -364,15 +369,16 @@ export class PetService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/pet`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -433,15 +439,16 @@ export class PetService {
             formParams = formParams.append('status', <any>status) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
     /**
@@ -506,15 +513,16 @@ export class PetService {
             formParams = formParams.append('file', <any>file) as any || formParams;
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<ApiResponse>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            convertFormParamsToString ? formParams.toString() : formParams, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { Order } from '../model/order';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -88,14 +88,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -129,14 +130,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`, httpOptions);
     }
 
     /**
@@ -170,14 +172,15 @@ export class StoreService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`, httpOptions);
     }
 
     /**
@@ -215,15 +218,16 @@ export class StoreService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<Order>(`${this.configuration.basePath}/store/order`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -11,17 +11,17 @@
  */
 /* tslint:disable:no-unused-variable member-ordering */
 
-import { Inject, Injectable, Optional }                      from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+         HttpResponse, HttpEvent } from '@angular/common/http';
+import { CustomHttpUrlEncodingCodec } from '../encoder';
 
-import { Observable }                                        from 'rxjs';
+import { Observable } from 'rxjs';
 
 import { User } from '../model/user';
 
-import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
-import { Configuration }                                     from '../configuration';
+import { BASE_PATH, COLLECTION_FORMATS } from '../variables';
+import { Configuration } from '../configuration';
 
 
 @Injectable({
@@ -92,15 +92,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -136,15 +137,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithArray`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -180,15 +182,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.post<any>(`${this.configuration.basePath}/user/createWithList`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
     /**
@@ -220,14 +223,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -261,14 +265,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`, httpOptions);
     }
 
     /**
@@ -314,15 +319,16 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
-            {
-                params: queryParameters,
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            params: queryParameters,
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`, httpOptions);
     }
 
     /**
@@ -350,14 +356,15 @@ export class UserService {
         const consumes: string[] = [
         ];
 
-        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
+        return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`, httpOptions);
     }
 
     /**
@@ -397,15 +404,16 @@ export class UserService {
             headers = headers.set('Content-Type', httpContentTypeSelected);
         }
 
+        const httpOptions: Object = {
+            withCredentials: this.configuration.withCredentials,
+            headers: headers,
+            observe: observe,
+            reportProgress: reportProgress,
+            responseType: this.configuration.selectResponseType(httpHeaderAcceptSelected)
+        };
+
         return this.httpClient.put<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
-            body,
-            {
-                withCredentials: this.configuration.withCredentials,
-                headers: headers,
-                observe: observe,
-                reportProgress: reportProgress
-            }
-        );
+            body, httpOptions);
     }
 
 }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/configuration.ts
@@ -63,6 +63,23 @@ export class Configuration {
     }
 
     /**
+    * Select the response type to use for httpclient library.
+    * Uses {@link Configuration#isJsonMime} to determine the correct accept content-type.
+    * If no content type is found set to json as default
+    * @param accept - the content types set as accepted in the request.
+    * @returns the selected content-type.
+    */
+    public selectResponseType(accept: string): 'arraybuffer' | 'blob' | 'json' | 'text' {
+        if (this.isTextMime(accept)) {
+            return 'text';
+        }
+        if (this.isBinaryMime(accept)) {
+            return 'blob';
+        }
+        return 'json';
+    }
+
+    /**
      * Check if the given MIME is a JSON MIME.
      * JSON MIME examples:
      *   application/json
@@ -75,5 +92,28 @@ export class Configuration {
     public isJsonMime(mime: string): boolean {
         const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
         return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+    }
+
+    /**
+    * Check if the given MIME is a text MIME.
+    * text MIME examples:
+    *   text/plain
+    *   text/html
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is text, false otherwise.
+    */
+    public isTextMime(mime: string): boolean {
+        return mime.toLowerCase().startsWith('text/');
+    }
+
+    /**
+    * Check if the given MIME is a binary MIME.
+    * binary MIME examples:
+    *   application/octet-stream
+    * @param mime - MIME (Multipurpose Internet Mail Extensions)
+    * @return True if the given MIME is binary, false otherwise.
+    */
+    public isBinaryMime(mime: string): boolean {
+        return mime.toLowerCase() === 'application/octet-stream';
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)


### Description of the PR

- fix #2035 :
fit HttpClient response type depend of the accept response send in the request  : 
default => json
application/octet-stream => blob
text/* => text
- minor whitespace indentation removing
