### PR TITLE
Use 4.0.2-SNAPSHOT version in gradle samples

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
   # install openapi-generator locally
   - mvn clean install --quiet
   # run the locally installed openapi-generator-gradle-plugin
-  - gradle -PopenApiGeneratorVersion=4.0.2-SNAPSHOT -b modules\openapi-generator-gradle-plugin\samples\local-spec\build.gradle buildGoSdk --info
+  - gradle -b modules\openapi-generator-gradle-plugin\samples\local-spec\build.gradle buildGoSdk --info
 test_script:
   # restore test-related files
   - copy /b/v/y CI\samples.ci\client\petstore\csharp\OpenAPIClient\src\Org.OpenAPITools.Test\Org.OpenAPITools.Test.csproj samples\client\petstore\csharp\OpenAPIClient\src\Org.OpenAPITools.Test\Org.OpenAPITools.Test.csproj

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle.properties
@@ -1,1 +1,1 @@
-openApiGeneratorVersion=4.0.1
+openApiGeneratorVersion=4.0.2-SNAPSHOT


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As discussed with @wing328  and @jimschubert during the `4.0.1` release, we would like to use SNAPSHOT version in the samples.

For the maven samples, this was solved with #3047. See [openapi-generator/modules/openapi-generator-maven-plugin/examples/
](https://github.com/OpenAPITools/openapi-generator/tree/dc81574f2b53e33fe7e8a5f93a5b79645424c3a0/modules/openapi-generator-maven-plugin/examples) folder.

For Gradle this PR is fixing this.
If the user do not have built the plugin locally, it will still work because of this section:
https://github.com/OpenAPITools/openapi-generator/blob/afcbab4d924a1ce740a4f833c8a1db20aa078ec8/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle#L11-L13

Then gradle will download the SNAPSHOT version from the distant maven repository.
