### PR TITLE
[typescript-rxjs] refactor to arrow functions and short hand object creation

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -43,96 +43,75 @@ export class {{classname}} extends BaseAPI {
         throwIfRequired(requestParameters, '{{paramName}}', '{{nickname}}');
         {{/required}}
         {{/allParams}}
-        const queryParameters: HttpQuery = {};
 
-        {{#queryParams}}
-        {{#isListContainer}}
-        if (requestParameters.{{paramName}}) {
+        const query: HttpQuery = {
+            {{#queryParams}}
+            {{#isListContainer}}
             {{#isCollectionFormatMulti}}
-            queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
+            '{{baseName}}': requestParameters.{{paramName}},
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}
-            queryParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(COLLECTION_FORMATS["{{collectionFormat}}"]);
+            '{{baseName}}': requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']),
             {{/isCollectionFormatMulti}}
-        }
-
-        {{/isListContainer}}
-        {{^isListContainer}}
-        if (requestParameters.{{paramName}} !== undefined && requestParameters.{{paramName}} !== null) {
+            {{/isListContainer}}
+            {{^isListContainer}}
             {{#isDateTime}}
-            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString();
+            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
             {{/isDateTime}}
             {{^isDateTime}}
             {{#isDate}}
-            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString();
+            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
             {{/isDate}}
             {{^isDate}}
-            queryParameters['{{baseName}}'] = requestParameters.{{paramName}};
+            '{{baseName}}': requestParameters.{{paramName}},
             {{/isDate}}
             {{/isDateTime}}
-        }
+            {{/isListContainer}}
+            {{/queryParams}}
+            {{#authMethods}}
+            {{#isApiKey}}
+            {{#isKeyInQuery}}
+            '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}'), // {{name}} authentication
+            {{/isKeyInQuery}}
+            {{/isApiKey}}
+            {{/authMethods}}
+        };
 
-        {{/isListContainer}}
-        {{/queryParams}}
-        const headerParameters: HttpHeaders = {};
-
-        {{#bodyParam}}
-        {{^consumes}}
-        headerParameters['Content-Type'] = 'application/json';
-
-        {{/consumes}}
-        {{#consumes.0}}
-        headerParameters['Content-Type'] = '{{{mediaType}}}';
-
-        {{/consumes.0}}
-        {{/bodyParam}}
-        {{#headerParams}}
-        {{#isListContainer}}
-        if (requestParameters.{{paramName}}) {
-            headerParameters['{{baseName}}'] = requestParameters.{{paramName}}.join(COLLECTION_FORMATS["{{collectionFormat}}"]));
-        }
-
-        {{/isListContainer}}
-        {{^isListContainer}}
-        if (requestParameters.{{paramName}} !== undefined && requestParameters.{{paramName}} !== null) {
-            headerParameters['{{baseName}}'] = String(requestParameters.{{paramName}});
-        }
-
-        {{/isListContainer}}
-        {{/headerParams}}
-        {{#authMethods}}
-        {{#isBasic}}
-        if (this.configuration && (this.configuration.username !== undefined || this.configuration.password !== undefined)) {
-            headerParameters["Authorization"] = "Basic " + btoa(this.configuration.username + ":" + this.configuration.password);
-        }
-
-        {{/isBasic}}
-        {{#isApiKey}}
-        {{#isKeyInHeader}}
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["{{keyParamName}}"] = this.configuration.apiKey("{{keyParamName}}"); // {{name}} authentication
-        }
-
-        {{/isKeyInHeader}}
-        {{#isKeyInQuery}}
-        if (this.configuration && this.configuration.apiKey) {
-            queryParameters["{{keyParamName}}"] = this.configuration.apiKey("{{keyParamName}}"); // {{name}} authentication
-        }
-
-        {{/isKeyInQuery}}
-        {{/isApiKey}}
-        {{#isOAuth}}
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            {{#bodyParam}}
+            {{^consumes}}
+            'Content-Type': 'application/json',
+            {{/consumes}}
+            {{#consumes.0}}
+            'Content-Type': '{{{mediaType}}}',
+            {{/consumes.0}}
+            {{/bodyParam}}
+            {{#headerParams}}
+            {{#isListContainer}}
+            '{{baseName}}': requestParameters.{{paramName}} && requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}'])),
+            {{/isListContainer}}
+            {{^isListContainer}}
+            '{{baseName}}': String(requestParameters.{{paramName}}),
+            {{/isListContainer}}
+            {{/headerParams}}
+            {{#authMethods}}
+            {{#isBasic}}
+            Authorization: this.configuration.username && this.configuration.password && `Basic ${btoa(this.configuration.username + ':' + this.configuration.password)}`,
+            {{/isBasic}}
+            {{#isApiKey}}
+            {{#isKeyInHeader}}
+            '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}'), // {{name}} authentication
+            {{/isKeyInHeader}}
+            {{/isApiKey}}
+            {{#isOAuth}}
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("{{name}}", [{{#scopes}}"{{{scope}}}"{{^-last}}, {{/-last}}{{/scopes}}]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('{{name}}', [{{#scopes}}'{{{scope}}}'{{^-last}}, {{/-last}}{{/scopes}}])
+                : this.configuration.accessToken),
+            {{/isOAuth}}
+            {{/authMethods}}
+        };
 
-        {{/isOAuth}}
-        {{/authMethods}}
         {{#hasFormParams}}
         const formData = new FormData();
         {{/hasFormParams}}
@@ -145,7 +124,7 @@ export class {{classname}} extends BaseAPI {
             })
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}
-            formData.append('{{baseName}}', requestParameters.{{paramName}}.join(COLLECTION_FORMATS["{{collectionFormat}}"]));
+            formData.append('{{baseName}}', requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']));
             {{/isCollectionFormatMulti}}
         }
 
@@ -158,10 +137,10 @@ export class {{classname}} extends BaseAPI {
         {{/isListContainer}}
         {{/formParams}}
         return this.request<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>({
-            path: `{{{path}}}`{{#pathParams}}.replace(`{${"{{baseName}}"}}`, encodeURIComponent(String(requestParameters.{{paramName}}))){{/pathParams}},
+            path: `{{{path}}}`{{#pathParams}}.replace({{=<% %>=}}`{<%baseName%>}`<%={{ }}=%>, encodeURIComponent(String(requestParameters.{{paramName}}))){{/pathParams}},
             method: '{{httpMethod}}',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             {{#hasBodyParam}}
             {{#bodyParam}}
             {{#isContainer}}
@@ -193,9 +172,9 @@ export class {{classname}} extends BaseAPI {
 {{#allParams}}
 {{#isEnum}}
 /**
-    * @export
-    * @enum {string}
-    */
+ * @export
+ * @enum {string}
+ */
 export enum {{operationIdCamelCase}}{{enumName}} {
 {{#allowableValues}}
     {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -55,26 +55,28 @@ export class {{classname}} extends BaseAPI {
             {{/bodyParam}}
             {{#headerParams}}
             {{#isListContainer}}
-            '{{baseName}}': requestParameters.{{paramName}} && requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}'])),
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}'])) }),
             {{/isListContainer}}
             {{^isListContainer}}
-            '{{baseName}}': String(requestParameters.{{paramName}}),
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': String(requestParameters.{{paramName}}) }),
             {{/isListContainer}}
             {{/headerParams}}
             {{#authMethods}}
             {{#isBasic}}
-            Authorization: this.configuration.username && this.configuration.password && `Basic ${btoa(this.configuration.username + ':' + this.configuration.password)}`,
+            ...(this.configuration.username && this.configuration.password && { Authorization: `Basic ${btoa(this.configuration.username + ':' + this.configuration.password)}` }),
             {{/isBasic}}
             {{#isApiKey}}
             {{#isKeyInHeader}}
-            '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}'), // {{name}} authentication
+            ...(this.configuration.apiKey && { '{{keyParamName}}': this.configuration.apiKey('{{keyParamName}}') }), // {{name}} authentication
             {{/isKeyInHeader}}
             {{/isApiKey}}
             {{#isOAuth}}
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('{{name}}', [{{#scopes}}'{{{scope}}}'{{^-last}}, {{/-last}}{{/scopes}}])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('{{name}}', [{{#scopes}}'{{{scope}}}'{{^-last}}, {{/-last}}{{/scopes}}])
+                    : this.configuration.accessToken)
+            }),
             {{/isOAuth}}
             {{/authMethods}}
         };
@@ -83,22 +85,22 @@ export class {{classname}} extends BaseAPI {
             {{#queryParams}}
             {{#isListContainer}}
             {{#isCollectionFormatMulti}}
-            '{{baseName}}': requestParameters.{{paramName}},
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': requestParameters.{{paramName}} }),
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}
-            '{{baseName}}': requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']),
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']) }),
             {{/isCollectionFormatMulti}}
             {{/isListContainer}}
             {{^isListContainer}}
             {{#isDateTime}}
-            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString() }),
             {{/isDateTime}}
             {{^isDateTime}}
             {{#isDate}}
-            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString() }),
             {{/isDate}}
             {{^isDate}}
-            '{{baseName}}': requestParameters.{{paramName}},
+            ...(requestParameters.{{paramName}} && { '{{baseName}}': requestParameters.{{paramName}} }),
             {{/isDate}}
             {{/isDateTime}}
             {{/isListContainer}}
@@ -106,7 +108,7 @@ export class {{classname}} extends BaseAPI {
             {{#authMethods}}
             {{#isApiKey}}
             {{#isKeyInQuery}}
-            '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}'), // {{name}} authentication
+            ...(this.configuration.apiKey && { '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}') }), // {{name}} authentication
             {{/isKeyInQuery}}
             {{/isApiKey}}
             {{/authMethods}}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -44,39 +44,6 @@ export class {{classname}} extends BaseAPI {
         {{/required}}
         {{/allParams}}
 
-        const query: HttpQuery = {
-            {{#queryParams}}
-            {{#isListContainer}}
-            {{#isCollectionFormatMulti}}
-            '{{baseName}}': requestParameters.{{paramName}},
-            {{/isCollectionFormatMulti}}
-            {{^isCollectionFormatMulti}}
-            '{{baseName}}': requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']),
-            {{/isCollectionFormatMulti}}
-            {{/isListContainer}}
-            {{^isListContainer}}
-            {{#isDateTime}}
-            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
-            {{/isDateTime}}
-            {{^isDateTime}}
-            {{#isDate}}
-            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
-            {{/isDate}}
-            {{^isDate}}
-            '{{baseName}}': requestParameters.{{paramName}},
-            {{/isDate}}
-            {{/isDateTime}}
-            {{/isListContainer}}
-            {{/queryParams}}
-            {{#authMethods}}
-            {{#isApiKey}}
-            {{#isKeyInQuery}}
-            '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}'), // {{name}} authentication
-            {{/isKeyInQuery}}
-            {{/isApiKey}}
-            {{/authMethods}}
-        };
-
         const headers: HttpHeaders = {
             {{#bodyParam}}
             {{^consumes}}
@@ -109,6 +76,39 @@ export class {{classname}} extends BaseAPI {
                 ? this.configuration.accessToken('{{name}}', [{{#scopes}}'{{{scope}}}'{{^-last}}, {{/-last}}{{/scopes}}])
                 : this.configuration.accessToken),
             {{/isOAuth}}
+            {{/authMethods}}
+        };
+
+        const query: HttpQuery = {
+            {{#queryParams}}
+            {{#isListContainer}}
+            {{#isCollectionFormatMulti}}
+            '{{baseName}}': requestParameters.{{paramName}},
+            {{/isCollectionFormatMulti}}
+            {{^isCollectionFormatMulti}}
+            '{{baseName}}': requestParameters.{{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']),
+            {{/isCollectionFormatMulti}}
+            {{/isListContainer}}
+            {{^isListContainer}}
+            {{#isDateTime}}
+            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
+            {{/isDateTime}}
+            {{^isDateTime}}
+            {{#isDate}}
+            '{{baseName}}': (requestParameters.{{paramName}} as any).toISOString(),
+            {{/isDate}}
+            {{^isDate}}
+            '{{baseName}}': requestParameters.{{paramName}},
+            {{/isDate}}
+            {{/isDateTime}}
+            {{/isListContainer}}
+            {{/queryParams}}
+            {{#authMethods}}
+            {{#isApiKey}}
+            {{#isKeyInQuery}}
+            '{{keyParamName}}': this.configuration.apiKey && this.configuration.apiKey('{{keyParamName}}'), // {{name}} authentication
+            {{/isKeyInQuery}}
+            {{/isApiKey}}
             {{/authMethods}}
         };
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -1,7 +1,7 @@
 // tslint:disable
 {{>licenseInfo}}
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 {{#imports.0}}
 import {
     {{#imports}}
@@ -37,13 +37,10 @@ export class {{classname}} extends BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    {{nickname}}({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    {{nickname}} = ({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Observable<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> => {
         {{#allParams}}
         {{#required}}
-        if (requestParameters.{{paramName}} === null || requestParameters.{{paramName}} === undefined) {
-            throw new RequiredError('{{paramName}}','Required parameter requestParameters.{{paramName}} was null or undefined when calling {{nickname}}.');
-        }
-
+        throwIfRequired(requestParameters, '{{paramName}}', '{{nickname}}');
         {{/required}}
         {{/allParams}}
         const queryParameters: HttpQuery = {};

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -132,7 +132,8 @@ export class BaseAPI {
         Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
-class RequiredError extends Error {
+// export for not being a breaking change
+export class RequiredError extends Error {
     name: 'RequiredError' = 'RequiredError';
 }
 
@@ -163,7 +164,7 @@ export interface RequestOpts {
     body?: HttpBody;
 }
 
-const queryString =(params: HttpQuery): string => Object.keys(params)
+const queryString = (params: HttpQuery): string => Object.keys(params)
     .map((key) => {
         const value = params[key];
         if (value instanceof Array) {
@@ -174,9 +175,12 @@ const queryString =(params: HttpQuery): string => Object.keys(params)
     })
     .join('&');
 
-export const throwIfRequired = (params: {[key: string]: any}, paramName: string, nickname: string) => {
-    if (!params || params[paramName] === null || params[paramName] === undefined) {
-        throw new RequiredError(`Required parameter ${paramName} was null or undefined when calling ${nickname}.`);
+// alias fallback for not being a breaking change
+export const querystring = queryString;
+
+export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
+    if (!params || params[key] === null || params[key] === undefined) {
+        throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
 
 export interface RequestContext extends RequestArgs {}

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -132,11 +132,8 @@ export class BaseAPI {
         Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
-export class RequiredError extends Error {
+class RequiredError extends Error {
     name: 'RequiredError' = 'RequiredError';
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
 }
 
 export const COLLECTION_FORMATS = {
@@ -176,6 +173,11 @@ const queryString =(params: HttpQuery): string => Object.keys(params)
         return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
     })
     .join('&');
+
+export const throwIfRequired = (params: {[key: string]: any}, paramName: string, nickname: string) => {
+    if (!params || params[paramName] === null || params[paramName] === undefined) {
+        throw new RequiredError(`Required parameter ${paramName} was null or undefined when calling ${nickname}.`);
+    }
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -182,6 +182,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     if (!params || params[key] === null || params[key] === undefined) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
+}
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -55,30 +55,26 @@ export class Configuration {
  * This is the base class for all generated API classes.
  */
 export class BaseAPI {
-    private middleware: Middleware[];
+    private middleware: Middleware[] = [];
 
     constructor(protected configuration = new Configuration()) {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    withMiddleware = <T extends BaseAPI>(middlewares: Middleware[]) => {
         const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
+        next.middleware = next.middleware.concat(middlewares);
         return next;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPreMiddleware = <T extends BaseAPI>(preMiddlewares: Array<Middleware['pre']>) =>
+        this.withMiddleware<T>(preMiddlewares.map((pre) => ({ pre })));
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPostMiddleware = <T extends BaseAPI>(postMiddlewares: Array<Middleware['post']>) =>
+        this.withMiddleware<T>(postMiddlewares.map((post) => ({ post })));
 
-    protected request<T>(context: RequestOpts): Observable<T> {
-        return this.rxjsRequest(this.createRequestArgs(context)).pipe(
+    protected request = <T>(context: RequestOpts): Observable<T> => 
+        this.rxjsRequest(this.createRequestArgs(context)).pipe(
             map((res) => {
                 if (res.status >= 200 && res.status < 300) {
                     return res.response as T;
@@ -86,15 +82,14 @@ export class BaseAPI {
                 throw res;
             })
         );
-    }
 
-    private createRequestArgs(context: RequestOpts): RequestArgs {
+    private createRequestArgs = (context: RequestOpts): RequestArgs => {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
+            // only add the queryString to the URL if there are query parameters.
             // this is done to avoid urls ending with a '?' character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + queryString(context.query);
         }
         const body = context.body instanceof FormData ? context.body : JSON.stringify(context.body);
         const options = {
@@ -105,9 +100,9 @@ export class BaseAPI {
         return { url, options };
     }
 
-    private rxjsRequest(params: RequestContext): Observable<AjaxResponse> {
-        const preMiddlewares = this.middleware && this.middleware.filter((item) => item.pre);
-        const postMiddlewares = this.middleware && this.middleware.filter((item) => item.post);
+    private rxjsRequest = (params: RequestContext): Observable<AjaxResponse> => {
+        const preMiddlewares = this.middleware.filter((item) => item.pre);
+        const postMiddlewares = this.middleware.filter((item) => item.post);
 
         return of(params).pipe(
             map((args) => {
@@ -133,12 +128,8 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+    private clone = <T extends BaseAPI>(): T => 
+        Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
 export class RequiredError extends Error {
@@ -175,18 +166,16 @@ export interface RequestOpts {
     body?: HttpBody;
 }
 
-export function querystring(params: HttpQuery): string {
-    return Object.keys(params)
-        .map((key) => {
-            const value = params[key];
-            if (value instanceof Array) {
-                return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
-                    .join('&');
-            }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
-        })
-        .join('&');
-}
+const queryString =(params: HttpQuery): string => Object.keys(params)
+    .map((key) => {
+        const value = params[key];
+        if (value instanceof Array) {
+            return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
+                .join('&');
+        }
+        return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
+    })
+    .join('&');
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     ApiResponse,
     Pet,
@@ -63,31 +63,25 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
-        }
+    addPet = (requestParameters: AddPetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'addPet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -95,33 +89,25 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
-        }
+    deletePet = (requestParameters: DeletePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'deletePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (requestParameters.apiKey !== undefined && requestParameters.apiKey !== null) {
-            headerParameters['api_key'] = String(requestParameters.apiKey);
-        }
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'api_key': String(requestParameters.apiKey),
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -129,33 +115,25 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        if (requestParameters.status === null || requestParameters.status === undefined) {
-            throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
-        }
+    findPetsByStatus = (requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'status', 'findPetsByStatus');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.status) {
-            queryParameters['status'] = requestParameters.status.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByStatus`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -163,33 +141,25 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        if (requestParameters.tags === null || requestParameters.tags === undefined) {
-            throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
-        }
+    findPetsByTags = (requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'tags', 'findPetsByTags');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.tags) {
-            queryParameters['tags'] = requestParameters.tags.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByTags`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -197,55 +167,46 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
-        }
+    getPetById = (requestParameters: GetPetByIdRequest): Observable<Pet> => {
+        throwIfRequired(requestParameters, 'petId', 'getPetById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<Pet>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Update an existing pet
      */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
-        }
+    updatePet = (requestParameters: UpdatePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'updatePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -253,23 +214,18 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
-        }
+    updatePetWithForm = (requestParameters: UpdatePetWithFormRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'updatePetWithForm');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.name !== undefined) {
@@ -281,10 +237,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -292,23 +248,18 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
-        }
+    uploadFile = (requestParameters: UploadFileRequest): Observable<ApiResponse> => {
+        throwIfRequired(requestParameters, 'petId', 'uploadFile');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.additionalMetadata !== undefined) {
@@ -320,10 +271,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<ApiResponse>({
-            path: `/pet/{petId}/uploadImage`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}/uploadImage`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -331,9 +282,9 @@ export class PetApi extends BaseAPI {
 }
 
 /**
-    * @export
-    * @enum {string}
-    */
+ * @export
+ * @enum {string}
+ */
 export enum FindPetsByStatusStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/PetApi.ts
@@ -69,9 +69,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -93,11 +95,13 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
-            'api_key': String(requestParameters.apiKey),
+            ...(requestParameters.apiKey && { 'api_key': String(requestParameters.apiKey) }),
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -120,13 +124,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.status && { 'status': requestParameters.status.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -146,13 +152,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.tags && { 'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -171,7 +179,7 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {
@@ -194,9 +202,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -219,9 +229,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -253,9 +265,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -62,7 +62,7 @@ export class StoreApi extends BaseAPI {
     getInventory = (): Observable<{ [key: string]: number; }> => {
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/StoreApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     Order,
 } from '../models';
@@ -38,20 +38,20 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
-        }
+    deleteOrder = (requestParameters: DeleteOrderRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'orderId', 'deleteOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -59,20 +59,20 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        const queryParameters: HttpQuery = {};
+    getInventory = (): Observable<{ [key: string]: number; }> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<{ [key: string]: number; }>({
             path: `/store/inventory`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -80,42 +80,41 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
-        }
+    getOrderById = (requestParameters: GetOrderByIdRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'orderId', 'getOrderById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Place an order for a pet
      */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
-        }
+    placeOrder = (requestParameters: PlaceOrderRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'body', 'placeOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
             path: `/store/order`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     User,
 } from '../models';
@@ -56,22 +56,21 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
-        }
+    createUser = (requestParameters: CreateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -79,22 +78,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
-        }
+    createUsersWithArrayInput = (requestParameters: CreateUsersWithArrayInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithArrayInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithArray`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -102,22 +100,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
-        }
+    createUsersWithListInput = (requestParameters: CreateUsersWithListInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithListInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithList`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -126,88 +123,82 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
-        }
+    deleteUser = (requestParameters: DeleteUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'deleteUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Get user by user name
      */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
-        }
+    getUserByName = (requestParameters: GetUserByNameRequest): Observable<User> => {
+        throwIfRequired(requestParameters, 'username', 'getUserByName');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<User>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs user into the system
      */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
-        }
+    loginUser = (requestParameters: LoginUserRequest): Observable<string> => {
+        throwIfRequired(requestParameters, 'username', 'loginUser');
+        throwIfRequired(requestParameters, 'password', 'loginUser');
 
-        if (requestParameters.password === null || requestParameters.password === undefined) {
-            throw new RequiredError('password','Required parameter requestParameters.password was null or undefined when calling loginUser.');
-        }
+        const headers: HttpHeaders = {
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.username !== undefined && requestParameters.username !== null) {
-            queryParameters['username'] = requestParameters.username;
-        }
-
-        if (requestParameters.password !== undefined && requestParameters.password !== null) {
-            queryParameters['password'] = requestParameters.password;
-        }
-
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+            'username': requestParameters.username,
+            'password': requestParameters.password,
+        };
 
         return this.request<string>({
             path: `/user/login`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs out current logged in user session
      */
-    logoutUser(): Observable<void> {
-        const queryParameters: HttpQuery = {};
+    logoutUser = (): Observable<void> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/logout`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -215,26 +206,22 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
-        }
+    updateUser = (requestParameters: UpdateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'updateUser');
+        throwIfRequired(requestParameters, 'body', 'updateUser');
 
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updateUser.');
-        }
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/apis/UserApi.ts
@@ -171,8 +171,8 @@ export class UserApi extends BaseAPI {
         };
 
         const query: HttpQuery = {
-            'username': requestParameters.username,
-            'password': requestParameters.password,
+            ...(requestParameters.username && { 'username': requestParameters.username }),
+            ...(requestParameters.password && { 'password': requestParameters.password }),
         };
 
         return this.request<string>({

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -66,30 +66,26 @@ export class Configuration {
  * This is the base class for all generated API classes.
  */
 export class BaseAPI {
-    private middleware: Middleware[];
+    private middleware: Middleware[] = [];
 
     constructor(protected configuration = new Configuration()) {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    withMiddleware = <T extends BaseAPI>(middlewares: Middleware[]) => {
         const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
+        next.middleware = next.middleware.concat(middlewares);
         return next;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPreMiddleware = <T extends BaseAPI>(preMiddlewares: Array<Middleware['pre']>) =>
+        this.withMiddleware<T>(preMiddlewares.map((pre) => ({ pre })));
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPostMiddleware = <T extends BaseAPI>(postMiddlewares: Array<Middleware['post']>) =>
+        this.withMiddleware<T>(postMiddlewares.map((post) => ({ post })));
 
-    protected request<T>(context: RequestOpts): Observable<T> {
-        return this.rxjsRequest(this.createRequestArgs(context)).pipe(
+    protected request = <T>(context: RequestOpts): Observable<T> => 
+        this.rxjsRequest(this.createRequestArgs(context)).pipe(
             map((res) => {
                 if (res.status >= 200 && res.status < 300) {
                     return res.response as T;
@@ -97,15 +93,14 @@ export class BaseAPI {
                 throw res;
             })
         );
-    }
 
-    private createRequestArgs(context: RequestOpts): RequestArgs {
+    private createRequestArgs = (context: RequestOpts): RequestArgs => {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
+            // only add the queryString to the URL if there are query parameters.
             // this is done to avoid urls ending with a '?' character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + queryString(context.query);
         }
         const body = context.body instanceof FormData ? context.body : JSON.stringify(context.body);
         const options = {
@@ -116,9 +111,9 @@ export class BaseAPI {
         return { url, options };
     }
 
-    private rxjsRequest(params: RequestContext): Observable<AjaxResponse> {
-        const preMiddlewares = this.middleware && this.middleware.filter((item) => item.pre);
-        const postMiddlewares = this.middleware && this.middleware.filter((item) => item.post);
+    private rxjsRequest = (params: RequestContext): Observable<AjaxResponse> => {
+        const preMiddlewares = this.middleware.filter((item) => item.pre);
+        const postMiddlewares = this.middleware.filter((item) => item.post);
 
         return of(params).pipe(
             map((args) => {
@@ -144,19 +139,13 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+    private clone = <T extends BaseAPI>(): T => 
+        Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
+// export for not being a breaking change
 export class RequiredError extends Error {
     name: 'RequiredError' = 'RequiredError';
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
 }
 
 export const COLLECTION_FORMATS = {
@@ -186,18 +175,24 @@ export interface RequestOpts {
     body?: HttpBody;
 }
 
-export function querystring(params: HttpQuery): string {
-    return Object.keys(params)
-        .map((key) => {
-            const value = params[key];
-            if (value instanceof Array) {
-                return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
-                    .join('&');
-            }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
-        })
-        .join('&');
-}
+const queryString = (params: HttpQuery): string => Object.keys(params)
+    .map((key) => {
+        const value = params[key];
+        if (value instanceof Array) {
+            return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
+                .join('&');
+        }
+        return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
+    })
+    .join('&');
+
+// alias fallback for not being a breaking change
+export const querystring = queryString;
+
+export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
+    if (!params || params[key] === null || params[key] === undefined) {
+        throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
+    }
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -193,6 +193,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     if (!params || params[key] === null || params[key] === undefined) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
+}
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     ApiResponse,
     Pet,
@@ -63,31 +63,25 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
-        }
+    addPet = (requestParameters: AddPetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'addPet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -95,33 +89,25 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
-        }
+    deletePet = (requestParameters: DeletePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'deletePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (requestParameters.apiKey !== undefined && requestParameters.apiKey !== null) {
-            headerParameters['api_key'] = String(requestParameters.apiKey);
-        }
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'api_key': String(requestParameters.apiKey),
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -129,33 +115,25 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        if (requestParameters.status === null || requestParameters.status === undefined) {
-            throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
-        }
+    findPetsByStatus = (requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'status', 'findPetsByStatus');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.status) {
-            queryParameters['status'] = requestParameters.status.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByStatus`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -163,33 +141,25 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        if (requestParameters.tags === null || requestParameters.tags === undefined) {
-            throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
-        }
+    findPetsByTags = (requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'tags', 'findPetsByTags');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.tags) {
-            queryParameters['tags'] = requestParameters.tags.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByTags`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -197,55 +167,46 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
-        }
+    getPetById = (requestParameters: GetPetByIdRequest): Observable<Pet> => {
+        throwIfRequired(requestParameters, 'petId', 'getPetById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<Pet>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Update an existing pet
      */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
-        }
+    updatePet = (requestParameters: UpdatePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'updatePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -253,23 +214,18 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
-        }
+    updatePetWithForm = (requestParameters: UpdatePetWithFormRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'updatePetWithForm');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.name !== undefined) {
@@ -281,10 +237,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -292,23 +248,18 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
-        }
+    uploadFile = (requestParameters: UploadFileRequest): Observable<ApiResponse> => {
+        throwIfRequired(requestParameters, 'petId', 'uploadFile');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.additionalMetadata !== undefined) {
@@ -320,10 +271,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<ApiResponse>({
-            path: `/pet/{petId}/uploadImage`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}/uploadImage`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -331,9 +282,9 @@ export class PetApi extends BaseAPI {
 }
 
 /**
-    * @export
-    * @enum {string}
-    */
+ * @export
+ * @enum {string}
+ */
 export enum FindPetsByStatusStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/PetApi.ts
@@ -69,9 +69,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -93,11 +95,13 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
-            'api_key': String(requestParameters.apiKey),
+            ...(requestParameters.apiKey && { 'api_key': String(requestParameters.apiKey) }),
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -120,13 +124,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.status && { 'status': requestParameters.status.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -146,13 +152,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.tags && { 'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -171,7 +179,7 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {
@@ -194,9 +202,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -219,9 +229,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -253,9 +265,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -62,7 +62,7 @@ export class StoreApi extends BaseAPI {
     getInventory = (): Observable<{ [key: string]: number; }> => {
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/StoreApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     Order,
 } from '../models';
@@ -38,20 +38,20 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
-        }
+    deleteOrder = (requestParameters: DeleteOrderRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'orderId', 'deleteOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -59,20 +59,20 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        const queryParameters: HttpQuery = {};
+    getInventory = (): Observable<{ [key: string]: number; }> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<{ [key: string]: number; }>({
             path: `/store/inventory`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -80,42 +80,41 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
-        }
+    getOrderById = (requestParameters: GetOrderByIdRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'orderId', 'getOrderById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Place an order for a pet
      */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
-        }
+    placeOrder = (requestParameters: PlaceOrderRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'body', 'placeOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
             path: `/store/order`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     User,
 } from '../models';
@@ -56,22 +56,21 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
-        }
+    createUser = (requestParameters: CreateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -79,22 +78,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
-        }
+    createUsersWithArrayInput = (requestParameters: CreateUsersWithArrayInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithArrayInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithArray`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -102,22 +100,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
-        }
+    createUsersWithListInput = (requestParameters: CreateUsersWithListInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithListInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithList`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -126,88 +123,82 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
-        }
+    deleteUser = (requestParameters: DeleteUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'deleteUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Get user by user name
      */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
-        }
+    getUserByName = (requestParameters: GetUserByNameRequest): Observable<User> => {
+        throwIfRequired(requestParameters, 'username', 'getUserByName');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<User>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs user into the system
      */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
-        }
+    loginUser = (requestParameters: LoginUserRequest): Observable<string> => {
+        throwIfRequired(requestParameters, 'username', 'loginUser');
+        throwIfRequired(requestParameters, 'password', 'loginUser');
 
-        if (requestParameters.password === null || requestParameters.password === undefined) {
-            throw new RequiredError('password','Required parameter requestParameters.password was null or undefined when calling loginUser.');
-        }
+        const headers: HttpHeaders = {
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.username !== undefined && requestParameters.username !== null) {
-            queryParameters['username'] = requestParameters.username;
-        }
-
-        if (requestParameters.password !== undefined && requestParameters.password !== null) {
-            queryParameters['password'] = requestParameters.password;
-        }
-
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+            'username': requestParameters.username,
+            'password': requestParameters.password,
+        };
 
         return this.request<string>({
             path: `/user/login`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs out current logged in user session
      */
-    logoutUser(): Observable<void> {
-        const queryParameters: HttpQuery = {};
+    logoutUser = (): Observable<void> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/logout`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -215,26 +206,22 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
-        }
+    updateUser = (requestParameters: UpdateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'updateUser');
+        throwIfRequired(requestParameters, 'body', 'updateUser');
 
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updateUser.');
-        }
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/apis/UserApi.ts
@@ -171,8 +171,8 @@ export class UserApi extends BaseAPI {
         };
 
         const query: HttpQuery = {
-            'username': requestParameters.username,
-            'password': requestParameters.password,
+            ...(requestParameters.username && { 'username': requestParameters.username }),
+            ...(requestParameters.password && { 'password': requestParameters.password }),
         };
 
         return this.request<string>({

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -66,30 +66,26 @@ export class Configuration {
  * This is the base class for all generated API classes.
  */
 export class BaseAPI {
-    private middleware: Middleware[];
+    private middleware: Middleware[] = [];
 
     constructor(protected configuration = new Configuration()) {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    withMiddleware = <T extends BaseAPI>(middlewares: Middleware[]) => {
         const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
+        next.middleware = next.middleware.concat(middlewares);
         return next;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPreMiddleware = <T extends BaseAPI>(preMiddlewares: Array<Middleware['pre']>) =>
+        this.withMiddleware<T>(preMiddlewares.map((pre) => ({ pre })));
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPostMiddleware = <T extends BaseAPI>(postMiddlewares: Array<Middleware['post']>) =>
+        this.withMiddleware<T>(postMiddlewares.map((post) => ({ post })));
 
-    protected request<T>(context: RequestOpts): Observable<T> {
-        return this.rxjsRequest(this.createRequestArgs(context)).pipe(
+    protected request = <T>(context: RequestOpts): Observable<T> => 
+        this.rxjsRequest(this.createRequestArgs(context)).pipe(
             map((res) => {
                 if (res.status >= 200 && res.status < 300) {
                     return res.response as T;
@@ -97,15 +93,14 @@ export class BaseAPI {
                 throw res;
             })
         );
-    }
 
-    private createRequestArgs(context: RequestOpts): RequestArgs {
+    private createRequestArgs = (context: RequestOpts): RequestArgs => {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
+            // only add the queryString to the URL if there are query parameters.
             // this is done to avoid urls ending with a '?' character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + queryString(context.query);
         }
         const body = context.body instanceof FormData ? context.body : JSON.stringify(context.body);
         const options = {
@@ -116,9 +111,9 @@ export class BaseAPI {
         return { url, options };
     }
 
-    private rxjsRequest(params: RequestContext): Observable<AjaxResponse> {
-        const preMiddlewares = this.middleware && this.middleware.filter((item) => item.pre);
-        const postMiddlewares = this.middleware && this.middleware.filter((item) => item.post);
+    private rxjsRequest = (params: RequestContext): Observable<AjaxResponse> => {
+        const preMiddlewares = this.middleware.filter((item) => item.pre);
+        const postMiddlewares = this.middleware.filter((item) => item.post);
 
         return of(params).pipe(
             map((args) => {
@@ -144,19 +139,13 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+    private clone = <T extends BaseAPI>(): T => 
+        Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
+// export for not being a breaking change
 export class RequiredError extends Error {
     name: 'RequiredError' = 'RequiredError';
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
 }
 
 export const COLLECTION_FORMATS = {
@@ -186,18 +175,24 @@ export interface RequestOpts {
     body?: HttpBody;
 }
 
-export function querystring(params: HttpQuery): string {
-    return Object.keys(params)
-        .map((key) => {
-            const value = params[key];
-            if (value instanceof Array) {
-                return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
-                    .join('&');
-            }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
-        })
-        .join('&');
-}
+const queryString = (params: HttpQuery): string => Object.keys(params)
+    .map((key) => {
+        const value = params[key];
+        if (value instanceof Array) {
+            return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
+                .join('&');
+        }
+        return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
+    })
+    .join('&');
+
+// alias fallback for not being a breaking change
+export const querystring = queryString;
+
+export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
+    if (!params || params[key] === null || params[key] === undefined) {
+        throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
+    }
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -193,6 +193,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     if (!params || params[key] === null || params[key] === undefined) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
+}
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     ApiResponse,
     Pet,
@@ -63,31 +63,25 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
-        }
+    addPet = (requestParameters: AddPetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'addPet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -95,33 +89,25 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
-        }
+    deletePet = (requestParameters: DeletePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'deletePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (requestParameters.apiKey !== undefined && requestParameters.apiKey !== null) {
-            headerParameters['api_key'] = String(requestParameters.apiKey);
-        }
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'api_key': String(requestParameters.apiKey),
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -129,33 +115,25 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        if (requestParameters.status === null || requestParameters.status === undefined) {
-            throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
-        }
+    findPetsByStatus = (requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'status', 'findPetsByStatus');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.status) {
-            queryParameters['status'] = requestParameters.status.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByStatus`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -163,33 +141,25 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        if (requestParameters.tags === null || requestParameters.tags === undefined) {
-            throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
-        }
+    findPetsByTags = (requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'tags', 'findPetsByTags');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.tags) {
-            queryParameters['tags'] = requestParameters.tags.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByTags`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -197,55 +167,46 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
-        }
+    getPetById = (requestParameters: GetPetByIdRequest): Observable<Pet> => {
+        throwIfRequired(requestParameters, 'petId', 'getPetById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<Pet>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Update an existing pet
      */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
-        }
+    updatePet = (requestParameters: UpdatePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'updatePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -253,23 +214,18 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
-        }
+    updatePetWithForm = (requestParameters: UpdatePetWithFormRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'updatePetWithForm');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.name !== undefined) {
@@ -281,10 +237,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -292,23 +248,18 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
-        }
+    uploadFile = (requestParameters: UploadFileRequest): Observable<ApiResponse> => {
+        throwIfRequired(requestParameters, 'petId', 'uploadFile');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.additionalMetadata !== undefined) {
@@ -320,10 +271,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<ApiResponse>({
-            path: `/pet/{petId}/uploadImage`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}/uploadImage`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -331,9 +282,9 @@ export class PetApi extends BaseAPI {
 }
 
 /**
-    * @export
-    * @enum {string}
-    */
+ * @export
+ * @enum {string}
+ */
 export enum FindPetsByStatusStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/PetApi.ts
@@ -69,9 +69,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -93,11 +95,13 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
-            'api_key': String(requestParameters.apiKey),
+            ...(requestParameters.apiKey && { 'api_key': String(requestParameters.apiKey) }),
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -120,13 +124,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.status && { 'status': requestParameters.status.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -146,13 +152,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.tags && { 'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -171,7 +179,7 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {
@@ -194,9 +202,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -219,9 +229,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -253,9 +265,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
@@ -62,7 +62,7 @@ export class StoreApi extends BaseAPI {
     getInventory = (): Observable<{ [key: string]: number; }> => {
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/StoreApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     Order,
 } from '../models';
@@ -38,20 +38,20 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
-        }
+    deleteOrder = (requestParameters: DeleteOrderRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'orderId', 'deleteOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -59,20 +59,20 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        const queryParameters: HttpQuery = {};
+    getInventory = (): Observable<{ [key: string]: number; }> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<{ [key: string]: number; }>({
             path: `/store/inventory`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -80,42 +80,41 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
-        }
+    getOrderById = (requestParameters: GetOrderByIdRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'orderId', 'getOrderById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Place an order for a pet
      */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
-        }
+    placeOrder = (requestParameters: PlaceOrderRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'body', 'placeOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
             path: `/store/order`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     User,
 } from '../models';
@@ -56,22 +56,21 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
-        }
+    createUser = (requestParameters: CreateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -79,22 +78,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
-        }
+    createUsersWithArrayInput = (requestParameters: CreateUsersWithArrayInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithArrayInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithArray`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -102,22 +100,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
-        }
+    createUsersWithListInput = (requestParameters: CreateUsersWithListInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithListInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithList`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -126,88 +123,82 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
-        }
+    deleteUser = (requestParameters: DeleteUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'deleteUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Get user by user name
      */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
-        }
+    getUserByName = (requestParameters: GetUserByNameRequest): Observable<User> => {
+        throwIfRequired(requestParameters, 'username', 'getUserByName');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<User>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs user into the system
      */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
-        }
+    loginUser = (requestParameters: LoginUserRequest): Observable<string> => {
+        throwIfRequired(requestParameters, 'username', 'loginUser');
+        throwIfRequired(requestParameters, 'password', 'loginUser');
 
-        if (requestParameters.password === null || requestParameters.password === undefined) {
-            throw new RequiredError('password','Required parameter requestParameters.password was null or undefined when calling loginUser.');
-        }
+        const headers: HttpHeaders = {
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.username !== undefined && requestParameters.username !== null) {
-            queryParameters['username'] = requestParameters.username;
-        }
-
-        if (requestParameters.password !== undefined && requestParameters.password !== null) {
-            queryParameters['password'] = requestParameters.password;
-        }
-
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+            'username': requestParameters.username,
+            'password': requestParameters.password,
+        };
 
         return this.request<string>({
             path: `/user/login`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs out current logged in user session
      */
-    logoutUser(): Observable<void> {
-        const queryParameters: HttpQuery = {};
+    logoutUser = (): Observable<void> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/logout`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -215,26 +206,22 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
-        }
+    updateUser = (requestParameters: UpdateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'updateUser');
+        throwIfRequired(requestParameters, 'body', 'updateUser');
 
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updateUser.');
-        }
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/apis/UserApi.ts
@@ -171,8 +171,8 @@ export class UserApi extends BaseAPI {
         };
 
         const query: HttpQuery = {
-            'username': requestParameters.username,
-            'password': requestParameters.password,
+            ...(requestParameters.username && { 'username': requestParameters.username }),
+            ...(requestParameters.password && { 'password': requestParameters.password }),
         };
 
         return this.request<string>({

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -66,30 +66,26 @@ export class Configuration {
  * This is the base class for all generated API classes.
  */
 export class BaseAPI {
-    private middleware: Middleware[];
+    private middleware: Middleware[] = [];
 
     constructor(protected configuration = new Configuration()) {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    withMiddleware = <T extends BaseAPI>(middlewares: Middleware[]) => {
         const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
+        next.middleware = next.middleware.concat(middlewares);
         return next;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPreMiddleware = <T extends BaseAPI>(preMiddlewares: Array<Middleware['pre']>) =>
+        this.withMiddleware<T>(preMiddlewares.map((pre) => ({ pre })));
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPostMiddleware = <T extends BaseAPI>(postMiddlewares: Array<Middleware['post']>) =>
+        this.withMiddleware<T>(postMiddlewares.map((post) => ({ post })));
 
-    protected request<T>(context: RequestOpts): Observable<T> {
-        return this.rxjsRequest(this.createRequestArgs(context)).pipe(
+    protected request = <T>(context: RequestOpts): Observable<T> => 
+        this.rxjsRequest(this.createRequestArgs(context)).pipe(
             map((res) => {
                 if (res.status >= 200 && res.status < 300) {
                     return res.response as T;
@@ -97,15 +93,14 @@ export class BaseAPI {
                 throw res;
             })
         );
-    }
 
-    private createRequestArgs(context: RequestOpts): RequestArgs {
+    private createRequestArgs = (context: RequestOpts): RequestArgs => {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
+            // only add the queryString to the URL if there are query parameters.
             // this is done to avoid urls ending with a '?' character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + queryString(context.query);
         }
         const body = context.body instanceof FormData ? context.body : JSON.stringify(context.body);
         const options = {
@@ -116,9 +111,9 @@ export class BaseAPI {
         return { url, options };
     }
 
-    private rxjsRequest(params: RequestContext): Observable<AjaxResponse> {
-        const preMiddlewares = this.middleware && this.middleware.filter((item) => item.pre);
-        const postMiddlewares = this.middleware && this.middleware.filter((item) => item.post);
+    private rxjsRequest = (params: RequestContext): Observable<AjaxResponse> => {
+        const preMiddlewares = this.middleware.filter((item) => item.pre);
+        const postMiddlewares = this.middleware.filter((item) => item.post);
 
         return of(params).pipe(
             map((args) => {
@@ -144,19 +139,13 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+    private clone = <T extends BaseAPI>(): T => 
+        Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
+// export for not being a breaking change
 export class RequiredError extends Error {
     name: 'RequiredError' = 'RequiredError';
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
 }
 
 export const COLLECTION_FORMATS = {
@@ -186,18 +175,24 @@ export interface RequestOpts {
     body?: HttpBody;
 }
 
-export function querystring(params: HttpQuery): string {
-    return Object.keys(params)
-        .map((key) => {
-            const value = params[key];
-            if (value instanceof Array) {
-                return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
-                    .join('&');
-            }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
-        })
-        .join('&');
-}
+const queryString = (params: HttpQuery): string => Object.keys(params)
+    .map((key) => {
+        const value = params[key];
+        if (value instanceof Array) {
+            return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
+                .join('&');
+        }
+        return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
+    })
+    .join('&');
+
+// alias fallback for not being a breaking change
+export const querystring = queryString;
+
+export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
+    if (!params || params[key] === null || params[key] === undefined) {
+        throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
+    }
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -193,6 +193,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     if (!params || params[key] === null || params[key] === undefined) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
+}
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     ApiResponse,
     Pet,
@@ -63,31 +63,25 @@ export class PetApi extends BaseAPI {
     /**
      * Add a new pet to the store
      */
-    addPet(requestParameters: AddPetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
-        }
+    addPet = (requestParameters: AddPetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'addPet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -95,33 +89,25 @@ export class PetApi extends BaseAPI {
     /**
      * Deletes a pet
      */
-    deletePet(requestParameters: DeletePetRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
-        }
+    deletePet = (requestParameters: DeletePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'deletePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (requestParameters.apiKey !== undefined && requestParameters.apiKey !== null) {
-            headerParameters['api_key'] = String(requestParameters.apiKey);
-        }
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'api_key': String(requestParameters.apiKey),
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -129,33 +115,25 @@ export class PetApi extends BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    findPetsByStatus(requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> {
-        if (requestParameters.status === null || requestParameters.status === undefined) {
-            throw new RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
-        }
+    findPetsByStatus = (requestParameters: FindPetsByStatusRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'status', 'findPetsByStatus');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.status) {
-            queryParameters['status'] = requestParameters.status.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByStatus`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -163,33 +141,25 @@ export class PetApi extends BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    findPetsByTags(requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> {
-        if (requestParameters.tags === null || requestParameters.tags === undefined) {
-            throw new RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
-        }
+    findPetsByTags = (requestParameters: FindPetsByTagsRequest): Observable<Array<Pet>> => {
+        throwIfRequired(requestParameters, 'tags', 'findPetsByTags');
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.tags) {
-            queryParameters['tags'] = requestParameters.tags.join(COLLECTION_FORMATS["csv"]);
-        }
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+        };
 
         return this.request<Array<Pet>>({
             path: `/pet/findByTags`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -197,55 +167,46 @@ export class PetApi extends BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    getPetById(requestParameters: GetPetByIdRequest): Observable<Pet> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
-        }
+    getPetById = (requestParameters: GetPetByIdRequest): Observable<Pet> => {
+        throwIfRequired(requestParameters, 'petId', 'getPetById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<Pet>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Update an existing pet
      */
-    updatePet(requestParameters: UpdatePetRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
-        }
+    updatePet = (requestParameters: UpdatePetRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'updatePet');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/pet`,
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -253,23 +214,18 @@ export class PetApi extends BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Observable<void> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
-        }
+    updatePetWithForm = (requestParameters: UpdatePetWithFormRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'petId', 'updatePetWithForm');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.name !== undefined) {
@@ -281,10 +237,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<void>({
-            path: `/pet/{petId}`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -292,23 +248,18 @@ export class PetApi extends BaseAPI {
     /**
      * uploads an image
      */
-    uploadFile(requestParameters: UploadFileRequest): Observable<ApiResponse> {
-        if (requestParameters.petId === null || requestParameters.petId === undefined) {
-            throw new RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
-        }
+    uploadFile = (requestParameters: UploadFileRequest): Observable<ApiResponse> => {
+        throwIfRequired(requestParameters, 'petId', 'uploadFile');
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
+        const headers: HttpHeaders = {
             // oauth required
-            if (typeof this.configuration.accessToken === 'function') {
-                headerParameters["Authorization"] = this.configuration.accessToken("petstore_auth", ["write:pets", "read:pets"]);
-            } else {
-                headerParameters["Authorization"] = this.configuration.accessToken;
-            }
-        }
+            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                : this.configuration.accessToken),
+        };
+
+        const query: HttpQuery = {
+        };
 
         const formData = new FormData();
         if (requestParameters.additionalMetadata !== undefined) {
@@ -320,10 +271,10 @@ export class PetApi extends BaseAPI {
         }
 
         return this.request<ApiResponse>({
-            path: `/pet/{petId}/uploadImage`.replace(`{${"petId"}}`, encodeURIComponent(String(requestParameters.petId))),
+            path: `/pet/{petId}/uploadImage`.replace(`{petId}`, encodeURIComponent(String(requestParameters.petId))),
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: formData,
         });
     }
@@ -331,9 +282,9 @@ export class PetApi extends BaseAPI {
 }
 
 /**
-    * @export
-    * @enum {string}
-    */
+ * @export
+ * @enum {string}
+ */
 export enum FindPetsByStatusStatusEnum {
     Available = 'available',
     Pending = 'pending',

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/PetApi.ts
@@ -69,9 +69,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -93,11 +95,13 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'deletePet');
 
         const headers: HttpHeaders = {
-            'api_key': String(requestParameters.apiKey),
+            ...(requestParameters.apiKey && { 'api_key': String(requestParameters.apiKey) }),
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -120,13 +124,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'status': requestParameters.status.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.status && { 'status': requestParameters.status.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -146,13 +152,15 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
-            'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']),
+            ...(requestParameters.tags && { 'tags': requestParameters.tags.join(COLLECTION_FORMATS['csv']) }),
         };
 
         return this.request<Array<Pet>>({
@@ -171,7 +179,7 @@ export class PetApi extends BaseAPI {
         throwIfRequired(requestParameters, 'petId', 'getPetById');
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {
@@ -194,9 +202,11 @@ export class PetApi extends BaseAPI {
         const headers: HttpHeaders = {
             'Content-Type': 'application/json',
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -219,9 +229,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {
@@ -253,9 +265,11 @@ export class PetApi extends BaseAPI {
 
         const headers: HttpHeaders = {
             // oauth required
-            Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
-                ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
-                : this.configuration.accessToken),
+            ...(this.configuration.accessToken && {
+                Authorization: this.configuration.accessToken && (typeof this.configuration.accessToken === 'function'
+                    ? this.configuration.accessToken('petstore_auth', ['write:pets', 'read:pets'])
+                    : this.configuration.accessToken)
+            }),
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -62,7 +62,7 @@ export class StoreApi extends BaseAPI {
     getInventory = (): Observable<{ [key: string]: number; }> => {
 
         const headers: HttpHeaders = {
-            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+            ...(this.configuration.apiKey && { 'api_key': this.configuration.apiKey('api_key') }), // api_key authentication
         };
 
         const query: HttpQuery = {

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/StoreApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     Order,
 } from '../models';
@@ -38,20 +38,20 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    deleteOrder(requestParameters: DeleteOrderRequest): Observable<void> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
-        }
+    deleteOrder = (requestParameters: DeleteOrderRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'orderId', 'deleteOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -59,20 +59,20 @@ export class StoreApi extends BaseAPI {
      * Returns a map of status codes to quantities
      * Returns pet inventories by status
      */
-    getInventory(): Observable<{ [key: string]: number; }> {
-        const queryParameters: HttpQuery = {};
+    getInventory = (): Observable<{ [key: string]: number; }> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+            'api_key': this.configuration.apiKey && this.configuration.apiKey('api_key'), // api_key authentication
+        };
 
-        if (this.configuration && this.configuration.apiKey) {
-            headerParameters["api_key"] = this.configuration.apiKey("api_key"); // api_key authentication
-        }
+        const query: HttpQuery = {
+        };
 
         return this.request<{ [key: string]: number; }>({
             path: `/store/inventory`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -80,42 +80,41 @@ export class StoreApi extends BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    getOrderById(requestParameters: GetOrderByIdRequest): Observable<Order> {
-        if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
-            throw new RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
-        }
+    getOrderById = (requestParameters: GetOrderByIdRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'orderId', 'getOrderById');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
-            path: `/store/order/{orderId}`.replace(`{${"orderId"}}`, encodeURIComponent(String(requestParameters.orderId))),
+            path: `/store/order/{orderId}`.replace(`{orderId}`, encodeURIComponent(String(requestParameters.orderId))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Place an order for a pet
      */
-    placeOrder(requestParameters: PlaceOrderRequest): Observable<Order> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
-        }
+    placeOrder = (requestParameters: PlaceOrderRequest): Observable<Order> => {
+        throwIfRequired(requestParameters, 'body', 'placeOrder');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<Order>({
             path: `/store/order`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -12,7 +12,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { BaseAPI, RequiredError, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
+import { BaseAPI, throwIfRequired, HttpHeaders, HttpQuery, COLLECTION_FORMATS } from '../runtime';
 import {
     User,
 } from '../models';
@@ -56,22 +56,21 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    createUser(requestParameters: CreateUserRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
-        }
+    createUser = (requestParameters: CreateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -79,22 +78,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
-        }
+    createUsersWithArrayInput = (requestParameters: CreateUsersWithArrayInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithArrayInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithArray`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -102,22 +100,21 @@ export class UserApi extends BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Observable<void> {
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
-        }
+    createUsersWithListInput = (requestParameters: CreateUsersWithListInputRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'body', 'createUsersWithListInput');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/createWithList`,
             method: 'POST',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }
@@ -126,88 +123,82 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    deleteUser(requestParameters: DeleteUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
-        }
+    deleteUser = (requestParameters: DeleteUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'deleteUser');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'DELETE',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Get user by user name
      */
-    getUserByName(requestParameters: GetUserByNameRequest): Observable<User> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
-        }
+    getUserByName = (requestParameters: GetUserByNameRequest): Observable<User> => {
+        throwIfRequired(requestParameters, 'username', 'getUserByName');
 
-        const queryParameters: HttpQuery = {};
+        const headers: HttpHeaders = {
+        };
 
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+        };
 
         return this.request<User>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs user into the system
      */
-    loginUser(requestParameters: LoginUserRequest): Observable<string> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
-        }
+    loginUser = (requestParameters: LoginUserRequest): Observable<string> => {
+        throwIfRequired(requestParameters, 'username', 'loginUser');
+        throwIfRequired(requestParameters, 'password', 'loginUser');
 
-        if (requestParameters.password === null || requestParameters.password === undefined) {
-            throw new RequiredError('password','Required parameter requestParameters.password was null or undefined when calling loginUser.');
-        }
+        const headers: HttpHeaders = {
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        if (requestParameters.username !== undefined && requestParameters.username !== null) {
-            queryParameters['username'] = requestParameters.username;
-        }
-
-        if (requestParameters.password !== undefined && requestParameters.password !== null) {
-            queryParameters['password'] = requestParameters.password;
-        }
-
-        const headerParameters: HttpHeaders = {};
+        const query: HttpQuery = {
+            'username': requestParameters.username,
+            'password': requestParameters.password,
+        };
 
         return this.request<string>({
             path: `/user/login`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
     /**
      * Logs out current logged in user session
      */
-    logoutUser(): Observable<void> {
-        const queryParameters: HttpQuery = {};
+    logoutUser = (): Observable<void> => {
 
-        const headerParameters: HttpHeaders = {};
+        const headers: HttpHeaders = {
+        };
+
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
             path: `/user/logout`,
             method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
         });
     }
 
@@ -215,26 +206,22 @@ export class UserApi extends BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    updateUser(requestParameters: UpdateUserRequest): Observable<void> {
-        if (requestParameters.username === null || requestParameters.username === undefined) {
-            throw new RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
-        }
+    updateUser = (requestParameters: UpdateUserRequest): Observable<void> => {
+        throwIfRequired(requestParameters, 'username', 'updateUser');
+        throwIfRequired(requestParameters, 'body', 'updateUser');
 
-        if (requestParameters.body === null || requestParameters.body === undefined) {
-            throw new RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updateUser.');
-        }
+        const headers: HttpHeaders = {
+            'Content-Type': 'application/json',
+        };
 
-        const queryParameters: HttpQuery = {};
-
-        const headerParameters: HttpHeaders = {};
-
-        headerParameters['Content-Type'] = 'application/json';
+        const query: HttpQuery = {
+        };
 
         return this.request<void>({
-            path: `/user/{username}`.replace(`{${"username"}}`, encodeURIComponent(String(requestParameters.username))),
+            path: `/user/{username}`.replace(`{username}`, encodeURIComponent(String(requestParameters.username))),
             method: 'PUT',
-            headers: headerParameters,
-            query: queryParameters,
+            headers,
+            query,
             body: requestParameters.body,
         });
     }

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/apis/UserApi.ts
@@ -171,8 +171,8 @@ export class UserApi extends BaseAPI {
         };
 
         const query: HttpQuery = {
-            'username': requestParameters.username,
-            'password': requestParameters.password,
+            ...(requestParameters.username && { 'username': requestParameters.username }),
+            ...(requestParameters.password && { 'password': requestParameters.password }),
         };
 
         return this.request<string>({

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -66,30 +66,26 @@ export class Configuration {
  * This is the base class for all generated API classes.
  */
 export class BaseAPI {
-    private middleware: Middleware[];
+    private middleware: Middleware[] = [];
 
     constructor(protected configuration = new Configuration()) {
         this.middleware = configuration.middleware;
     }
 
-    withMiddleware<T extends BaseAPI>(this: T, ...middlewares: Middleware[]) {
+    withMiddleware = <T extends BaseAPI>(middlewares: Middleware[]) => {
         const next = this.clone<T>();
-        next.middleware = next.middleware.concat(...middlewares);
+        next.middleware = next.middleware.concat(middlewares);
         return next;
     }
 
-    withPreMiddleware<T extends BaseAPI>(this: T, ...preMiddlewares: Array<Middleware['pre']>) {
-        const middlewares = preMiddlewares.map((pre) => ({ pre }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPreMiddleware = <T extends BaseAPI>(preMiddlewares: Array<Middleware['pre']>) =>
+        this.withMiddleware<T>(preMiddlewares.map((pre) => ({ pre })));
 
-    withPostMiddleware<T extends BaseAPI>(this: T, ...postMiddlewares: Array<Middleware['post']>) {
-        const middlewares = postMiddlewares.map((post) => ({ post }));
-        return this.withMiddleware<T>(...middlewares);
-    }
+    withPostMiddleware = <T extends BaseAPI>(postMiddlewares: Array<Middleware['post']>) =>
+        this.withMiddleware<T>(postMiddlewares.map((post) => ({ post })));
 
-    protected request<T>(context: RequestOpts): Observable<T> {
-        return this.rxjsRequest(this.createRequestArgs(context)).pipe(
+    protected request = <T>(context: RequestOpts): Observable<T> => 
+        this.rxjsRequest(this.createRequestArgs(context)).pipe(
             map((res) => {
                 if (res.status >= 200 && res.status < 300) {
                     return res.response as T;
@@ -97,15 +93,14 @@ export class BaseAPI {
                 throw res;
             })
         );
-    }
 
-    private createRequestArgs(context: RequestOpts): RequestArgs {
+    private createRequestArgs = (context: RequestOpts): RequestArgs => {
         let url = this.configuration.basePath + context.path;
         if (context.query !== undefined && Object.keys(context.query).length !== 0) {
-            // only add the querystring to the URL if there are query parameters.
+            // only add the queryString to the URL if there are query parameters.
             // this is done to avoid urls ending with a '?' character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + queryString(context.query);
         }
         const body = context.body instanceof FormData ? context.body : JSON.stringify(context.body);
         const options = {
@@ -116,9 +111,9 @@ export class BaseAPI {
         return { url, options };
     }
 
-    private rxjsRequest(params: RequestContext): Observable<AjaxResponse> {
-        const preMiddlewares = this.middleware && this.middleware.filter((item) => item.pre);
-        const postMiddlewares = this.middleware && this.middleware.filter((item) => item.post);
+    private rxjsRequest = (params: RequestContext): Observable<AjaxResponse> => {
+        const preMiddlewares = this.middleware.filter((item) => item.pre);
+        const postMiddlewares = this.middleware.filter((item) => item.post);
 
         return of(params).pipe(
             map((args) => {
@@ -144,19 +139,13 @@ export class BaseAPI {
      * Create a shallow clone of `this` by constructing a new instance
      * and then shallow cloning data members.
      */
-    private clone<T extends BaseAPI>(this: T): T {
-        const constructor = this.constructor as any;
-        const next = new constructor(this.configuration);
-        next.middleware = this.middleware.slice();
-        return next;
-    }
+    private clone = <T extends BaseAPI>(): T => 
+        Object.assign(Object.create(Object.getPrototypeOf(this)), this)
 }
 
+// export for not being a breaking change
 export class RequiredError extends Error {
     name: 'RequiredError' = 'RequiredError';
-    constructor(public field: string, msg?: string) {
-        super(msg);
-    }
 }
 
 export const COLLECTION_FORMATS = {
@@ -186,18 +175,24 @@ export interface RequestOpts {
     body?: HttpBody;
 }
 
-export function querystring(params: HttpQuery): string {
-    return Object.keys(params)
-        .map((key) => {
-            const value = params[key];
-            if (value instanceof Array) {
-                return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
-                    .join('&');
-            }
-            return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
-        })
-        .join('&');
-}
+const queryString = (params: HttpQuery): string => Object.keys(params)
+    .map((key) => {
+        const value = params[key];
+        if (value instanceof Array) {
+            return value.map((val) => `${encodeURIComponent(key)}=${encodeURIComponent(String(val))}`)
+                .join('&');
+        }
+        return `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`;
+    })
+    .join('&');
+
+// alias fallback for not being a breaking change
+export const querystring = queryString;
+
+export const throwIfRequired = (params: {[key: string]: any}, key: string, nickname: string) => {
+    if (!params || params[key] === null || params[key] === undefined) {
+        throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
+    }
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -193,6 +193,7 @@ export const throwIfRequired = (params: {[key: string]: any}, key: string, nickn
     if (!params || params[key] === null || params[key] === undefined) {
         throw new RequiredError(`Required parameter ${key} was null or undefined when calling ${nickname}.`);
     }
+}
 
 export interface RequestContext extends RequestArgs {}
 export interface ResponseContext extends RequestArgs {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

* refactor to arrow functions where possible
* abstract error throwing null checks into a function `throwIfRequired`
* remove unused parameter in `RequiredError` (this is a breaking change if people are using it outside the generated code)
* refactor `headers` and `query` objects to be created inline to be less verbose and skip redundant null checks

This all results in a noticeable code savings. 
In my current react project with CRA2 (9 controllers and 14 endpoints) I get a build with 4368 characters less which is about 4%, although file size after gzip it is only 230 Bytes which is about 1%.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)