### PR TITLE
[core] Initial implementation of a validation framework in core

### DIFF
--- a/modules/openapi-generator-core/pom.xml
+++ b/modules/openapi-generator-core/pom.xml
@@ -13,4 +13,12 @@
   <artifactId>openapi-generator-core</artifactId>
   <name>openapi-generator-core</name>
   <url>https://github.com/openapitools/openapi-generator</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/GenericValidator.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/GenericValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+import java.util.List;
+
+/**
+ * A generic implementation of a validator instance which simply applies rules to an input instance.
+ *
+ * @param <TInput> The type of object being evaluated.
+ */
+@SuppressWarnings({"WeakerAccess"})
+public class GenericValidator<TInput> implements Validator<TInput> {
+    private List<ValidationRule> rules;
+
+    /**
+     * Constructs a new instance of {@link GenericValidator}.
+     *
+     * @param rules The rules to be evaluated during validation.
+     */
+    public GenericValidator(List<ValidationRule> rules) {
+        this.rules = rules;
+    }
+
+    /**
+     * Validates input, resulting in a instance of {@link ValidationResult} which provides details on all validations performed (success, error, warning).
+     *
+     * @param input The object instance to be validated.
+     *
+     * @return A {@link ValidationResult} which details the success, error, and warning validation results.
+     */
+    @Override
+    public ValidationResult validate(TInput input) {
+        ValidationResult result = new ValidationResult();
+        if (rules != null) {
+            rules.forEach(it -> {
+                boolean passes = it.evaluate(input);
+                if (passes) {
+                    result.addResult(Validated.valid(it));
+                } else {
+                    result.addResult(Validated.invalid(it, it.getFailureMessage()));
+                }
+            });
+        }
+        return result;
+    }
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Invalid.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Invalid.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+/**
+ * Represents a {@link Validated} state which is "Invalid" to some degree of {@link Severity}.
+ */
+@SuppressWarnings({"WeakerAccess"})
+public final class Invalid extends Validated {
+    private String message;
+    private ValidationRule rule;
+
+    /**
+     * Constructs a new {@link Invalid} instance.
+     *
+     * @param rule The rule which was evaluated and resulted in this state.
+     * @param message The message to be displayed for this invalid state.
+     */
+    Invalid(ValidationRule rule, String message) {
+        this.rule = rule;
+        this.message = message;
+    }
+
+    @Override
+    String getMessage() {
+        return message;
+    }
+
+    @Override
+    ValidationRule getRule() {
+        return rule;
+    }
+
+    /**
+     * Get details about the severity of this invalid state.
+     * For instance, is this an {@link Severity#ERROR} or simply a {@link Severity#WARNING}.
+     *
+     * @return The {@link Severity} enum detailing this state's severity.
+     */
+    public Severity getSeverity() {
+        return rule.getSeverity();
+    }
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Severity.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Severity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+/**
+ * Defines different levels of severity to be used during validation.
+ */
+public enum Severity {
+    /**
+     * Lower severity indicating that the target state may be unpredictable, no longer supported, or known to have issues.
+     * Marking a type with this value should not result in application exceptions under normal operating circumstances.
+     */
+    WARNING,
+    /**
+     * Higher severity indicating that the target state is not supported, or is known to cause problems with the application.
+     * Marking a type with this value should result in an application exception or error exit code under normal operating circumstances.
+     */
+    ERROR
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Valid.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Valid.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+/**
+ * Represents a {@link Validated} state which is "valid" according to the defined rule.
+ */
+public final class Valid extends Validated {
+    private ValidationRule rule;
+
+    /**
+     * Constructs a new {@link Valid} instance.
+     *
+     * @param rule The rule which was evaluated and resulted in this state.
+     */
+    Valid(ValidationRule rule) {
+        this.rule = rule;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+
+    @Override
+    public ValidationRule getRule() {
+        return rule;
+    }
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Validated.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Validated.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+/**
+ * Provides details about the state of a completed validation.
+ */
+public abstract class Validated {
+    /**
+     * Defines whether or not the validation resulted in a "valid" condition.
+     *
+     * @return <code>true</code> if the instance passed validation of the rule returned by {@link Validated#getRule()}.
+     */
+    boolean isValid() {
+        return this instanceof Valid;
+    }
+
+    /**
+     * Gets the rule which was evaluated and resulted in this state.
+     *
+     * @return The instance of {@link ValidationRule} which was evaluated.
+     */
+    abstract ValidationRule getRule();
+
+    /**
+     * Gets the message with details about this validated state.
+     *
+     * @return A string intended to be displayed to a user.
+     */
+    abstract String getMessage();
+
+    /**
+     * Creates an instance of an {@link Invalid} validation state.
+     *
+     * @param rule The rule which was evaluated.
+     * @param message The message to display to a user.
+     *
+     * @return A {@link Validated} instance representing an invalid state according to the rule.
+     */
+    public static Validated invalid(ValidationRule rule, String message) {
+        return new Invalid(rule, message);
+    }
+
+    /**
+     * Creates an instance of an {@link Valid} validation state.
+     *
+     * @param rule The rule which was evaluated.
+     *
+     * @return A {@link Validated} instance representing a valid state according to the rule.
+     */
+    public static Validated valid(ValidationRule rule) {
+        return new Valid(rule);
+    }
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/ValidationResult.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/ValidationResult.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulates details about the result of a validation test.
+ */
+@SuppressWarnings("WeakerAccess")
+public final class ValidationResult {
+    private final List<Validated> validations;
+
+    /**
+     * Constructs a new {@link ValidationResult} instance, backed by the provided validations (useful for testing).
+     *
+     * @param validations A pre-defined set of validations to begin with.
+     */
+    private ValidationResult(List<Validated> validations) {
+        this.validations = Collections.synchronizedList(validations);
+    }
+
+    /**
+     * Constructs a new {@link ValidationResult} instance.
+     */
+    public ValidationResult() {
+        this(new ArrayList<>());
+    }
+
+    /**
+     * Gets all the validated states resulting from the evaluation. This includes all {@link Valid} and {@link Invalid} instances.
+     *
+     * @return All validated results.
+     */
+    public List<Validated> getAll() {
+        return  validations;
+    }
+
+    /**
+     * Gets a filtered list of {@link Valid} states.
+     *
+     * @return A list containing only {@link Valid} states.
+     */
+    public List<Valid> getValid(){
+        return validations.stream().filter(Validated::isValid).map(it -> (Valid)it).collect(Collectors.toList());
+    }
+
+    /**
+     * Gets a filters list of {@link Invalid} states with the level of {@link Severity#ERROR}
+     *
+     * @return A list of all validation errors.
+     */
+    public List<Invalid> getErrors(){
+        return validations.stream()
+                .filter(it -> !it.isValid())
+                .map(it -> (Invalid)it)
+                .filter(it -> it.getSeverity().equals(Severity.ERROR))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets a filtered list of {@link Invalid} states with the level of {@link Severity#WARNING}
+     *
+     * @return A list of all validation warnings.
+     */
+    public List<Invalid> getWarnings(){
+        return validations.stream()
+                .filter(it -> !it.isValid())
+                .map(it -> (Invalid)it)
+                .filter(it -> it.getSeverity().equals(Severity.WARNING))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Adds a validation state to the final results.
+     *
+     * @param validated The {@link Valid} or {@link Invalid} instance to add to validations.
+     */
+    public void addResult(Validated validated) {
+        synchronized (validations) {
+            ValidationRule rule = validated.getRule();
+            if (rule != null && !rule.equals(ValidationRule.empty())) {
+                validations.add(validated);
+            }
+        }
+    }
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/ValidationRule.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/ValidationRule.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+import java.util.function.Function;
+
+/**
+ * Defines a rule to be evaluated against some target object.
+ */
+@SuppressWarnings("WeakerAccess")
+public class ValidationRule {
+    private Severity severity;
+    private String description;
+    private String failureMessage;
+    private Function<Object, Boolean> test;
+
+    /**
+     * Constructs a new instance of {@link ValidationRule}
+     *
+     * @param severity The declared severity if this validation rule fails.
+     * @param description A description to help differentiate this rule from others (not intended to be user-facing).
+     * @param failureMessage The message to be displayed in the event of a test failure (intended to be user-facing).
+     * @param test The test condition to be applied as a part of this rule, when this function returns <code>true</code>,
+     *             the evaluated instance will be considered "valid" according to this rule.
+     */
+    ValidationRule(Severity severity, String description, String failureMessage, Function<Object, Boolean> test) {
+        this.severity = severity;
+        this.description = description;
+        this.failureMessage = failureMessage;
+        this.test = test;
+    }
+
+    /**
+     * Gets the message to be displayed in the event of a test failure (intended to be user-facing).
+     *
+     * @return A string message
+     */
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    /**
+     * Evalute an instance of an object against this rule.
+     *
+     * @param input The instance to be evaluated.
+     *
+     * @return <code>true</code> if the object state is valid according to this rule, otherwise <code>false</code>.
+     */
+    public boolean evaluate(Object input) {
+        return test.apply(input);
+    }
+
+    /**
+     * Get the level of severity which this rule considers a failure in evaluation. For example, if this is {@link Severity#WARNING} and
+     * a call to {@link ValidationRule#evaluate(Object)} returns <code>false</code>, a user should not expect an error to be thrown under
+     * normal operation.
+     *
+     * @return An enum defining how severe a failure to evaluate this rule should be considered by the caller.
+     */
+    public Severity getSeverity() {
+        return severity;
+    }
+
+    /**
+     * Gets a description to help differentiate this rule from others (not intended to be user-facing).
+     *
+     * @return A string description.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Constructs an empty rule (useful for testing).
+     *
+     * @return An "empty" rule.
+     */
+    static ValidationRule empty() {
+        return new ValidationRule(Severity.ERROR, "empty", "failure message", (i) -> false);
+    }
+
+    /**
+     * Create an instance of a {@link ValidationRule}
+     *
+     * @param severity The declared severity if this validation rule fails.
+     * @param description A description to help differentiate this rule from others (not intended to be user-facing).
+     * @param failureMessage The message to be displayed in the event of a test failure (intended to be user-facing).
+     * @param fn The test condition to be applied as a part of this rule, when this function returns <code>true</code>,
+     *             the evaluated instance will be considered "valid" according to this rule.
+     * @param <T> The type of the object being evaluated.
+     *
+     * @return A new instance of a {@link ValidationRule}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ValidationRule create(Severity severity, String description, String failureMessage, Function<T, Boolean> fn) {
+        return new ValidationRule(severity, description, failureMessage, (Function<Object, Boolean>) fn);
+    }
+
+    /**
+     * Create an instance of a {@link ValidationRule} which should result in an error should the evaluate of this rule fail.
+     *
+     * @param failureMessage The message to be displayed in the event of a test failure (intended to be user-facing).
+     * @param fn The test condition to be applied as a part of this rule, when this function returns <code>true</code>,
+     *             the evaluated instance will be considered "valid" according to this rule.
+     * @param <T> The type of the object being evaluated.
+     *
+     * @return A new instance of a {@link ValidationRule}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ValidationRule error(String failureMessage, Function<T, Boolean> fn) {
+        return new ValidationRule(Severity.ERROR, null, failureMessage, (Function<Object, Boolean>) fn);
+    }
+
+    /**
+     * Create an instance of a {@link ValidationRule} which should result in a warning should the evaluate of this rule fail.
+     *
+     * @param description A description to help differentiate this rule from others (not intended to be user-facing).
+     * @param failureMessage The message to be displayed in the event of a test failure (intended to be user-facing).
+     * @param fn The test condition to be applied as a part of this rule, when this function returns <code>true</code>,
+     *             the evaluated instance will be considered "valid" according to this rule.
+     * @param <T> The type of the object being evaluated.
+     *
+     * @return A new instance of a {@link ValidationRule}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ValidationRule warn(String description, String failureMessage, Function<T, Boolean> fn) {
+        return new ValidationRule(Severity.WARNING, description, failureMessage, (Function<Object, Boolean>) fn);
+    }
+
+    @Override
+    public String toString() {
+        return "ValidationRule{" +
+                "severity=" + severity +
+                ", description='" + description + '\'' +
+                ", failureMessage='" + failureMessage + '\'' +
+                '}';
+    }
+}

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Validator.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/validator/Validator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+/**
+ * Defines a contract allowing some input to be validated.
+ *
+ * @param <TInput> The type of the input object.
+ */
+@FunctionalInterface
+public interface Validator<TInput> {
+    /**
+     * Validates input, resulting in a instance of {@link ValidationResult} which provides details on all validations performed (success, error, warning).
+     *
+     * @param input The object instance to be validated.
+     *
+     * @return A {@link ValidationResult} which details the success, error, and warning validation results.
+     */
+    ValidationResult validate(TInput input);
+}

--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validator/GenericValidatorTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validator/GenericValidatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class GenericValidatorTest {
+    class Person {
+        private int age;
+        private String name;
+
+        Person(String name, int age) {
+            this.age = age;
+            this.name = name;
+        }
+    }
+
+    private static boolean isValidAge(Person person) {
+        return person.age > 0;
+    }
+
+    private static boolean isAdult(Person person) {
+        return person.age > 18;
+    }
+
+    private static boolean isNameSet(Person person) {
+        return person.name != null && person.name.length() > 0;
+    }
+
+    private static boolean isNameValid(Person person) {
+        String pattern = "^[A-Z][a-z]*$";
+        return person.name.matches(pattern);
+    }
+
+    private static boolean isNameNormalLength(Person person) {
+        return person.name.length() < 10;
+    }
+
+    private List<ValidationRule> validationRules = Arrays.asList(
+            ValidationRule.error("Age must be positive and more than zero", GenericValidatorTest::isValidAge),
+            ValidationRule.error("Only adults (18 years old and older)", GenericValidatorTest::isAdult),
+            ValidationRule.error("Name isn't set!", GenericValidatorTest::isNameSet),
+            ValidationRule.error("Name isn't formatted correct", GenericValidatorTest::isNameValid),
+            ValidationRule.warn("Name too long?", "Name may be too long.", GenericValidatorTest::isNameNormalLength)
+    );
+
+    @Test
+    public void testGenericValidatorSuccesses(){
+        Person person = new Person("Jim", 23);
+        GenericValidator<Person> validator = new GenericValidator<>(validationRules);
+        ValidationResult result = validator.validate(person);
+        List<Validated> validated = result.getAll();
+        List<Valid> valid = result.getValid();
+        List<Invalid> invalid = result.getErrors();
+
+        assertEquals(validated.size(), 5, "Expected 5 validations to run.");
+        assertEquals(valid.size(), 5, "Expected all validations to succeed");
+        assertEquals(invalid.size(), 0, "Expected zero validations to fail.");
+    }
+
+    @Test
+    public void testGenericValidatorSingleConditionFails(){
+        Person person = new Person("Jim", 3);
+        GenericValidator<Person> validator = new GenericValidator<>(validationRules);
+        ValidationResult result = validator.validate(person);
+        List<Validated> validated = result.getAll();
+        List<Valid> valid = result.getValid();
+        List<Invalid> errors = result.getErrors();
+        List<Invalid> warnings = result.getWarnings();
+
+        assertEquals(validated.size(), 5, "Expected 5 validations to run.");
+        assertEquals(valid.size(), 4, "Expected 4 validations to succeed");
+        assertEquals(errors.size(), 1, "Expected 1 validation to fail.");
+        assertEquals(warnings.size(), 0, "Expected no warnings to be triggered.");
+
+        Invalid failed = errors.get(0);
+        assertEquals(failed.getMessage(), "Only adults (18 years old and older)");
+    }
+
+    @Test
+    public void testGenericValidatorMultipleConditionsFail(){
+        Person person = new Person("asdf", 3);
+        GenericValidator<Person> validator = new GenericValidator<>(validationRules);
+        ValidationResult result = validator.validate(person);
+        List<Validated> validated = result.getAll();
+        List<Valid> valid = result.getValid();
+        List<Invalid> errors = result.getErrors();
+        List<Invalid> warnings = result.getWarnings();
+
+        assertEquals(validated.size(), 5, "Expected 5 validations to run.");
+        assertEquals(valid.size(), 3, "Expected 3 validations to succeed");
+        assertEquals(errors.size(), 2, "Expected 2 validations to fail.");
+        assertEquals(warnings.size(), 0, "Expected no warnings to be triggered.");
+
+        Optional<Invalid> nameValidation = errors.stream().filter(it -> it.getMessage().contains("formatted")).findFirst();
+        Optional<Invalid> ageValidation = errors.stream().filter(it -> it.getMessage().contains("adults")).findFirst();
+
+        assertTrue(nameValidation.isPresent(), "Expected validation on name formatting to fail.");
+        assertTrue(ageValidation.isPresent(), "Expected validation on age requirements to fail.");
+        assertEquals(nameValidation.get().getMessage(), "Name isn't formatted correct");
+        assertEquals(ageValidation.get().getMessage(), "Only adults (18 years old and older)");
+    }
+
+    @Test
+    public void testGenericValidatorErrorsAndWarnings(){
+        Person person = new Person("0123456789asdfghjkl", 3);
+        GenericValidator<Person> validator = new GenericValidator<>(validationRules);
+        ValidationResult result = validator.validate(person);
+        List<Validated> validated = result.getAll();
+        List<Valid> valid = result.getValid();
+        List<Invalid> errors = result.getErrors();
+        List<Invalid> warnings = result.getWarnings();
+
+        assertEquals(validated.size(), 5, "Expected 5 validations to run.");
+        assertEquals(valid.size(), 2, "Expected 2 validations to succeed");
+        assertEquals(errors.size(), 2, "Expected 2 validations to fail.");
+        assertEquals(warnings.size(), 1, "Expected 1 warning to be triggered.");
+
+        Optional<Invalid> nameValidation = errors.stream().filter(it -> it.getMessage().contains("formatted")).findFirst();
+        Optional<Invalid> ageValidation = errors.stream().filter(it -> it.getMessage().contains("adults")).findFirst();
+        Invalid nameLengthWarning = warnings.get(0);
+
+        assertTrue(nameValidation.isPresent(), "Expected validation on name formatting to fail.");
+        assertTrue(ageValidation.isPresent(), "Expected validation on age requirements to fail.");
+        assertEquals(nameValidation.get().getMessage(), "Name isn't formatted correct");
+        assertEquals(ageValidation.get().getMessage(), "Only adults (18 years old and older)");
+        assertEquals(nameLengthWarning.getMessage(), "Name may be too long.");
+    }
+}

--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validator/ValidatedTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validator/ValidatedTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class ValidatedTest {
+    @Test
+    public void isValidTrueForValidType(){
+        boolean isValid = Validated.valid(ValidationRule.empty()).isValid();
+        assertTrue(isValid);
+    }
+
+    @Test
+    public void isValidFalseForInvalidType(){
+        boolean isValid = Validated.invalid(ValidationRule.empty(), "test").isValid();
+        assertFalse(isValid);
+    }
+}

--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validator/ValidationRuleTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/validator/ValidationRuleTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.validator;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class ValidationRuleTest {
+    class Sample {
+        private String name;
+
+        public Sample(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private static boolean checkName(Sample input) {
+        return input.getName() != null && input.getName().length() > 7;
+    }
+
+    private static boolean checkPattern(Sample input) {
+        String pattern = "^[A-Z][a-z]*$";
+        return input.getName() != null && input.getName().matches(pattern);
+    }
+
+    @Test
+    public void createMethodUsingMethodReference(){
+        Sample nil = new Sample(null);
+        Sample six = new Sample("123456");
+        Sample seven = new Sample("1234567");
+        Sample eight = new Sample("12345678");
+        ValidationRule result = ValidationRule.error("test", ValidationRuleTest::checkName);
+        assertFalse(result.evaluate(nil));
+        assertFalse(result.evaluate(six));
+        assertFalse(result.evaluate(seven));
+        assertTrue(result.evaluate(eight));
+    }
+
+    @Test
+    public void createMethodUsingLambda(){
+        Sample nil = new Sample(null);
+        Sample lowercase = new Sample("jim");
+        Sample titlecase = new Sample("Jim");
+        ValidationRule result = ValidationRule.error("test", i -> checkPattern((Sample)i));
+        assertFalse(result.evaluate(nil));
+        assertFalse(result.evaluate(lowercase));
+        assertTrue(result.evaluate(titlecase));
+    }
+}

--- a/modules/openapi-generator/pom.xml
+++ b/modules/openapi-generator/pom.xml
@@ -313,7 +313,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator-core</artifactId>
-            <version>4.0.2-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -153,14 +153,21 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-version}</version>
                 <configuration>
-<!--                    <forkCount>0</forkCount>-->
-<!--                    <reuseForks>false</reuseForks>-->
+                    <!-- Setting forkCount=0 allows for easy debugging of tests using Remote Debugger (in case things fail during testing but pass otherwise) -->
+                    <forkCount>0</forkCount>
+                    <reuseForks>false</reuseForks>
                     <printSummary>true</printSummary>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <junitArtifactName>none:none</junitArtifactName>
                     <testNGArtifactName>org.testng:testng</testNGArtifactName>
                     <argLine>-XX:+StartAttachListener</argLine>
                     <argLine>-javaagent:"${settings.localRepository}/org/jmockit/jmockit/${jmockit-version}/jmockit-${jmockit-version}.jar"</argLine>
+                    <properties>
+                        <property>
+                            <name>surefire.testng.verbose</name>
+                            <value>2</value>
+                        </property>
+                    </properties>
                 </configuration>
             </plugin>
             <plugin>
@@ -1287,12 +1294,12 @@
         </profile>
     </profiles>
     <modules>
+        <module>modules/openapi-generator-core</module>
         <module>modules/openapi-generator</module>
         <module>modules/openapi-generator-cli</module>
         <module>modules/openapi-generator-maven-plugin</module>
         <module>modules/openapi-generator-gradle-plugin</module>
         <module>modules/openapi-generator-online</module>
-        <module>modules/openapi-generator-core</module>
     </modules>
     <reporting>
         <outputDirectory>target/site</outputDirectory>
@@ -1374,8 +1381,8 @@
         <jmustache-version>1.14</jmustache-version>
         <handlebars.java-version>4.1.2</handlebars.java-version>
         <testng-version>6.14.3</testng-version>
-        <surefire-version>2.22.1</surefire-version>
-        <jmockit-version>1.43</jmockit-version>
+        <surefire-version>3.0.0-M3</surefire-version>
+        <jmockit-version>1.44   </jmockit-version>
         <reflections-version>0.9.10</reflections-version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-version}</version>
                 <configuration>
+<!--                    <forkCount>0</forkCount>-->
+<!--                    <reuseForks>false</reuseForks>-->
+                    <printSummary>true</printSummary>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <junitArtifactName>none:none</junitArtifactName>
                     <testNGArtifactName>org.testng:testng</testNGArtifactName>

--- a/pom.xml
+++ b/pom.xml
@@ -163,10 +163,6 @@
                     <argLine>-XX:+StartAttachListener</argLine>
                     <argLine>-javaagent:"${settings.localRepository}/org/jmockit/jmockit/${jmockit-version}/jmockit-${jmockit-version}.jar"</argLine>
                     <properties>
-                        <property>
-                            <name>surefire.testng.verbose</name>
-                            <value>2</value>
-                        </property>
                     </properties>
                 </configuration>
             </plugin>
@@ -1382,7 +1378,7 @@
         <handlebars.java-version>4.1.2</handlebars.java-version>
         <testng-version>6.14.3</testng-version>
         <surefire-version>3.0.0-M3</surefire-version>
-        <jmockit-version>1.44   </jmockit-version>
+        <jmockit-version>1.46</jmockit-version>
         <reflections-version>0.9.10</reflections-version>
     </properties>
 </project>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This adds a simple validation framework to the core module, which aims to give us a consistent way of applying errors/warnings. I'm opening this to generate some discussion about the usability of it.

I intend to use this in #2946 to pull validations out of `CodegenConfigurator` into a self-contained and testable type. I also intend to look into applying this to #1086. I could also see this being useful to validate certain conditions we assume to be required for passing data context to templates (see #837).

The goal here is to create a generic validator which can be applied to an OpenAPI Document, allowing us to provide warnings and errors specific to openapi-generator (in addition to those provided by swagger-parser). This has been made generic so, for example, we could apply validations to other spec documents if/when we support them. We could also create an interface which allows a generator to provide conventional typed validations for that generator.

For example:

```java
package org.openapitools.codegen;

import org.openapitools.codegen.validator.Validator;

public interface ValidatableGenerator<T extends CodegenConfig> {
    Validator<T> getValidator();
}
```

This could be applied to a generator so we can provide errors and warnings prior to generation. Applying this to a generator might look like this:

```diff
diff --git a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
index 85d6f7a60d..dcaa4aff1e 100644
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -23,6 +23,9 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.URLPathUtils;
+import org.openapitools.codegen.validator.GenericValidator;
+import org.openapitools.codegen.validator.ValidationRule;
+import org.openapitools.codegen.validator.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +37,7 @@ import java.util.Map;
 
 import static java.util.UUID.randomUUID;
 
-public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
+public class AspNetCoreServerCodegen extends AbstractCSharpCodegen implements ValidatableGenerator<AspNetCoreServerCodegen> {
 
     public static final String USE_SWASHBUCKLE = "useSwashbuckle";
     public static final String ASPNET_CORE_VERSION = "aspnetCoreVersion";
@@ -52,6 +55,8 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
     public static final String COMPATIBILITY_VERSION = "compatibilityVersion";
     public static final String IS_LIBRARY = "isLibrary";
 
+    private GenericValidator<AspNetCoreServerCodegen> validator;
+
     private String packageGuid = "{" + randomUUID().toString().toUpperCase(Locale.ROOT) + "}";
 
     @SuppressWarnings("hiding")
@@ -91,6 +96,15 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
 
         cliOptions.clear();
 
+        this.validator = new GenericValidator<>(Arrays.asList(
+            ValidationRule.warn("library + modelClassModifier", "Option 'modelClassModifier' is not supported for library outputs.",
+                    (AspNetCoreServerCodegen i)  -> "library".equals(i.library) && ("" + i.modelClassModifier.getOptValue()).length() > 0
+            ),
+            ValidationRule.warn("abstract classes/methods", "Methods must be abstract when a class is marked abstract",
+                    (AspNetCoreServerCodegen i) -> "abstract".equals(classModifier.getOptValue()) && operationModifier.getOptValue().length() > 0 && !"abstract".equals(operationModifier.getOptValue())
+            )
+        ));
+
         typeMapping.put("boolean", "bool");
         typeMapping.put("integer", "int");
         typeMapping.put("float", "float");
@@ -228,6 +242,11 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         return "Generates an ASP.NET Core Web API server.";
     }
 
+    @Override
+    public Validator<AspNetCoreServerCodegen> getValidator() {
+        return this.validator;
+    }
+
     @Override
     public void preprocessOpenAPI(OpenAPI openAPI) {
         super.preprocessOpenAPI(openAPI);
```

With the above, we could allow options to treat warnings as errors and fail before writing any files.

cc @OpenAPITools/generator-core-team @OpenAPITools/openapi-generator-collaborators 