### PR TITLE
Fix StrictSpec param name for maven

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -245,7 +245,7 @@ public class CodeGenMojo extends AbstractMojo {
      * To treat a document strictly against the spec.
      */
     @Parameter(name = "strictSpec", property = "openapi.generator.maven.plugin.strictSpec", required = false)
-    private Boolean strictSpecBehavior;
+    private Boolean strictSpec;
 
     /**
      * To generate alias (array, map) as model
@@ -471,8 +471,8 @@ public class CodeGenMojo extends AbstractMojo {
                 configurator.setValidateSpec(!skipValidateSpec);
             }
 
-            if (strictSpecBehavior != null) {
-                configurator.setStrictSpecBehavior(strictSpecBehavior);
+            if (strictSpec != null) {
+                configurator.setStrictSpecBehavior(strictSpec);
             }
 
             if (logToStderr != null) {


### PR DESCRIPTION
Must fix #3070

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

@wing328
@jimschubert
@cbornet
@ackintosh
@jmini
