### PR TITLE
[fix] Assign template directory to additional properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -223,6 +223,7 @@ public class CodegenConfigurator {
     }
 
     public CodegenConfigurator setImportMappings(Map<String, String> importMappings) {
+        this.importMappings = importMappings;
         generatorSettingsBuilder.withImportMappings(importMappings);
         return this;
     }
@@ -234,6 +235,7 @@ public class CodegenConfigurator {
     }
 
     public CodegenConfigurator setInstantiationTypes(Map<String, String> instantiationTypes) {
+        this.instantiationTypes = instantiationTypes;
         generatorSettingsBuilder.withInstantiationTypes(instantiationTypes);
         return this;
     }
@@ -295,6 +297,7 @@ public class CodegenConfigurator {
     }
 
     public CodegenConfigurator setReservedWordsMappings(Map<String, String> reservedWordMappings) {
+        this.reservedWordMappings = reservedWordMappings;
         generatorSettingsBuilder.withReservedWordMappings(reservedWordMappings);
         return this;
     }
@@ -310,6 +313,7 @@ public class CodegenConfigurator {
     }
 
     public CodegenConfigurator setSystemProperties(Map<String, String> systemProperties) {
+        this.systemProperties = systemProperties;
         workflowSettingsBuilder.withSystemProperties(systemProperties);
         return this;
     }
@@ -326,6 +330,7 @@ public class CodegenConfigurator {
     }
 
     public CodegenConfigurator setTypeMappings(Map<String, String> typeMappings) {
+        this.typeMappings = typeMappings;
         generatorSettingsBuilder.withTypeMappings(typeMappings);
         return this;
     }
