### PR TITLE
[core] consider content in parameters and headers when computing unused schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -176,17 +176,14 @@ public class ModelUtils {
                         if (parameter.getSchema() != null) {
                             visitSchema(openAPI, parameter.getSchema(), null, visitedSchemas, visitor);
                         }
+                        visitContent(openAPI, parameter.getContent(), visitor, visitedSchemas);
                     }
                 }
 
                 //RequestBody:
                 RequestBody requestBody = getReferencedRequestBody(openAPI, operation.getRequestBody());
-                if (requestBody != null && requestBody.getContent() != null) {
-                    for (Entry<String, MediaType> e : requestBody.getContent().entrySet()) {
-                        if (e.getValue().getSchema() != null) {
-                            visitSchema(openAPI, e.getValue().getSchema(), e.getKey(), visitedSchemas, visitor);
-                        }
-                    }
+                if (requestBody != null) {
+                    visitContent(openAPI, requestBody.getContent(), visitor, visitedSchemas);
                 }
 
                 //Responses:
@@ -194,19 +191,14 @@ public class ModelUtils {
                     for (ApiResponse r : operation.getResponses().values()) {
                         ApiResponse apiResponse = getReferencedApiResponse(openAPI, r);
                         if (apiResponse != null) {
-                            if (apiResponse.getContent() != null) {
-                                for (Entry<String, MediaType> e : apiResponse.getContent().entrySet()) {
-                                    if (e.getValue().getSchema() != null) {
-                                        visitSchema(openAPI, e.getValue().getSchema(), e.getKey(), visitedSchemas, visitor);
-                                    }
-                                }
-                            }
+                            visitContent(openAPI, apiResponse.getContent(), visitor, visitedSchemas);
                             if (apiResponse.getHeaders() != null) {
                                 for (Entry<String, Header> e : apiResponse.getHeaders().entrySet()) {
                                     Header header = getReferencedHeader(openAPI, e.getValue());
                                     if (header.getSchema() != null) {
                                         visitSchema(openAPI, header.getSchema(), e.getKey(), visitedSchemas, visitor);
                                     }
+                                    visitContent(openAPI, header.getContent(), visitor, visitedSchemas);
                                 }
                             }
                         }
@@ -223,6 +215,16 @@ public class ModelUtils {
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    private static void visitContent(OpenAPI openAPI, Content content, OpenAPISchemaVisitor visitor, List<String> visitedSchemas) {
+        if (content != null) {
+            for (Entry<String, MediaType> e : content.entrySet()) {
+                if (e.getValue().getSchema() != null) {
+                    visitSchema(openAPI, e.getValue().getSchema(), e.getKey(), visitedSchemas, visitor);
                 }
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -170,15 +170,7 @@ public class ModelUtils {
         if (allOperations != null) {
             for (Operation operation : allOperations) {
                 //Params:
-                if (operation.getParameters() != null) {
-                    for (Parameter p : operation.getParameters()) {
-                        Parameter parameter = getReferencedParameter(openAPI, p);
-                        if (parameter.getSchema() != null) {
-                            visitSchema(openAPI, parameter.getSchema(), null, visitedSchemas, visitor);
-                        }
-                        visitContent(openAPI, parameter.getContent(), visitor, visitedSchemas);
-                    }
-                }
+                visitParameters(openAPI, operation.getParameters(), visitor, visitedSchemas);
 
                 //RequestBody:
                 RequestBody requestBody = getReferencedRequestBody(openAPI, operation.getRequestBody());
@@ -216,6 +208,21 @@ public class ModelUtils {
                         }
                     }
                 }
+            }
+        }
+        //Params:
+        visitParameters(openAPI, pathItem.getParameters(), visitor, visitedSchemas);
+    }
+
+    private static void visitParameters(OpenAPI openAPI, List<Parameter> parameters, OpenAPISchemaVisitor visitor,
+            List<String> visitedSchemas) {
+        if (parameters != null) {
+            for (Parameter p : parameters) {
+                Parameter parameter = getReferencedParameter(openAPI, p);
+                if (parameter.getSchema() != null) {
+                    visitSchema(openAPI, parameter.getSchema(), null, visitedSchemas, visitor);
+                }
+                visitContent(openAPI, parameter.getContent(), visitor, visitedSchemas);
             }
         }
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -37,7 +37,7 @@ public class ModelUtilsTest {
     public void testGetAllUsedSchemas() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
-        Assert.assertEquals(allUsedSchemas.size(), 34);
+        Assert.assertEquals(allUsedSchemas.size(), 36);
 
         Assert.assertTrue(allUsedSchemas.contains("SomeObjShared"), "contains 'SomeObjShared'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj1"), "contains 'UnusedObj1'");
@@ -73,6 +73,8 @@ public class ModelUtilsTest {
         Assert.assertTrue(allUsedSchemas.contains("SOutput22"), "contains 'SInput22'");
         Assert.assertTrue(allUsedSchemas.contains("SomeHeader23"), "contains 'SomeHeader23'");
         Assert.assertTrue(allUsedSchemas.contains("SomeHeader24"), "contains 'SomeHeader24'");
+        Assert.assertTrue(allUsedSchemas.contains("SomeObj25"), "contains 'SomeObj25'");
+        Assert.assertTrue(allUsedSchemas.contains("SomeObj26"), "contains 'SomeObj26'");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -37,7 +37,7 @@ public class ModelUtilsTest {
     public void testGetAllUsedSchemas() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/unusedSchemas.yaml");
         List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
-        Assert.assertEquals(allUsedSchemas.size(), 36);
+        Assert.assertEquals(allUsedSchemas.size(), 38);
 
         Assert.assertTrue(allUsedSchemas.contains("SomeObjShared"), "contains 'SomeObjShared'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj1"), "contains 'UnusedObj1'");
@@ -75,6 +75,8 @@ public class ModelUtilsTest {
         Assert.assertTrue(allUsedSchemas.contains("SomeHeader24"), "contains 'SomeHeader24'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj25"), "contains 'SomeObj25'");
         Assert.assertTrue(allUsedSchemas.contains("SomeObj26"), "contains 'SomeObj26'");
+        Assert.assertTrue(allUsedSchemas.contains("Param27"), "contains 'Param27'");
+        Assert.assertTrue(allUsedSchemas.contains("Param28"), "contains 'Param28'");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
@@ -328,6 +328,30 @@ paths:
                 application/json:
                   schema:
                     $ref: "#/components/schemas/SomeObj26"
+  /some/p27/{q}:
+    parameters:
+     - name: q
+       in: path
+       schema:
+         $ref: "#/components/schemas/Param27"
+    post:
+      operationId: op27
+      responses:
+        '200':
+          description: OK
+  /some/p28/{q}:
+    parameters:
+     - name: q
+       in: path
+       content:
+         application/json:
+           schema:
+             $ref: "#/components/schemas/Param28"
+    post:
+      operationId: op27
+      responses:
+        '200':
+          description: OK
 components:
   schemas:
     UnusedObj1:
@@ -604,6 +628,18 @@ components:
         q1:
           type: string
         q2:
+          type: string
+    Param27:
+      type: string
+      enum:
+        - alpha
+        - beta
+    Param28:
+      type: object
+      properties:
+        r1:
+          type: string
+        r2:
           type: string
     SomeObjShared:
       type: object

--- a/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/unusedSchemas.yaml
@@ -301,6 +301,33 @@ paths:
           headers:
             x-app-info:
               $ref: "#/components/headers/sharedHeader24"
+  /some/p25:
+    post:
+      operationId: op25
+      parameters:
+       - name: q
+         in: query
+         content:
+           application/json:
+             schema:
+              $ref: "#/components/schemas/SomeObj25"
+      responses:
+        '200':
+          description: OK
+  /some/p26:
+    post:
+      operationId: op26
+      responses:
+        '200':
+          description: OK
+          headers:
+            x-something:
+              description: basic app info
+              style: simple
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/SomeObj26"
 components:
   schemas:
     UnusedObj1:
@@ -564,6 +591,20 @@ components:
     SomeHeader24:
       type: integer
       format: int64
+    SomeObj25:
+      type: object
+      properties:
+        p1:
+          type: string
+        p2:
+          type: string
+    SomeObj26:
+      type: object
+      properties:
+        q1:
+          type: string
+        q2:
+          type: string
     SomeObjShared:
       type: object
       properties:


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project]
(https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @OpenAPITools/generator-core-team 

### Description of the PR

Introduced with #74 and updated with #1232 and #2138, the `ModelUtils.getUnusedSchemas(OpenAPI)` returns all schemas that are not used in an OpenAPI specification.

This PR fixes the case where a `Schema` is referenced in an `Content` of and `Header` or `Parameter`.

Original issue: #50 


