### PR TITLE
Added RxJava2 to java-vertx server codegen

### DIFF
--- a/docs/generators/java-vertx.md
+++ b/docs/generators/java-vertx.md
@@ -42,5 +42,6 @@ sidebar_label: java-vertx
 |parentArtifactId|parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |parentVersion|parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd><dl>|null|
-|rxInterface|When specified, API interfaces are generated with RX and methods return Single&lt;&gt; and Comparable.| |false|
+|rxInterface|When specified, API interfaces are generated with RxJava and methods return Single<> and Completable.| |false|
+|rxVersion2|When specified in combination with **rxInterface**, package imports are generated for RxJava2.| |false|
 |vertxSwaggerRouterVersion|Specify the version of the swagger router library| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
@@ -44,6 +44,7 @@ public class JavaVertXServerCodegen extends AbstractJavaCodegen {
     public static final String ROOT_PACKAGE = "rootPackage";
 
     public static final String RX_INTERFACE_OPTION = "rxInterface";
+    public static final String RX_VERSION_2_OPTION = "rxVersion2";
     public static final String VERTX_SWAGGER_ROUTER_VERSION_OPTION = "vertxSwaggerRouterVersion";
 
     /**
@@ -88,6 +89,9 @@ public class JavaVertXServerCodegen extends AbstractJavaCodegen {
         cliOptions.add(CliOption.newBoolean(RX_INTERFACE_OPTION,
                 "When specified, API interfaces are generated with RX "
                         + "and methods return Single<> and Comparable."));
+        cliOptions.add(CliOption.newBoolean(RX_VERSION_2_OPTION,
+                "When specified in combination with rxInterface, "
+                        + "API interfaces are generated with RxJava2."));
         cliOptions.add(CliOption.newString(VERTX_SWAGGER_ROUTER_VERSION_OPTION,
                 "Specify the version of the swagger router library"));
 

--- a/modules/openapi-generator/src/main/resources/JavaVertXServer/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaVertXServer/api.mustache
@@ -4,8 +4,8 @@ package {{package}};
 {{/imports}}
 
 {{#rxInterface}}
-import rx.Completable;
-import rx.Single;
+import {{#rxVersion2}}io.reactivex{{/rxVersion2}}{{^rxVersion2}}rx{{/rxVersion2}}.Completable;
+import {{#rxVersion2}}io.reactivex{{/rxVersion2}}{{^rxVersion2}}rx{{/rxVersion2}}.Single;
 {{/rxInterface}}
 {{^rxInterface}}
 import io.vertx.core.AsyncResult;


### PR DESCRIPTION
RxJava2 uses another base package. To support this package in java-vertx server codegen, a rxVersion2 boolean flag/option was added which defaults to false.

@wing328