### PR TITLE
Add maven plugin test to Shippable CI

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -12,6 +12,9 @@ build:
   ci:
     - java -version
     - mvn --quiet clean install -Dmaven.javadoc.skip=true
+    # test maven plugin
+    - mvn clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml
+    - mvn clean compile -f modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml
     # ensure all modifications created by 'mature' generators are in the git repo
     # below move to CircleCI ./bin/utils/ensure-up-to-date
     # prepare environment for tests


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

cc @OpenAPITools/generator-core-team 
