### PR TITLE
[openapi-yaml] Prerequisities for Swagger 2 template.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/OpenAPIYamlGenerator.java
@@ -18,9 +18,23 @@
 package org.openapitools.codegen.languages;
 
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.templating.mustache.CamelCaseLambda;
+import org.openapitools.codegen.templating.mustache.IndentedLambda;
+import org.openapitools.codegen.templating.mustache.LowercaseLambda;
+import org.openapitools.codegen.templating.mustache.TitlecaseLambda;
+import org.openapitools.codegen.templating.mustache.UppercaseLambda;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import io.swagger.v3.oas.models.Operation;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfig {
@@ -61,6 +75,44 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
         }
         LOGGER.info("Output file [outputFile={}]", outputFile);
         supportingFiles.add(new SupportingFile("openapi.mustache", outputFile));
+
+        addMustacheLambdas(additionalProperties);
+    }
+
+    private void addMustacheLambdas(Map<String, Object> objs) {
+
+        Map<String, Mustache.Lambda> lambdas = new ImmutableMap.Builder<String, Mustache.Lambda>()
+                .put("lowercase", new LowercaseLambda().generator(this))
+                .put("uppercase", new UppercaseLambda())
+                .put("titlecase", new TitlecaseLambda())
+                .put("camelcase", new CamelCaseLambda().generator(this))
+                .put("indented", new IndentedLambda())
+                .put("indented_8", new IndentedLambda(8, " "))
+                .put("indented_12", new IndentedLambda(12, " "))
+                .put("indented_16", new IndentedLambda(16, " "))
+                .put("onchange",  new OnChangeLambda())
+                .build();
+
+        if (objs.containsKey("lambda")) {
+            LOGGER.warn("A property named 'lambda' already exists. Mustache lambdas renamed from 'lambda' to '_lambda'. " +
+                    "You'll likely need to use a custom template, " +
+                    "see https://github.com/OpenAPITools/openapi-generator/blob/master/docs/templating.md. ");
+            objs.put("_lambda", lambdas);
+        } else {
+            objs.put("lambda", lambdas);
+        }
+    }
+
+    /**
+     * Group operations by resourcePath so that operations with same path and
+     * different http method can be rendered one after the other.
+     */
+    @Override
+    public void addOperationToGroup(String tag, String resourcePath, Operation operation, CodegenOperation
+            co, Map<String, List<CodegenOperation>> operations) {
+        List<CodegenOperation> opList = operations.computeIfAbsent(resourcePath,
+                k -> new ArrayList<>());
+        opList.add(co);
     }
 
     @Override
@@ -79,6 +131,26 @@ public class OpenAPIYamlGenerator extends DefaultCodegen implements CodegenConfi
     public String escapeUnsafeCharacters(String input) {
         // just return the original string
         return input;
+    }
+
+    /**
+     * Lambda writes current fragment to the output when it is different than
+     * previous fragment.
+     */
+    public static class OnChangeLambda implements Mustache.Lambda {
+        private static final Logger LOGGER = LoggerFactory.getLogger(OnChangeLambda.class);
+
+        private String lastVal = null;
+
+        @Override
+        public void execute(Template.Fragment frag, Writer out) throws IOException {
+            String curVal = frag.execute();
+            LOGGER.debug("[lastVal={}, curVal={}]", lastVal, curVal);
+            if (curVal != null && !curVal.equals(lastVal)) {
+                out.write(curVal);
+                lastVal = curVal;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I am looking for a way to convert from Openapi 3 to Swagger 2 specification. I think `openapi-yaml` generator with custom template is a good starting point. 

In order to start, I needed to modify current generator to:
1. Group operations by resourcePath (they are grouped by tag currently) so that operations with same path are rendered one after the other:
    Example:
```
      /pet:
        post:
          .....
        put:
          .....
      /pet/findByStatus:
        get:
        .....
```

   And not (it might happen when grouped by a tag):
```
      /pet:
        post:
        .....
      /pet/findByStatus:
        get:
        .....
      /pet: 
        put:
        .....
 ```

2. Created a Mustache lambda `OnChangeLambda` to return fragment only when current fragment is different than previous fragment. It will be used to render endpoint path only for a first operation in group.

3. Registered lambdas like lowercase, onchage (above one), uppercase, etc.

Later I am hoping to submit Swagger 2 template a new library.
