### PR TITLE
Perl: Generate templated travis configuration

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PerlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PerlClientCodegen.java
@@ -167,6 +167,7 @@ public class PerlClientCodegen extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
         supportingFiles.add(new SupportingFile("gitignore.mustache", "", ".gitignore"));
         supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
+        supportingFiles.add(new SupportingFile("travis.mustache", "", ".travis.yml"));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/perl/travis.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/travis.mustache
@@ -1,0 +1,9 @@
+# https://docs.travis-ci.com/user/languages/perl/
+#
+
+language: perl
+
+perl:
+  - "5.28"
+
+sudo: false


### PR DESCRIPTION
render `.travis.yml` configuration for generated openapi perl client referring to the instructions https://docs.travis-ci.com/user/languages/perl/