### PR TITLE
Prefix request interfaces with classname of api

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -15,7 +15,7 @@ import {
 {{#operations}}
 {{#operation}}
 {{#allParams.0}}
-export interface {{operationIdCamelCase}}Request {
+export interface {{classname}}{{operationIdCamelCase}}Request {
     {{#allParams}}
     {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}};
     {{/allParams}}
@@ -39,7 +39,7 @@ export class {{classname}} extends runtime.BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    async {{nickname}}Raw({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
+    async {{nickname}}Raw({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<runtime.ApiResponse<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
         {{#allParams}}
         {{#required}}
         if (requestParameters.{{paramName}} === null || requestParameters.{{paramName}} === undefined) {
@@ -226,7 +226,7 @@ export class {{classname}} extends runtime.BaseAPI {
      * {{&summary}}
      {{/summary}}
      */
-    async {{nickname}}({{#allParams.0}}requestParameters: {{operationIdCamelCase}}Request{{/allParams.0}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{/allParams.0}}): Promise<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
         const response = await this.{{nickname}}Raw({{#allParams.0}}requestParameters{{/allParams.0}});
         return await response.value();

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -22,38 +22,38 @@ import {
     PetToJSON,
 } from '../models';
 
-export interface AddPetRequest {
+export interface PetApiAddPetRequest {
     body: Pet;
 }
 
-export interface DeletePetRequest {
+export interface PetApiDeletePetRequest {
     petId: number;
     apiKey?: string;
 }
 
-export interface FindPetsByStatusRequest {
+export interface PetApiFindPetsByStatusRequest {
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
-export interface FindPetsByTagsRequest {
+export interface PetApiFindPetsByTagsRequest {
     tags: Array<string>;
 }
 
-export interface GetPetByIdRequest {
+export interface PetApiGetPetByIdRequest {
     petId: number;
 }
 
-export interface UpdatePetRequest {
+export interface PetApiUpdatePetRequest {
     body: Pet;
 }
 
-export interface UpdatePetWithFormRequest {
+export interface PetApiUpdatePetWithFormRequest {
     petId: number;
     name?: string;
     status?: string;
 }
 
-export interface UploadFileRequest {
+export interface PetApiUploadFileRequest {
     petId: number;
     additionalMetadata?: string;
     file?: Blob;
@@ -67,7 +67,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: PetApiAddPetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -101,14 +101,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
+    async addPet(requestParameters: PetApiAddPetRequest): Promise<void> {
         await this.addPetRaw(requestParameters);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: PetApiDeletePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
+    async deletePet(requestParameters: PetApiDeletePetRequest): Promise<void> {
         await this.deletePetRaw(requestParameters);
     }
 
@@ -151,7 +151,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -187,7 +187,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
+    async findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByStatusRaw(requestParameters);
         return await response.value();
     }
@@ -196,7 +196,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -232,7 +232,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
+    async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters);
         return await response.value();
     }
@@ -241,7 +241,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -268,7 +268,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
+    async getPetById(requestParameters: PetApiGetPetByIdRequest): Promise<Pet> {
         const response = await this.getPetByIdRaw(requestParameters);
         return await response.value();
     }
@@ -276,7 +276,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: PetApiUpdatePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -310,14 +310,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
+    async updatePet(requestParameters: PetApiUpdatePetRequest): Promise<void> {
         await this.updatePetRaw(requestParameters);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -358,14 +358,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
+    async updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest): Promise<void> {
         await this.updatePetWithFormRaw(requestParameters);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: PetApiUploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -406,7 +406,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
+    async uploadFile(requestParameters: PetApiUploadFileRequest): Promise<ModelApiResponse> {
         const response = await this.uploadFileRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -19,15 +19,15 @@ import {
     OrderToJSON,
 } from '../models';
 
-export interface DeleteOrderRequest {
+export interface StoreApiDeleteOrderRequest {
     orderId: string;
 }
 
-export interface GetOrderByIdRequest {
+export interface StoreApiGetOrderByIdRequest {
     orderId: number;
 }
 
-export interface PlaceOrderRequest {
+export interface StoreApiPlaceOrderRequest {
     body: Order;
 }
 
@@ -40,7 +40,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -63,7 +63,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
+    async deleteOrder(requestParameters: StoreApiDeleteOrderRequest): Promise<void> {
         await this.deleteOrderRaw(requestParameters);
     }
 
@@ -103,7 +103,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -126,7 +126,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
+    async getOrderById(requestParameters: StoreApiGetOrderByIdRequest): Promise<Order> {
         const response = await this.getOrderByIdRaw(requestParameters);
         return await response.value();
     }
@@ -134,7 +134,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -159,7 +159,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
+    async placeOrder(requestParameters: StoreApiPlaceOrderRequest): Promise<Order> {
         const response = await this.placeOrderRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -19,32 +19,32 @@ import {
     UserToJSON,
 } from '../models';
 
-export interface CreateUserRequest {
+export interface UserApiCreateUserRequest {
     body: User;
 }
 
-export interface CreateUsersWithArrayInputRequest {
+export interface UserApiCreateUsersWithArrayInputRequest {
     body: Array<User>;
 }
 
-export interface CreateUsersWithListInputRequest {
+export interface UserApiCreateUsersWithListInputRequest {
     body: Array<User>;
 }
 
-export interface DeleteUserRequest {
+export interface UserApiDeleteUserRequest {
     username: string;
 }
 
-export interface GetUserByNameRequest {
+export interface UserApiGetUserByNameRequest {
     username: string;
 }
 
-export interface LoginUserRequest {
+export interface UserApiLoginUserRequest {
     username: string;
     password: string;
 }
 
-export interface UpdateUserRequest {
+export interface UserApiUpdateUserRequest {
     username: string;
     body: User;
 }
@@ -58,7 +58,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: UserApiCreateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -84,14 +84,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
+    async createUser(requestParameters: UserApiCreateUserRequest): Promise<void> {
         await this.createUserRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -116,14 +116,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
+    async createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<void> {
         await this.createUsersWithArrayInputRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
+    async createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<void> {
         await this.createUsersWithListInputRaw(requestParameters);
     }
 
@@ -156,7 +156,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: UserApiDeleteUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -179,14 +179,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
+    async deleteUser(requestParameters: UserApiDeleteUserRequest): Promise<void> {
         await this.deleteUserRaw(requestParameters);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -208,7 +208,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
+    async getUserByName(requestParameters: UserApiGetUserByNameRequest): Promise<User> {
         const response = await this.getUserByNameRaw(requestParameters);
         return await response.value();
     }
@@ -216,7 +216,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: UserApiLoginUserRequest): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -250,7 +250,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
+    async loginUser(requestParameters: UserApiLoginUserRequest): Promise<string> {
         const response = await this.loginUserRaw(requestParameters);
         return await response.value();
     }
@@ -284,7 +284,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UserApiUpdateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -314,7 +314,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
+    async updateUser(requestParameters: UserApiUpdateUserRequest): Promise<void> {
         await this.updateUserRaw(requestParameters);
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/apis/PetApi.ts
@@ -22,38 +22,38 @@ import {
     PetToJSON,
 } from '../models';
 
-export interface AddPetRequest {
+export interface PetApiAddPetRequest {
     body: Pet;
 }
 
-export interface DeletePetRequest {
+export interface PetApiDeletePetRequest {
     petId: number;
     apiKey?: string;
 }
 
-export interface FindPetsByStatusRequest {
+export interface PetApiFindPetsByStatusRequest {
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
-export interface FindPetsByTagsRequest {
+export interface PetApiFindPetsByTagsRequest {
     tags: Array<string>;
 }
 
-export interface GetPetByIdRequest {
+export interface PetApiGetPetByIdRequest {
     petId: number;
 }
 
-export interface UpdatePetRequest {
+export interface PetApiUpdatePetRequest {
     body: Pet;
 }
 
-export interface UpdatePetWithFormRequest {
+export interface PetApiUpdatePetWithFormRequest {
     petId: number;
     name?: string;
     status?: string;
 }
 
-export interface UploadFileRequest {
+export interface PetApiUploadFileRequest {
     petId: number;
     additionalMetadata?: string;
     file?: Blob;
@@ -67,7 +67,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: PetApiAddPetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -101,14 +101,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
+    async addPet(requestParameters: PetApiAddPetRequest): Promise<void> {
         await this.addPetRaw(requestParameters);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: PetApiDeletePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
+    async deletePet(requestParameters: PetApiDeletePetRequest): Promise<void> {
         await this.deletePetRaw(requestParameters);
     }
 
@@ -151,7 +151,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -187,7 +187,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
+    async findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByStatusRaw(requestParameters);
         return await response.value();
     }
@@ -196,7 +196,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -232,7 +232,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
+    async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters);
         return await response.value();
     }
@@ -241,7 +241,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -268,7 +268,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
+    async getPetById(requestParameters: PetApiGetPetByIdRequest): Promise<Pet> {
         const response = await this.getPetByIdRaw(requestParameters);
         return await response.value();
     }
@@ -276,7 +276,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: PetApiUpdatePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -310,14 +310,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
+    async updatePet(requestParameters: PetApiUpdatePetRequest): Promise<void> {
         await this.updatePetRaw(requestParameters);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -358,14 +358,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
+    async updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest): Promise<void> {
         await this.updatePetWithFormRaw(requestParameters);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: PetApiUploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -406,7 +406,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
+    async uploadFile(requestParameters: PetApiUploadFileRequest): Promise<ModelApiResponse> {
         const response = await this.uploadFileRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/apis/StoreApi.ts
@@ -19,15 +19,15 @@ import {
     OrderToJSON,
 } from '../models';
 
-export interface DeleteOrderRequest {
+export interface StoreApiDeleteOrderRequest {
     orderId: string;
 }
 
-export interface GetOrderByIdRequest {
+export interface StoreApiGetOrderByIdRequest {
     orderId: number;
 }
 
-export interface PlaceOrderRequest {
+export interface StoreApiPlaceOrderRequest {
     body: Order;
 }
 
@@ -40,7 +40,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -63,7 +63,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
+    async deleteOrder(requestParameters: StoreApiDeleteOrderRequest): Promise<void> {
         await this.deleteOrderRaw(requestParameters);
     }
 
@@ -103,7 +103,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -126,7 +126,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
+    async getOrderById(requestParameters: StoreApiGetOrderByIdRequest): Promise<Order> {
         const response = await this.getOrderByIdRaw(requestParameters);
         return await response.value();
     }
@@ -134,7 +134,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -159,7 +159,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
+    async placeOrder(requestParameters: StoreApiPlaceOrderRequest): Promise<Order> {
         const response = await this.placeOrderRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/apis/UserApi.ts
@@ -19,32 +19,32 @@ import {
     UserToJSON,
 } from '../models';
 
-export interface CreateUserRequest {
+export interface UserApiCreateUserRequest {
     body: User;
 }
 
-export interface CreateUsersWithArrayInputRequest {
+export interface UserApiCreateUsersWithArrayInputRequest {
     body: Array<User>;
 }
 
-export interface CreateUsersWithListInputRequest {
+export interface UserApiCreateUsersWithListInputRequest {
     body: Array<User>;
 }
 
-export interface DeleteUserRequest {
+export interface UserApiDeleteUserRequest {
     username: string;
 }
 
-export interface GetUserByNameRequest {
+export interface UserApiGetUserByNameRequest {
     username: string;
 }
 
-export interface LoginUserRequest {
+export interface UserApiLoginUserRequest {
     username: string;
     password: string;
 }
 
-export interface UpdateUserRequest {
+export interface UserApiUpdateUserRequest {
     username: string;
     body: User;
 }
@@ -58,7 +58,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: UserApiCreateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -84,14 +84,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
+    async createUser(requestParameters: UserApiCreateUserRequest): Promise<void> {
         await this.createUserRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -116,14 +116,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
+    async createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<void> {
         await this.createUsersWithArrayInputRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
+    async createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<void> {
         await this.createUsersWithListInputRaw(requestParameters);
     }
 
@@ -156,7 +156,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: UserApiDeleteUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -179,14 +179,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
+    async deleteUser(requestParameters: UserApiDeleteUserRequest): Promise<void> {
         await this.deleteUserRaw(requestParameters);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -208,7 +208,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
+    async getUserByName(requestParameters: UserApiGetUserByNameRequest): Promise<User> {
         const response = await this.getUserByNameRaw(requestParameters);
         return await response.value();
     }
@@ -216,7 +216,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: UserApiLoginUserRequest): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -250,7 +250,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
+    async loginUser(requestParameters: UserApiLoginUserRequest): Promise<string> {
         const response = await this.loginUserRaw(requestParameters);
         return await response.value();
     }
@@ -284,7 +284,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UserApiUpdateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -314,7 +314,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
+    async updateUser(requestParameters: UserApiUpdateUserRequest): Promise<void> {
         await this.updateUserRaw(requestParameters);
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -22,38 +22,38 @@ import {
     PetToJSON,
 } from '../models';
 
-export interface AddPetRequest {
+export interface PetApiAddPetRequest {
     body: Pet;
 }
 
-export interface DeletePetRequest {
+export interface PetApiDeletePetRequest {
     petId: number;
     apiKey?: string;
 }
 
-export interface FindPetsByStatusRequest {
+export interface PetApiFindPetsByStatusRequest {
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
-export interface FindPetsByTagsRequest {
+export interface PetApiFindPetsByTagsRequest {
     tags: Array<string>;
 }
 
-export interface GetPetByIdRequest {
+export interface PetApiGetPetByIdRequest {
     petId: number;
 }
 
-export interface UpdatePetRequest {
+export interface PetApiUpdatePetRequest {
     body: Pet;
 }
 
-export interface UpdatePetWithFormRequest {
+export interface PetApiUpdatePetWithFormRequest {
     petId: number;
     name?: string;
     status?: string;
 }
 
-export interface UploadFileRequest {
+export interface PetApiUploadFileRequest {
     petId: number;
     additionalMetadata?: string;
     file?: Blob;
@@ -67,7 +67,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: PetApiAddPetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -101,14 +101,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
+    async addPet(requestParameters: PetApiAddPetRequest): Promise<void> {
         await this.addPetRaw(requestParameters);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: PetApiDeletePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
+    async deletePet(requestParameters: PetApiDeletePetRequest): Promise<void> {
         await this.deletePetRaw(requestParameters);
     }
 
@@ -151,7 +151,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -187,7 +187,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
+    async findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByStatusRaw(requestParameters);
         return await response.value();
     }
@@ -196,7 +196,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -232,7 +232,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
+    async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters);
         return await response.value();
     }
@@ -241,7 +241,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -268,7 +268,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
+    async getPetById(requestParameters: PetApiGetPetByIdRequest): Promise<Pet> {
         const response = await this.getPetByIdRaw(requestParameters);
         return await response.value();
     }
@@ -276,7 +276,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: PetApiUpdatePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -310,14 +310,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
+    async updatePet(requestParameters: PetApiUpdatePetRequest): Promise<void> {
         await this.updatePetRaw(requestParameters);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -358,14 +358,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
+    async updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest): Promise<void> {
         await this.updatePetWithFormRaw(requestParameters);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: PetApiUploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -406,7 +406,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
+    async uploadFile(requestParameters: PetApiUploadFileRequest): Promise<ModelApiResponse> {
         const response = await this.uploadFileRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -19,15 +19,15 @@ import {
     OrderToJSON,
 } from '../models';
 
-export interface DeleteOrderRequest {
+export interface StoreApiDeleteOrderRequest {
     orderId: string;
 }
 
-export interface GetOrderByIdRequest {
+export interface StoreApiGetOrderByIdRequest {
     orderId: number;
 }
 
-export interface PlaceOrderRequest {
+export interface StoreApiPlaceOrderRequest {
     body: Order;
 }
 
@@ -40,7 +40,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -63,7 +63,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
+    async deleteOrder(requestParameters: StoreApiDeleteOrderRequest): Promise<void> {
         await this.deleteOrderRaw(requestParameters);
     }
 
@@ -103,7 +103,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -126,7 +126,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
+    async getOrderById(requestParameters: StoreApiGetOrderByIdRequest): Promise<Order> {
         const response = await this.getOrderByIdRaw(requestParameters);
         return await response.value();
     }
@@ -134,7 +134,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -159,7 +159,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
+    async placeOrder(requestParameters: StoreApiPlaceOrderRequest): Promise<Order> {
         const response = await this.placeOrderRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -19,32 +19,32 @@ import {
     UserToJSON,
 } from '../models';
 
-export interface CreateUserRequest {
+export interface UserApiCreateUserRequest {
     body: User;
 }
 
-export interface CreateUsersWithArrayInputRequest {
+export interface UserApiCreateUsersWithArrayInputRequest {
     body: Array<User>;
 }
 
-export interface CreateUsersWithListInputRequest {
+export interface UserApiCreateUsersWithListInputRequest {
     body: Array<User>;
 }
 
-export interface DeleteUserRequest {
+export interface UserApiDeleteUserRequest {
     username: string;
 }
 
-export interface GetUserByNameRequest {
+export interface UserApiGetUserByNameRequest {
     username: string;
 }
 
-export interface LoginUserRequest {
+export interface UserApiLoginUserRequest {
     username: string;
     password: string;
 }
 
-export interface UpdateUserRequest {
+export interface UserApiUpdateUserRequest {
     username: string;
     body: User;
 }
@@ -58,7 +58,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: UserApiCreateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -84,14 +84,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
+    async createUser(requestParameters: UserApiCreateUserRequest): Promise<void> {
         await this.createUserRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -116,14 +116,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
+    async createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<void> {
         await this.createUsersWithArrayInputRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
+    async createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<void> {
         await this.createUsersWithListInputRaw(requestParameters);
     }
 
@@ -156,7 +156,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: UserApiDeleteUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -179,14 +179,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
+    async deleteUser(requestParameters: UserApiDeleteUserRequest): Promise<void> {
         await this.deleteUserRaw(requestParameters);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -208,7 +208,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
+    async getUserByName(requestParameters: UserApiGetUserByNameRequest): Promise<User> {
         const response = await this.getUserByNameRaw(requestParameters);
         return await response.value();
     }
@@ -216,7 +216,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: UserApiLoginUserRequest): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -250,7 +250,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
+    async loginUser(requestParameters: UserApiLoginUserRequest): Promise<string> {
         const response = await this.loginUserRaw(requestParameters);
         return await response.value();
     }
@@ -284,7 +284,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UserApiUpdateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -314,7 +314,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
+    async updateUser(requestParameters: UserApiUpdateUserRequest): Promise<void> {
         await this.updateUserRaw(requestParameters);
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/apis/PetApi.ts
@@ -22,38 +22,38 @@ import {
     PetToJSON,
 } from '../models';
 
-export interface AddPetRequest {
+export interface PetApiAddPetRequest {
     body: Pet;
 }
 
-export interface DeletePetRequest {
+export interface PetApiDeletePetRequest {
     petId: number;
     apiKey?: string;
 }
 
-export interface FindPetsByStatusRequest {
+export interface PetApiFindPetsByStatusRequest {
     status: Array<FindPetsByStatusStatusEnum>;
 }
 
-export interface FindPetsByTagsRequest {
+export interface PetApiFindPetsByTagsRequest {
     tags: Array<string>;
 }
 
-export interface GetPetByIdRequest {
+export interface PetApiGetPetByIdRequest {
     petId: number;
 }
 
-export interface UpdatePetRequest {
+export interface PetApiUpdatePetRequest {
     body: Pet;
 }
 
-export interface UpdatePetWithFormRequest {
+export interface PetApiUpdatePetWithFormRequest {
     petId: number;
     name?: string;
     status?: string;
 }
 
-export interface UploadFileRequest {
+export interface PetApiUploadFileRequest {
     petId: number;
     additionalMetadata?: string;
     file?: Blob;
@@ -67,7 +67,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPetRaw(requestParameters: AddPetRequest): Promise<runtime.ApiResponse<void>> {
+    async addPetRaw(requestParameters: PetApiAddPetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling addPet.');
         }
@@ -101,14 +101,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Add a new pet to the store
      */
-    async addPet(requestParameters: AddPetRequest): Promise<void> {
+    async addPet(requestParameters: PetApiAddPetRequest): Promise<void> {
         await this.addPetRaw(requestParameters);
     }
 
     /**
      * Deletes a pet
      */
-    async deletePetRaw(requestParameters: DeletePetRequest): Promise<runtime.ApiResponse<void>> {
+    async deletePetRaw(requestParameters: PetApiDeletePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling deletePet.');
         }
@@ -143,7 +143,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Deletes a pet
      */
-    async deletePet(requestParameters: DeletePetRequest): Promise<void> {
+    async deletePet(requestParameters: PetApiDeletePetRequest): Promise<void> {
         await this.deletePetRaw(requestParameters);
     }
 
@@ -151,7 +151,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.status === null || requestParameters.status === undefined) {
             throw new runtime.RequiredError('status','Required parameter requestParameters.status was null or undefined when calling findPetsByStatus.');
         }
@@ -187,7 +187,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
      */
-    async findPetsByStatus(requestParameters: FindPetsByStatusRequest): Promise<Array<Pet>> {
+    async findPetsByStatus(requestParameters: PetApiFindPetsByStatusRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByStatusRaw(requestParameters);
         return await response.value();
     }
@@ -196,7 +196,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
+    async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
             throw new runtime.RequiredError('tags','Required parameter requestParameters.tags was null or undefined when calling findPetsByTags.');
         }
@@ -232,7 +232,7 @@ export class PetApi extends runtime.BaseAPI {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      */
-    async findPetsByTags(requestParameters: FindPetsByTagsRequest): Promise<Array<Pet>> {
+    async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters);
         return await response.value();
     }
@@ -241,7 +241,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetByIdRaw(requestParameters: GetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
+    async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest): Promise<runtime.ApiResponse<Pet>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling getPetById.');
         }
@@ -268,7 +268,7 @@ export class PetApi extends runtime.BaseAPI {
      * Returns a single pet
      * Find pet by ID
      */
-    async getPetById(requestParameters: GetPetByIdRequest): Promise<Pet> {
+    async getPetById(requestParameters: PetApiGetPetByIdRequest): Promise<Pet> {
         const response = await this.getPetByIdRaw(requestParameters);
         return await response.value();
     }
@@ -276,7 +276,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePetRaw(requestParameters: UpdatePetRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetRaw(requestParameters: PetApiUpdatePetRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling updatePet.');
         }
@@ -310,14 +310,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Update an existing pet
      */
-    async updatePet(requestParameters: UpdatePetRequest): Promise<void> {
+    async updatePet(requestParameters: PetApiUpdatePetRequest): Promise<void> {
         await this.updatePetRaw(requestParameters);
     }
 
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
+    async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling updatePetWithForm.');
         }
@@ -358,14 +358,14 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Updates a pet in the store with form data
      */
-    async updatePetWithForm(requestParameters: UpdatePetWithFormRequest): Promise<void> {
+    async updatePetWithForm(requestParameters: PetApiUpdatePetWithFormRequest): Promise<void> {
         await this.updatePetWithFormRaw(requestParameters);
     }
 
     /**
      * uploads an image
      */
-    async uploadFileRaw(requestParameters: UploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
+    async uploadFileRaw(requestParameters: PetApiUploadFileRequest): Promise<runtime.ApiResponse<ModelApiResponse>> {
         if (requestParameters.petId === null || requestParameters.petId === undefined) {
             throw new runtime.RequiredError('petId','Required parameter requestParameters.petId was null or undefined when calling uploadFile.');
         }
@@ -406,7 +406,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * uploads an image
      */
-    async uploadFile(requestParameters: UploadFileRequest): Promise<ModelApiResponse> {
+    async uploadFile(requestParameters: PetApiUploadFileRequest): Promise<ModelApiResponse> {
         const response = await this.uploadFileRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/apis/StoreApi.ts
@@ -19,15 +19,15 @@ import {
     OrderToJSON,
 } from '../models';
 
-export interface DeleteOrderRequest {
+export interface StoreApiDeleteOrderRequest {
     orderId: string;
 }
 
-export interface GetOrderByIdRequest {
+export interface StoreApiGetOrderByIdRequest {
     orderId: number;
 }
 
-export interface PlaceOrderRequest {
+export interface StoreApiPlaceOrderRequest {
     body: Order;
 }
 
@@ -40,7 +40,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrderRaw(requestParameters: DeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling deleteOrder.');
         }
@@ -63,7 +63,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
      * Delete purchase order by ID
      */
-    async deleteOrder(requestParameters: DeleteOrderRequest): Promise<void> {
+    async deleteOrder(requestParameters: StoreApiDeleteOrderRequest): Promise<void> {
         await this.deleteOrderRaw(requestParameters);
     }
 
@@ -103,7 +103,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderByIdRaw(requestParameters: GetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
+    async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.orderId === null || requestParameters.orderId === undefined) {
             throw new runtime.RequiredError('orderId','Required parameter requestParameters.orderId was null or undefined when calling getOrderById.');
         }
@@ -126,7 +126,7 @@ export class StoreApi extends runtime.BaseAPI {
      * For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
      * Find purchase order by ID
      */
-    async getOrderById(requestParameters: GetOrderByIdRequest): Promise<Order> {
+    async getOrderById(requestParameters: StoreApiGetOrderByIdRequest): Promise<Order> {
         const response = await this.getOrderByIdRaw(requestParameters);
         return await response.value();
     }
@@ -134,7 +134,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrderRaw(requestParameters: PlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
+    async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest): Promise<runtime.ApiResponse<Order>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling placeOrder.');
         }
@@ -159,7 +159,7 @@ export class StoreApi extends runtime.BaseAPI {
     /**
      * Place an order for a pet
      */
-    async placeOrder(requestParameters: PlaceOrderRequest): Promise<Order> {
+    async placeOrder(requestParameters: StoreApiPlaceOrderRequest): Promise<Order> {
         const response = await this.placeOrderRaw(requestParameters);
         return await response.value();
     }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/apis/UserApi.ts
@@ -19,32 +19,32 @@ import {
     UserToJSON,
 } from '../models';
 
-export interface CreateUserRequest {
+export interface UserApiCreateUserRequest {
     body: User;
 }
 
-export interface CreateUsersWithArrayInputRequest {
+export interface UserApiCreateUsersWithArrayInputRequest {
     body: Array<User>;
 }
 
-export interface CreateUsersWithListInputRequest {
+export interface UserApiCreateUsersWithListInputRequest {
     body: Array<User>;
 }
 
-export interface DeleteUserRequest {
+export interface UserApiDeleteUserRequest {
     username: string;
 }
 
-export interface GetUserByNameRequest {
+export interface UserApiGetUserByNameRequest {
     username: string;
 }
 
-export interface LoginUserRequest {
+export interface UserApiLoginUserRequest {
     username: string;
     password: string;
 }
 
-export interface UpdateUserRequest {
+export interface UserApiUpdateUserRequest {
     username: string;
     body: User;
 }
@@ -58,7 +58,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUserRaw(requestParameters: CreateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async createUserRaw(requestParameters: UserApiCreateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUser.');
         }
@@ -84,14 +84,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Create user
      */
-    async createUser(requestParameters: CreateUserRequest): Promise<void> {
+    async createUser(requestParameters: UserApiCreateUserRequest): Promise<void> {
         await this.createUserRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -116,14 +116,14 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithArrayInput(requestParameters: CreateUsersWithArrayInputRequest): Promise<void> {
+    async createUsersWithArrayInput(requestParameters: UserApiCreateUsersWithArrayInputRequest): Promise<void> {
         await this.createUsersWithArrayInputRaw(requestParameters);
     }
 
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
+    async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling createUsersWithListInput.');
         }
@@ -148,7 +148,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Creates list of users with given input array
      */
-    async createUsersWithListInput(requestParameters: CreateUsersWithListInputRequest): Promise<void> {
+    async createUsersWithListInput(requestParameters: UserApiCreateUsersWithListInputRequest): Promise<void> {
         await this.createUsersWithListInputRaw(requestParameters);
     }
 
@@ -156,7 +156,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUserRaw(requestParameters: DeleteUserRequest): Promise<runtime.ApiResponse<void>> {
+    async deleteUserRaw(requestParameters: UserApiDeleteUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling deleteUser.');
         }
@@ -179,14 +179,14 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Delete user
      */
-    async deleteUser(requestParameters: DeleteUserRequest): Promise<void> {
+    async deleteUser(requestParameters: UserApiDeleteUserRequest): Promise<void> {
         await this.deleteUserRaw(requestParameters);
     }
 
     /**
      * Get user by user name
      */
-    async getUserByNameRaw(requestParameters: GetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
+    async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest): Promise<runtime.ApiResponse<User>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling getUserByName.');
         }
@@ -208,7 +208,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Get user by user name
      */
-    async getUserByName(requestParameters: GetUserByNameRequest): Promise<User> {
+    async getUserByName(requestParameters: UserApiGetUserByNameRequest): Promise<User> {
         const response = await this.getUserByNameRaw(requestParameters);
         return await response.value();
     }
@@ -216,7 +216,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUserRaw(requestParameters: LoginUserRequest): Promise<runtime.ApiResponse<string>> {
+    async loginUserRaw(requestParameters: UserApiLoginUserRequest): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling loginUser.');
         }
@@ -250,7 +250,7 @@ export class UserApi extends runtime.BaseAPI {
     /**
      * Logs user into the system
      */
-    async loginUser(requestParameters: LoginUserRequest): Promise<string> {
+    async loginUser(requestParameters: UserApiLoginUserRequest): Promise<string> {
         const response = await this.loginUserRaw(requestParameters);
         return await response.value();
     }
@@ -284,7 +284,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUserRaw(requestParameters: UpdateUserRequest): Promise<runtime.ApiResponse<void>> {
+    async updateUserRaw(requestParameters: UserApiUpdateUserRequest): Promise<runtime.ApiResponse<void>> {
         if (requestParameters.username === null || requestParameters.username === undefined) {
             throw new runtime.RequiredError('username','Required parameter requestParameters.username was null or undefined when calling updateUser.');
         }
@@ -314,7 +314,7 @@ export class UserApi extends runtime.BaseAPI {
      * This can only be done by the logged in user.
      * Updated user
      */
-    async updateUser(requestParameters: UpdateUserRequest): Promise<void> {
+    async updateUser(requestParameters: UserApiUpdateUserRequest): Promise<void> {
         await this.updateUserRaw(requestParameters);
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @leonyu

### Description of the PR

At the moment the `typescript-fetch` generator outputs interfaces for each operation. For example: `OperationARequest`. This request interface can reside in multiple API classes when the specification has duplicate operation ids. This results in name collisions when the typescript library tries to export all types from the API files in a single file.

The duplicate operationIds are the result of OpenAPI specification generators that derive the specification from code. Usually they generate tags from classes and operationId from method names.

This PR will prefix the classname of the API to each of the `{{operationId}}Request` interfaces. That way such collisions will happen to a lesser degree.

This replaces the PR filed against master (#3111).