### PR TITLE
Ruby: Avoid double escaping path items

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -2,7 +2,6 @@
 {{> api_info}}
 =end
 
-require 'uri'
 require 'cgi'
 
 module {{moduleName}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -7,7 +7,6 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
 
 module {{moduleName}}
   class ApiClient
@@ -256,7 +255,7 @@ module {{moduleName}}
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      @config.base_url + path
     end
 
     # Builds the HTTP request body

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -2,8 +2,6 @@
 {{> api_info}}
 =end
 
-require 'uri'
-
 module {{moduleName}}
   class Configuration
     # Defines url scheme
@@ -166,8 +164,7 @@ module {{moduleName}}
     end
 
     def base_url
-      url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
     end
 
     # Gets API key (with prefix if set).

--- a/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api_client.rb
@@ -15,7 +15,6 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
 
 module Petstore
   class ApiClient
@@ -262,7 +261,7 @@ module Petstore
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      @config.base_url + path
     end
 
     # Builds the HTTP request body

--- a/samples/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/client/petstore/ruby/lib/petstore/configuration.rb
@@ -10,8 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
-
 module Petstore
   class Configuration
     # Defines url scheme
@@ -174,8 +172,7 @@ module Petstore
     end
 
     def base_url
-      url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
     end
 
     # Gets API key (with prefix if set).

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/another_fake_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/default_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_classname_tags123_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/pet_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/store_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/user_api.rb
@@ -10,7 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
 require 'cgi'
 
 module Petstore

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api_client.rb
@@ -15,7 +15,6 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
 
 module Petstore
   class ApiClient
@@ -262,7 +261,7 @@ module Petstore
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      @config.base_url + path
     end
 
     # Builds the HTTP request body

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/configuration.rb
@@ -10,8 +10,6 @@ OpenAPI Generator version: 4.0.2-SNAPSHOT
 
 =end
 
-require 'uri'
-
 module Petstore
   class Configuration
     # Defines url scheme
@@ -174,8 +172,7 @@ module Petstore
     end
 
     def base_url
-      url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
`URI.encode` is obsolete. `CGI.escape`, `URI.encode_www_form` or
`URI.encode_www_form_component` are recommended instead.
https://ruby-doc.org/stdlib-2.6/libdoc/uri/rdoc/URI/Escape.html#method-i-escape

URI.encode has different behaviour to CGI.escape:

```ruby
URI.encode('hello/world?test%string')
=> "hello/world?test%25string"
CGI.escape('hello/world?test%string')
=> "hello%2Fworld%3Ftest%25string"
```

I recently raised pull request #3039
201cbdce29cc6cdbbbe9efcb1afb250a05bc2ffd

That pull request escapes path items at insertion.

Before either pull request, the path item 'hello?world' would go into
the URL as 'hello?world'. That behaviour was insecure as if an attacker
could control the path item value, they could change the URL the
application connected to.

After #3039 'hello?world' would go in as 'hello%253Fworld'. This was
safer than before, but it's still not correct.
If I'd realised at the time, I would have made it correct at the time.

What this pull request does is make it go in as 'hello%35world', which
is correct.

ApiClient::build_request_url was URI.encoding the whole path.
This wasn't protecting against all undesirable characters in the path
items, but was escaping % characters a 2nd time which was unhelpful.

I have additionally removed URI.encode from Configuration::base_url as I
can't see any benefit it could be bringing.
There is no justification for it in the commit where it was originally
added: 47c8597d36a9bc0983ba5c40e2489bb094f9f076

CC: ruby technical committee @cliffano @zlx @autopp

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

see above

