### PR TITLE
Adds default property values in ASP .NET Core models

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [[ -f "${codegen}" && -n "$(java ${JAVA_OPTS} -jar "${codegen}" completion | 
     command=$1
     shift
     exec java ${JAVA_OPTS} -jar "${codegen}" "${command}" "$@"
-elif [[ -n "$(echo commands | tr ',' '\n' | grep "^$1\$" )" ]]; then
+elif [[ -n "$(echo $commands | tr ',' '\n' | grep "^$1\$" )" ]]; then
     # If CLI jar does not exist, and $1 is a known CLI command, build the CLI jar and run that command.
     if [[ ! -f "${codegen}" ]]; then
         (cd "${GEN_DIR}" && exec mvn -am -pl "modules/openapi-generator-cli" -Duser.home=$(dirname $MAVEN_CONFIG) package)

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.0/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.0/model.mustache
@@ -28,10 +28,10 @@ namespace {{packageName}}.Models
         {{/required}}
         [DataMember(Name="{{baseName}}", EmitDefaultValue={{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}})]
         {{#isEnum}}
-        public {{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} { get; set; }
+        public {{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} { get; set; }{{#defaultValue}} = {{{defaultValue}}};{{/defaultValue}}
         {{/isEnum}}
         {{^isEnum}}
-        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
+        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }{{#defaultValue}} = {{{defaultValue}}};{{/defaultValue}}
         {{/isEnum}}
         {{#hasMore}}
         {{/hasMore}}

--- a/modules/openapi-generator/src/main/resources/aspnetcore/2.1/model.mustache
+++ b/modules/openapi-generator/src/main/resources/aspnetcore/2.1/model.mustache
@@ -31,10 +31,10 @@ namespace {{modelPackage}}
         {{/pattern}}
         [DataMember(Name="{{baseName}}", EmitDefaultValue={{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}})]
         {{#isEnum}}
-        public {{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} { get; set; }
+        public {{{datatypeWithEnum}}}{{#isEnum}}{{^isContainer}}?{{/isContainer}}{{/isEnum}} {{name}} { get; set; }{{#defaultValue}} = {{{defaultValue}}};{{/defaultValue}}
         {{/isEnum}}
         {{^isEnum}}
-        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
+        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }{{#defaultValue}} = {{{defaultValue}}};{{/defaultValue}}
         {{/isEnum}}
         {{#hasMore}}
         {{/hasMore}}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

#### Changes
* Addresses #3359 
* Also fixes a small syntax error in `docker-entrypoint.sh`.

#### Tests
* `./run-in-docker.sh mvn package` successfully builds & runs tests. 
*  `./run-in-docker.sh generate ...` produces the following.
###### Schema
```
openapi: '3.0.0'
info:
  version: 1.0.0
  title: API with Default Values
servers:
  - url: http://localhost:8080
paths:
  /test:
    post:
      operationId: testDefaults
      requestBody:
        required: true
        content:
          application/json:
            schema:
              '$ref': '#/components/schemas/Payload'
      responses:
        '200':
          description: Ok
components:
  schemas:
    Payload:
      type: object
      properties:
        stringProp:
          type: string
          default: foo
        intProp:
          type: integer
          default: 123
        floatProp:
          type: number
          format: float
          default: 1.23
        doubleProp:
          type: number
          format: double
          default: 1.234
        decimalProp:
          type: number
          format: decimal
          default: 1.2345
        enumProp:
          type: string
          enum: [One, Two, Three]
          default: Two
```
###### Generated model properties
```
[DataContract]
public partial class Payload : IEquatable<Payload>
{ 
    /// <summary>
    /// Gets or Sets StringProp
    /// </summary>
    [DataMember(Name="stringProp", EmitDefaultValue=false)]
    public string StringProp { get; set; } = "foo";

    /// <summary>
    /// Gets or Sets IntProp
    /// </summary>
    [DataMember(Name="intProp", EmitDefaultValue=false)]
    public int? IntProp { get; set; } = 123;

    /// <summary>
    /// Gets or Sets FloatProp
    /// </summary>
    [DataMember(Name="floatProp", EmitDefaultValue=false)]
    public float? FloatProp { get; set; } = 1.23F;

    /// <summary>
    /// Gets or Sets DoubleProp
    /// </summary>
    [DataMember(Name="doubleProp", EmitDefaultValue=false)]
    public double? DoubleProp { get; set; } = 1.234D;

    /// <summary>
    /// Gets or Sets DecimalProp
    /// </summary>
    [DataMember(Name="decimalProp", EmitDefaultValue=false)]
    public decimal? DecimalProp { get; set; } = 1.2345M;

    /// <summary>
    /// Gets or Sets EnumProp
    /// </summary>
    [DataMember(Name="enumProp", EmitDefaultValue=false)]
    public EnumPropEnum? EnumProp { get; set; } = EnumPropEnum.TwoEnum;
}
``` 

### Reviewers
@mandrean, @jimschubert