@@ -453,6 +458,9 @@ public class CodegenConfigurator {
         config.languageSpecificPrimitives().addAll(generatorSettings.getLanguageSpecificPrimitives());
         config.reservedWordsMappings().putAll(generatorSettings.getReservedWordMappings());
         config.additionalProperties().putAll(generatorSettings.getAdditionalProperties());
+
+        // any other additional properties?
+        config.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, workflowSettings.getTemplateDir());
 
         ClientOptInput input = new ClientOptInput()
                 .config(config);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -460,7 +460,10 @@ public class CodegenConfigurator {
         config.additionalProperties().putAll(generatorSettings.getAdditionalProperties());
 
         // any other additional properties?
-        config.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, workflowSettings.getTemplateDir());
+        String templateDir = workflowSettings.getTemplateDir();
+        if (templateDir != null) {
+            config.additionalProperties().put(CodegenConstants.TEMPLATE_DIR, workflowSettings.getTemplateDir());
+        }
 
         ClientOptInput input = new ClientOptInput()
                 .config(config);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.config;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenConfig;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.DefaultGenerator;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class CodegenConfiguratorTest {
+    private void want(Map<String, Object> additionalProperties, String key, Object expected) {
+        assertEquals(additionalProperties.getOrDefault(key, null), expected);
+    }
+
+    @Test
+    public void shouldSetConfiglProperties() throws IOException {
+        // This tests that properties we set on CodegenConfigurator make it down into generator properties,
+        // limiting to those managed in DefaultCodegen.
+        Map<String, Object> properties = new HashMap<String, Object>() {{
+           put("foo", "bar");
+           put("baz", "quux");
+           put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, true);
+           put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, true);
+           put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, false);
+           put(CodegenConstants.ENSURE_UNIQUE_PARAMS, true);
+           put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, true);
+           put(CodegenConstants.REMOVE_OPERATION_ID_PREFIX, false);
+           put(CodegenConstants.DOCEXTENSION, "D");
+           put(CodegenConstants.ENABLE_POST_PROCESS_FILE, false);
+           put(CodegenConstants.GENERATE_ALIAS_AS_MODEL, true);
+        }};
+
+        File output = Files.createTempDirectory("test").toFile();
+        File template = Files.createTempDirectory("test").toFile();
+        String outDir = output.getAbsolutePath().replace("\\", "/");
+        String templateDir = template.getAbsolutePath().replace("\\", "/");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/ping.yaml")
+                .addImportMapping("one", "two")
+                .addInstantiationType("three", "four")
+                .addLanguageSpecificPrimitive("five")
+                .addSystemProperty("six", "seven")
+                .addTypeMapping("eight", "nine")
+                .setApiPackage("test-api")
+                .setArtifactId("test-artifactId")
+                .setArtifactVersion("test-artifactVersion")
+                .setAuth("test-auth")
+                .setGitRepoId("git")
+                .setGitUserId("user")
+                .setGroupId("group")
+                .setHttpUserAgent("agent")
+                .setModelNamePrefix("model-prefix")
+                .setModelNameSuffix("model-suffix")
+                .setModelPackage("model-package")
+                .setPackageName("package-name")
+                .setReleaseNote("release-note")
+                .setTemplateDir(templateDir)
+                .setOutputDir(outDir);
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+
+        CodegenConfig config = clientOptInput.getConfig();
+        config.processOpts();
+
+        Map<String, Object> props = config.additionalProperties();
+
+        // This verifies that things we expect to make it into the template will, as a result of this CodegenConfigurator.
+        want(props, CodegenConstants.MODEL_PACKAGE, "model_package"); // * mutated by codegen
+        want(props, CodegenConstants.API_PACKAGE, "test_api"); // * mutated by codegen
+        want(props, CodegenConstants.HIDE_GENERATION_TIMESTAMP, true);
+        want(props, CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, true);
+        want(props, CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, false);
+        want(props, CodegenConstants.ENSURE_UNIQUE_PARAMS, true);
+        want(props, CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, true);
+        want(props, CodegenConstants.MODEL_NAME_PREFIX, "model-prefix");
+        want(props, CodegenConstants.MODEL_NAME_SUFFIX, "model-suffix");
+        want(props, CodegenConstants.REMOVE_OPERATION_ID_PREFIX, false);
+        want(props, CodegenConstants.DOCEXTENSION, "D");
+        want(props, CodegenConstants.ENABLE_POST_PROCESS_FILE, false);
+        want(props, CodegenConstants.GENERATE_ALIAS_AS_MODEL, true);
+        want(props, CodegenConstants.TEMPLATE_DIR, templateDir);
+        want(props, CodegenConstants.GIT_REPO_ID, "git");
+        want(props, CodegenConstants.GIT_USER_ID, "user");
+        want(props, CodegenConstants.GROUP_ID, "group");
+        want(props, CodegenConstants.ARTIFACT_ID, "test-artifactId");
+        want(props, CodegenConstants.ARTIFACT_VERSION, "test-artifactVersion");
+        want(props, CodegenConstants.HTTP_USER_AGENT, "agent");
+        want(props, CodegenConstants.RELEASE_NOTE, "release-note");
+        want(props, CodegenConstants.PACKAGE_NAME, "package-name");
+
+        // test custom properties
+        want(props, "foo", "bar");
+        want(props, "baz", "quux");
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,8 +56,9 @@ public class CodegenConfiguratorTest {
 
         File output = Files.createTempDirectory("test").toFile();
         File template = Files.createTempDirectory("test").toFile();
-        String outDir = output.getAbsolutePath().replace("\\", "/");
-        String templateDir = template.getAbsolutePath().replace("\\", "/");
+        String outDir = Paths.get(output.toURI()).toAbsolutePath().toString();
+        String templateDir = Paths.get(template.toURI()).toAbsolutePath().toString();
+
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("java")
                 .setAdditionalProperties(properties)

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -58,7 +58,7 @@ export class BaseAPI {
             // only add the querystring to the URL if there are query parameters.
             // this is done to avoid urls ending with a "?" character which buggy webservers
             // do not handle correctly sometimes.
-            url += '?' + querystring(context.query);
+            url += '?' + this.configuration.queryParamsStringify(context.query);
         }
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
@@ -127,6 +127,7 @@ export interface ConfigurationParameters {
     basePath?: string; // override base path
     fetchApi?: FetchAPI; // override for fetch implementation
     middleware?: Middleware[]; // middleware to apply before/after fetch requests
+    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
@@ -146,6 +147,10 @@ export class Configuration {
 
     get middleware(): Middleware[] {
         return this.configuration.middleware || [];
+    }
+
+    get queryParamsStringify(): (params: HTTPQuery) => string {
+        return this.configuration.queryParamsStringify || querystring;
     }
 
     get username(): string | undefined {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/.gitignore
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/.gitignore
@@ -1,0 +1,54 @@
+# ref: https://github.com/github/gitignore/blob/master/Symfony.gitignore
+
+# Cache and logs (Symfony2)
+/app/cache/*
+/app/logs/*
+!app/cache/.gitkeep
+!app/logs/.gitkeep
+
+# Email spool folder
+/app/spool/*
+
+# Cache, session files and logs (Symfony3)
+/var/cache/*
+/var/logs/*
+/var/sessions/*
+!var/cache/.gitkeep
+!var/logs/.gitkeep
+!var/sessions/.gitkeep
+
+# Parameters
+/app/config/parameters.yml
+/app/config/parameters.ini
+
+# Managed by Composer
+/app/bootstrap.php.cache
+/var/bootstrap.php.cache
+/bin/*
+!bin/console
+!bin/symfony_requirements
+/vendor/
+
+# Assets and user uploads
+/web/bundles/
+/web/uploads/
+
+# PHPUnit
+/app/phpunit.xml
+/phpunit.xml
+
+# Build data
+/build/
+
+# Composer PHAR
+/composer.phar
+
+# Backup entities generated with doctrine:generate:entities command
+**/Entity/*~
+
+# Embedded web-server pid file
+/.web-server-pid
+
+# From root gitignore
+/Tests/cache/
+/Tests/logs/


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

As part of settings refactor, I had missed assigning the value of templateDir to additional properties. This result in 4.1.0-SNAPSHOT branch with borked custom template support.

This PR makes that asignment, and fixes some other potential issues with internal state in CodegenConfigurator (`set*` methods).

Added a unit test which evaluates additional properties exist on a CodegenConfig instance after calling `processOpts()`. The test is limited to those properties known to be processed by DefaultCodegen.

cc @OpenAPITools/generator-core-team 
fixes #3364
