### PR TITLE
[typescript-fetch] support custom stringify for query string

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -47,7 +47,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.stringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -116,6 +116,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -135,6 +136,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get stringify(): (params: HTTPQuery) => string {
+        return this.configuration.stringify || querystring;
     }
 
     get username(): string | undefined {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -47,7 +47,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + this.configuration.stringify(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -116,7 +116,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -138,8 +138,8 @@ export class Configuration {
         return this.configuration.middleware || [];
     }
 
-    get stringify(): (params: HTTPQuery) => string {
-        return this.configuration.stringify || querystring;
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.stringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,6 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -146,6 +147,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get stringify(): (params: HTTPQuery) => string {
+        return this.configuration.stringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + this.configuration.stringify(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,7 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -149,8 +149,8 @@ export class Configuration {
         return this.configuration.middleware || [];
     }
 
-    get stringify(): (params: HTTPQuery) => string {
-        return this.configuration.stringify || querystring;
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.stringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,6 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -146,6 +147,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get stringify(): (params: HTTPQuery) => string {
+        return this.configuration.stringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + this.configuration.stringify(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,7 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -149,8 +149,8 @@ export class Configuration {
         return this.configuration.middleware || [];
     }
 
-    get stringify(): (params: HTTPQuery) => string {
-        return this.configuration.stringify || querystring;
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.stringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,6 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -146,6 +147,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get stringify(): (params: HTTPQuery) => string {
+        return this.configuration.stringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + this.configuration.stringify(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,7 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -149,8 +149,8 @@ export class Configuration {
         return this.configuration.middleware || [];
     }
 
-    get stringify(): (params: HTTPQuery) => string {
-        return this.configuration.stringify || querystring;
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.stringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,6 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -146,6 +147,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get stringify(): (params: HTTPQuery) => string {
+        return this.configuration.stringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + this.configuration.stringify(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,7 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    stringify?: (params: HTTPQuery) => string; // stringify function for query strings
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -149,8 +149,8 @@ export class Configuration {
         return this.configuration.middleware || [];
     }
 
-    get stringify(): (params: HTTPQuery) => string {
-        return this.configuration.stringify || querystring;
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

It would be helpful if the query string formatting could be configured.
Solution for example for the deep query string:
```
import { Configuration, PetApi } from './api'
import { stringify } from 'qs'

const config = new Configuration({ queryParamsStringify: stringify })
const api = new PetApi(config)
```

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)