### PR TITLE
[Java][jersey2]: Documentation changes and making example snippet compilable

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -90,8 +90,9 @@ import java.util.*;
 public class {{{classname}}}Example {
 
     public static void main(String[] args) {
-        {{#hasAuthMethods}}ApiClient defaultClient = Configuration.getDefaultApiClient();
-        {{#authMethods}}{{#isBasic}}
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("{{{basePath}}}");
+        {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
         // Configure HTTP basic authorization: {{{name}}}
         HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setUsername("YOUR USERNAME");
@@ -107,7 +108,7 @@ public class {{{classname}}}Example {
         {{/authMethods}}
         {{/hasAuthMethods}}
 
-        {{{classname}}} apiInstance = new {{{classname}}}();
+        {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
         {{#allParams}}
         {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
         {{/allParams}}
@@ -116,6 +117,9 @@ public class {{{classname}}}Example {
             System.out.println(result);{{/returnType}}
         } catch (ApiException e) {
             System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
             e.printStackTrace();
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -84,9 +84,6 @@ import {{{invokerPackage}}}.auth.*;
 import {{{modelPackage}}}.*;
 import {{{package}}}.{{{classname}}};
 
-import java.io.File;
-import java.util.*;
-
 public class {{{classname}}}Example {
 
     public static void main(String[] args) {

--- a/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
@@ -23,41 +23,50 @@ Method | HTTP request | Description
 ### Example
 
 ```java
-// Import classes:{{#hasAuthMethods}}
-//import {{{invokerPackage}}}.ApiClient;{{/hasAuthMethods}}
-//import {{{invokerPackage}}}.ApiException;{{#hasAuthMethods}}
-//import {{{invokerPackage}}}.Configuration;
-//import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
-//import {{{package}}}.{{{classname}}};
+// Import classes:
+import {{{invokerPackage}}}.ApiClient;
+import {{{invokerPackage}}}.ApiException;
+import {{{invokerPackage}}}.Configuration;{{#hasAuthMethods}}
+import {{{invokerPackage}}}.auth.*;{{/hasAuthMethods}}
+import {{{invokerPackage}}}.models.*;
+import {{{package}}}.{{{classname}}};
 
-{{#hasAuthMethods}}
-ApiClient defaultClient = Configuration.getDefaultApiClient();
-{{#authMethods}}{{#isBasic}}
-// Configure HTTP basic authorization: {{{name}}}
-HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
-{{{name}}}.setUsername("YOUR USERNAME");
-{{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
-// Configure API key authorization: {{{name}}}
-ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
-{{{name}}}.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
-// Configure OAuth2 access token for authorization: {{{name}}}
-OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
-{{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
-{{/authMethods}}
-{{/hasAuthMethods}}
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("{{{basePath}}}");
+        {{#hasAuthMethods}}
+        {{#authMethods}}{{#isBasic}}
+        // Configure HTTP basic authorization: {{{name}}}
+        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setUsername("YOUR USERNAME");
+        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+        // Configure API key authorization: {{{name}}}
+        ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //{{{name}}}.setApiKeyPrefix("Token");{{/isApiKey}}{{#isOAuth}}
+        // Configure OAuth2 access token for authorization: {{{name}}}
+        OAuth {{{name}}} = (OAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setAccessToken("YOUR ACCESS TOKEN");{{/isOAuth}}
+        {{/authMethods}}
+        {{/hasAuthMethods}}
 
-{{{classname}}} apiInstance = new {{{classname}}}();
-{{#allParams}}
-{{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
-{{/allParams}}
-try {
-    {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
-    System.out.println(result);{{/returnType}}
-} catch (ApiException e) {
-    System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
-    e.printStackTrace();
+        {{{classname}}} apiInstance = new {{{classname}}}(defaultClient);
+        {{#allParams}}
+        {{{dataType}}} {{{paramName}}} = {{{example}}}; // {{{dataType}}} | {{{description}}}
+        {{/allParams}}
+        try {
+            {{#returnType}}{{{returnType}}} result = {{/returnType}}apiInstance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}});{{#returnType}}
+            System.out.println(result);{{/returnType}}
+        } catch (ApiException e) {
+            System.err.println("Exception when calling {{{classname}}}#{{{operationId}}}");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -81,6 +90,15 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: {{#consumes}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/consumes}}{{^consumes}}Not defined{{/consumes}}
 - **Accept**: {{#produces}}{{{mediaType}}}{{#hasMore}}, {{/hasMore}}{{/produces}}{{^produces}}Not defined{{/produces}}
+
+{{#responses.0}}
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+{{#responses}}
+**{{code}}** | {{message}} | {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} |
+{{/responses}}
+{{/responses.0}}
 
 {{/operation}}
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
@@ -96,7 +96,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 {{#responses}}
-**{{code}}** | {{message}} | {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} |
+| **{{code}}** | {{message}} | {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} |
 {{/responses}}
 {{/responses.0}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -50,6 +50,15 @@ public class {{classname}} {
    * @return {{returnType}}
    {{/returnType}}
    * @throws ApiException if fails to make API call
+   {{#responses.0}}
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+   {{/responses.0}}
    {{#isDeprecated}}
    * @deprecated
    {{/isDeprecated}}
@@ -79,6 +88,15 @@ public class {{classname}} {
    * @return ApiResponse&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
    {{/returnType}}
    * @throws ApiException if fails to make API call
+   {{#responses.0}}
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        {{#responses}}
+        <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+        {{/responses}}
+     </table>
+   {{/responses.0}}
    {{#isDeprecated}}
    * @deprecated
    {{/isDeprecated}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -170,6 +170,15 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <tags>
+                                <tag>
+                                    <name>http.response.details</name>
+                                    <placement>a</placement>
+                                    <head>Http Response Details:</head>
+                                </tag>
+                 	        </tags>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/samples/client/petstore/java/google-api-client/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/google-api-client/docs/FakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/google-api-client/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/google-api-client/docs/PetApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/google-api-client/docs/StoreApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/google-api-client/docs/UserApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/jersey1/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey1/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey1/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey1/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey1/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey1/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/jersey1/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey1/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -151,6 +151,15 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <tags>
+                                <tag>
+                                    <name>http.response.details</name>
+                                    <placement>a</placement>
+                                    <head>Http Response Details:</head>
+                                </tag>
+                 	        </tags>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -41,6 +41,11 @@ public class AnotherFakeApi {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client call123testSpecialTags(Client body) throws ApiException {
     return call123testSpecialTagsWithHttpInfo(body).getData();
@@ -52,6 +57,11 @@ public class AnotherFakeApi {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -48,6 +48,11 @@ public class FakeApi {
    * this route creates an XmlItem
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createXmlItem(XmlItem xmlItem) throws ApiException {
 
@@ -59,6 +64,11 @@ public class FakeApi {
    * this route creates an XmlItem
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
     Object localVarPostBody = xmlItem;
@@ -100,6 +110,11 @@ public class FakeApi {
    * @param body Input boolean as post body (optional)
    * @return Boolean
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
+     </table>
    */
   public Boolean fakeOuterBooleanSerialize(Boolean body) throws ApiException {
     return fakeOuterBooleanSerializeWithHttpInfo(body).getData();
@@ -111,6 +126,11 @@ public class FakeApi {
    * @param body Input boolean as post body (optional)
    * @return ApiResponse&lt;Boolean&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
     Object localVarPostBody = body;
@@ -147,6 +167,11 @@ public class FakeApi {
    * @param body Input composite as post body (optional)
    * @return OuterComposite
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
+     </table>
    */
   public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws ApiException {
     return fakeOuterCompositeSerializeWithHttpInfo(body).getData();
@@ -158,6 +183,11 @@ public class FakeApi {
    * @param body Input composite as post body (optional)
    * @return ApiResponse&lt;OuterComposite&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
     Object localVarPostBody = body;
@@ -194,6 +224,11 @@ public class FakeApi {
    * @param body Input number as post body (optional)
    * @return BigDecimal
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
+     </table>
    */
   public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws ApiException {
     return fakeOuterNumberSerializeWithHttpInfo(body).getData();
@@ -205,6 +240,11 @@ public class FakeApi {
    * @param body Input number as post body (optional)
    * @return ApiResponse&lt;BigDecimal&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
     Object localVarPostBody = body;
@@ -241,6 +281,11 @@ public class FakeApi {
    * @param body Input string as post body (optional)
    * @return String
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
+     </table>
    */
   public String fakeOuterStringSerialize(String body) throws ApiException {
     return fakeOuterStringSerializeWithHttpInfo(body).getData();
@@ -252,6 +297,11 @@ public class FakeApi {
    * @param body Input string as post body (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
     Object localVarPostBody = body;
@@ -287,6 +337,11 @@ public class FakeApi {
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public void testBodyWithFileSchema(FileSchemaTestClass body) throws ApiException {
 
@@ -298,6 +353,11 @@ public class FakeApi {
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
     Object localVarPostBody = body;
@@ -339,6 +399,11 @@ public class FakeApi {
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public void testBodyWithQueryParams(String query, User body) throws ApiException {
 
@@ -351,6 +416,11 @@ public class FakeApi {
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
     Object localVarPostBody = body;
@@ -398,6 +468,11 @@ public class FakeApi {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client testClientModel(Client body) throws ApiException {
     return testClientModelWithHttpInfo(body).getData();
@@ -409,6 +484,11 @@ public class FakeApi {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;
@@ -462,6 +542,12 @@ public class FakeApi {
    * @param password None (optional)
    * @param paramCallback None (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
 
@@ -486,6 +572,12 @@ public class FakeApi {
    * @param password None (optional)
    * @param paramCallback None (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
     Object localVarPostBody = new Object();
@@ -576,6 +668,12 @@ if (paramCallback != null)
    * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
    * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid request </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
+     </table>
    */
   public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
 
@@ -594,6 +692,12 @@ if (paramCallback != null)
    * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
    * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid request </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
     Object localVarPostBody = new Object();
@@ -646,6 +750,11 @@ if (enumFormString != null)
    * @param booleanGroup Boolean in group parameters (optional)
    * @param int64Group Integer in group parameters (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Someting wrong </td><td>  -  </td></tr>
+     </table>
    */
   public void testGroupParameters(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
 
@@ -662,6 +771,11 @@ if (enumFormString != null)
    * @param booleanGroup Boolean in group parameters (optional)
    * @param int64Group Integer in group parameters (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Someting wrong </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
     Object localVarPostBody = new Object();
@@ -720,6 +834,11 @@ if (booleanGroup != null)
    * 
    * @param param request body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void testInlineAdditionalProperties(Map<String, String> param) throws ApiException {
 
@@ -731,6 +850,11 @@ if (booleanGroup != null)
    * 
    * @param param request body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
     Object localVarPostBody = param;
@@ -772,6 +896,11 @@ if (booleanGroup != null)
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void testJsonFormData(String param, String param2) throws ApiException {
 
@@ -784,6 +913,11 @@ if (booleanGroup != null)
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
     Object localVarPostBody = new Object();

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -41,6 +41,11 @@ public class FakeClassnameTags123Api {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client testClassname(Client body) throws ApiException {
     return testClassnameWithHttpInfo(body).getData();
@@ -52,6 +57,11 @@ public class FakeClassnameTags123Api {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/PetApi.java
@@ -42,6 +42,12 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public void addPet(Pet body) throws ApiException {
 
@@ -53,6 +59,12 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
     Object localVarPostBody = body;
@@ -94,6 +106,12 @@ public class PetApi {
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
+     </table>
    */
   public void deletePet(Long petId, String apiKey) throws ApiException {
 
@@ -106,6 +124,12 @@ public class PetApi {
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
     Object localVarPostBody = new Object();
@@ -150,6 +174,12 @@ public class PetApi {
    * @param status Status values that need to be considered for filter (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
+     </table>
    */
   public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
     return findPetsByStatusWithHttpInfo(status).getData();
@@ -161,6 +191,12 @@ public class PetApi {
    * @param status Status values that need to be considered for filter (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
     Object localVarPostBody = new Object();
@@ -203,6 +239,12 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid tag value </td><td>  -  </td></tr>
+     </table>
    * @deprecated
    */
   @Deprecated
@@ -216,6 +258,12 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid tag value </td><td>  -  </td></tr>
+     </table>
    * @deprecated
    */
   @Deprecated
@@ -260,6 +308,13 @@ public class PetApi {
    * @param petId ID of pet to return (required)
    * @return Pet
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+     </table>
    */
   public Pet getPetById(Long petId) throws ApiException {
     return getPetByIdWithHttpInfo(petId).getData();
@@ -271,6 +326,13 @@ public class PetApi {
    * @param petId ID of pet to return (required)
    * @return ApiResponse&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -312,6 +374,14 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
+     </table>
    */
   public void updatePet(Pet body) throws ApiException {
 
@@ -323,6 +393,14 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
     Object localVarPostBody = body;
@@ -365,6 +443,11 @@ public class PetApi {
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public void updatePetWithForm(Long petId, String name, String status) throws ApiException {
 
@@ -378,6 +461,11 @@ public class PetApi {
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
     Object localVarPostBody = new Object();
@@ -426,6 +514,11 @@ if (status != null)
    * @param file file to upload (optional)
    * @return ModelApiResponse
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
     return uploadFileWithHttpInfo(petId, additionalMetadata, file).getData();
@@ -439,6 +532,11 @@ if (status != null)
    * @param file file to upload (optional)
    * @return ApiResponse&lt;ModelApiResponse&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
     Object localVarPostBody = new Object();
@@ -487,6 +585,11 @@ if (file != null)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @return ModelApiResponse
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
     return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata).getData();
@@ -500,6 +603,11 @@ if (file != null)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @return ApiResponse&lt;ModelApiResponse&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
     Object localVarPostBody = new Object();

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -40,6 +40,12 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public void deleteOrder(String orderId) throws ApiException {
 
@@ -51,6 +57,12 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -92,6 +104,11 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @return Map&lt;String, Integer&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Map<String, Integer> getInventory() throws ApiException {
     return getInventoryWithHttpInfo().getData();
@@ -102,6 +119,11 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
     Object localVarPostBody = new Object();
@@ -138,6 +160,13 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched (required)
    * @return Order
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public Order getOrderById(Long orderId) throws ApiException {
     return getOrderByIdWithHttpInfo(orderId).getData();
@@ -149,6 +178,13 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -191,6 +227,12 @@ public class StoreApi {
    * @param body order placed for purchasing the pet (required)
    * @return Order
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
+     </table>
    */
   public Order placeOrder(Order body) throws ApiException {
     return placeOrderWithHttpInfo(body).getData();
@@ -202,6 +244,12 @@ public class StoreApi {
    * @param body order placed for purchasing the pet (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/UserApi.java
@@ -40,6 +40,11 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUser(User body) throws ApiException {
 
@@ -51,6 +56,11 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
     Object localVarPostBody = body;
@@ -91,6 +101,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUsersWithArrayInput(List<User> body) throws ApiException {
 
@@ -102,6 +117,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
     Object localVarPostBody = body;
@@ -142,6 +162,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUsersWithListInput(List<User> body) throws ApiException {
 
@@ -153,6 +178,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
     Object localVarPostBody = body;
@@ -193,6 +223,12 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void deleteUser(String username) throws ApiException {
 
@@ -204,6 +240,12 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
     Object localVarPostBody = new Object();
@@ -246,6 +288,13 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return User
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public User getUserByName(String username) throws ApiException {
     return getUserByNameWithHttpInfo(username).getData();
@@ -257,6 +306,13 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return ApiResponse&lt;User&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
     Object localVarPostBody = new Object();
@@ -300,6 +356,12 @@ public class UserApi {
    * @param password The password for login in clear text (required)
    * @return String
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  </td></tr>
+        <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
+     </table>
    */
   public String loginUser(String username, String password) throws ApiException {
     return loginUserWithHttpInfo(username, password).getData();
@@ -312,6 +374,12 @@ public class UserApi {
    * @param password The password for login in clear text (required)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  </td></tr>
+        <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
     Object localVarPostBody = new Object();
@@ -358,6 +426,11 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void logoutUser() throws ApiException {
 
@@ -368,6 +441,11 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
     Object localVarPostBody = new Object();
@@ -404,6 +482,12 @@ public class UserApi {
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid user supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void updateUser(String username, User body) throws ApiException {
 
@@ -416,6 +500,12 @@ public class UserApi {
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid user supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java8/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -151,6 +151,15 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <tags>
+                                <tag>
+                                    <name>http.response.details</name>
+                                    <placement>a</placement>
+                                    <head>Http Response Details:</head>
+                                </tag>
+                 	        </tags>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -41,6 +41,11 @@ public class AnotherFakeApi {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client call123testSpecialTags(Client body) throws ApiException {
     return call123testSpecialTagsWithHttpInfo(body).getData();
@@ -52,6 +57,11 @@ public class AnotherFakeApi {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -48,6 +48,11 @@ public class FakeApi {
    * this route creates an XmlItem
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createXmlItem(XmlItem xmlItem) throws ApiException {
 
@@ -59,6 +64,11 @@ public class FakeApi {
    * this route creates an XmlItem
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
     Object localVarPostBody = xmlItem;
@@ -100,6 +110,11 @@ public class FakeApi {
    * @param body Input boolean as post body (optional)
    * @return Boolean
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
+     </table>
    */
   public Boolean fakeOuterBooleanSerialize(Boolean body) throws ApiException {
     return fakeOuterBooleanSerializeWithHttpInfo(body).getData();
@@ -111,6 +126,11 @@ public class FakeApi {
    * @param body Input boolean as post body (optional)
    * @return ApiResponse&lt;Boolean&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
     Object localVarPostBody = body;
@@ -147,6 +167,11 @@ public class FakeApi {
    * @param body Input composite as post body (optional)
    * @return OuterComposite
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
+     </table>
    */
   public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws ApiException {
     return fakeOuterCompositeSerializeWithHttpInfo(body).getData();
@@ -158,6 +183,11 @@ public class FakeApi {
    * @param body Input composite as post body (optional)
    * @return ApiResponse&lt;OuterComposite&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
     Object localVarPostBody = body;
@@ -194,6 +224,11 @@ public class FakeApi {
    * @param body Input number as post body (optional)
    * @return BigDecimal
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
+     </table>
    */
   public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws ApiException {
     return fakeOuterNumberSerializeWithHttpInfo(body).getData();
@@ -205,6 +240,11 @@ public class FakeApi {
    * @param body Input number as post body (optional)
    * @return ApiResponse&lt;BigDecimal&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
     Object localVarPostBody = body;
@@ -241,6 +281,11 @@ public class FakeApi {
    * @param body Input string as post body (optional)
    * @return String
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
+     </table>
    */
   public String fakeOuterStringSerialize(String body) throws ApiException {
     return fakeOuterStringSerializeWithHttpInfo(body).getData();
@@ -252,6 +297,11 @@ public class FakeApi {
    * @param body Input string as post body (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
     Object localVarPostBody = body;
@@ -287,6 +337,11 @@ public class FakeApi {
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public void testBodyWithFileSchema(FileSchemaTestClass body) throws ApiException {
 
@@ -298,6 +353,11 @@ public class FakeApi {
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
     Object localVarPostBody = body;
@@ -339,6 +399,11 @@ public class FakeApi {
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public void testBodyWithQueryParams(String query, User body) throws ApiException {
 
@@ -351,6 +416,11 @@ public class FakeApi {
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
     Object localVarPostBody = body;
@@ -398,6 +468,11 @@ public class FakeApi {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client testClientModel(Client body) throws ApiException {
     return testClientModelWithHttpInfo(body).getData();
@@ -409,6 +484,11 @@ public class FakeApi {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;
@@ -462,6 +542,12 @@ public class FakeApi {
    * @param password None (optional)
    * @param paramCallback None (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
 
@@ -486,6 +572,12 @@ public class FakeApi {
    * @param password None (optional)
    * @param paramCallback None (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
     Object localVarPostBody = new Object();
@@ -576,6 +668,12 @@ if (paramCallback != null)
    * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
    * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid request </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
+     </table>
    */
   public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
 
@@ -594,6 +692,12 @@ if (paramCallback != null)
    * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
    * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid request </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
     Object localVarPostBody = new Object();
@@ -646,6 +750,11 @@ if (enumFormString != null)
    * @param booleanGroup Boolean in group parameters (optional)
    * @param int64Group Integer in group parameters (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Someting wrong </td><td>  -  </td></tr>
+     </table>
    */
   public void testGroupParameters(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
 
@@ -662,6 +771,11 @@ if (enumFormString != null)
    * @param booleanGroup Boolean in group parameters (optional)
    * @param int64Group Integer in group parameters (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Someting wrong </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
     Object localVarPostBody = new Object();
@@ -720,6 +834,11 @@ if (booleanGroup != null)
    * 
    * @param param request body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void testInlineAdditionalProperties(Map<String, String> param) throws ApiException {
 
@@ -731,6 +850,11 @@ if (booleanGroup != null)
    * 
    * @param param request body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
     Object localVarPostBody = param;
@@ -772,6 +896,11 @@ if (booleanGroup != null)
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void testJsonFormData(String param, String param2) throws ApiException {
 
@@ -784,6 +913,11 @@ if (booleanGroup != null)
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
     Object localVarPostBody = new Object();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -41,6 +41,11 @@ public class FakeClassnameTags123Api {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client testClassname(Client body) throws ApiException {
     return testClassnameWithHttpInfo(body).getData();
@@ -52,6 +57,11 @@ public class FakeClassnameTags123Api {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/PetApi.java
@@ -42,6 +42,12 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public void addPet(Pet body) throws ApiException {
 
@@ -53,6 +59,12 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
     Object localVarPostBody = body;
@@ -94,6 +106,12 @@ public class PetApi {
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
+     </table>
    */
   public void deletePet(Long petId, String apiKey) throws ApiException {
 
@@ -106,6 +124,12 @@ public class PetApi {
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
     Object localVarPostBody = new Object();
@@ -150,6 +174,12 @@ public class PetApi {
    * @param status Status values that need to be considered for filter (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
+     </table>
    */
   public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
     return findPetsByStatusWithHttpInfo(status).getData();
@@ -161,6 +191,12 @@ public class PetApi {
    * @param status Status values that need to be considered for filter (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
     Object localVarPostBody = new Object();
@@ -203,6 +239,12 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid tag value </td><td>  -  </td></tr>
+     </table>
    * @deprecated
    */
   @Deprecated
@@ -216,6 +258,12 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid tag value </td><td>  -  </td></tr>
+     </table>
    * @deprecated
    */
   @Deprecated
@@ -260,6 +308,13 @@ public class PetApi {
    * @param petId ID of pet to return (required)
    * @return Pet
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+     </table>
    */
   public Pet getPetById(Long petId) throws ApiException {
     return getPetByIdWithHttpInfo(petId).getData();
@@ -271,6 +326,13 @@ public class PetApi {
    * @param petId ID of pet to return (required)
    * @return ApiResponse&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -312,6 +374,14 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
+     </table>
    */
   public void updatePet(Pet body) throws ApiException {
 
@@ -323,6 +393,14 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
     Object localVarPostBody = body;
@@ -365,6 +443,11 @@ public class PetApi {
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public void updatePetWithForm(Long petId, String name, String status) throws ApiException {
 
@@ -378,6 +461,11 @@ public class PetApi {
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
     Object localVarPostBody = new Object();
@@ -426,6 +514,11 @@ if (status != null)
    * @param file file to upload (optional)
    * @return ModelApiResponse
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
     return uploadFileWithHttpInfo(petId, additionalMetadata, file).getData();
@@ -439,6 +532,11 @@ if (status != null)
    * @param file file to upload (optional)
    * @return ApiResponse&lt;ModelApiResponse&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
     Object localVarPostBody = new Object();
@@ -487,6 +585,11 @@ if (file != null)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @return ModelApiResponse
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
     return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata).getData();
@@ -500,6 +603,11 @@ if (file != null)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @return ApiResponse&lt;ModelApiResponse&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
     Object localVarPostBody = new Object();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -40,6 +40,12 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public void deleteOrder(String orderId) throws ApiException {
 
@@ -51,6 +57,12 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -92,6 +104,11 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @return Map&lt;String, Integer&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Map<String, Integer> getInventory() throws ApiException {
     return getInventoryWithHttpInfo().getData();
@@ -102,6 +119,11 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
     Object localVarPostBody = new Object();
@@ -138,6 +160,13 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched (required)
    * @return Order
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public Order getOrderById(Long orderId) throws ApiException {
     return getOrderByIdWithHttpInfo(orderId).getData();
@@ -149,6 +178,13 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -191,6 +227,12 @@ public class StoreApi {
    * @param body order placed for purchasing the pet (required)
    * @return Order
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
+     </table>
    */
   public Order placeOrder(Order body) throws ApiException {
     return placeOrderWithHttpInfo(body).getData();
@@ -202,6 +244,12 @@ public class StoreApi {
    * @param body order placed for purchasing the pet (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/UserApi.java
@@ -40,6 +40,11 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUser(User body) throws ApiException {
 
@@ -51,6 +56,11 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
     Object localVarPostBody = body;
@@ -91,6 +101,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUsersWithArrayInput(List<User> body) throws ApiException {
 
@@ -102,6 +117,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
     Object localVarPostBody = body;
@@ -142,6 +162,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUsersWithListInput(List<User> body) throws ApiException {
 
@@ -153,6 +178,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
     Object localVarPostBody = body;
@@ -193,6 +223,12 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void deleteUser(String username) throws ApiException {
 
@@ -204,6 +240,12 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
     Object localVarPostBody = new Object();
@@ -246,6 +288,13 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return User
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public User getUserByName(String username) throws ApiException {
     return getUserByNameWithHttpInfo(username).getData();
@@ -257,6 +306,13 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return ApiResponse&lt;User&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
     Object localVarPostBody = new Object();
@@ -300,6 +356,12 @@ public class UserApi {
    * @param password The password for login in clear text (required)
    * @return String
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  </td></tr>
+        <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
+     </table>
    */
   public String loginUser(String username, String password) throws ApiException {
     return loginUserWithHttpInfo(username, password).getData();
@@ -312,6 +374,12 @@ public class UserApi {
    * @param password The password for login in clear text (required)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  </td></tr>
+        <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
     Object localVarPostBody = new Object();
@@ -358,6 +426,11 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void logoutUser() throws ApiException {
 
@@ -368,6 +441,11 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
     Object localVarPostBody = new Object();
@@ -404,6 +482,12 @@ public class UserApi {
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid user supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void updateUser(String username, User body) throws ApiException {
 
@@ -416,6 +500,12 @@ public class UserApi {
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid user supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2/docs/PetApi.md
+++ b/samples/client/petstore/java/jersey2/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/jersey2/docs/StoreApi.md
+++ b/samples/client/petstore/java/jersey2/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/jersey2/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -151,6 +151,15 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <tags>
+                                <tag>
+                                    <name>http.response.details</name>
+                                    <placement>a</placement>
+                                    <head>Http Response Details:</head>
+                                </tag>
+                 	        </tags>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -41,6 +41,11 @@ public class AnotherFakeApi {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client call123testSpecialTags(Client body) throws ApiException {
     return call123testSpecialTagsWithHttpInfo(body).getData();
@@ -52,6 +57,11 @@ public class AnotherFakeApi {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> call123testSpecialTagsWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -48,6 +48,11 @@ public class FakeApi {
    * this route creates an XmlItem
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createXmlItem(XmlItem xmlItem) throws ApiException {
 
@@ -59,6 +64,11 @@ public class FakeApi {
    * this route creates an XmlItem
    * @param xmlItem XmlItem Body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws ApiException {
     Object localVarPostBody = xmlItem;
@@ -100,6 +110,11 @@ public class FakeApi {
    * @param body Input boolean as post body (optional)
    * @return Boolean
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
+     </table>
    */
   public Boolean fakeOuterBooleanSerialize(Boolean body) throws ApiException {
     return fakeOuterBooleanSerializeWithHttpInfo(body).getData();
@@ -111,6 +126,11 @@ public class FakeApi {
    * @param body Input boolean as post body (optional)
    * @return ApiResponse&lt;Boolean&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output boolean </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws ApiException {
     Object localVarPostBody = body;
@@ -147,6 +167,11 @@ public class FakeApi {
    * @param body Input composite as post body (optional)
    * @return OuterComposite
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
+     </table>
    */
   public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws ApiException {
     return fakeOuterCompositeSerializeWithHttpInfo(body).getData();
@@ -158,6 +183,11 @@ public class FakeApi {
    * @param body Input composite as post body (optional)
    * @return ApiResponse&lt;OuterComposite&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output composite </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws ApiException {
     Object localVarPostBody = body;
@@ -194,6 +224,11 @@ public class FakeApi {
    * @param body Input number as post body (optional)
    * @return BigDecimal
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
+     </table>
    */
   public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws ApiException {
     return fakeOuterNumberSerializeWithHttpInfo(body).getData();
@@ -205,6 +240,11 @@ public class FakeApi {
    * @param body Input number as post body (optional)
    * @return ApiResponse&lt;BigDecimal&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output number </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws ApiException {
     Object localVarPostBody = body;
@@ -241,6 +281,11 @@ public class FakeApi {
    * @param body Input string as post body (optional)
    * @return String
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
+     </table>
    */
   public String fakeOuterStringSerialize(String body) throws ApiException {
     return fakeOuterStringSerializeWithHttpInfo(body).getData();
@@ -252,6 +297,11 @@ public class FakeApi {
    * @param body Input string as post body (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Output string </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<String> fakeOuterStringSerializeWithHttpInfo(String body) throws ApiException {
     Object localVarPostBody = body;
@@ -287,6 +337,11 @@ public class FakeApi {
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public void testBodyWithFileSchema(FileSchemaTestClass body) throws ApiException {
 
@@ -298,6 +353,11 @@ public class FakeApi {
    * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws ApiException {
     Object localVarPostBody = body;
@@ -339,6 +399,11 @@ public class FakeApi {
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public void testBodyWithQueryParams(String query, User body) throws ApiException {
 
@@ -351,6 +416,11 @@ public class FakeApi {
    * @param query  (required)
    * @param body  (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws ApiException {
     Object localVarPostBody = body;
@@ -398,6 +468,11 @@ public class FakeApi {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client testClientModel(Client body) throws ApiException {
     return testClientModelWithHttpInfo(body).getData();
@@ -409,6 +484,11 @@ public class FakeApi {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> testClientModelWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;
@@ -462,6 +542,12 @@ public class FakeApi {
    * @param password None (optional)
    * @param paramCallback None (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
 
@@ -486,6 +572,12 @@ public class FakeApi {
    * @param password None (optional)
    * @param paramCallback None (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws ApiException {
     Object localVarPostBody = new Object();
@@ -576,6 +668,12 @@ if (paramCallback != null)
    * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
    * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid request </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
+     </table>
    */
   public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
 
@@ -594,6 +692,12 @@ if (paramCallback != null)
    * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
    * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid request </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws ApiException {
     Object localVarPostBody = new Object();
@@ -646,6 +750,11 @@ if (enumFormString != null)
    * @param booleanGroup Boolean in group parameters (optional)
    * @param int64Group Integer in group parameters (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Someting wrong </td><td>  -  </td></tr>
+     </table>
    */
   public void testGroupParameters(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
 
@@ -662,6 +771,11 @@ if (enumFormString != null)
    * @param booleanGroup Boolean in group parameters (optional)
    * @param int64Group Integer in group parameters (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Someting wrong </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws ApiException {
     Object localVarPostBody = new Object();
@@ -720,6 +834,11 @@ if (booleanGroup != null)
    * 
    * @param param request body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void testInlineAdditionalProperties(Map<String, String> param) throws ApiException {
 
@@ -731,6 +850,11 @@ if (booleanGroup != null)
    * 
    * @param param request body (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws ApiException {
     Object localVarPostBody = param;
@@ -772,6 +896,11 @@ if (booleanGroup != null)
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void testJsonFormData(String param, String param2) throws ApiException {
 
@@ -784,6 +913,11 @@ if (booleanGroup != null)
    * @param param field1 (required)
    * @param param2 field2 (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws ApiException {
     Object localVarPostBody = new Object();

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -41,6 +41,11 @@ public class FakeClassnameTags123Api {
    * @param body client model (required)
    * @return Client
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Client testClassname(Client body) throws ApiException {
     return testClassnameWithHttpInfo(body).getData();
@@ -52,6 +57,11 @@ public class FakeClassnameTags123Api {
    * @param body client model (required)
    * @return ApiResponse&lt;Client&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Client> testClassnameWithHttpInfo(Client body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -42,6 +42,12 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public void addPet(Pet body) throws ApiException {
 
@@ -53,6 +59,12 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> addPetWithHttpInfo(Pet body) throws ApiException {
     Object localVarPostBody = body;
@@ -94,6 +106,12 @@ public class PetApi {
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
+     </table>
    */
   public void deletePet(Long petId, String apiKey) throws ApiException {
 
@@ -106,6 +124,12 @@ public class PetApi {
    * @param petId Pet id to delete (required)
    * @param apiKey  (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid pet value </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws ApiException {
     Object localVarPostBody = new Object();
@@ -150,6 +174,12 @@ public class PetApi {
    * @param status Status values that need to be considered for filter (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
+     </table>
    */
   public List<Pet> findPetsByStatus(List<String> status) throws ApiException {
     return findPetsByStatusWithHttpInfo(status).getData();
@@ -161,6 +191,12 @@ public class PetApi {
    * @param status Status values that need to be considered for filter (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid status value </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws ApiException {
     Object localVarPostBody = new Object();
@@ -203,6 +239,12 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return List&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid tag value </td><td>  -  </td></tr>
+     </table>
    * @deprecated
    */
   @Deprecated
@@ -216,6 +258,12 @@ public class PetApi {
    * @param tags Tags to filter by (required)
    * @return ApiResponse&lt;List&lt;Pet&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid tag value </td><td>  -  </td></tr>
+     </table>
    * @deprecated
    */
   @Deprecated
@@ -260,6 +308,13 @@ public class PetApi {
    * @param petId ID of pet to return (required)
    * @return Pet
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+     </table>
    */
   public Pet getPetById(Long petId) throws ApiException {
     return getPetByIdWithHttpInfo(petId).getData();
@@ -271,6 +326,13 @@ public class PetApi {
    * @param petId ID of pet to return (required)
    * @return ApiResponse&lt;Pet&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Pet> getPetByIdWithHttpInfo(Long petId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -312,6 +374,14 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
+     </table>
    */
   public void updatePet(Pet body) throws ApiException {
 
@@ -323,6 +393,14 @@ public class PetApi {
    * 
    * @param body Pet object that needs to be added to the store (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Pet not found </td><td>  -  </td></tr>
+        <tr><td> 405 </td><td> Validation exception </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updatePetWithHttpInfo(Pet body) throws ApiException {
     Object localVarPostBody = body;
@@ -365,6 +443,11 @@ public class PetApi {
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public void updatePetWithForm(Long petId, String name, String status) throws ApiException {
 
@@ -378,6 +461,11 @@ public class PetApi {
    * @param name Updated name of the pet (optional)
    * @param status Updated status of the pet (optional)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 405 </td><td> Invalid input </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws ApiException {
     Object localVarPostBody = new Object();
@@ -426,6 +514,11 @@ if (status != null)
    * @param file file to upload (optional)
    * @return ModelApiResponse
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws ApiException {
     return uploadFileWithHttpInfo(petId, additionalMetadata, file).getData();
@@ -439,6 +532,11 @@ if (status != null)
    * @param file file to upload (optional)
    * @return ApiResponse&lt;ModelApiResponse&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws ApiException {
     Object localVarPostBody = new Object();
@@ -487,6 +585,11 @@ if (file != null)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @return ModelApiResponse
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
     return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata).getData();
@@ -500,6 +603,11 @@ if (file != null)
    * @param additionalMetadata Additional data to pass to server (optional)
    * @return ApiResponse&lt;ModelApiResponse&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws ApiException {
     Object localVarPostBody = new Object();

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -40,6 +40,12 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public void deleteOrder(String orderId) throws ApiException {
 
@@ -51,6 +57,12 @@ public class StoreApi {
    * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
    * @param orderId ID of the order that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deleteOrderWithHttpInfo(String orderId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -92,6 +104,11 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @return Map&lt;String, Integer&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public Map<String, Integer> getInventory() throws ApiException {
     return getInventoryWithHttpInfo().getData();
@@ -102,6 +119,11 @@ public class StoreApi {
    * Returns a map of status codes to quantities
    * @return ApiResponse&lt;Map&lt;String, Integer&gt;&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Map<String, Integer>> getInventoryWithHttpInfo() throws ApiException {
     Object localVarPostBody = new Object();
@@ -138,6 +160,13 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched (required)
    * @return Order
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public Order getOrderById(Long orderId) throws ApiException {
     return getOrderByIdWithHttpInfo(orderId).getData();
@@ -149,6 +178,13 @@ public class StoreApi {
    * @param orderId ID of pet that needs to be fetched (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid ID supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Order not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Order> getOrderByIdWithHttpInfo(Long orderId) throws ApiException {
     Object localVarPostBody = new Object();
@@ -191,6 +227,12 @@ public class StoreApi {
    * @param body order placed for purchasing the pet (required)
    * @return Order
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
+     </table>
    */
   public Order placeOrder(Order body) throws ApiException {
     return placeOrderWithHttpInfo(body).getData();
@@ -202,6 +244,12 @@ public class StoreApi {
    * @param body order placed for purchasing the pet (required)
    * @return ApiResponse&lt;Order&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid Order </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Order> placeOrderWithHttpInfo(Order body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -40,6 +40,11 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUser(User body) throws ApiException {
 
@@ -51,6 +56,11 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param body Created user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUserWithHttpInfo(User body) throws ApiException {
     Object localVarPostBody = body;
@@ -91,6 +101,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUsersWithArrayInput(List<User> body) throws ApiException {
 
@@ -102,6 +117,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws ApiException {
     Object localVarPostBody = body;
@@ -142,6 +162,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void createUsersWithListInput(List<User> body) throws ApiException {
 
@@ -153,6 +178,11 @@ public class UserApi {
    * 
    * @param body List of user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws ApiException {
     Object localVarPostBody = body;
@@ -193,6 +223,12 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void deleteUser(String username) throws ApiException {
 
@@ -204,6 +240,12 @@ public class UserApi {
    * This can only be done by the logged in user.
    * @param username The name that needs to be deleted (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> deleteUserWithHttpInfo(String username) throws ApiException {
     Object localVarPostBody = new Object();
@@ -246,6 +288,13 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return User
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public User getUserByName(String username) throws ApiException {
     return getUserByNameWithHttpInfo(username).getData();
@@ -257,6 +306,13 @@ public class UserApi {
    * @param username The name that needs to be fetched. Use user1 for testing. (required)
    * @return ApiResponse&lt;User&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Invalid username supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<User> getUserByNameWithHttpInfo(String username) throws ApiException {
     Object localVarPostBody = new Object();
@@ -300,6 +356,12 @@ public class UserApi {
    * @param password The password for login in clear text (required)
    * @return String
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  </td></tr>
+        <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
+     </table>
    */
   public String loginUser(String username, String password) throws ApiException {
     return loginUserWithHttpInfo(username, password).getData();
@@ -312,6 +374,12 @@ public class UserApi {
    * @param password The password for login in clear text (required)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> successful operation </td><td>  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  </td></tr>
+        <tr><td> 400 </td><td> Invalid username/password supplied </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<String> loginUserWithHttpInfo(String username, String password) throws ApiException {
     Object localVarPostBody = new Object();
@@ -358,6 +426,11 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public void logoutUser() throws ApiException {
 
@@ -368,6 +441,11 @@ public class UserApi {
    * Logs out current logged in user session
    * 
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 0 </td><td> successful operation </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> logoutUserWithHttpInfo() throws ApiException {
     Object localVarPostBody = new Object();
@@ -404,6 +482,12 @@ public class UserApi {
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid user supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public void updateUser(String username, User body) throws ApiException {
 
@@ -416,6 +500,12 @@ public class UserApi {
    * @param username name that need to be deleted (required)
    * @param body Updated user object (required)
    * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 400 </td><td> Invalid user supplied </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> User not found </td><td>  -  </td></tr>
+     </table>
    */
   public ApiResponse<Void> updateUserWithHttpInfo(String username, User body) throws ApiException {
     Object localVarPostBody = body;

--- a/samples/client/petstore/java/resteasy/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resteasy/docs/FakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resteasy/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resteasy/docs/PetApi.md
+++ b/samples/client/petstore/java/resteasy/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resteasy/docs/StoreApi.md
+++ b/samples/client/petstore/java/resteasy/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/resteasy/docs/UserApi.md
+++ b/samples/client/petstore/java/resteasy/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/PetApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/StoreApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/UserApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/resttemplate/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate/docs/PetApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/resttemplate/docs/StoreApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/resttemplate/docs/UserApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/retrofit2/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/retrofit2/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/PetApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/StoreApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/vertx/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/vertx/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/vertx/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-AsyncFile binary = new AsyncFile(); // AsyncFile | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        AsyncFile binary = new AsyncFile(); // AsyncFile | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/vertx/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/vertx/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/vertx/docs/PetApi.md
+++ b/samples/client/petstore/java/vertx/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-AsyncFile file = new AsyncFile(); // AsyncFile | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        AsyncFile file = new AsyncFile(); // AsyncFile | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-AsyncFile requiredFile = new AsyncFile(); // AsyncFile | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        AsyncFile requiredFile = new AsyncFile(); // AsyncFile | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/vertx/docs/StoreApi.md
+++ b/samples/client/petstore/java/vertx/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/vertx/docs/UserApi.md
+++ b/samples/client/petstore/java/vertx/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 

--- a/samples/client/petstore/java/webclient/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/AnotherFakeApi.md
@@ -20,18 +20,30 @@ To test special tags and operation ID starting with number
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.AnotherFakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.AnotherFakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-AnotherFakeApi apiInstance = new AnotherFakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.call123testSpecialTags(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
-    e.printStackTrace();
+        AnotherFakeApi apiInstance = new AnotherFakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.call123testSpecialTags(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling AnotherFakeApi#call123testSpecialTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -54,4 +66,9 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -32,17 +32,29 @@ this route creates an XmlItem
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
-try {
-    apiInstance.createXmlItem(xmlItem);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#createXmlItem");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        XmlItem xmlItem = new XmlItem(); // XmlItem | XmlItem Body
+        try {
+            apiInstance.createXmlItem(xmlItem);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#createXmlItem");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -66,6 +78,11 @@ No authorization required
 - **Content-Type**: application/xml, application/xml; charset=utf-8, application/xml; charset=utf-16, text/xml, text/xml; charset=utf-8, text/xml; charset=utf-16
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## fakeOuterBooleanSerialize
 
@@ -79,18 +96,30 @@ Test serialization of outer boolean types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Boolean body = true; // Boolean | Input boolean as post body
-try {
-    Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Boolean body = true; // Boolean | Input boolean as post body
+        try {
+            Boolean result = apiInstance.fakeOuterBooleanSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterBooleanSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -114,6 +143,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output boolean |  -  |
+
 
 ## fakeOuterCompositeSerialize
 
@@ -127,18 +161,30 @@ Test serialization of object with outer number type
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
-try {
-    OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        OuterComposite body = new OuterComposite(); // OuterComposite | Input composite as post body
+        try {
+            OuterComposite result = apiInstance.fakeOuterCompositeSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterCompositeSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -162,6 +208,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output composite |  -  |
+
 
 ## fakeOuterNumberSerialize
 
@@ -175,18 +226,30 @@ Test serialization of outer number types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
-try {
-    BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal body = new BigDecimal(); // BigDecimal | Input number as post body
+        try {
+            BigDecimal result = apiInstance.fakeOuterNumberSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterNumberSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -210,6 +273,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output number |  -  |
+
 
 ## fakeOuterStringSerialize
 
@@ -223,18 +291,30 @@ Test serialization of outer string types
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String body = "body_example"; // String | Input string as post body
-try {
-    String result = apiInstance.fakeOuterStringSerialize(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String body = "body_example"; // String | Input string as post body
+        try {
+            String result = apiInstance.fakeOuterStringSerialize(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#fakeOuterStringSerialize");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -258,6 +338,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: */*
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Output string |  -  |
+
 
 ## testBodyWithFileSchema
 
@@ -271,17 +356,29 @@ For this test, the body for this request much reference a schema named &#x60;Fil
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
-try {
-    apiInstance.testBodyWithFileSchema(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        FileSchemaTestClass body = new FileSchemaTestClass(); // FileSchemaTestClass | 
+        try {
+            apiInstance.testBodyWithFileSchema(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithFileSchema");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -305,6 +402,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testBodyWithQueryParams
 
@@ -316,18 +418,30 @@ No authorization required
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String query = "query_example"; // String | 
-User body = new User(); // User | 
-try {
-    apiInstance.testBodyWithQueryParams(query, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String query = "query_example"; // String | 
+        User body = new User(); // User | 
+        try {
+            apiInstance.testBodyWithQueryParams(query, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testBodyWithQueryParams");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -352,6 +466,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
+
 
 ## testClientModel
 
@@ -365,18 +484,30 @@ To test \&quot;client\&quot; model
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClientModel(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testClientModel");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClientModel(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testClientModel");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -400,6 +531,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testEndpointParameters
 
@@ -413,39 +549,48 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure HTTP basic authorization: http_basic_test
+        HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
+        http_basic_test.setUsername("YOUR USERNAME");
+        http_basic_test.setPassword("YOUR PASSWORD");
 
-// Configure HTTP basic authorization: http_basic_test
-HttpBasicAuth http_basic_test = (HttpBasicAuth) defaultClient.getAuthentication("http_basic_test");
-http_basic_test.setUsername("YOUR USERNAME");
-http_basic_test.setPassword("YOUR PASSWORD");
-
-FakeApi apiInstance = new FakeApi();
-BigDecimal number = new BigDecimal(); // BigDecimal | None
-Double _double = 3.4D; // Double | None
-String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
-byte[] _byte = null; // byte[] | None
-Integer integer = 56; // Integer | None
-Integer int32 = 56; // Integer | None
-Long int64 = 56L; // Long | None
-Float _float = 3.4F; // Float | None
-String string = "string_example"; // String | None
-File binary = new File("/path/to/file"); // File | None
-LocalDate date = new LocalDate(); // LocalDate | None
-OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
-String password = "password_example"; // String | None
-String paramCallback = "paramCallback_example"; // String | None
-try {
-    apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEndpointParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        BigDecimal number = new BigDecimal(); // BigDecimal | None
+        Double _double = 3.4D; // Double | None
+        String patternWithoutDelimiter = "patternWithoutDelimiter_example"; // String | None
+        byte[] _byte = null; // byte[] | None
+        Integer integer = 56; // Integer | None
+        Integer int32 = 56; // Integer | None
+        Long int64 = 56L; // Long | None
+        Float _float = 3.4F; // Float | None
+        String string = "string_example"; // String | None
+        File binary = new File("/path/to/file"); // File | None
+        LocalDate date = new LocalDate(); // LocalDate | None
+        OffsetDateTime dateTime = new OffsetDateTime(); // OffsetDateTime | None
+        String password = "password_example"; // String | None
+        String paramCallback = "paramCallback_example"; // String | None
+        try {
+            apiInstance.testEndpointParameters(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEndpointParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -482,6 +627,12 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## testEnumParameters
 
@@ -495,24 +646,36 @@ To test enum parameters
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
-String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
-List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
-String enumQueryString = "-efg"; // String | Query parameter enum test (string)
-Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
-Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
-List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
-String enumFormString = "-efg"; // String | Form parameter enum test (string)
-try {
-    apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testEnumParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> enumHeaderStringArray = Arrays.asList("$"); // List<String> | Header parameter enum test (string array)
+        String enumHeaderString = "-efg"; // String | Header parameter enum test (string)
+        List<String> enumQueryStringArray = Arrays.asList("$"); // List<String> | Query parameter enum test (string array)
+        String enumQueryString = "-efg"; // String | Query parameter enum test (string)
+        Integer enumQueryInteger = 56; // Integer | Query parameter enum test (double)
+        Double enumQueryDouble = 3.4D; // Double | Query parameter enum test (double)
+        List<String> enumFormStringArray = "$"; // List<String> | Form parameter enum test (string array)
+        String enumFormString = "-efg"; // String | Form parameter enum test (string)
+        try {
+            apiInstance.testEnumParameters(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testEnumParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -543,6 +706,12 @@ No authorization required
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid request |  -  |
+| **404** | Not found |  -  |
+
 
 ## testGroupParameters
 
@@ -556,22 +725,34 @@ Fake endpoint to test group parameters (optional)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Integer requiredStringGroup = 56; // Integer | Required String in group parameters
-Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
-Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
-Integer stringGroup = 56; // Integer | String in group parameters
-Boolean booleanGroup = true; // Boolean | Boolean in group parameters
-Long int64Group = 56L; // Long | Integer in group parameters
-try {
-    apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testGroupParameters");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Integer requiredStringGroup = 56; // Integer | Required String in group parameters
+        Boolean requiredBooleanGroup = true; // Boolean | Required Boolean in group parameters
+        Long requiredInt64Group = 56L; // Long | Required Integer in group parameters
+        Integer stringGroup = 56; // Integer | String in group parameters
+        Boolean booleanGroup = true; // Boolean | Boolean in group parameters
+        Long int64Group = 56L; // Long | Integer in group parameters
+        try {
+            apiInstance.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testGroupParameters");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -600,6 +781,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Someting wrong |  -  |
+
 
 ## testInlineAdditionalProperties
 
@@ -611,17 +797,29 @@ test inline additionalProperties
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-Map<String, String> param = new HashMap(); // Map<String, String> | request body
-try {
-    apiInstance.testInlineAdditionalProperties(param);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        Map<String, String> param = new HashMap(); // Map<String, String> | request body
+        try {
+            apiInstance.testInlineAdditionalProperties(param);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testInlineAdditionalProperties");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -645,6 +843,11 @@ No authorization required
 - **Content-Type**: application/json
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## testJsonFormData
 
@@ -656,18 +859,30 @@ test json serialization of form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.FakeApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-FakeApi apiInstance = new FakeApi();
-String param = "param_example"; // String | field1
-String param2 = "param2_example"; // String | field2
-try {
-    apiInstance.testJsonFormData(param, param2);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeApi#testJsonFormData");
-    e.printStackTrace();
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        String param = "param_example"; // String | field1
+        String param2 = "param2_example"; // String | field2
+        try {
+            apiInstance.testJsonFormData(param, param2);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testJsonFormData");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -691,4 +906,9 @@ No authorization required
 
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/webclient/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/java/webclient/docs/FakeClassnameTags123Api.md
@@ -20,28 +20,37 @@ To test class name in snake case
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.FakeClassnameTags123Api;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeClassnameTags123Api;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key_query
+        ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
+        api_key_query.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key_query.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key_query
-ApiKeyAuth api_key_query = (ApiKeyAuth) defaultClient.getAuthentication("api_key_query");
-api_key_query.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key_query.setApiKeyPrefix("Token");
-
-FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api();
-Client body = new Client(); // Client | client model
-try {
-    Client result = apiInstance.testClassname(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
-    e.printStackTrace();
+        FakeClassnameTags123Api apiInstance = new FakeClassnameTags123Api(defaultClient);
+        Client body = new Client(); // Client | client model
+        try {
+            Client result = apiInstance.testClassname(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeClassnameTags123Api#testClassname");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -64,4 +73,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: application/json
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/webclient/docs/PetApi.md
+++ b/samples/client/petstore/java/webclient/docs/PetApi.md
@@ -26,25 +26,34 @@ Add a new pet to the store
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.addPet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#addPet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.addPet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#addPet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -68,6 +77,12 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **405** | Invalid input |  -  |
+
 
 ## deletePet
 
@@ -79,26 +94,35 @@ Deletes a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | Pet id to delete
-String apiKey = "apiKey_example"; // String | 
-try {
-    apiInstance.deletePet(petId, apiKey);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#deletePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | Pet id to delete
+        String apiKey = "apiKey_example"; // String | 
+        try {
+            apiInstance.deletePet(petId, apiKey);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#deletePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -123,6 +147,12 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid pet value |  -  |
+
 
 ## findPetsByStatus
 
@@ -136,26 +166,35 @@ Multiple status values can be provided with comma separated strings
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
-try {
-    List<Pet> result = apiInstance.findPetsByStatus(status);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByStatus");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> status = Arrays.asList("available"); // List<String> | Status values that need to be considered for filter
+        try {
+            List<Pet> result = apiInstance.findPetsByStatus(status);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByStatus");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -179,6 +218,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid status value |  -  |
+
 
 ## findPetsByTags
 
@@ -192,26 +237,35 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
-try {
-    List<Pet> result = apiInstance.findPetsByTags(tags);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#findPetsByTags");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        List<String> tags = Arrays.asList(); // List<String> | Tags to filter by
+        try {
+            List<Pet> result = apiInstance.findPetsByTags(tags);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#findPetsByTags");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -235,6 +289,12 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid tag value |  -  |
+
 
 ## getPetById
 
@@ -248,28 +308,37 @@ Returns a single pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to return
-try {
-    Pet result = apiInstance.getPetById(petId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#getPetById");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to return
+        try {
+            Pet result = apiInstance.getPetById(petId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#getPetById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -293,6 +362,13 @@ Name | Type | Description  | Notes
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+
 
 ## updatePet
 
@@ -304,25 +380,34 @@ Update an existing pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
-try {
-    apiInstance.updatePet(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePet");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Pet body = new Pet(); // Pet | Pet object that needs to be added to the store
+        try {
+            apiInstance.updatePet(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePet");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -346,6 +431,14 @@ null (empty response body)
 - **Content-Type**: application/json, application/xml
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Pet not found |  -  |
+| **405** | Validation exception |  -  |
+
 
 ## updatePetWithForm
 
@@ -357,27 +450,36 @@ Updates a pet in the store with form data
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet that needs to be updated
-String name = "name_example"; // String | Updated name of the pet
-String status = "status_example"; // String | Updated status of the pet
-try {
-    apiInstance.updatePetWithForm(petId, name, status);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#updatePetWithForm");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet that needs to be updated
+        String name = "name_example"; // String | Updated name of the pet
+        String status = "status_example"; // String | Updated status of the pet
+        try {
+            apiInstance.updatePetWithForm(petId, name, status);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#updatePetWithForm");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -403,6 +505,11 @@ null (empty response body)
 - **Content-Type**: application/x-www-form-urlencoded
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **405** | Invalid input |  -  |
+
 
 ## uploadFile
 
@@ -414,28 +521,37 @@ uploads an image
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-File file = new File("/path/to/file"); // File | file to upload
-try {
-    ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        File file = new File("/path/to/file"); // File | file to upload
+        try {
+            ModelApiResponse result = apiInstance.uploadFile(petId, additionalMetadata, file);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -461,6 +577,11 @@ Name | Type | Description  | Notes
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## uploadFileWithRequiredFile
 
@@ -472,28 +593,37 @@ uploads an image (required)
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.PetApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.PetApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure OAuth2 access token for authorization: petstore_auth
+        OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
+        petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
 
-// Configure OAuth2 access token for authorization: petstore_auth
-OAuth petstore_auth = (OAuth) defaultClient.getAuthentication("petstore_auth");
-petstore_auth.setAccessToken("YOUR ACCESS TOKEN");
-
-PetApi apiInstance = new PetApi();
-Long petId = 56L; // Long | ID of pet to update
-File requiredFile = new File("/path/to/file"); // File | file to upload
-String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
-try {
-    ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
-    e.printStackTrace();
+        PetApi apiInstance = new PetApi(defaultClient);
+        Long petId = 56L; // Long | ID of pet to update
+        File requiredFile = new File("/path/to/file"); // File | file to upload
+        String additionalMetadata = "additionalMetadata_example"; // String | Additional data to pass to server
+        try {
+            ModelApiResponse result = apiInstance.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling PetApi#uploadFileWithRequiredFile");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -518,4 +648,9 @@ Name | Type | Description  | Notes
 
 - **Content-Type**: multipart/form-data
 - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
 

--- a/samples/client/petstore/java/webclient/docs/StoreApi.md
+++ b/samples/client/petstore/java/webclient/docs/StoreApi.md
@@ -23,17 +23,29 @@ For valid response try integer IDs with value &lt; 1000. Anything above 1000 or 
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
-try {
-    apiInstance.deleteOrder(orderId);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#deleteOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        String orderId = "orderId_example"; // String | ID of the order that needs to be deleted
+        try {
+            apiInstance.deleteOrder(orderId);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#deleteOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -57,6 +69,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## getInventory
 
@@ -70,27 +88,36 @@ Returns a map of status codes to quantities
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiClient;
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.Configuration;
-//import org.openapitools.client.auth.*;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
-ApiClient defaultClient = Configuration.getDefaultApiClient();
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+        
+        // Configure API key authorization: api_key
+        ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
+        api_key.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //api_key.setApiKeyPrefix("Token");
 
-// Configure API key authorization: api_key
-ApiKeyAuth api_key = (ApiKeyAuth) defaultClient.getAuthentication("api_key");
-api_key.setApiKey("YOUR API KEY");
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//api_key.setApiKeyPrefix("Token");
-
-StoreApi apiInstance = new StoreApi();
-try {
-    Map<String, Integer> result = apiInstance.getInventory();
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getInventory");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        try {
+            Map<String, Integer> result = apiInstance.getInventory();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getInventory");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -111,6 +138,11 @@ This endpoint does not need any parameter.
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+
 
 ## getOrderById
 
@@ -124,18 +156,30 @@ For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other val
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Long orderId = 56L; // Long | ID of pet that needs to be fetched
-try {
-    Order result = apiInstance.getOrderById(orderId);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#getOrderById");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Long orderId = 56L; // Long | ID of pet that needs to be fetched
+        try {
+            Order result = apiInstance.getOrderById(orderId);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#getOrderById");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -159,6 +203,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid ID supplied |  -  |
+| **404** | Order not found |  -  |
+
 
 ## placeOrder
 
@@ -170,18 +221,30 @@ Place an order for a pet
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.StoreApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.StoreApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-StoreApi apiInstance = new StoreApi();
-Order body = new Order(); // Order | order placed for purchasing the pet
-try {
-    Order result = apiInstance.placeOrder(body);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling StoreApi#placeOrder");
-    e.printStackTrace();
+        StoreApi apiInstance = new StoreApi(defaultClient);
+        Order body = new Order(); // Order | order placed for purchasing the pet
+        try {
+            Order result = apiInstance.placeOrder(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling StoreApi#placeOrder");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -204,4 +267,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid Order |  -  |
 

--- a/samples/client/petstore/java/webclient/docs/UserApi.md
+++ b/samples/client/petstore/java/webclient/docs/UserApi.md
@@ -27,17 +27,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-User body = new User(); // User | Created user object
-try {
-    apiInstance.createUser(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        User body = new User(); // User | Created user object
+        try {
+            apiInstance.createUser(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -61,6 +73,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## createUsersWithArrayInput
 
@@ -72,17 +89,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithArrayInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithArrayInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithArrayInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -105,6 +134,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## createUsersWithListInput
@@ -117,17 +151,29 @@ Creates list of users with given input array
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-List<User> body = Arrays.asList(null); // List<User> | List of user object
-try {
-    apiInstance.createUsersWithListInput(body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#createUsersWithListInput");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        try {
+            apiInstance.createUsersWithListInput(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#createUsersWithListInput");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -150,6 +196,11 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
 
 
 ## deleteUser
@@ -164,17 +215,29 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be deleted
-try {
-    apiInstance.deleteUser(username);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#deleteUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be deleted
+        try {
+            apiInstance.deleteUser(username);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#deleteUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -198,6 +261,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## getUserByName
 
@@ -209,18 +278,30 @@ Get user by user name
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
-try {
-    User result = apiInstance.getUserByName(username);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#getUserByName");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The name that needs to be fetched. Use user1 for testing.
+        try {
+            User result = apiInstance.getUserByName(username);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#getUserByName");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -244,6 +325,13 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  -  |
+| **400** | Invalid username supplied |  -  |
+| **404** | User not found |  -  |
+
 
 ## loginUser
 
@@ -255,19 +343,31 @@ Logs user into the system
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | The user name for login
-String password = "password_example"; // String | The password for login in clear text
-try {
-    String result = apiInstance.loginUser(username, password);
-    System.out.println(result);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#loginUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | The user name for login
+        String password = "password_example"; // String | The password for login in clear text
+        try {
+            String result = apiInstance.loginUser(username, password);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#loginUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -292,6 +392,12 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: application/xml, application/json
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | successful operation |  * X-Rate-Limit - calls per hour allowed by the user <br>  * X-Expires-After - date in UTC when token expires <br>  |
+| **400** | Invalid username/password supplied |  -  |
+
 
 ## logoutUser
 
@@ -303,16 +409,28 @@ Logs out current logged in user session
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-try {
-    apiInstance.logoutUser();
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#logoutUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        try {
+            apiInstance.logoutUser();
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#logoutUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -333,6 +451,11 @@ No authorization required
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **0** | successful operation |  -  |
+
 
 ## updateUser
 
@@ -346,18 +469,30 @@ This can only be done by the logged in user.
 
 ```java
 // Import classes:
-//import org.openapitools.client.ApiException;
-//import org.openapitools.client.api.UserApi;
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.UserApi;
 
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
-UserApi apiInstance = new UserApi();
-String username = "username_example"; // String | name that need to be deleted
-User body = new User(); // User | Updated user object
-try {
-    apiInstance.updateUser(username, body);
-} catch (ApiException e) {
-    System.err.println("Exception when calling UserApi#updateUser");
-    e.printStackTrace();
+        UserApi apiInstance = new UserApi(defaultClient);
+        String username = "username_example"; // String | name that need to be deleted
+        User body = new User(); // User | Updated user object
+        try {
+            apiInstance.updateUser(username, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling UserApi#updateUser");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
 }
 ```
 
@@ -381,4 +516,10 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **400** | Invalid user supplied |  -  |
+| **404** | User not found |  -  |
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Closes: #3059
Closes: #3060

For Java Jersey2's client, following changes are done.
* Adding Http response details on each method's summary.
* Adding Http response details on the api docs (Jersey2 is using common api_doc.mustache and so other client's petstore projects were also update in this pull request).
* On api docs, example snippet was updated to make it compilable.
* On Readme, example snippet was updated to make it compilable on Readme(Jersey2 is using common readme.mustache and so other client's petstore projects were also update in this pull request).

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)