### PR TITLE
Ruby: Allow dynamic parameters

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -841,6 +841,31 @@ produces:
 x-content-type: application/json
 ```
 
+### Ruby-client
+
+#### x-allow-dynamic-resource
+
+Each parameter object located in a path (path parameter) may specify `x-allow-dynamic-resource`.
+This will encode `%`, `?` and `#` characters as usual, but not encode `/` characters.
+
+```yaml
+paths:
+  /account/{id}/{resource}:
+    get:
+      operationId:
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: integer
+        - name: resource
+          in: path
+          # allows slashes to be used in the path parameter
+          x-allow-dynamic-resource: true
+          schema:
+            type: string
+```
+
 ### Rust-server
 
 #### x-responseId

--- a/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api.mustache
@@ -123,7 +123,7 @@ module {{moduleName}}
       {{/hasValidation}}
       {{/allParams}}
       # resource path
-      local_var_path = '{{{path}}}'{{#pathParams}}.sub('{' + '{{baseName}}' + '}', CGI.escape({{paramName}}.to_s)){{/pathParams}}
+      local_var_path = '{{{path}}}'{{#pathParams}}.sub('{' + '{{baseName}}' + '}', CGI.escape({{paramName}}.to_s){{#vendorExtensions.x-allow-dynamic-resource}}.gsub('%2F', '/'){{/vendorExtensions.x-allow-dynamic-resource}}){{/pathParams}}
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -131,8 +131,6 @@ module {{moduleName}}
       {{#required}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param({{{paramName}}}, :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}{{{paramName}}}{{/collectionFormat}}
       {{/required}}
-      {{/queryParams}}
-      {{#queryParams}}
       {{^required}}
       query_params[:'{{{baseName}}}'] = {{#collectionFormat}}@api_client.build_collection_param(opts[:'{{{paramName}}}'], :{{{collectionFormat}}}){{/collectionFormat}}{{^collectionFormat}}opts[:'{{{paramName}}}']{{/collectionFormat}} if !opts[:'{{{paramName}}}'].nil?
       {{/required}}

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1030,6 +1030,21 @@ paths:
                   format: binary
               required:
                 - requiredFile
+  /fake/dynamic-resource/{dynamic}:
+    get:
+      tags:
+        - fake
+      summary: https://github.com/OpenAPITools/openapi-generator/issues/3119
+      responses:
+        200:
+          description: OK
+      parameters:
+        - name: dynamic
+          in: path
+          required: true
+          x-allow-dynamic-resource: true
+          schema:
+            type: string
   /fake/health:
     get:
       tags:

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
@@ -85,6 +85,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *AnotherFakeApi* | [**call123TestSpecialTags**](docs/Api/AnotherFakeApi.md#call123testspecialtags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**fooGet**](docs/Api/DefaultApi.md#fooget) | **GET** /foo | 
+*FakeApi* | [**fakeDynamicResourceDynamicGet**](docs/Api/FakeApi.md#fakedynamicresourcedynamicget) | **GET** /fake/dynamic-resource/{dynamic} | https://github.com/OpenAPITools/openapi-generator/issues/3119
 *FakeApi* | [**fakeHealthGet**](docs/Api/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint
 *FakeApi* | [**fakeOuterBooleanSerialize**](docs/Api/FakeApi.md#fakeouterbooleanserialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fakeOuterCompositeSerialize**](docs/Api/FakeApi.md#fakeoutercompositeserialize) | **POST** /fake/outer/composite | 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -4,6 +4,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**fakeDynamicResourceDynamicGet**](FakeApi.md#fakeDynamicResourceDynamicGet) | **GET** /fake/dynamic-resource/{dynamic} | https://github.com/OpenAPITools/openapi-generator/issues/3119
 [**fakeHealthGet**](FakeApi.md#fakeHealthGet) | **GET** /fake/health | Health check endpoint
 [**fakeOuterBooleanSerialize**](FakeApi.md#fakeOuterBooleanSerialize) | **POST** /fake/outer/boolean | 
 [**fakeOuterCompositeSerialize**](FakeApi.md#fakeOuterCompositeSerialize) | **POST** /fake/outer/composite | 
@@ -18,6 +19,59 @@ Method | HTTP request | Description
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
 
+
+
+## fakeDynamicResourceDynamicGet
+
+> fakeDynamicResourceDynamicGet($dynamic)
+
+https://github.com/OpenAPITools/openapi-generator/issues/3119
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$dynamic = 'dynamic_example'; // string | 
+
+try {
+    $apiInstance->fakeDynamicResourceDynamicGet($dynamic);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->fakeDynamicResourceDynamicGet: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **dynamic** | **string**|  |
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../../README.md#documentation-for-models)
+[[Back to README]](../../README.md)
 
 
 ## fakeHealthGet

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -116,6 +116,230 @@ class FakeApi
     }
 
     /**
+     * Operation fakeDynamicResourceDynamicGet
+     *
+     * https://github.com/OpenAPITools/openapi-generator/issues/3119
+     *
+     * @param  string $dynamic dynamic (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function fakeDynamicResourceDynamicGet($dynamic)
+    {
+        $this->fakeDynamicResourceDynamicGetWithHttpInfo($dynamic);
+    }
+
+    /**
+     * Operation fakeDynamicResourceDynamicGetWithHttpInfo
+     *
+     * https://github.com/OpenAPITools/openapi-generator/issues/3119
+     *
+     * @param  string $dynamic (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function fakeDynamicResourceDynamicGetWithHttpInfo($dynamic)
+    {
+        $request = $this->fakeDynamicResourceDynamicGetRequest($dynamic);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation fakeDynamicResourceDynamicGetAsync
+     *
+     * https://github.com/OpenAPITools/openapi-generator/issues/3119
+     *
+     * @param  string $dynamic (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function fakeDynamicResourceDynamicGetAsync($dynamic)
+    {
+        return $this->fakeDynamicResourceDynamicGetAsyncWithHttpInfo($dynamic)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation fakeDynamicResourceDynamicGetAsyncWithHttpInfo
+     *
+     * https://github.com/OpenAPITools/openapi-generator/issues/3119
+     *
+     * @param  string $dynamic (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function fakeDynamicResourceDynamicGetAsyncWithHttpInfo($dynamic)
+    {
+        $returnType = '';
+        $request = $this->fakeDynamicResourceDynamicGetRequest($dynamic);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'fakeDynamicResourceDynamicGet'
+     *
+     * @param  string $dynamic (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function fakeDynamicResourceDynamicGetRequest($dynamic)
+    {
+        // verify the required parameter 'dynamic' is set
+        if ($dynamic === null || (is_array($dynamic) && count($dynamic) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $dynamic when calling fakeDynamicResourceDynamicGet'
+            );
+        }
+
+        $resourcePath = '/fake/dynamic-resource/{dynamic}';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+        // path params
+        if ($dynamic !== null) {
+            $resourcePath = str_replace(
+                '{' . 'dynamic' . '}',
+                ObjectSerializer::toPathValue($dynamic),
+                $resourcePath
+            );
+        }
+
+        // body params
+        $_tempBody = null;
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                []
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                [],
+                []
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            if ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Operation fakeHealthGet
      *
      * Health check endpoint

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
@@ -73,6 +73,16 @@ class FakeApiTest extends TestCase
     }
 
     /**
+     * Test case for fakeDynamicResourceDynamicGet
+     *
+     * https://github.com/OpenAPITools/openapi-generator/issues/3119.
+     *
+     */
+    public function testFakeDynamicResourceDynamicGet()
+    {
+    }
+
+    /**
      * Test case for fakeHealthGet
      *
      * Health check endpoint.

--- a/samples/openapi3/client/petstore/python/README.md
+++ b/samples/openapi3/client/petstore/python/README.md
@@ -73,6 +73,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 *DefaultApi* | [**foo_get**](docs/DefaultApi.md#foo_get) | **GET** /foo | 
+*FakeApi* | [**fake_dynamic_resource_dynamic_get**](docs/FakeApi.md#fake_dynamic_resource_dynamic_get) | **GET** /fake/dynamic-resource/{dynamic} | https://github.com/OpenAPITools/openapi-generator/issues/3119
 *FakeApi* | [**fake_health_get**](docs/FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
 *FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -4,6 +4,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**fake_dynamic_resource_dynamic_get**](FakeApi.md#fake_dynamic_resource_dynamic_get) | **GET** /fake/dynamic-resource/{dynamic} | https://github.com/OpenAPITools/openapi-generator/issues/3119
 [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
 [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
@@ -18,6 +19,57 @@ Method | HTTP request | Description
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
 
+
+# **fake_dynamic_resource_dynamic_get**
+> fake_dynamic_resource_dynamic_get(dynamic)
+
+https://github.com/OpenAPITools/openapi-generator/issues/3119
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+
+# create an instance of the API class
+api_instance = petstore_api.FakeApi()
+dynamic = 'dynamic_example' # str | 
+
+try:
+    # https://github.com/OpenAPITools/openapi-generator/issues/3119
+    api_instance.fake_dynamic_resource_dynamic_get(dynamic)
+except ApiException as e:
+    print("Exception when calling FakeApi->fake_dynamic_resource_dynamic_get: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **dynamic** | **str**|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | OK |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **fake_health_get**
 > HealthCheckResult fake_health_get()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -36,6 +36,108 @@ class FakeApi(object):
             api_client = ApiClient()
         self.api_client = api_client
 
+    def fake_dynamic_resource_dynamic_get(self, dynamic, **kwargs):  # noqa: E501
+        """https://github.com/OpenAPITools/openapi-generator/issues/3119  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.fake_dynamic_resource_dynamic_get(dynamic, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param str dynamic: (required)
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.fake_dynamic_resource_dynamic_get_with_http_info(dynamic, **kwargs)  # noqa: E501
+
+    def fake_dynamic_resource_dynamic_get_with_http_info(self, dynamic, **kwargs):  # noqa: E501
+        """https://github.com/OpenAPITools/openapi-generator/issues/3119  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.fake_dynamic_resource_dynamic_get_with_http_info(dynamic, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param str dynamic: (required)
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['dynamic']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method fake_dynamic_resource_dynamic_get" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'dynamic' is set
+        if ('dynamic' not in local_var_params or
+                local_var_params['dynamic'] is None):
+            raise ApiValueError("Missing the required parameter `dynamic` when calling `fake_dynamic_resource_dynamic_get`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'dynamic' in local_var_params:
+            path_params['dynamic'] = local_var_params['dynamic']  # noqa: E501
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/dynamic-resource/{dynamic}', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def fake_health_get(self, **kwargs):  # noqa: E501
         """Health check endpoint  # noqa: E501
 

--- a/samples/openapi3/client/petstore/ruby/README.md
+++ b/samples/openapi3/client/petstore/ruby/README.md
@@ -77,6 +77,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *Petstore::AnotherFakeApi* | [**call_123_test_special_tags**](docs/AnotherFakeApi.md#call_123_test_special_tags) | **PATCH** /another-fake/dummy | To test special tags
 *Petstore::DefaultApi* | [**foo_get**](docs/DefaultApi.md#foo_get) | **GET** /foo | 
+*Petstore::FakeApi* | [**fake_dynamic_resource_dynamic_get**](docs/FakeApi.md#fake_dynamic_resource_dynamic_get) | **GET** /fake/dynamic-resource/{dynamic} | https://github.com/OpenAPITools/openapi-generator/issues/3119
 *Petstore::FakeApi* | [**fake_health_get**](docs/FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
 *Petstore::FakeApi* | [**fake_outer_boolean_serialize**](docs/FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 *Petstore::FakeApi* | [**fake_outer_composite_serialize**](docs/FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 

--- a/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
@@ -4,6 +4,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**fake_dynamic_resource_dynamic_get**](FakeApi.md#fake_dynamic_resource_dynamic_get) | **GET** /fake/dynamic-resource/{dynamic} | https://github.com/OpenAPITools/openapi-generator/issues/3119
 [**fake_health_get**](FakeApi.md#fake_health_get) | **GET** /fake/health | Health check endpoint
 [**fake_outer_boolean_serialize**](FakeApi.md#fake_outer_boolean_serialize) | **POST** /fake/outer/boolean | 
 [**fake_outer_composite_serialize**](FakeApi.md#fake_outer_composite_serialize) | **POST** /fake/outer/composite | 
@@ -18,6 +19,50 @@ Method | HTTP request | Description
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
 
+
+
+## fake_dynamic_resource_dynamic_get
+
+> fake_dynamic_resource_dynamic_get(dynamic)
+
+https://github.com/OpenAPITools/openapi-generator/issues/3119
+
+### Example
+
+```ruby
+# load the gem
+require 'petstore'
+
+api_instance = Petstore::FakeApi.new
+dynamic = 'dynamic_example' # String | 
+
+begin
+  #https://github.com/OpenAPITools/openapi-generator/issues/3119
+  api_instance.fake_dynamic_resource_dynamic_get(dynamic)
+rescue Petstore::ApiError => e
+  puts "Exception when calling FakeApi->fake_dynamic_resource_dynamic_get: #{e}"
+end
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **dynamic** | **String**|  | 
+
+### Return type
+
+nil (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
 
 
 ## fake_health_get

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -19,6 +19,64 @@ module Petstore
     def initialize(api_client = ApiClient.default)
       @api_client = api_client
     end
+    # https://github.com/OpenAPITools/openapi-generator/issues/3119
+    # @param dynamic [String] 
+    # @param [Hash] opts the optional parameters
+    # @return [nil]
+    def fake_dynamic_resource_dynamic_get(dynamic, opts = {})
+      fake_dynamic_resource_dynamic_get_with_http_info(dynamic, opts)
+      nil
+    end
+
+    # https://github.com/OpenAPITools/openapi-generator/issues/3119
+    # @param dynamic [String] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def fake_dynamic_resource_dynamic_get_with_http_info(dynamic, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: FakeApi.fake_dynamic_resource_dynamic_get ...'
+      end
+      # verify the required parameter 'dynamic' is set
+      if @api_client.config.client_side_validation && dynamic.nil?
+        fail ArgumentError, "Missing the required parameter 'dynamic' when calling FakeApi.fake_dynamic_resource_dynamic_get"
+      end
+      # resource path
+      local_var_path = '/fake/dynamic-resource/{dynamic}'.sub('{' + 'dynamic' + '}', CGI.escape(dynamic.to_s))
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: FakeApi#fake_dynamic_resource_dynamic_get\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Health check endpoint
     # @param [Hash] opts the optional parameters
     # @return [HealthCheckResult]

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -41,7 +41,7 @@ module Petstore
         fail ArgumentError, "Missing the required parameter 'dynamic' when calling FakeApi.fake_dynamic_resource_dynamic_get"
       end
       # resource path
-      local_var_path = '/fake/dynamic-resource/{dynamic}'.sub('{' + 'dynamic' + '}', CGI.escape(dynamic.to_s))
+      local_var_path = '/fake/dynamic-resource/{dynamic}'.sub('{' + 'dynamic' + '}', CGI.escape(dynamic.to_s).gsub('%2F', '/'))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -32,6 +32,17 @@ describe 'FakeApi' do
     end
   end
 
+  # unit tests for fake_dynamic_resource_dynamic_get
+  # https://github.com/OpenAPITools/openapi-generator/issues/3119
+  # @param dynamic 
+  # @param [Hash] opts the optional parameters
+  # @return [nil]
+  describe 'fake_dynamic_resource_dynamic_get test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   # unit tests for fake_health_get
   # Health check endpoint
   # @param [Hash] opts the optional parameters

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -65,6 +65,18 @@ public class FakeApi  {
    }
 
     @GET
+    @Path("/dynamic-resource/{dynamic}")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "https://github.com/OpenAPITools/openapi-generator/issues/3119", notes = "", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "OK", response = Void.class) })
+    public Response fakeDynamicResourceDynamicGet(@ApiParam(value = "",required=true) @PathParam("dynamic") String dynamic
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.fakeDynamicResourceDynamicGet(dynamic, securityContext);
+    }
+    @GET
     @Path("/health")
     
     @Produces({ "application/json" })

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.validation.constraints.*;
 
 public abstract class FakeApiService {
+    public abstract Response fakeDynamicResourceDynamicGet(String dynamic,SecurityContext securityContext) throws NotFoundException;
     public abstract Response fakeHealthGet(SecurityContext securityContext) throws NotFoundException;
     public abstract Response fakeOuterBooleanSerialize(Boolean body,SecurityContext securityContext) throws NotFoundException;
     public abstract Response fakeOuterCompositeSerialize(OuterComposite outerComposite,SecurityContext securityContext) throws NotFoundException;

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -27,6 +27,11 @@ import javax.validation.constraints.*;
 
 public class FakeApiServiceImpl extends FakeApiService {
     @Override
+    public Response fakeDynamicResourceDynamicGet(String dynamic, SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
     public Response fakeHealthGet(SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
    No- I don't think this is going to be the accepted solution, so I won't get their attention at this point.

### Description of the PR

Add an option `x-allow-dynamic-resource` to tell path parameters not to encode slashes (`/`). This provides a route for backwards compatibility for people who rely on slashes not being encoded.

I've only done this for Ruby-client. 

The 1st commit is where I change the sample YAML and add the route.
The 2nd commit is when I add the extension to Ruby.

https://github.com/OpenAPITools/openapi-generator/issues/3119