### PR TITLE
[gradle] Document consuming via gradle plugin portal

### DIFF
--- a/modules/openapi-generator-gradle-plugin/README.adoc
+++ b/modules/openapi-generator-gradle-plugin/README.adoc
@@ -40,12 +40,23 @@ compileJava.dependsOn tasks.openApiGenerate
 
 == Plugin Setup
 
+[source,group]
+----
+plugins {
+  id "org.openapi.generator" version "4.0.1"
+}
+----
+
+Using https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application[legacy plugin application]:
+
 [source,groovy]
 ----
 buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
+    // or, via Gradle Plugin Portal:
+    // url "https://plugins.gradle.org/m2/"
   }
   dependencies {
     classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.1"
@@ -54,11 +65,6 @@ buildscript {
 
 apply plugin: 'org.openapi.generator'
 ----
-
-[NOTE]
-====
-The gradle plugin is not currently published to https://plugins.gradle.org/m2/.
-====
 
 == Configuration
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add documentation notes for consuming via Gradle Plugin Portal

See #2505 