### PR TITLE
[maven-plugin] fix strictSpec parameter

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -244,7 +244,7 @@ public class CodeGenMojo extends AbstractMojo {
     /**
      * To treat a document strictly against the spec.
      */
-    @Parameter(name = "strictSpec", property = "openapi.generator.maven.plugin.strictSpec", required = false)
+    @Parameter(name = "strictSpecBehavior", alias = "strictSpec", property = "openapi.generator.maven.plugin.strictSpec", required = false)
     private Boolean strictSpecBehavior;
 
     /**


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Introduced with #2783, the `strictSpec` parameter causes the an error in the `4.0.1` maven plugin:

```
[ERROR] Failed to execute goal org.openapitools:openapi-generator-maven-plugin:4.0.1:generate (generate-client-code): Unable to parse configuration of mojo org.openapitools:openapi-generator-maven-plugin:4.0.1:generate for parameter strictSpec: Cannot find 'strictSpec' in class org.openapitools.codegen.plugin.CodeGenMojo -> [Help 1]
```

This PR is about to fix it.