### PR TITLE
[Java] Handle discriminator mapping non-ref name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1860,8 +1860,10 @@ public class DefaultCodegen implements CodegenConfig {
         discriminator.setMapping(schema.getDiscriminator().getMapping());
         if (schema.getDiscriminator().getMapping() != null && !schema.getDiscriminator().getMapping().isEmpty()) {
             for (Entry<String, String> e : schema.getDiscriminator().getMapping().entrySet()) {
-                String name = toModelName(ModelUtils.getSimpleRef(e.getValue())); // e.g e.getValue => #/components/schemas/Dog
-                discriminator.getMappedModels().add(new MappedModel(e.getKey(), name));
+                String nameOrRef = e.getValue();
+                String name = nameOrRef.indexOf('/') >= 0 ? ModelUtils.getSimpleRef(nameOrRef) : nameOrRef;
+                String modelName = toModelName(name);
+                discriminator.getMappedModels().add(new MappedModel(e.getKey(), modelName));
             }
         } else {
             Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -582,7 +582,7 @@ public class DefaultCodegenTest {
         test.setPropertyName("DollarUnderscoretype");
         test.setMapping(new HashMap<>());
         test.getMapping().put("a", "#/components/schemas/Adult");
-        test.getMapping().put("c", "#/components/schemas/Child");
+        test.getMapping().put("c", "Child");
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("a", "Adult"));
         test.getMappedModels().add(new CodegenDiscriminator.MappedModel("c", "Child"));
         Assert.assertEquals(discriminator, test);

--- a/modules/openapi-generator/src/test/resources/3_0/allOf.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf.yaml
@@ -32,7 +32,7 @@ components:
         propertyName: $_type
         mapping:
           a: '#/components/schemas/Adult'
-          c: '#/components/schemas/Child'
+          c: Child
       properties:
         $_type:
           type: string


### PR DESCRIPTION
## PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The `mapping` property of the [Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminatorObject) is "An object to hold mappings between payload values and schema names or references."  The subsequent examples in the spec have `mapping`s of both types.  The `mapping` support introduced in #536 only supports references.

This pull request updates the code to support names which are not references (identified by lack of `/`) in addition to references and changes a test mapping to cover this case.

Thanks for considering,
Kevin

CC:  @0v1se, @jmini (from #536)
CC technical committee:  @bbdouglas, @sreeshas, @jfiala, @lukoyanov, @cbornet, @jeff9finger, @karismann, @Zomzog