### PR TITLE
[scala-play-server] Fix generated enums named after a reserved word

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPlayFrameworkServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPlayFrameworkServerCodegen.java
@@ -358,7 +358,15 @@ public class ScalaPlayFrameworkServerCodegen extends AbstractScalaCodegen implem
 
     @Override
     public String toEnumName(CodegenProperty property) {
-        return camelize(property.name);
+        return camelizeStripReservedEscape(property.name);
+    }
+
+    public String camelizeStripReservedEscape(String str) {
+        if (str.startsWith("`") && str.endsWith("`")) {
+            str = str.substring(1, str.length() - 1);
+        }
+
+        return camelize(str);
     }
 
     @Override


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This is a bugfix for the Scala-Play language.  
When an enum property's name is a reserved word in Scala, it is escaped with backticks (in `AbstractScalaCodegen`) so the generated code can compile. However, generating code with backticks is a bit tricky - the name must start and end with a backtick else the code doesn't compile.

In Scala-Play language, when enum properties are generated, the enum definition is contained inside the companion object of the model. The name of the enum is camelized (as per `toEnumName` method). To be able to serialize the enums, a corresponding JSON format must be introduced as well, named `<EnumName>JsonFormat`. If the enum name contains backticks (as is the case with a reserved word), the JSON format will contain backticks that are not properly terminated.

For example, given the property name `type`, it is escaped to ``` `type` ```, and the enum name is camelized to ``` `Type` ```, and the resulting JSON format is named ``` `Type`JsonFormat ``` which produces invalid Scala code.

To fix this, I changed `toEnumName` to strip the backticks before camelizing the property's name. As of now there are no reserved words in Scala that start with an uppercase; using predefined type names (such as `Int`, `Array`, `Any` and so on) as the enum name does not affect the compilation (i.e. these are valid names that can compile).

### Technical Committee
@clasnake, @jimschubert, @shijinkui, @ramzimaalej