### PR TITLE
[java rest-assured] prevent reqSpec reuse between requests

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/ApiClient.mustache
@@ -34,13 +34,13 @@ public class ApiClient {
      {{#apiInfo}}
      {{#apis}}
     public {{classname}} {{classVarName}}() {
-        return {{classname}}.{{classVarName}}(config.baseReqSpec.get());
+        return {{classname}}.{{classVarName}}(config.reqSpecSupplier);
     }
      {{/apis}}
      {{/apiInfo}}
 
     public static class Config {
-        private Supplier<RequestSpecBuilder> baseReqSpec = () -> new RequestSpecBuilder()
+        private Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
                 {{#basePath}}.setBaseUri(BASE_URI){{/basePath}}
                 .setConfig(config().objectMapperConfig(objectMapperConfig().defaultObjectMapper(gson())));
 
@@ -50,7 +50,7 @@ public class ApiClient {
          * @return configuration
          */
         public Config reqSpecSupplier(Supplier<RequestSpecBuilder> supplier) {
-            this.baseReqSpec = supplier;
+            this.reqSpecSupplier = supplier;
             return this;
         }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/api.mustache
@@ -31,14 +31,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "{{{baseName}}}")
 public class {{classname}} {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private {{classname}}(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private {{classname}}(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static {{classname}} {{classVarName}}(RequestSpecBuilder reqSpec) {
-        return new {{classname}}(reqSpec);
+    public static {{classname}} {{classVarName}}(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new {{classname}}(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 {{#operations}}
@@ -54,18 +63,18 @@ public class {{classname}} {
     @Deprecated
     {{/isDeprecated}}
     public {{operationIdCamelCase}}Oper {{operationId}}() {
-        return new {{operationIdCamelCase}}Oper(reqSpec);
+        return new {{operationIdCamelCase}}Oper(createReqSpec());
     }
 {{/operation}}
 {{/operations}}
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public {{classname}} reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public {{classname}} reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -216,22 +225,22 @@ public class {{classname}} {
         {{/formParams}}
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public {{operationIdCamelCase}}Oper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public {{operationIdCamelCase}}Oper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public {{operationIdCamelCase}}Oper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public {{operationIdCamelCase}}Oper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
@@ -37,26 +37,26 @@ public class ApiClient {
     }
 
     public AnotherFakeApi anotherFake() {
-        return AnotherFakeApi.anotherFake(config.baseReqSpec.get());
+        return AnotherFakeApi.anotherFake(config.reqSpecSupplier);
     }
     public FakeApi fake() {
-        return FakeApi.fake(config.baseReqSpec.get());
+        return FakeApi.fake(config.reqSpecSupplier);
     }
     public FakeClassnameTags123Api fakeClassnameTags123() {
-        return FakeClassnameTags123Api.fakeClassnameTags123(config.baseReqSpec.get());
+        return FakeClassnameTags123Api.fakeClassnameTags123(config.reqSpecSupplier);
     }
     public PetApi pet() {
-        return PetApi.pet(config.baseReqSpec.get());
+        return PetApi.pet(config.reqSpecSupplier);
     }
     public StoreApi store() {
-        return StoreApi.store(config.baseReqSpec.get());
+        return StoreApi.store(config.reqSpecSupplier);
     }
     public UserApi user() {
-        return UserApi.user(config.baseReqSpec.get());
+        return UserApi.user(config.reqSpecSupplier);
     }
 
     public static class Config {
-        private Supplier<RequestSpecBuilder> baseReqSpec = () -> new RequestSpecBuilder()
+        private Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
                 .setBaseUri(BASE_URI)
                 .setConfig(config().objectMapperConfig(objectMapperConfig().defaultObjectMapper(gson())));
 
@@ -66,7 +66,7 @@ public class ApiClient {
          * @return configuration
          */
         public Config reqSpecSupplier(Supplier<RequestSpecBuilder> supplier) {
-            this.baseReqSpec = supplier;
+            this.reqSpecSupplier = supplier;
             return this;
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -39,14 +39,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "AnotherFake")
 public class AnotherFakeApi {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private AnotherFakeApi(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private AnotherFakeApi(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static AnotherFakeApi anotherFake(RequestSpecBuilder reqSpec) {
-        return new AnotherFakeApi(reqSpec);
+    public static AnotherFakeApi anotherFake(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new AnotherFakeApi(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 
@@ -57,16 +66,16 @@ public class AnotherFakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public Call123testSpecialTagsOper call123testSpecialTags() {
-        return new Call123testSpecialTagsOper(reqSpec);
+        return new Call123testSpecialTagsOper(createReqSpec());
     }
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public AnotherFakeApi reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public AnotherFakeApi reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -122,22 +131,22 @@ public class AnotherFakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public Call123testSpecialTagsOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public Call123testSpecialTagsOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public Call123testSpecialTagsOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public Call123testSpecialTagsOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -47,14 +47,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "Fake")
 public class FakeApi {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private FakeApi(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private FakeApi(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static FakeApi fake(RequestSpecBuilder reqSpec) {
-        return new FakeApi(reqSpec);
+    public static FakeApi fake(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new FakeApi(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 
@@ -65,7 +74,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public CreateXmlItemOper createXmlItem() {
-        return new CreateXmlItemOper(reqSpec);
+        return new CreateXmlItemOper(createReqSpec());
     }
 
     @ApiOperation(value = "",
@@ -75,7 +84,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "Output boolean")  })
     public FakeOuterBooleanSerializeOper fakeOuterBooleanSerialize() {
-        return new FakeOuterBooleanSerializeOper(reqSpec);
+        return new FakeOuterBooleanSerializeOper(createReqSpec());
     }
 
     @ApiOperation(value = "",
@@ -85,7 +94,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "Output composite")  })
     public FakeOuterCompositeSerializeOper fakeOuterCompositeSerialize() {
-        return new FakeOuterCompositeSerializeOper(reqSpec);
+        return new FakeOuterCompositeSerializeOper(createReqSpec());
     }
 
     @ApiOperation(value = "",
@@ -95,7 +104,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "Output number")  })
     public FakeOuterNumberSerializeOper fakeOuterNumberSerialize() {
-        return new FakeOuterNumberSerializeOper(reqSpec);
+        return new FakeOuterNumberSerializeOper(createReqSpec());
     }
 
     @ApiOperation(value = "",
@@ -105,7 +114,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "Output string")  })
     public FakeOuterStringSerializeOper fakeOuterStringSerialize() {
-        return new FakeOuterStringSerializeOper(reqSpec);
+        return new FakeOuterStringSerializeOper(createReqSpec());
     }
 
     @ApiOperation(value = "",
@@ -115,7 +124,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "Success")  })
     public TestBodyWithFileSchemaOper testBodyWithFileSchema() {
-        return new TestBodyWithFileSchemaOper(reqSpec);
+        return new TestBodyWithFileSchemaOper(createReqSpec());
     }
 
     @ApiOperation(value = "",
@@ -125,7 +134,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "Success")  })
     public TestBodyWithQueryParamsOper testBodyWithQueryParams() {
-        return new TestBodyWithQueryParamsOper(reqSpec);
+        return new TestBodyWithQueryParamsOper(createReqSpec());
     }
 
     @ApiOperation(value = "To test \"client\" model",
@@ -135,7 +144,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public TestClientModelOper testClientModel() {
-        return new TestClientModelOper(reqSpec);
+        return new TestClientModelOper(createReqSpec());
     }
 
     @ApiOperation(value = "Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 ",
@@ -146,7 +155,7 @@ public class FakeApi {
             @ApiResponse(code = 400, message = "Invalid username supplied") ,
             @ApiResponse(code = 404, message = "User not found")  })
     public TestEndpointParametersOper testEndpointParameters() {
-        return new TestEndpointParametersOper(reqSpec);
+        return new TestEndpointParametersOper(createReqSpec());
     }
 
     @ApiOperation(value = "To test enum parameters",
@@ -157,7 +166,7 @@ public class FakeApi {
             @ApiResponse(code = 400, message = "Invalid request") ,
             @ApiResponse(code = 404, message = "Not found")  })
     public TestEnumParametersOper testEnumParameters() {
-        return new TestEnumParametersOper(reqSpec);
+        return new TestEnumParametersOper(createReqSpec());
     }
 
     @ApiOperation(value = "Fake endpoint to test group parameters (optional)",
@@ -167,7 +176,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 400, message = "Someting wrong")  })
     public TestGroupParametersOper testGroupParameters() {
-        return new TestGroupParametersOper(reqSpec);
+        return new TestGroupParametersOper(createReqSpec());
     }
 
     @ApiOperation(value = "test inline additionalProperties",
@@ -177,7 +186,7 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public TestInlineAdditionalPropertiesOper testInlineAdditionalProperties() {
-        return new TestInlineAdditionalPropertiesOper(reqSpec);
+        return new TestInlineAdditionalPropertiesOper(createReqSpec());
     }
 
     @ApiOperation(value = "test json serialization of form data",
@@ -187,16 +196,16 @@ public class FakeApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public TestJsonFormDataOper testJsonFormData() {
-        return new TestJsonFormDataOper(reqSpec);
+        return new TestJsonFormDataOper(createReqSpec());
     }
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public FakeApi reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public FakeApi reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -241,22 +250,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public CreateXmlItemOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public CreateXmlItemOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public CreateXmlItemOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public CreateXmlItemOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -312,22 +321,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public FakeOuterBooleanSerializeOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public FakeOuterBooleanSerializeOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public FakeOuterBooleanSerializeOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public FakeOuterBooleanSerializeOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -383,22 +392,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public FakeOuterCompositeSerializeOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public FakeOuterCompositeSerializeOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public FakeOuterCompositeSerializeOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public FakeOuterCompositeSerializeOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -454,22 +463,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public FakeOuterNumberSerializeOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public FakeOuterNumberSerializeOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public FakeOuterNumberSerializeOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public FakeOuterNumberSerializeOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -525,22 +534,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public FakeOuterStringSerializeOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public FakeOuterStringSerializeOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public FakeOuterStringSerializeOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public FakeOuterStringSerializeOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -585,22 +594,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestBodyWithFileSchemaOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestBodyWithFileSchemaOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestBodyWithFileSchemaOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestBodyWithFileSchemaOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -657,22 +666,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestBodyWithQueryParamsOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestBodyWithQueryParamsOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestBodyWithQueryParamsOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestBodyWithQueryParamsOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -728,22 +737,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestClientModelOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestClientModelOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestClientModelOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestClientModelOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -946,22 +955,22 @@ public class FakeApi {
          }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestEndpointParametersOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestEndpointParametersOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestEndpointParametersOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestEndpointParametersOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -1092,22 +1101,22 @@ public class FakeApi {
          }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestEnumParametersOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestEnumParametersOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestEnumParametersOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestEnumParametersOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -1213,22 +1222,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestGroupParametersOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestGroupParametersOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestGroupParametersOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestGroupParametersOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -1273,22 +1282,22 @@ public class FakeApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestInlineAdditionalPropertiesOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestInlineAdditionalPropertiesOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestInlineAdditionalPropertiesOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestInlineAdditionalPropertiesOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -1347,22 +1356,22 @@ public class FakeApi {
          }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestJsonFormDataOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestJsonFormDataOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestJsonFormDataOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestJsonFormDataOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -39,14 +39,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "FakeClassnameTags123")
 public class FakeClassnameTags123Api {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private FakeClassnameTags123Api(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private FakeClassnameTags123Api(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static FakeClassnameTags123Api fakeClassnameTags123(RequestSpecBuilder reqSpec) {
-        return new FakeClassnameTags123Api(reqSpec);
+    public static FakeClassnameTags123Api fakeClassnameTags123(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new FakeClassnameTags123Api(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 
@@ -57,16 +66,16 @@ public class FakeClassnameTags123Api {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public TestClassnameOper testClassname() {
-        return new TestClassnameOper(reqSpec);
+        return new TestClassnameOper(createReqSpec());
     }
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public FakeClassnameTags123Api reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public FakeClassnameTags123Api reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -122,22 +131,22 @@ public class FakeClassnameTags123Api {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public TestClassnameOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public TestClassnameOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public TestClassnameOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public TestClassnameOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
@@ -41,14 +41,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "Pet")
 public class PetApi {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private PetApi(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private PetApi(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static PetApi pet(RequestSpecBuilder reqSpec) {
-        return new PetApi(reqSpec);
+    public static PetApi pet(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new PetApi(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 
@@ -60,7 +69,7 @@ public class PetApi {
             @ApiResponse(code = 200, message = "successful operation") ,
             @ApiResponse(code = 405, message = "Invalid input")  })
     public AddPetOper addPet() {
-        return new AddPetOper(reqSpec);
+        return new AddPetOper(createReqSpec());
     }
 
     @ApiOperation(value = "Deletes a pet",
@@ -71,7 +80,7 @@ public class PetApi {
             @ApiResponse(code = 200, message = "successful operation") ,
             @ApiResponse(code = 400, message = "Invalid pet value")  })
     public DeletePetOper deletePet() {
-        return new DeletePetOper(reqSpec);
+        return new DeletePetOper(createReqSpec());
     }
 
     @ApiOperation(value = "Finds Pets by status",
@@ -82,7 +91,7 @@ public class PetApi {
             @ApiResponse(code = 200, message = "successful operation") ,
             @ApiResponse(code = 400, message = "Invalid status value")  })
     public FindPetsByStatusOper findPetsByStatus() {
-        return new FindPetsByStatusOper(reqSpec);
+        return new FindPetsByStatusOper(createReqSpec());
     }
 
     @ApiOperation(value = "Finds Pets by tags",
@@ -94,7 +103,7 @@ public class PetApi {
             @ApiResponse(code = 400, message = "Invalid tag value")  })
     @Deprecated
     public FindPetsByTagsOper findPetsByTags() {
-        return new FindPetsByTagsOper(reqSpec);
+        return new FindPetsByTagsOper(createReqSpec());
     }
 
     @ApiOperation(value = "Find pet by ID",
@@ -106,7 +115,7 @@ public class PetApi {
             @ApiResponse(code = 400, message = "Invalid ID supplied") ,
             @ApiResponse(code = 404, message = "Pet not found")  })
     public GetPetByIdOper getPetById() {
-        return new GetPetByIdOper(reqSpec);
+        return new GetPetByIdOper(createReqSpec());
     }
 
     @ApiOperation(value = "Update an existing pet",
@@ -119,7 +128,7 @@ public class PetApi {
             @ApiResponse(code = 404, message = "Pet not found") ,
             @ApiResponse(code = 405, message = "Validation exception")  })
     public UpdatePetOper updatePet() {
-        return new UpdatePetOper(reqSpec);
+        return new UpdatePetOper(createReqSpec());
     }
 
     @ApiOperation(value = "Updates a pet in the store with form data",
@@ -129,7 +138,7 @@ public class PetApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 405, message = "Invalid input")  })
     public UpdatePetWithFormOper updatePetWithForm() {
-        return new UpdatePetWithFormOper(reqSpec);
+        return new UpdatePetWithFormOper(createReqSpec());
     }
 
     @ApiOperation(value = "uploads an image",
@@ -139,7 +148,7 @@ public class PetApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public UploadFileOper uploadFile() {
-        return new UploadFileOper(reqSpec);
+        return new UploadFileOper(createReqSpec());
     }
 
     @ApiOperation(value = "uploads an image (required)",
@@ -149,16 +158,16 @@ public class PetApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public UploadFileWithRequiredFileOper uploadFileWithRequiredFile() {
-        return new UploadFileWithRequiredFileOper(reqSpec);
+        return new UploadFileWithRequiredFileOper(createReqSpec());
     }
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public PetApi reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public PetApi reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -203,22 +212,22 @@ public class PetApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public AddPetOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public AddPetOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public AddPetOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public AddPetOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -276,22 +285,22 @@ public class PetApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public DeletePetOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public DeletePetOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public DeletePetOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public DeletePetOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -348,22 +357,22 @@ public class PetApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public FindPetsByStatusOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public FindPetsByStatusOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public FindPetsByStatusOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public FindPetsByStatusOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -422,22 +431,22 @@ public class PetApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public FindPetsByTagsOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public FindPetsByTagsOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public FindPetsByTagsOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public FindPetsByTagsOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -494,22 +503,22 @@ public class PetApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public GetPetByIdOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public GetPetByIdOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public GetPetByIdOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public GetPetByIdOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -554,22 +563,22 @@ public class PetApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public UpdatePetOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public UpdatePetOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public UpdatePetOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public UpdatePetOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -640,22 +649,22 @@ public class PetApi {
          }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public UpdatePetWithFormOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public UpdatePetWithFormOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public UpdatePetWithFormOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public UpdatePetWithFormOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -737,22 +746,22 @@ public class PetApi {
          }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public UploadFileOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public UploadFileOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public UploadFileOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public UploadFileOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -834,22 +843,22 @@ public class PetApi {
          }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public UploadFileWithRequiredFileOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public UploadFileWithRequiredFileOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public UploadFileWithRequiredFileOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public UploadFileWithRequiredFileOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -39,14 +39,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "Store")
 public class StoreApi {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private StoreApi(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private StoreApi(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static StoreApi store(RequestSpecBuilder reqSpec) {
-        return new StoreApi(reqSpec);
+    public static StoreApi store(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new StoreApi(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 
@@ -58,7 +67,7 @@ public class StoreApi {
             @ApiResponse(code = 400, message = "Invalid ID supplied") ,
             @ApiResponse(code = 404, message = "Order not found")  })
     public DeleteOrderOper deleteOrder() {
-        return new DeleteOrderOper(reqSpec);
+        return new DeleteOrderOper(createReqSpec());
     }
 
     @ApiOperation(value = "Returns pet inventories by status",
@@ -68,7 +77,7 @@ public class StoreApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 200, message = "successful operation")  })
     public GetInventoryOper getInventory() {
-        return new GetInventoryOper(reqSpec);
+        return new GetInventoryOper(createReqSpec());
     }
 
     @ApiOperation(value = "Find purchase order by ID",
@@ -80,7 +89,7 @@ public class StoreApi {
             @ApiResponse(code = 400, message = "Invalid ID supplied") ,
             @ApiResponse(code = 404, message = "Order not found")  })
     public GetOrderByIdOper getOrderById() {
-        return new GetOrderByIdOper(reqSpec);
+        return new GetOrderByIdOper(createReqSpec());
     }
 
     @ApiOperation(value = "Place an order for a pet",
@@ -91,16 +100,16 @@ public class StoreApi {
             @ApiResponse(code = 200, message = "successful operation") ,
             @ApiResponse(code = 400, message = "Invalid Order")  })
     public PlaceOrderOper placeOrder() {
-        return new PlaceOrderOper(reqSpec);
+        return new PlaceOrderOper(createReqSpec());
     }
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public StoreApi reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public StoreApi reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -146,22 +155,22 @@ public class StoreApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public DeleteOrderOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public DeleteOrderOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public DeleteOrderOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public DeleteOrderOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -206,22 +215,22 @@ public class StoreApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public GetInventoryOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public GetInventoryOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public GetInventoryOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public GetInventoryOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -278,22 +287,22 @@ public class StoreApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public GetOrderByIdOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public GetOrderByIdOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public GetOrderByIdOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public GetOrderByIdOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -349,22 +358,22 @@ public class StoreApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public PlaceOrderOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public PlaceOrderOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public PlaceOrderOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public PlaceOrderOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -39,14 +39,23 @@ import static io.restassured.http.Method.*;
 @Api(value = "User")
 public class UserApi {
 
-    private RequestSpecBuilder reqSpec;
+    private Supplier<RequestSpecBuilder> reqSpecSupplier;
+    private Consumer<RequestSpecBuilder> reqSpecCustomizer;
 
-    private UserApi(RequestSpecBuilder reqSpec) {
-        this.reqSpec = reqSpec;
+    private UserApi(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        this.reqSpecSupplier = reqSpecSupplier;
     }
 
-    public static UserApi user(RequestSpecBuilder reqSpec) {
-        return new UserApi(reqSpec);
+    public static UserApi user(Supplier<RequestSpecBuilder> reqSpecSupplier) {
+        return new UserApi(reqSpecSupplier);
+    }
+
+    private RequestSpecBuilder createReqSpec() {
+        RequestSpecBuilder reqSpec = reqSpecSupplier.get();
+        if(reqSpecCustomizer != null) {
+            reqSpecCustomizer.accept(reqSpec);
+        }
+        return reqSpec;
     }
 
 
@@ -57,7 +66,7 @@ public class UserApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 0, message = "successful operation")  })
     public CreateUserOper createUser() {
-        return new CreateUserOper(reqSpec);
+        return new CreateUserOper(createReqSpec());
     }
 
     @ApiOperation(value = "Creates list of users with given input array",
@@ -67,7 +76,7 @@ public class UserApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 0, message = "successful operation")  })
     public CreateUsersWithArrayInputOper createUsersWithArrayInput() {
-        return new CreateUsersWithArrayInputOper(reqSpec);
+        return new CreateUsersWithArrayInputOper(createReqSpec());
     }
 
     @ApiOperation(value = "Creates list of users with given input array",
@@ -77,7 +86,7 @@ public class UserApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 0, message = "successful operation")  })
     public CreateUsersWithListInputOper createUsersWithListInput() {
-        return new CreateUsersWithListInputOper(reqSpec);
+        return new CreateUsersWithListInputOper(createReqSpec());
     }
 
     @ApiOperation(value = "Delete user",
@@ -88,7 +97,7 @@ public class UserApi {
             @ApiResponse(code = 400, message = "Invalid username supplied") ,
             @ApiResponse(code = 404, message = "User not found")  })
     public DeleteUserOper deleteUser() {
-        return new DeleteUserOper(reqSpec);
+        return new DeleteUserOper(createReqSpec());
     }
 
     @ApiOperation(value = "Get user by user name",
@@ -100,7 +109,7 @@ public class UserApi {
             @ApiResponse(code = 400, message = "Invalid username supplied") ,
             @ApiResponse(code = 404, message = "User not found")  })
     public GetUserByNameOper getUserByName() {
-        return new GetUserByNameOper(reqSpec);
+        return new GetUserByNameOper(createReqSpec());
     }
 
     @ApiOperation(value = "Logs user into the system",
@@ -111,7 +120,7 @@ public class UserApi {
             @ApiResponse(code = 200, message = "successful operation") ,
             @ApiResponse(code = 400, message = "Invalid username/password supplied")  })
     public LoginUserOper loginUser() {
-        return new LoginUserOper(reqSpec);
+        return new LoginUserOper(createReqSpec());
     }
 
     @ApiOperation(value = "Logs out current logged in user session",
@@ -121,7 +130,7 @@ public class UserApi {
     @ApiResponses(value = { 
             @ApiResponse(code = 0, message = "successful operation")  })
     public LogoutUserOper logoutUser() {
-        return new LogoutUserOper(reqSpec);
+        return new LogoutUserOper(createReqSpec());
     }
 
     @ApiOperation(value = "Updated user",
@@ -132,16 +141,16 @@ public class UserApi {
             @ApiResponse(code = 400, message = "Invalid user supplied") ,
             @ApiResponse(code = 404, message = "User not found")  })
     public UpdateUserOper updateUser() {
-        return new UpdateUserOper(reqSpec);
+        return new UpdateUserOper(createReqSpec());
     }
 
     /**
-     * Customise request specification
-     * @param consumer consumer
+     * Customize request specification
+     * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
      * @return api
      */
-    public UserApi reqSpec(Consumer<RequestSpecBuilder> consumer) {
-        consumer.accept(reqSpec);
+    public UserApi reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+        this.reqSpecCustomizer = reqSpecCustomizer;
         return this;
     }
 
@@ -186,22 +195,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public CreateUserOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public CreateUserOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public CreateUserOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public CreateUserOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -246,22 +255,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public CreateUsersWithArrayInputOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public CreateUsersWithArrayInputOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public CreateUsersWithArrayInputOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public CreateUsersWithArrayInputOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -306,22 +315,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public CreateUsersWithListInputOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public CreateUsersWithListInputOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public CreateUsersWithListInputOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public CreateUsersWithListInputOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -367,22 +376,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public DeleteUserOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public DeleteUserOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public DeleteUserOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public DeleteUserOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -439,22 +448,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public GetUserByNameOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public GetUserByNameOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public GetUserByNameOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public GetUserByNameOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -523,22 +532,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public LoginUserOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public LoginUserOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public LoginUserOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public LoginUserOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -572,22 +581,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public LogoutUserOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public LogoutUserOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public LogoutUserOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public LogoutUserOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }
@@ -644,22 +653,22 @@ public class UserApi {
         }
 
         /**
-         * Customise request specification
-         * @param consumer consumer
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
          * @return operation
          */
-        public UpdateUserOper reqSpec(Consumer<RequestSpecBuilder> consumer) {
-            consumer.accept(reqSpec);
+        public UpdateUserOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
             return this;
         }
 
         /**
-         * Customise response specification
-         * @param consumer consumer
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
          * @return operation
          */
-        public UpdateUserOper respSpec(Consumer<ResponseSpecBuilder> consumer) {
-            consumer.accept(respSpec);
+        public UpdateUserOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
             return this;
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.  
Java: @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

Fixes #3370

### Description of the PR

Tested with this spec:
```yaml
openapi: 3.0.1
info:
  title: ping test
  version: '1.0'
servers:
  - url: 'http://localhost:8080/'
paths:
  /ping:
    get:
      operationId: pingGet
      tags:
       - lorem
      parameters:
       - in: query
         name: q
         schema:
           type: string
       - in: query
         name: r
         schema:
           type: string
      responses:
        '201':
          description: Ok
```

With a this test using [MockServer](https://github.com/jamesdbloom/mockserver) (more on this to come in #689):

```java
public class LoremApiTest {

    private ClientAndServer mockServer;
    private LoremApi api;

    @Before
    public void createApi() {
        mockServer = ClientAndServer.startClientAndServer();
        String port =  "" + mockServer.getLocalPort();
        StringCounter counterA = new StringCounter("a_value_", 1);
        StringCounter counterB = new StringCounter("b_value_", 1);
        api = ApiClient.api(ApiClient.Config.apiConfig().reqSpecSupplier(
                () -> new RequestSpecBuilder()
                        .setConfig(config().objectMapperConfig(objectMapperConfig().defaultObjectMapper(gson())))
                        .addHeader("x-header-a",  counterA.nextValue())
                        .addFilter(new ErrorLoggingFilter())
                        .setBaseUri("http://localhost:" + port ))).lorem()
                .reqSpec(r -> r.addHeader("x-header-b", counterB.nextValue()));
    }
    
    @After
    public void stopMockServer() {
        mockServer.stop();
    }

    /**
     * Ok
     */
    @Test
    public void shouldSee201AfterPingGet() {
        StringCounter counterC = new StringCounter("c_value_", 1);

        mockServer
        .when(
                HttpRequest.request()
                        .withPath("/ping")
        )
        .respond(
                HttpResponse.response()
                        .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), "application/json")
                        .withStatusCode(201)
                        .withBody("{ \"status\": \"ok\"}")
        );

        String q1 = "param1";
        api.pingGet()
            .reqSpec(r -> r.addHeader("x-header-c", counterC.nextValue()))
            .qQuery(q1).execute(r -> r.prettyPeek());
        
        String q2 = "param2";
        String r2 = "param2";
        api.pingGet()
            .reqSpec(r -> r.addHeader("x-header-c", counterC.nextValue()))
            .qQuery(q2).rQuery(r2).execute(r -> r.prettyPeek());
        
        HttpRequest[] recordedRequests = mockServer.retrieveRecordedRequests(
                HttpRequest.request()
                    .withPath("/ping")
        );
        Assert.assertEquals(2, recordedRequests.length);

        Assert.assertEquals(1, recordedRequests[0].getQueryStringParameterList().size());
        Assert.assertEquals("q", recordedRequests[0].getQueryStringParameterList().get(0).getName().getValue());
        Assert.assertEquals(1, recordedRequests[0].getQueryStringParameterList().get(0).getValues().size());
        Assert.assertEquals("param1", recordedRequests[0].getQueryStringParameterList().get(0).getValues().get(0).getValue());
        Assert.assertEquals("a_value_1", recordedRequests[0].getFirstHeader("x-header-a"));
        Assert.assertEquals("b_value_1", recordedRequests[0].getFirstHeader("x-header-b"));
        Assert.assertEquals("c_value_1", recordedRequests[0].getFirstHeader("x-header-c"));

        Assert.assertEquals(2, recordedRequests[1].getQueryStringParameterList().size());
        Assert.assertEquals("a_value_2", recordedRequests[1].getFirstHeader("x-header-a"));
        Assert.assertEquals("b_value_2", recordedRequests[1].getFirstHeader("x-header-b"));
        Assert.assertEquals("c_value_2", recordedRequests[1].getFirstHeader("x-header-c"));
        Assert.assertEquals("q", recordedRequests[1].getQueryStringParameterList().get(0).getName().getValue());
        Assert.assertEquals(1, recordedRequests[1].getQueryStringParameterList().get(0).getValues().size());
        Assert.assertEquals("param2", recordedRequests[1].getQueryStringParameterList().get(0).getValues().get(0).getValue());
    }
}
```

Was failing before and now it is no longer the case.

