### PR TITLE
generate schema classes for optionally provided secondary spec files

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -66,6 +66,10 @@ public class Generate implements Runnable {
             description = "location of the OpenAPI spec, as URL or file (required)")
     private String spec;
 
+    @Option(name = {"--additional-schemas-input-specs"}, title = "additional spec files", required = false,
+            description = "comma separated list of locations of OpenAPI specs, as URL or file for which components should be generated (optional)")
+    private String additionalSchemasInputSpecs;
+
     @Option(name = {"-t", "--template-dir"}, title = "template directory",
             description = "folder containing the template files")
     private String templateDir;
@@ -272,12 +276,15 @@ public class Generate implements Runnable {
         }
 
         if (isNotEmpty(spec)) {
-            if (!spec.matches("^http(s)?://.*") && !new File(spec).exists()) {
-                System.err.println("[error] The spec file is not found: " + spec);
-                System.err.println("[error] Check the path of the OpenAPI spec and try again.");
-                System.exit(1);
-            }
+            checkSpecPath(spec);
             configurator.setInputSpec(spec);
+        }
+
+        if (isNotEmpty(additionalSchemasInputSpecs)) {
+            for (String additionalModelInputSpec : additionalSchemasInputSpecs.split(",")) {
+                checkSpecPath(additionalModelInputSpec);
+                configurator.getAdditionalSchemasInputSpecs().add(additionalModelInputSpec);
+            }
         }
 
         if (isNotEmpty(generatorName)) {
@@ -397,6 +404,14 @@ public class Generate implements Runnable {
         } catch (GeneratorNotFoundException e) {
             System.err.println(e.getMessage());
             System.err.println("[error] Check the spelling of the generator's name and try again.");
+            System.exit(1);
+        }
+    }
+
+    private void checkSpecPath(String spec) {
+        if (!spec.matches("^http(s)?://.*") && !new File(spec).exists()) {
+            System.err.println("[error] The spec file is not found: " + spec);
+            System.err.println("[error] Check the path of the OpenAPI spec and try again.");
             System.exit(1);
         }
     }

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -32,6 +32,7 @@ import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyRese
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -107,6 +108,12 @@ public class CodeGenMojo extends AbstractMojo {
      */
     @Parameter(name = "inputSpec", property = "openapi.generator.maven.plugin.inputSpec", required = true)
     private String inputSpec;
+
+    /**
+     * Comma separated list of locations of OpenAPI specs, as URL or file for which models should be generated.
+     */
+    @Parameter(name = "additionalSchemasInputSpecs", property = "openapi.generator.maven.plugin.additionalSchemasInputSpecs", required = false)
+    private String additionalSchemasInputSpecs;
 
     /**
      * Git user ID, e.g. swagger-api.
@@ -453,6 +460,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (isNotEmpty(inputSpec)) {
                 configurator.setInputSpec(inputSpec);
+            }
+
+            if (isNotEmpty(additionalSchemasInputSpecs)) {
+                configurator.setAdditionalSchemasInputSpecs(Arrays.asList(additionalSchemasInputSpecs.split(",")));
             }
 
             if (isNotEmpty(gitUserId)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -109,6 +109,10 @@ public interface CodegenConfig {
 
     void setInputSpec(String inputSpec);
 
+    List<String> getAdditionalSchemasInputSpecs();
+
+    void setAdditionalSchemasInputSpecs(List<String> additionalSchemasInputSpecs);
+
     String getOutputDir();
 
     void setOutputDir(String dir);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -67,6 +67,7 @@ public class DefaultCodegen implements CodegenConfig {
 
     protected GeneratorMetadata generatorMetadata;
     protected String inputSpec;
+    protected List<String> additionalSchemasInputSpecs;
     protected String outputFolder = "";
     protected Set<String> defaultIncludes = new HashSet<String>();
     protected Map<String, String> typeMapping = new HashMap<String, String>();
@@ -701,6 +702,16 @@ public class DefaultCodegen implements CodegenConfig {
 
     public void setInputSpec(String inputSpec) {
         this.inputSpec = inputSpec;
+    }
+
+    @Override
+    public List<String> getAdditionalSchemasInputSpecs() {
+        return additionalSchemasInputSpecs;
+    }
+
+    @Override
+    public void setAdditionalSchemasInputSpecs(List<String> additionalSchemasInputSpecs) {
+        this.additionalSchemasInputSpecs = additionalSchemasInputSpecs;
     }
 
     public void setTemplateDir(String templateDir) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This allows to generate classes for (technically) unused schemas in secondary specification files using the new option `--additional-schemas-input-specs` - see #3257.

fixes #3257

