### PR TITLE
Fix generated code in cases where multiple APIs define the same options.

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -44,7 +44,7 @@ type {{classname}}Service service
 */
 {{#hasOptionalParams}}
 
-type {{{nickname}}}Opts struct {
+type {{{classname}}}_{{{nickname}}}Opts struct {
 {{#allParams}}
 {{^required}}
 {{#isPrimitiveType}}

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -102,7 +102,7 @@ Test serialization of outer boolean types
 @return bool
 */
 
-type FakeOuterBooleanSerializeOpts struct {
+type FakeApi_FakeOuterBooleanSerializeOpts struct {
 	Body optional.Bool
 }
 
@@ -200,7 +200,7 @@ Test serialization of object with outer number type
 @return OuterComposite
 */
 
-type FakeOuterCompositeSerializeOpts struct {
+type FakeApi_FakeOuterCompositeSerializeOpts struct {
 	Body optional.Interface
 }
 
@@ -302,7 +302,7 @@ Test serialization of outer number types
 @return float32
 */
 
-type FakeOuterNumberSerializeOpts struct {
+type FakeApi_FakeOuterNumberSerializeOpts struct {
 	Body optional.Float32
 }
 
@@ -400,7 +400,7 @@ Test serialization of outer string types
 @return string
 */
 
-type FakeOuterStringSerializeOpts struct {
+type FakeApi_FakeOuterStringSerializeOpts struct {
 	Body optional.String
 }
 
@@ -736,7 +736,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
  * @param "Callback" (optional.String) -  None
 */
 
-type TestEndpointParametersOpts struct {
+type FakeApi_TestEndpointParametersOpts struct {
 	Integer optional.Int32
 	Int32_ optional.Int32
 	Int64_ optional.Int64
@@ -882,7 +882,7 @@ To test enum parameters
  * @param "EnumFormString" (optional.String) -  Form parameter enum test (string)
 */
 
-type TestEnumParametersOpts struct {
+type FakeApi_TestEnumParametersOpts struct {
 	EnumHeaderStringArray optional.Interface
 	EnumHeaderString optional.String
 	EnumQueryStringArray optional.Interface
@@ -990,7 +990,7 @@ Fake endpoint to test group parameters (optional)
  * @param "Int64Group" (optional.Int64) -  Integer in group parameters
 */
 
-type TestGroupParametersOpts struct {
+type FakeApi_TestGroupParametersOpts struct {
 	StringGroup optional.Int32
 	BooleanGroup optional.Bool
 	Int64Group optional.Int64

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -102,7 +102,7 @@ PetApiService Deletes a pet
  * @param "ApiKey" (optional.String) - 
 */
 
-type DeletePetOpts struct {
+type PetApi_DeletePetOpts struct {
 	ApiKey optional.String
 }
 
@@ -522,7 +522,7 @@ PetApiService Updates a pet in the store with form data
  * @param "Status" (optional.String) -  Updated status of the pet
 */
 
-type UpdatePetWithFormOpts struct {
+type PetApi_UpdatePetWithFormOpts struct {
 	Name optional.String
 	Status optional.String
 }
@@ -604,7 +604,7 @@ PetApiService uploads an image
 @return ApiResponse
 */
 
-type UploadFileOpts struct {
+type PetApi_UploadFileOpts struct {
 	AdditionalMetadata optional.String
 	File optional.Interface
 }
@@ -718,7 +718,7 @@ PetApiService uploads an image (required)
 @return ApiResponse
 */
 
-type UploadFileWithRequiredFileOpts struct {
+type PetApi_UploadFileWithRequiredFileOpts struct {
 	AdditionalMetadata optional.String
 }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Add the class name to the options struct in case APIs *cough* Kubernetes *cough* re-use the same options names in multiple different revisions of the API.

cc @antihax @bvwells @grokify @kemokemo
