### PR TITLE
[scala-play-server] Fix API doc url

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-play-server/app/apiDocController.scala.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-play-server/app/apiDocController.scala.mustache
@@ -6,6 +6,6 @@ import play.api.mvc._
 @Singleton
 class ApiDocController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
   def api: Action[AnyContent] = Action {
-    Redirect("/assets/lib/swagger-ui/index.html?/url=/assets/openapi.json")
+    Redirect("/assets/lib/swagger-ui/index.html?url=/assets/openapi.json")
   }
 }

--- a/samples/server/petstore/scala-play-server/app/api/ApiDocController.scala
+++ b/samples/server/petstore/scala-play-server/app/api/ApiDocController.scala
@@ -6,6 +6,6 @@ import play.api.mvc._
 @Singleton
 class ApiDocController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
   def api: Action[AnyContent] = Action {
-    Redirect("/assets/lib/swagger-ui/index.html?/url=/assets/openapi.json")
+    Redirect("/assets/lib/swagger-ui/index.html?url=/assets/openapi.json")
   }
 }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

A simple typo fix. When navigating to the API doc url (`/api`) the swagger-ui is supposed to show the OpenAPI spec that was used to generate the project, but it shows the generic petstore instead. This happens because the query parameter name is invalid - `/url` instead of `url`. When the slash is removed the API docs are shown as intended.