### PR TITLE
typescript-fetch: fix basic type errors

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/index.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/index.mustache
@@ -1,3 +1,9 @@
 export * from './runtime';
+{{#apiInfo}}
+{{#apis.0}}
 export * from './apis';
+{{/apis.0}}
+{{/apiInfo}}
+{{#models.0}}
 export * from './models';
+{{/models.0}}

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,6 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -146,6 +147,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {


### PR DESCRIPTION
* use proper response for simple object return types
* exclude api and/or model support files and imports if none are generated

fixes #3167

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)

