### PR TITLE
[Ruby][Client] Add "send" to ruby reserved word list

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -91,7 +91,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         // local variable names used in API methods (endpoints)
         for (String word : Arrays.asList(
                 "local_var_path", "query_params", "header_params", "_header_accept", "_header_accept_result",
-                "_header_content_type", "form_params", "post_body", "auth_names")) {
+                "_header_content_type", "form_params", "post_body", "auth_names", "send")) {
             reservedWords.add(word.toLowerCase(Locale.ROOT));
         }
 


### PR DESCRIPTION
Ruby clients call `self.send(:"#{key}=", value)`.  This breaks if a response entity exposes a 'send' attribute.

This change adds ruby's "#send" to the reserved word list for the ruby generator.
