### PR TITLE
Ruby: Add option for old path parameter behaviour

### DIFF
--- a/docs/generators/ruby-client.md
+++ b/docs/generators/ruby-client.md
@@ -1,0 +1,10 @@
+
+---
+id: generator-opts-client-ruby-client
+title: Config Options for ruby client
+sidebar_label: ruby-client
+---
+
+| Option | Description | Values | Default |
+| ------ | ----------- | ------ | ------- |
+|compatibilitySlashesInPathParameters|Don't encode slashes in path parameters. Not compatible with the OpenAPI standard. Designed to support projects which relied on the non-standard behaviour before it was fixed.| |false|

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client.mustache
@@ -254,6 +254,9 @@ module {{moduleName}}
 
     def build_request_url(path)
       # Add leading and trailing slashes to path
+      {{#compatibilitySlashesInPathParameters}}
+      path = path.gsub('%2F', '/')
+      {{/compatibilitySlashesInPathParameters}}
       path = "/#{path}".gsub(/\/+/, '/')
       @config.base_url + path
     end

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_spec.mustache
@@ -40,6 +40,25 @@ describe {{moduleName}}::ApiClient do
           expect({{moduleName}}::Configuration.default.base_path).to eq('')
         end
       end
+
+      describe 'build_request_path' do
+        {{#compatibilitySlashesInPathParameters}}
+        it 'un-does encoding of slashes' do
+          {{moduleName}}.configure { |c| c.host = 'http://example.com' }
+          path = '/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery'
+          url = {{moduleName}}::ApiClient.new.build_request_url(path)
+          expect(url).to eq('http://example.com/pulp/api/v3/artifacts/1/%3Fquery')
+        end
+        {{/compatibilitySlashesInPathParameters}}
+        {{^compatibilitySlashesInPathParameters}}
+        it 'leaves slashes encoded' do
+          {{moduleName}}.configure { |c| c.host = 'http://example.com' }
+          path = '/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery'
+          url = {{moduleName}}::ApiClient.new.build_request_url(path)
+          expect(url).to eq('http://example.com/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery')
+        end
+        {{/compatibilitySlashesInPathParameters}}
+      end
     end
   end
 

--- a/samples/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/client/petstore/ruby/spec/api_client_spec.rb
@@ -48,6 +48,15 @@ describe Petstore::ApiClient do
           expect(Petstore::Configuration.default.base_path).to eq('')
         end
       end
+
+      describe 'build_request_path' do
+        it 'leaves slashes encoded' do
+          Petstore.configure { |c| c.host = 'http://example.com' }
+          path = '/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery'
+          url = Petstore::ApiClient.new.build_request_url(path)
+          expect(url).to eq('http://example.com/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery')
+        end
+      end
     end
   end
 

--- a/samples/openapi3/client/petstore/ruby/spec/api_client_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api_client_spec.rb
@@ -48,6 +48,15 @@ describe Petstore::ApiClient do
           expect(Petstore::Configuration.default.base_path).to eq('')
         end
       end
+
+      describe 'build_request_path' do
+        it 'leaves slashes encoded' do
+          Petstore.configure { |c| c.host = 'http://example.com' }
+          path = '/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery'
+          url = Petstore::ApiClient.new.build_request_url(path)
+          expect(url).to eq('http://example.com/%2Fpulp%2Fapi%2Fv3%2Fartifacts%2F1%2F%3Fquery')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The OpenAPI standard is to percent encode special characters such as
slashes, hashes and question marks when they appear in path parameters.

The Ruby client generator was buggy. It did not encode these characters.
So a few days ago I fixed it.
https://github.com/OpenAPITools/openapi-generator/pull/3039

Unfortunately, some projects rely on the incorrect behaviour.
In particular, they need slashes not to be escaped.

For example:
https://github.com/OpenAPITools/openapi-generator/issues/3119

I've added an additional property to the ruby generator to undo the
escaping of slashes in path parameters. This will enable those projects
to continue to make use of the Ruby client code generator.
`--additional-properties compatibilitySlashesInPathParameters`

I'd suggest the long term plan for projects that need this behaviour
should be to work with the OpenAPI Specification writers to support
marking certain path parameters as allowing slashes.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@cliffano @zlx @autopp 

### Description of the PR

Fix #3119
See above
