### PR TITLE
Use io.swagger.util.Yaml instead of io.swagger.v3.core.util.Yaml to add  quotes around string value and fix compatibility with parser using yaml 1.1.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
@@ -3,7 +3,7 @@ package org.openapitools.codegen.serializer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import io.swagger.v3.core.util.Yaml;
+import io.swagger.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/serializer/SerializerUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/serializer/SerializerUtilsTest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -39,53 +40,67 @@ public class SerializerUtilsTest {
                 .description("Some description")
                 .operationId("pingOp")
                 .responses(new ApiResponses().addApiResponse("200", new ApiResponse().description("Ok")))));
-        openAPI.components(new Components().addSchemas("SomeObject", new ObjectSchema().description("An Obj").addProperties("id", new StringSchema())));
+        openAPI.components(new Components().addSchemas("SomeObject", new ObjectSchema().description("An Obj")
+                .addProperties("id", new StringSchema())
+                .addProperties("stringBoolean", new StringSchema()._default("true"))
+                .addProperties("switch", new StringSchema()._default("on"))
+                .addProperties("valid", new BooleanSchema()._default(true))));
         openAPI.setExtensions(new LinkedHashMap<>()); // required because swagger-core is using HashMap instead of LinkedHashMap internally.
         openAPI.addExtension("x-custom", "value1");
         openAPI.addExtension("x-other", "value2");
 
         String content = SerializerUtils.toYamlString(openAPI);
-        String expected = "openapi: 3.0.1\n" + 
+        String expected = "---\n" +
+               "openapi: \"3.0.1\"\n" + 
                "info:\n" + 
-               "  description: Some description\n" + 
-               "  title: Some title\n" + 
+               "  description: \"Some description\"\n" + 
+               "  title: \"Some title\"\n" + 
                "externalDocs:\n" + 
-               "  description: a-description\n" + 
-               "  url: http://abcdef.com\n" + 
+               "  description: \"a-description\"\n" + 
+               "  url: \"http://abcdef.com\"\n" + 
                "servers:\n" + 
-               "- description: first server\n" + 
-               "  url: http://www.server1.com\n" + 
-               "- description: second server\n" + 
-               "  url: http://www.server2.com\n" + 
+               "- description: \"first server\"\n" + 
+               "  url: \"http://www.server1.com\"\n" + 
+               "- description: \"second server\"\n" + 
+               "  url: \"http://www.server2.com\"\n" + 
                "security:\n" + 
                "- some_auth:\n" + 
-               "  - write\n" + 
-               "  - read\n" + 
+               "  - \"write\"\n" + 
+               "  - \"read\"\n" + 
                "tags:\n" + 
-               "- description: some 1 description\n" + 
-               "  name: tag1\n" + 
-               "- description: some 2 description\n" + 
-               "  name: tag2\n" + 
-               "- description: some 3 description\n" + 
-               "  name: tag3\n" + 
+               "- description: \"some 1 description\"\n" + 
+               "  name: \"tag1\"\n" + 
+               "- description: \"some 2 description\"\n" + 
+               "  name: \"tag2\"\n" + 
+               "- description: \"some 3 description\"\n" + 
+               "  name: \"tag3\"\n" + 
                "paths:\n" + 
                "  /ping/pong:\n" + 
                "    get:\n" + 
-               "      description: Some description\n" + 
-               "      operationId: pingOp\n" + 
+               "      description: \"Some description\"\n" + 
+               "      operationId: \"pingOp\"\n" + 
                "      responses:\n" + 
                "        200:\n" + 
-               "          description: Ok\n" + 
+               "          description: \"Ok\"\n" + 
                "components:\n" + 
                "  schemas:\n" + 
                "    SomeObject:\n" + 
-               "      description: An Obj\n" + 
+               "      description: \"An Obj\"\n" + 
                "      properties:\n" + 
                "        id:\n" + 
-               "          type: string\n" + 
-               "      type: object\n" + 
-               "x-custom: value1\n" + 
-               "x-other: value2\n";
+               "          type: \"string\"\n" + 
+               "        stringBoolean:\n" + 
+               "          default: \"true\"\n" + 
+               "          type: \"string\"\n" +
+               "        switch:\n" + 
+               "          default: \"on\"\n" + 
+               "          type: \"string\"\n" +
+               "        valid:\n" + 
+               "          default: true\n" + 
+               "          type: \"boolean\"\n" + 
+               "      type: \"object\"\n" + 
+               "x-custom: \"value1\"\n" + 
+               "x-other: \"value2\"\n";
         assertEquals(content, expected);
     }
 
@@ -102,19 +117,20 @@ public class SerializerUtilsTest {
                 .responses(new ApiResponses().addApiResponse("200", new ApiResponse().description("Ok")))));
 
         String content = SerializerUtils.toYamlString(openAPI);
-        String expected = "openapi: 3.0.1\n" + 
+        String expected = "---\n" +
+                "openapi: \"3.0.1\"\n" + 
                 "info:\n" + 
-                "  title: Some title\n" + 
+                "  title: \"Some title\"\n" + 
                 "servers:\n" + 
-                "- url: http://www.server1.com\n" + 
+                "- url: \"http://www.server1.com\"\n" + 
                 "paths:\n" + 
                 "  /ping/pong:\n" + 
                 "    get:\n" + 
-                "      description: Some description\n" + 
-                "      operationId: pingOp\n" + 
+                "      description: \"Some description\"\n" + 
+                "      operationId: \"pingOp\"\n" + 
                 "      responses:\n" + 
                 "        200:\n" + 
-                "          description: Ok\n"; 
+                "          description: \"Ok\"\n"; 
         assertEquals(content, expected);
     }
 }


### PR DESCRIPTION

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fix #3196

In spec 1.1, some words without quotes can be implicitly converted to
 a boolean like "yes" or "on" (See https://yaml.org/type/bool.html)
In v3.core.util.Yaml with MINIMIZE_QUOTES enabled, the formatter created
 a YAML but forget to protect some words.

PRs are created to fix this in the formatter:
 - https://github.com/FasterXML/jackson-dataformats-text/pull/137
 - https://github.com/FasterXML/jackson-dataformats-text/pull/138

Until the PRs will be merged and released, this patch fix it by
re-adding quotes.
