### PR TITLE
Ruby client: escape path parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -3,6 +3,7 @@
 =end
 
 require 'uri'
+require 'cgi'
 
 module {{moduleName}}
 {{#operations}}
@@ -123,7 +124,7 @@ module {{moduleName}}
       {{/hasValidation}}
       {{/allParams}}
       # resource path
-      local_var_path = '{{{path}}}'{{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
+      local_var_path = '{{{path}}}'{{#pathParams}}.sub('{' + '{{baseName}}' + '}', CGI.escape({{paramName}}.to_s)){{/pathParams}}
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class AnotherFakeApi

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class FakeApi

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class FakeClassnameTags123Api

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class PetApi
@@ -103,7 +104,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.delete_pet"
       end
       # resource path
-      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -290,7 +291,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.get_pet_by_id"
       end
       # resource path
-      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -414,7 +415,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.update_pet_with_form"
       end
       # resource path
-      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -480,7 +481,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.upload_file"
       end
       # resource path
-      local_var_path = '/pet/{petId}/uploadImage'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}/uploadImage'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -552,7 +553,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'required_file' when calling PetApi.upload_file_with_required_file"
       end
       # resource path
-      local_var_path = '/fake/{petId}/uploadImageWithRequiredFile'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/fake/{petId}/uploadImageWithRequiredFile'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class StoreApi
@@ -43,7 +44,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.delete_order"
       end
       # resource path
-      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
+      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', CGI.escape(order_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -167,7 +168,7 @@ module Petstore
       end
 
       # resource path
-      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
+      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', CGI.escape(order_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class UserApi
@@ -219,7 +220,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.delete_user"
       end
       # resource path
-      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
+      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', CGI.escape(username.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -277,7 +278,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.get_user_by_name"
       end
       # resource path
-      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
+      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', CGI.escape(username.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -465,7 +466,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'body' when calling UserApi.update_user"
       end
       # resource path
-      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
+      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', CGI.escape(username.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class AnotherFakeApi

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class DefaultApi

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class FakeApi

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class FakeClassnameTags123Api

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class PetApi
@@ -103,7 +104,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.delete_pet"
       end
       # resource path
-      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -290,7 +291,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.get_pet_by_id"
       end
       # resource path
-      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -414,7 +415,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.update_pet_with_form"
       end
       # resource path
-      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -480,7 +481,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'pet_id' when calling PetApi.upload_file"
       end
       # resource path
-      local_var_path = '/pet/{petId}/uploadImage'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/pet/{petId}/uploadImage'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -552,7 +553,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'required_file' when calling PetApi.upload_file_with_required_file"
       end
       # resource path
-      local_var_path = '/fake/{petId}/uploadImageWithRequiredFile'.sub('{' + 'petId' + '}', pet_id.to_s)
+      local_var_path = '/fake/{petId}/uploadImageWithRequiredFile'.sub('{' + 'petId' + '}', CGI.escape(pet_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class StoreApi
@@ -43,7 +44,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'order_id' when calling StoreApi.delete_order"
       end
       # resource path
-      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
+      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', CGI.escape(order_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -167,7 +168,7 @@ module Petstore
       end
 
       # resource path
-      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', order_id.to_s)
+      local_var_path = '/store/order/{order_id}'.sub('{' + 'order_id' + '}', CGI.escape(order_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -11,6 +11,7 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 =end
 
 require 'uri'
+require 'cgi'
 
 module Petstore
   class UserApi
@@ -225,7 +226,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.delete_user"
       end
       # resource path
-      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
+      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', CGI.escape(username.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -283,7 +284,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'username' when calling UserApi.get_user_by_name"
       end
       # resource path
-      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
+      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', CGI.escape(username.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -471,7 +472,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'user' when calling UserApi.update_user"
       end
       # resource path
-      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', username.to_s)
+      local_var_path = '/user/{username}'.sub('{' + 'username' + '}', CGI.escape(username.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}


### PR DESCRIPTION
Path parameters should be escaped when encoded into the path.

In the path '/pet/{petId}' let's pretend petId is a string instead of a
number.

If the user uses "Bobby" as the petId then they correctly get the path
'/pet/Bobby'.
But if they put 'Bobby/Tables' as the petId then they used to get the
path '/pet/Bobby/Tables' which will be interpreted by the server as a
different route.

Using CGI::Escape they now get '/pet/Bobby%2FTables' which is correct.


Ruby technical committee:
@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

See top

