### PR TITLE
Ktor Fix KtorExperimentalAPI import

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/AppMain.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/AppMain.kt.mustache
@@ -21,10 +21,10 @@ import io.ktor.locations.Locations
 import io.ktor.metrics.Metrics
 import io.ktor.routing.Routing
 import java.util.concurrent.TimeUnit
+import io.ktor.util.KtorExperimentalAPI
 {{#hasAuthMethods}}
 import io.ktor.auth.Authentication
 import io.ktor.auth.oauth
-import io.ktor.util.KtorExperimentalAPI
 import org.openapitools.server.infrastructure.ApiKeyCredential
 import org.openapitools.server.infrastructure.ApiPrincipal
 import org.openapitools.server.infrastructure.apiKeyAuth

--- a/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/AppMain.kt
+++ b/samples/server/petstore/kotlin-server/ktor/src/main/kotlin/org/openapitools/server/AppMain.kt
@@ -21,9 +21,9 @@ import io.ktor.locations.Locations
 import io.ktor.metrics.Metrics
 import io.ktor.routing.Routing
 import java.util.concurrent.TimeUnit
+import io.ktor.util.KtorExperimentalAPI
 import io.ktor.auth.Authentication
 import io.ktor.auth.oauth
-import io.ktor.util.KtorExperimentalAPI
 import org.openapitools.server.infrastructure.ApiKeyCredential
 import org.openapitools.server.infrastructure.ApiPrincipal
 import org.openapitools.server.infrastructure.apiKeyAuth


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Move KtorExperimentalAPI import out of hasAuthMethods.

Fix #2967

@jimschubert
@dr4ke616
@karismann