### PR TITLE
[online] Honor generator environment variable and system property

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/configuration/OpenAPIDocumentationConfig.java
@@ -68,7 +68,11 @@ public class OpenAPIDocumentationConfig {
     public Docket customImplementation(){
         String host;
         try {
-            host = new URI(System.getProperty("GENERATOR_HOST", "http://localhost")).getHost();
+            String baseUrl = System.getenv("GENERATOR_HOST");
+            if (baseUrl == null) {
+                baseUrl = System.getProperty("generator.host", "http://localhost");
+            }
+            host = new URI(baseUrl).getHost();
         } catch (URISyntaxException e) {
             host = "";
         }


### PR DESCRIPTION
Previously, this pulled from the GENERATOR_HOST system property. This
should have been an environment variable. Fallback is now generator.host
system property.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
