### PR TITLE
[C++][Pistache] Fix warnings

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/api-source.mustache
@@ -14,7 +14,7 @@ using namespace {{modelNamespace}};{{/hasModelImport}}
 
 {{classname}}::{{classname}}(std::shared_ptr<Pistache::Rest::Router> rtr) { 
     router = rtr;
-};
+}
 
 void {{classname}}::init() {
     setupRoutes();
@@ -32,7 +32,7 @@ void {{classname}}::setupRoutes() {
 }
 
 {{#operation}}
-void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Request &{{#hasParams}}request{{/hasParams}}, Pistache::Http::ResponseWriter response) {
     {{#vendorExtensions.x-codegen-pistache-isParsingSupported}}
     {{#hasPathParams}}
     // Getting the path params
@@ -92,7 +92,7 @@ void {{classname}}::{{operationIdSnakeCase}}_handler(const Pistache::Rest::Reque
 }
 {{/operation}}
 
-void {{classname}}::{{classnameSnakeLowerCase}}_default_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void {{classname}}::{{classnameSnakeLowerCase}}_default_handler(const Pistache::Rest::Request &, Pistache::Http::ResponseWriter response) {
     response.send(Pistache::Http::Code::Not_Found, "The requested method does not exist");
 }
 

--- a/samples/server/petstore/cpp-pistache/api/PetApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/PetApi.cpp
@@ -23,7 +23,7 @@ using namespace org::openapitools::server::model;
 
 PetApi::PetApi(std::shared_ptr<Pistache::Rest::Router> rtr) { 
     router = rtr;
-};
+}
 
 void PetApi::init() {
     setupRoutes();
@@ -201,7 +201,7 @@ void PetApi::upload_file_handler(const Pistache::Rest::Request &request, Pistach
 
 }
 
-void PetApi::pet_api_default_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void PetApi::pet_api_default_handler(const Pistache::Rest::Request &, Pistache::Http::ResponseWriter response) {
     response.send(Pistache::Http::Code::Not_Found, "The requested method does not exist");
 }
 

--- a/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/StoreApi.cpp
@@ -23,7 +23,7 @@ using namespace org::openapitools::server::model;
 
 StoreApi::StoreApi(std::shared_ptr<Pistache::Rest::Router> rtr) { 
     router = rtr;
-};
+}
 
 void StoreApi::init() {
     setupRoutes();
@@ -58,7 +58,7 @@ void StoreApi::delete_order_handler(const Pistache::Rest::Request &request, Pist
     }
 
 }
-void StoreApi::get_inventory_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void StoreApi::get_inventory_handler(const Pistache::Rest::Request &, Pistache::Http::ResponseWriter response) {
 
     try {
       this->get_inventory(response);
@@ -111,7 +111,7 @@ void StoreApi::place_order_handler(const Pistache::Rest::Request &request, Pista
 
 }
 
-void StoreApi::store_api_default_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void StoreApi::store_api_default_handler(const Pistache::Rest::Request &, Pistache::Http::ResponseWriter response) {
     response.send(Pistache::Http::Code::Not_Found, "The requested method does not exist");
 }
 

--- a/samples/server/petstore/cpp-pistache/api/UserApi.cpp
+++ b/samples/server/petstore/cpp-pistache/api/UserApi.cpp
@@ -23,7 +23,7 @@ using namespace org::openapitools::server::model;
 
 UserApi::UserApi(std::shared_ptr<Pistache::Rest::Router> rtr) { 
     router = rtr;
-};
+}
 
 void UserApi::init() {
     setupRoutes();
@@ -170,7 +170,7 @@ void UserApi::login_user_handler(const Pistache::Rest::Request &request, Pistach
     }
 
 }
-void UserApi::logout_user_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void UserApi::logout_user_handler(const Pistache::Rest::Request &, Pistache::Http::ResponseWriter response) {
 
     try {
       this->logout_user(response);
@@ -208,7 +208,7 @@ void UserApi::update_user_handler(const Pistache::Rest::Request &request, Pistac
 
 }
 
-void UserApi::user_api_default_handler(const Pistache::Rest::Request &request, Pistache::Http::ResponseWriter response) {
+void UserApi::user_api_default_handler(const Pistache::Rest::Request &, Pistache::Http::ResponseWriter response) {
     response.send(Pistache::Http::Code::Not_Found, "The requested method does not exist");
 }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@ravinikam @stkrwork @etherealjoy @MartinDelille 

### Description of the PR
GCC would complain about two warnings
```
(...)/api/(...)Api.cpp:24:92: warning: extra ‘;’ [-Wpedantic]
 (...)Api::(...)Api(std::shared_ptr<Pistache::Rest::Router> rtr) { router = rtr; };
```

```
(..)/api/(...)Api.cpp: In member function ‘void org::openapitools::server::api::(...)Api::(...)_api_default_handler(const Pistache::Rest::Request&, Pistache::Http::ResponseWriter)’:
(...)/api/(...)Api.cpp:124:69: warning: unused parameter ‘request’ [-Wunused-parameter]
 void (...)Api::(...)_api_default_handler(const Pistache::Rest::Request& request,
```