### PR TITLE
[C++][Pistache] Add compatibility for nlohmann-json 3.5.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/model-source.mustache
@@ -37,7 +37,7 @@ void to_json(nlohmann::json& j, const {{classname}}& o)
 void from_json(const nlohmann::json& j, {{classname}}& o)
 {
     {{#vars}}
-    {{#required}}j.at("{{baseName}}").get_to(o.m_{{name}});{{/required}}{{^required}}if(j.contains("{{baseName}}"))
+    {{#required}}j.at("{{baseName}}").get_to(o.m_{{name}});{{/required}}{{^required}}if(j.find("{{baseName}}") != j.end())
     {
         j.at("{{baseName}}").get_to(o.m_{{name}});
         o.m_{{name}}IsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
+++ b/samples/server/petstore/cpp-pistache/model/ApiResponse.cpp
@@ -51,17 +51,17 @@ void to_json(nlohmann::json& j, const ApiResponse& o)
 
 void from_json(const nlohmann::json& j, ApiResponse& o)
 {
-    if(j.contains("code"))
+    if(j.find("code") != j.end())
     {
         j.at("code").get_to(o.m_Code);
         o.m_CodeIsSet = true;
     } 
-    if(j.contains("type"))
+    if(j.find("type") != j.end())
     {
         j.at("type").get_to(o.m_Type);
         o.m_TypeIsSet = true;
     } 
-    if(j.contains("message"))
+    if(j.find("message") != j.end())
     {
         j.at("message").get_to(o.m_Message);
         o.m_MessageIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Category.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Category.cpp
@@ -47,12 +47,12 @@ void to_json(nlohmann::json& j, const Category& o)
 
 void from_json(const nlohmann::json& j, Category& o)
 {
-    if(j.contains("id"))
+    if(j.find("id") != j.end())
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(j.contains("name"))
+    if(j.find("name") != j.end())
     {
         j.at("name").get_to(o.m_Name);
         o.m_NameIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Inline_object.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Inline_object.cpp
@@ -47,12 +47,12 @@ void to_json(nlohmann::json& j, const Inline_object& o)
 
 void from_json(const nlohmann::json& j, Inline_object& o)
 {
-    if(j.contains("name"))
+    if(j.find("name") != j.end())
     {
         j.at("name").get_to(o.m_Name);
         o.m_NameIsSet = true;
     } 
-    if(j.contains("status"))
+    if(j.find("status") != j.end())
     {
         j.at("status").get_to(o.m_Status);
         o.m_StatusIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Inline_object_1.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Inline_object_1.cpp
@@ -46,12 +46,12 @@ void to_json(nlohmann::json& j, const Inline_object_1& o)
 
 void from_json(const nlohmann::json& j, Inline_object_1& o)
 {
-    if(j.contains("additionalMetadata"))
+    if(j.find("additionalMetadata") != j.end())
     {
         j.at("additionalMetadata").get_to(o.m_AdditionalMetadata);
         o.m_AdditionalMetadataIsSet = true;
     } 
-    if(j.contains("file"))
+    if(j.find("file") != j.end())
     {
         j.at("file").get_to(o.m_file);
         o.m_fileIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Order.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Order.cpp
@@ -63,32 +63,32 @@ void to_json(nlohmann::json& j, const Order& o)
 
 void from_json(const nlohmann::json& j, Order& o)
 {
-    if(j.contains("id"))
+    if(j.find("id") != j.end())
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(j.contains("petId"))
+    if(j.find("petId") != j.end())
     {
         j.at("petId").get_to(o.m_PetId);
         o.m_PetIdIsSet = true;
     } 
-    if(j.contains("quantity"))
+    if(j.find("quantity") != j.end())
     {
         j.at("quantity").get_to(o.m_Quantity);
         o.m_QuantityIsSet = true;
     } 
-    if(j.contains("shipDate"))
+    if(j.find("shipDate") != j.end())
     {
         j.at("shipDate").get_to(o.m_ShipDate);
         o.m_ShipDateIsSet = true;
     } 
-    if(j.contains("status"))
+    if(j.find("status") != j.end())
     {
         j.at("status").get_to(o.m_Status);
         o.m_StatusIsSet = true;
     } 
-    if(j.contains("complete"))
+    if(j.find("complete") != j.end())
     {
         j.at("complete").get_to(o.m_Complete);
         o.m_CompleteIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Pet.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Pet.cpp
@@ -56,24 +56,24 @@ void to_json(nlohmann::json& j, const Pet& o)
 
 void from_json(const nlohmann::json& j, Pet& o)
 {
-    if(j.contains("id"))
+    if(j.find("id") != j.end())
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(j.contains("category"))
+    if(j.find("category") != j.end())
     {
         j.at("category").get_to(o.m_Category);
         o.m_CategoryIsSet = true;
     } 
     j.at("name").get_to(o.m_Name);
     j.at("photoUrls").get_to(o.m_PhotoUrls);
-    if(j.contains("tags"))
+    if(j.find("tags") != j.end())
     {
         j.at("tags").get_to(o.m_Tags);
         o.m_TagsIsSet = true;
     } 
-    if(j.contains("status"))
+    if(j.find("status") != j.end())
     {
         j.at("status").get_to(o.m_Status);
         o.m_StatusIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/Tag.cpp
+++ b/samples/server/petstore/cpp-pistache/model/Tag.cpp
@@ -47,12 +47,12 @@ void to_json(nlohmann::json& j, const Tag& o)
 
 void from_json(const nlohmann::json& j, Tag& o)
 {
-    if(j.contains("id"))
+    if(j.find("id") != j.end())
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(j.contains("name"))
+    if(j.find("name") != j.end())
     {
         j.at("name").get_to(o.m_Name);
         o.m_NameIsSet = true;

--- a/samples/server/petstore/cpp-pistache/model/User.cpp
+++ b/samples/server/petstore/cpp-pistache/model/User.cpp
@@ -71,42 +71,42 @@ void to_json(nlohmann::json& j, const User& o)
 
 void from_json(const nlohmann::json& j, User& o)
 {
-    if(j.contains("id"))
+    if(j.find("id") != j.end())
     {
         j.at("id").get_to(o.m_Id);
         o.m_IdIsSet = true;
     } 
-    if(j.contains("username"))
+    if(j.find("username") != j.end())
     {
         j.at("username").get_to(o.m_Username);
         o.m_UsernameIsSet = true;
     } 
-    if(j.contains("firstName"))
+    if(j.find("firstName") != j.end())
     {
         j.at("firstName").get_to(o.m_FirstName);
         o.m_FirstNameIsSet = true;
     } 
-    if(j.contains("lastName"))
+    if(j.find("lastName") != j.end())
     {
         j.at("lastName").get_to(o.m_LastName);
         o.m_LastNameIsSet = true;
     } 
-    if(j.contains("email"))
+    if(j.find("email") != j.end())
     {
         j.at("email").get_to(o.m_Email);
         o.m_EmailIsSet = true;
     } 
-    if(j.contains("password"))
+    if(j.find("password") != j.end())
     {
         j.at("password").get_to(o.m_Password);
         o.m_PasswordIsSet = true;
     } 
-    if(j.contains("phone"))
+    if(j.find("phone") != j.end())
     {
         j.at("phone").get_to(o.m_Phone);
         o.m_PhoneIsSet = true;
     } 
-    if(j.contains("userStatus"))
+    if(j.find("userStatus") != j.end())
     {
         j.at("userStatus").get_to(o.m_UserStatus);
         o.m_UserStatusIsSet = true;


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@ravinikam @stkrwork @etherealjoy @MartinDelille 

### Description of the PR

While generated sample downloads nlohmann-json from GitHub, it could also be provided by operating system. Debian 10 Buster provides nlohmann-json3-dev package with 3.5.0 version [https://packages.debian.org/buster/nlohmann-json3-dev](https://packages.debian.org/buster/nlohmann-json3-dev).

`contains` was added in 3.6.0 [https://github.com/nlohmann/json/releases/tag/v3.6.0](https://github.com/nlohmann/json/releases/tag/v3.6.0)

This change makes generated code compatible with 3.5.0.

Here's the code I tested it with:
```c++
#include <nlohmann/json.hpp>
#include <iostream>

void check_with_find(char const * const key, nlohmann::json const &json)
{
  if (json.find(key) != json.end())
    std::cout << "find: " << key << " exists!\n";
  else
    std::cout << "find: " << key << " does not exist!\n";
}

void check_with_contains(char const * const key, nlohmann::json const &json)
{
  if (json.contains(key))
    std::cout << "contains: " << key << " exists!\n";
  else
    std::cout << "contains: " << key << " does not exist!\n";
}

int main()
{
  constexpr char const * existing_key = "hello";
  constexpr char const * not_existing_key = "there";

  nlohmann::json json;  
  json[existing_key] = "general";

  check_with_find(existing_key, json);
  check_with_find(not_existing_key, json);
  check_with_contains(existing_key, json);
  check_with_contains(not_existing_key, json);
}
```

Output:
```
$ g++ -std=c++17 -Wall -Wextra -pedantic json-find.cpp -o json-find
$ ./json-find
find: hello exists!
find: there does not exist!
contains: hello exists!
contains: there does not exist!
```

`contains` is implemented as:
```
template<typename KeyT>
bool contains(KeyT&& key) const
{
    return is_object() and m_value.object->find(std::forward<KeyT>(key)) != m_value.object->end();
}
```
So it's almost the same code