### PR TITLE
feat: configurable limit of simultaneous connections (python/asyncio)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -38,8 +38,11 @@ class RESTResponse(io.IOBase):
 
 class RESTClientObject(object):
 
-    def __init__(self, configuration, pools_size=4, maxsize=4):
+    def __init__(self, configuration, pools_size=4, maxsize=None):
+
         # maxsize is number of requests to host that are allowed in parallel
+        if maxsize is None:
+            maxsize = configuration.connection_pool_maxsize
 
         # ca_certs
         if configuration.ssl_ca_cert:

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -116,6 +116,13 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         """Set this to True/False to enable/disable SSL hostname verification.
         """
 
+        {{#asyncio}}
+        self.connection_pool_maxsize = 100
+        """This value is passed to the aiohttp to limit simultaneous connections.
+           Default values is 100, None means no-limit.
+        """
+        {{/asyncio}}
+        {{^asyncio}}
         self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
         """urllib3 connection pool's maximum number of connections saved
            per pool. urllib3 uses 1 connection as default value, but this is
@@ -123,6 +130,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
            requests to the same host, which is often the case here.
            cpu_count * 5 is used as default value to increase performance.
         """
+        {{/asyncio}}
 
         self.proxy = None
         """Proxy URL

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -6,7 +6,9 @@ from __future__ import absolute_import
 
 import copy
 import logging
+{{^asyncio}}
 import multiprocessing
+{{/asyncio}}
 import sys
 import urllib3
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 import copy
 import logging
-import multiprocessing
 import sys
 import urllib3
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -115,12 +115,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         """Set this to True/False to enable/disable SSL hostname verification.
         """
 
-        self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
-        """urllib3 connection pool's maximum number of connections saved
-           per pool. urllib3 uses 1 connection as default value, but this is
-           not the best value when you are making a lot of possibly parallel
-           requests to the same host, which is often the case here.
-           cpu_count * 5 is used as default value to increase performance.
+        self.connection_pool_maxsize = 100
+        """This value is passed to the aiohttp to limit simultaneous connections.
+           Default values is 100, None means no-limit.
         """
 
         self.proxy = None

--- a/samples/client/petstore/python-asyncio/petstore_api/rest.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/rest.py
@@ -46,8 +46,11 @@ class RESTResponse(io.IOBase):
 
 class RESTClientObject(object):
 
-    def __init__(self, configuration, pools_size=4, maxsize=4):
+    def __init__(self, configuration, pools_size=4, maxsize=None):
+
         # maxsize is number of requests to host that are allowed in parallel
+        if maxsize is None:
+            maxsize = configuration.connection_pool_maxsize
 
         # ca_certs
         if configuration.ssl_ca_cert:


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

A current generated asyncio client limits number of simultaneous connections to 4 and this values is not configurable by the configuration object. In PR I use value from configuration and set default to 100 (it's default value recommended by the aiohttp library).

Thanks for reviewing and merging it :)

CC: @wing328 @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @Jyhess (2019/01)

