### PR TITLE
Check classVarName against reserved keywords, renamed snakeCase to lowerCamelCase

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -810,7 +810,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return the snake-cased variable name
      */
     public String toApiVarName(String name) {
-        return snakeCase(name);
+        return lowerCamelCase(name);
     }
 
     /**
@@ -1533,13 +1533,13 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
-     * Return the snake-case of the string
+     * Return the lowerCamelCase of the string
      *
-     * @param name string to be snake-cased
-     * @return snake-cased string
+     * @param name string to be lowerCamelCased
+     * @return lowerCamelCase string
      */
     @SuppressWarnings("static-method")
-    public String snakeCase(String name) {
+    public String lowerCamelCase(String name) {
         return (name.length() > 0) ? (Character.toLowerCase(name.charAt(0)) + name.substring(1)) : "";
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangClientCodegen.java
@@ -128,7 +128,7 @@ public class ErlangClientCodegen extends DefaultCodegen implements CodegenConfig
             if (languageSpecificPrimitives.contains(type))
                 return (type);
         } else
-            type = getTypeDeclaration(toModelName(snakeCase(schemaType)));
+            type = getTypeDeclaration(toModelName(lowerCamelCase(schemaType)));
         return type;
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangProperCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ErlangProperCodegen.java
@@ -137,7 +137,7 @@ public class ErlangProperCodegen extends DefaultCodegen implements CodegenConfig
         } else if (typeMapping.containsKey(typeDeclaration)) {
             return typeMapping.get(typeDeclaration);
         } else {
-            return getTypeDeclaration(toModelName(snakeCase(typeDeclaration)));
+            return getTypeDeclaration(toModelName(lowerCamelCase(typeDeclaration)));
         }
     }
 
@@ -179,7 +179,7 @@ public class ErlangProperCodegen extends DefaultCodegen implements CodegenConfig
         } else if (typeMapping.containsKey(schemaType)) {
             return typeMapping.get(schemaType);
         } else {
-            return getTypeDeclaration(toModelName(snakeCase(schemaType)));
+            return getTypeDeclaration(toModelName(lowerCamelCase(schemaType)));
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -695,4 +695,12 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         return mime != null && JSON_VENDOR_MIME_PATTERN.matcher(mime).matches();
     }
 
+    @Override
+    public String toApiVarName(String name) {
+        String apiVarName = super.toApiVarName(name);
+        if (reservedWords.contains(apiVarName)) {
+            apiVarName = escapeReservedWord(apiVarName);
+        }
+        return apiVarName;
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -200,7 +200,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         if (alias != null && !alias.isEmpty()) {
             this.bundleAlias = alias.toLowerCase(Locale.ROOT);
         } else {
-            this.bundleAlias = snakeCase(bundleName).replaceAll("([A-Z]+)", "\\_$1").toLowerCase(Locale.ROOT);
+            this.bundleAlias = lowerCamelCase(bundleName).replaceAll("([A-Z]+)", "\\_$1").toLowerCase(Locale.ROOT);
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.assertTrue;
 public class JavaClientCodegenTest {
 
     @Test
-    public void arraysInRequestBody() throws Exception {
+    public void arraysInRequestBody() {
         OpenAPI openAPI = TestUtils.createOpenAPI();
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
@@ -77,8 +77,7 @@ public class JavaClientCodegenTest {
     }
 
     @Test
-    public void nullValuesInComposedSchema() throws Exception {
-        OpenAPI openAPI = TestUtils.createOpenAPI();
+    public void nullValuesInComposedSchema() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         ComposedSchema schema = new ComposedSchema();
         CodegenModel result = codegen.fromModel("CompSche",
@@ -166,7 +165,7 @@ public class JavaClientCodegenTest {
     }
 
     @Test
-    public void testPackageNamesSetInvokerDerivedFromApi() throws Exception {
+    public void testPackageNamesSetInvokerDerivedFromApi() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
         codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
@@ -181,7 +180,7 @@ public class JavaClientCodegenTest {
     }
 
     @Test
-    public void testPackageNamesSetInvokerDerivedFromModel() throws Exception {
+    public void testPackageNamesSetInvokerDerivedFromModel() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
         codegen.processOpts();
@@ -426,5 +425,13 @@ public class JavaClientCodegenTest {
         codegenParameter.baseName = name;
         codegenParameter.dataType = "String";
         return codegenParameter;
+    }
+
+    @Test
+    public void escapeName() {
+        final JavaClientCodegen codegen = new JavaClientCodegen();
+        assertEquals("_default", codegen.toApiVarName("Default"));
+        assertEquals("_int", codegen.toApiVarName("int"));
+        assertEquals("pony", codegen.toApiVarName("pony"));
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Use escapeReservedWord on classVarName.

Must fix #1831 and #13

Also renamed snakeCase() to lowerCamelCase() to match with the method behavior. 

@bbdouglas 
@sreeshas 
@jfiala 
@lukoyanov 
@cbornet 
@jeff9finger 
@karismann 