### PR TITLE
[java] fix javadoc configuration

### DIFF
--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -12,6 +12,7 @@ if [ "$NODE_INDEX" = "1" ]; then
   #cp CI/pom.xml.circleci pom.xml
   java -version
   mvn --quiet verify -Psamples.circleci
+  mvn --quiet javadoc:javadoc -Psamples.circleci
 
   # generate all petstore samples (client, servers, doc)
   ./bin/run-all-petstore

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -161,3 +161,7 @@ dependencies {
     {{/java8}}
     testCompile "junit:junit:$junit_version"
 }
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -170,17 +170,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -143,3 +143,7 @@ dependencies {
     {{/threetenbp}}
     testCompile 'junit:junit:4.12'
 }
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -149,17 +149,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/modules/openapi-generator/src/main/resources/java-pkmst/config/appconfig.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/config/appconfig.mustache
@@ -87,7 +87,7 @@ public class AppConfig extends WebMvcConfigurerAdapter {
 	 * .exposedHeaders("header1", "header2")
 	 * .allowCredentials(false).maxAge(3600);
 	 * 
-	 * @return
+	 * @return a new WebMvcConfigurer instance
 	 */
 	@Bean
 	public WebMvcConfigurer corsConfigurer() {

--- a/modules/openapi-generator/src/main/resources/java-pkmst/security/oAuth2SecurityConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/security/oAuth2SecurityConfiguration.mustache
@@ -18,7 +18,7 @@ import org.springframework.security.oauth2.provider.request.DefaultOAuth2Request
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
 /**
- * Provides a convenient base class for creating a {@link WebSecurityConfigurer}
+ * Provides a convenient base class for creating a WebSecurityConfigurer
  * instance. The implementation allows customization by overriding methods.
  *
  * @see EnableWebSecurity

--- a/modules/openapi-generator/src/main/resources/java-pkmst/security/resourceServerConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/security/resourceServerConfiguration.mustache
@@ -10,7 +10,7 @@ import org.springframework.http.HttpMethod;
 /**
  * Configurer class for <code>@EnableResourceServer</code> classes. This class adjust the access
  * rules and paths that are protected by OAuth2 security. If more than one configures the same property, then the last
- * one wins. The configurers are sorted by {@link Order} before being applied.
+ * one wins. The configurers are sorted by Order before being applied.
  * 
  * @author pkmst
  * 

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -151,17 +151,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -112,3 +112,7 @@ dependencies {
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     testCompile "junit:junit:$junit_version"
 }
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -151,17 +151,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -114,3 +114,7 @@ dependencies {
     compile "com.brsanthu:migbase64:2.2"
     testCompile "junit:junit:$junit_version"
 }
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -151,17 +151,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -108,3 +108,7 @@ dependencies {
     compile 'org.threeten:threetenbp:1.3.5'
     testCompile 'junit:junit:4.12'
 }
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -142,17 +142,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -108,3 +108,7 @@ dependencies {
     compile 'org.threeten:threetenbp:1.3.5'
     testCompile 'junit:junit:4.12'
 }
+
+javadoc {
+    options.tags = [ "http.response.details:a:Http Response Details" ]
+}

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -142,17 +142,17 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <tags>
-                                <tag>
-                                    <name>http.response.details</name>
-                                    <placement>a</placement>
-                                    <head>Http Response Details:</head>
-                                </tag>
-                 	        </tags>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <tags>
+                        <tag>
+                            <name>http.response.details</name>
+                            <placement>a</placement>
+                            <head>Http Response Details:</head>
+                        </tag>
+                    </tags>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/config/AppConfig.java
+++ b/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/config/AppConfig.java
@@ -20,7 +20,7 @@ public class AppConfig extends WebMvcConfigurerAdapter {
 	 * .exposedHeaders("header1", "header2")
 	 * .allowCredentials(false).maxAge(3600);
 	 * 
-	 * @return
+	 * @return a new WebMvcConfigurer instance
 	 */
 	@Bean
 	public WebMvcConfigurer corsConfigurer() {

--- a/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/security/OAuth2SecurityConfiguration.java
+++ b/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/security/OAuth2SecurityConfiguration.java
@@ -18,7 +18,7 @@ import org.springframework.security.oauth2.provider.request.DefaultOAuth2Request
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
 /**
- * Provides a convenient base class for creating a {@link WebSecurityConfigurer}
+ * Provides a convenient base class for creating a WebSecurityConfigurer
  * instance. The implementation allows customization by overriding methods.
  *
  * @see EnableWebSecurity

--- a/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/security/ResourceServerConfiguration.java
+++ b/samples/server/petstore/java-pkmst/src/main/java/com/prokarma/pkmst/security/ResourceServerConfiguration.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpMethod;
 /**
  * Configurer class for <code>@EnableResourceServer</code> classes. This class adjust the access
  * rules and paths that are protected by OAuth2 security. If more than one configures the same property, then the last
- * one wins. The configurers are sorted by {@link Order} before being applied.
+ * one wins. The configurers are sorted by Order before being applied.
  * 
  * @author pkmst
  * 


### PR DESCRIPTION
Fixes #3299.

The special javadoc tag `@http.response.details` needs to be declared correctly, so that the javadoc can be built.

---

For maven, this PR changes where the `<configuration>` block is added.
It was inside the `<execution>` bloc, but the example in the documetation ([Configuring Custom Javadoc Tags](https://maven.apache.org/plugins/maven-javadoc-plugin/examples/tag-configuration.html)) adds it directly in the `<plugin>` bloc.

For gradle, the [javadoc](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.javadoc.Javadoc.html) page do not really mention the `tags` option, but 
[GRADLE-1563](https://issues.gradle.org/browse/GRADLE-1563) does. See also [this question](https://stackoverflow.com/a/35121736/91497) on stackoverflow.
