### PR TITLE
[Typescript-Fetch] If a query parameter is a date, format it as YYYY-MM-DD

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -69,7 +69,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{/isDateTime}}
             {{^isDateTime}}
             {{#isDate}}
-            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString();
+            queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString().substr(0,10);
             {{/isDate}}
             {{^isDate}}
             queryParameters['{{baseName}}'] = requestParameters.{{paramName}};


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Tech Committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10)

### Description of the PR

For query parameters that are specified as `type: string` and `format: date`, the URL now contains the entire ISO-string while it should only include the date part in format `YYYY-MM-DD`. This distinction between `date` and `date-time` is already properly made in the models, but not in the client API generation.

In my project I cannot use the generated library for certain API calls that include something like `?date=` in their URL. The remote server may reject the request because it's not in the format `YYYY-MM-DD`.

I noticed that the sample Petstore does not include an example that uses `format: date`. There are ones that use `format: date-time`. I guess that adding such an operation means that all samples must be regenerated and checked, which I thought is something out of the scope of this PR.