### PR TITLE
[typescript] remove duplicate TypeScriptJqueryClientCodegen.SNAPSHOT field

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptJqueryClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptJqueryClientCodegen.java
@@ -35,7 +35,6 @@ public class TypeScriptJqueryClientCodegen extends AbstractTypeScriptClientCodeg
     private static final Logger LOGGER = LoggerFactory.getLogger(TypeScriptJqueryClientCodegen.class);
 
     public static final String NPM_REPOSITORY = "npmRepository";
-    public static final String SNAPSHOT = "snapshot";
     public static final String JQUERY_ALREADY_IMPORTED = "jqueryAlreadyImported";
 
     protected String npmRepository = null;


### PR DESCRIPTION
We decided to not use fields hiding other in child classes, because this is a bad practice in Java.

This PR fixes following error:

> The field TypeScriptJqueryClientCodegen.SNAPSHOT is hiding a field from type
 AbstractTypeScriptClientCodegen