### PR TITLE
fixes #2830

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/api_client.mustache
@@ -44,11 +44,7 @@ class ApiClient {
           {{#model}}
         case '{{classname}}':
             {{#isEnum}}
-          // Enclose the value in a list so that Dartson can use a transformer
-          // to decode it.
-          final listValue = [value];
-          final List<dynamic> listResult = dson.map(listValue, []);
-          return listResult[0];
+              return new {{classname}}TypeTransformer().decode(value);
             {{/isEnum}}
             {{^isEnum}}
           return new {{classname}}.fromJson(value);

--- a/modules/openapi-generator/src/main/resources/dart/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/enum.mustache
@@ -1,4 +1,3 @@
-@Entity()
 class {{classname}} {
   /// The underlying value of this enum member.
   final {{dataType}} value;
@@ -15,14 +14,12 @@ class {{classname}} {
   {{/allowableValues}}
 }
 
-class {{classname}}TypeTransformer extends TypeTransformer<{{classname}}> {
+class {{classname}}TypeTransformer {
 
-  @override
   dynamic encode({{classname}} data) {
     return data.value;
   }
 
-  @override
   {{classname}} decode(dynamic data) {
     switch (data) {
       {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/model_test.mustache
@@ -5,7 +5,9 @@ import 'package:test/test.dart';
 
 // tests for {{classname}}
 void main() {
+  {{^isEnum}}
   var instance = new {{classname}}();
+  {{/isEnum}}
 
   group('test {{classname}}', () {
     {{#vars}}

--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -44,11 +44,7 @@ class ApiClient {
           {{#model}}
         case '{{classname}}':
             {{#isEnum}}
-          // Enclose the value in a list so that Dartson can use a transformer
-          // to decode it.
-          final listValue = [value];
-          final List<dynamic> listResult = dson.map(listValue, []);
-          return listResult[0];
+              return {{classname}}TypeTransformer().decode(value);
             {{/isEnum}}
             {{^isEnum}}
           return {{classname}}.fromJson(value);

--- a/modules/openapi-generator/src/main/resources/dart2/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/enum.mustache
@@ -1,4 +1,4 @@
-@Entity()
+
 class {{classname}} {
   /// The underlying value of this enum member.
   final {{dataType}} value;
@@ -15,14 +15,12 @@ class {{classname}} {
   {{/allowableValues}}
 }
 
-class {{classname}}TypeTransformer extends TypeTransformer<{{classname}}> {
+class {{classname}}TypeTransformer {
 
-  @override
   dynamic encode({{classname}} data) {
     return data.value;
   }
 
-  @override
   {{classname}} decode(dynamic data) {
     switch (data) {
       {{#allowableValues}}

--- a/modules/openapi-generator/src/main/resources/dart2/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/model_test.mustache
@@ -5,7 +5,9 @@ import 'package:test/test.dart';
 
 // tests for {{classname}}
 void main() {
-  var instance = new Pet();
+{{^isEnum}}
+  var instance = new {{classname}}();
+{{/isEnum}}
 
   group('test {{classname}}', () {
     {{#vars}}


### PR DESCRIPTION

@jaumard @swipesight @ircecho

### PR checklist

- [YES] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [YES] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [YES] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [YES] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- resolves issues around using dartson library
- resolves issue that tests are using "new Pet()" rather than
the class itself.
- does NOT resolve crazy ugly enum choices
- fixes #2830

