### PR TITLE
[typescript-angular] Add encoder configuration, fix default encoder (#3372)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -4,16 +4,15 @@
 import { Inject, Injectable, Optional }                      from '@angular/core';
 {{#useHttpClient}}
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
 import { CustomHttpParameterCodec }                          from '../encoder';
 {{/useHttpClient}}
 {{^useHttpClient}}
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
 {{/useHttpClient}}
-
 {{^useRxJS6}}
 import { Observable }                                        from 'rxjs/Observable';
 {{/useRxJS6}}
@@ -59,6 +58,12 @@ export class {{classname}} {
     protected basePath = '{{{basePath}}}';
     public defaultHeaders = new {{#useHttpClient}}Http{{/useHttpClient}}Headers();
     public configuration = new Configuration();
+{{#useHttpClient}}
+    public encoder: HttpParameterCodec;
+{{/useHttpClient}}
+{{^useHttpClient}}
+    public encoder: QueryEncoder;
+{{/useHttpClient}}
 
     constructor(protected {{#useHttpClient}}httpClient: HttpClient{{/useHttpClient}}{{^useHttpClient}}http: Http{{/useHttpClient}}, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -69,6 +74,12 @@ export class {{classname}} {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+{{#useHttpClient}}
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
+{{/useHttpClient}}
+{{^useHttpClient}}
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
+{{/useHttpClient}}
     }
 
     /**
@@ -143,10 +154,10 @@ export class {{classname}} {
 
 {{#hasQueryParams}}
         {{#useHttpClient}}
-        let queryParameters = new HttpParams({encoder: this.configuration.encoder || new CustomHttpParameterCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         {{/useHttpClient}}
         {{^useHttpClient}}
-        let queryParameters = new URLSearchParams('', this.configuration.encoder || new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         {{/useHttpClient}}
 {{#queryParams}}
         {{#isListContainer}}
@@ -280,12 +291,12 @@ export class {{classname}} {
             formParams = new FormData();
         } else {
 {{#useHttpClient}}
-            formParams = new HttpParams({encoder: this.configuration.encoder || new CustomHttpParameterCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
 {{/useHttpClient}}
 {{^useHttpClient}}
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', this.configuration.encoder || new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
 {{/useHttpClient}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -5,7 +5,7 @@ import { Inject, Injectable, Optional }                      from '@angular/core
 {{#useHttpClient}}
 import { HttpClient, HttpHeaders, HttpParams,
          HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
+import { CustomHttpParameterCodec }                          from '../encoder';
 {{/useHttpClient}}
 {{^useHttpClient}}
 import { Http, Headers, URLSearchParams }                    from '@angular/http';
@@ -143,10 +143,10 @@ export class {{classname}} {
 
 {{#hasQueryParams}}
         {{#useHttpClient}}
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.configuration.encoder || new CustomHttpParameterCodec()});
         {{/useHttpClient}}
         {{^useHttpClient}}
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.configuration.encoder || new CustomQueryEncoderHelper());
         {{/useHttpClient}}
 {{#queryParams}}
         {{#isListContainer}}
@@ -280,12 +280,12 @@ export class {{classname}} {
             formParams = new FormData();
         } else {
 {{#useHttpClient}}
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.configuration.encoder || new CustomHttpParameterCodec()});
 {{/useHttpClient}}
 {{^useHttpClient}}
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.configuration.encoder || new CustomQueryEncoderHelper());
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
 {{/useHttpClient}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
@@ -5,6 +5,12 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+{{#useHttpClient}}
+    encoder?: HttpParameterCodec;
+{{/useHttpClient}}
+{{^useHttpClient}}
+    encoder?: QueryEncoder;
+{{/useHttpClient}}
 }
 
 export class Configuration {
@@ -14,6 +20,12 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+{{#useHttpClient}}
+    encoder?: HttpParameterCodec;
+{{/useHttpClient}}
+{{^useHttpClient}}
+    encoder?: QueryEncoder;
+{{/useHttpClient}}
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +34,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/configuration.mustache
@@ -1,3 +1,10 @@
+{{#useHttpClient}}
+import { HttpParameterCodec } from '@angular/common/http';
+{{/useHttpClient}}
+{{^useHttpClient}}
+import { QueryEncoder } from '@angular/http';
+{{/useHttpClient}}
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
@@ -15,7 +15,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 {{/useHttpClient}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
@@ -1,30 +1,27 @@
 {{#useHttpClient}}
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 {{/useHttpClient}}
 {{^useHttpClient}}
-    import { QueryEncoder } from '@angular/http';
+import { QueryEncoder } from '@angular/http';
 {{/useHttpClient}}
 
 {{#useHttpClient}}
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 {{/useHttpClient}}
 {{^useHttpClient}}
 /**
-* CustomQueryEncoderHelper
+* Custom QueryEncoder
 * Fix plus sign (+) not encoding, so sent as blank space
 * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
 */

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -307,7 +308,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (status) {
             queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -361,7 +362,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (tags) {
             queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -548,7 +549,7 @@ export class PetService {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }
@@ -624,7 +625,7 @@ export class PetService {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -410,7 +411,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (username !== undefined && username !== null) {
             queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v2/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/configuration.ts
@@ -1,3 +1,5 @@
+import { QueryEncoder } from '@angular/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v2/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v2/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/encoder.ts
@@ -1,7 +1,7 @@
-    import { QueryEncoder } from '@angular/http';
+import { QueryEncoder } from '@angular/http';
 
 /**
-* CustomQueryEncoderHelper
+* Custom QueryEncoder
 * Fix plus sign (+) not encoding, so sent as blank space
 * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
 */

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -307,7 +308,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (status) {
             queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -361,7 +362,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (tags) {
             queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -548,7 +549,7 @@ export class PetService {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }
@@ -624,7 +625,7 @@ export class PetService {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -410,7 +411,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (username !== undefined && username !== null) {
             queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v2/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/configuration.ts
@@ -1,3 +1,5 @@
+import { QueryEncoder } from '@angular/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v2/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
@@ -1,7 +1,7 @@
-    import { QueryEncoder } from '@angular/http';
+import { QueryEncoder } from '@angular/http';
 
 /**
-* CustomQueryEncoderHelper
+* Custom QueryEncoder
 * Fix plus sign (+) not encoding, so sent as blank space
 * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
 */

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -34,6 +33,7 @@ export class PetService implements PetServiceInterface {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -44,6 +44,7 @@ export class PetService implements PetServiceInterface {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -308,7 +309,7 @@ export class PetService implements PetServiceInterface {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (status) {
             queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -362,7 +363,7 @@ export class PetService implements PetServiceInterface {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (tags) {
             queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -549,7 +550,7 @@ export class PetService implements PetServiceInterface {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }
@@ -625,7 +626,7 @@ export class PetService implements PetServiceInterface {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -33,6 +32,7 @@ export class StoreService implements StoreServiceInterface {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class StoreService implements StoreServiceInterface {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -33,6 +32,7 @@ export class UserService implements UserServiceInterface {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class UserService implements UserServiceInterface {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -411,7 +412,7 @@ export class UserService implements UserServiceInterface {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (username !== undefined && username !== null) {
             queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/configuration.ts
@@ -1,3 +1,5 @@
+import { QueryEncoder } from '@angular/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
@@ -1,7 +1,7 @@
-    import { QueryEncoder } from '@angular/http';
+import { QueryEncoder } from '@angular/http';
 
 /**
-* CustomQueryEncoderHelper
+* Custom QueryEncoder
 * Fix plus sign (+) not encoding, so sent as blank space
 * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
 */

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs/Observable';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -31,6 +30,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -41,6 +41,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -178,7 +179,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -233,7 +234,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -421,7 +422,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -494,7 +495,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs/Observable';
 
 import { Order } from '../model/order';
@@ -30,6 +29,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs/Observable';
 
 import { User } from '../model/user';
@@ -30,6 +29,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -288,7 +289,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v4.3/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v4.3/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -307,7 +308,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (status) {
             queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -361,7 +362,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (tags) {
             queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -548,7 +549,7 @@ export class PetService {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }
@@ -624,7 +625,7 @@ export class PetService {
         } else {
             // TODO: this fails if a parameter is a file, the api can't consume "multipart/form-data" and a blob is passed.
             convertFormParamsToString = true;
-            formParams = new URLSearchParams('', new CustomQueryEncoderHelper());
+            formParams = new URLSearchParams('', this.encoder);
             // set the content-type explicitly to avoid having it set to 'text/plain'
             headers.set('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
         }

--- a/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
@@ -12,11 +12,10 @@
 /* tslint:disable:no-unused-variable member-ordering */
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
-import { Http, Headers, URLSearchParams }                    from '@angular/http';
-import { RequestMethod, RequestOptions, RequestOptionsArgs } from '@angular/http';
-import { Response, ResponseContentType }                     from '@angular/http';
+import { Http, Headers, URLSearchParams,
+        RequestMethod, RequestOptions, RequestOptionsArgs,
+        Response, ResponseContentType, QueryEncoder }        from '@angular/http';
 import { CustomQueryEncoderHelper }                          from '../encoder';
-
 import { Observable }                                        from 'rxjs/Observable';
 import '../rxjs-operators';
 
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new Headers();
     public configuration = new Configuration();
+    public encoder: QueryEncoder;
 
     constructor(protected http: Http, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
     /**
@@ -410,7 +411,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new URLSearchParams('', new CustomQueryEncoderHelper());
+        let queryParameters = new URLSearchParams('', this.encoder);
         if (username !== undefined && username !== null) {
             queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
@@ -1,3 +1,5 @@
+import { QueryEncoder } from '@angular/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: QueryEncoder;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
@@ -1,7 +1,7 @@
-    import { QueryEncoder } from '@angular/http';
+import { QueryEncoder } from '@angular/http';
 
 /**
-* CustomQueryEncoderHelper
+* Custom QueryEncoder
 * Fix plus sign (+) not encoding, so sent as blank space
 * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
 */

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -31,6 +30,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -41,6 +41,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -178,7 +179,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -233,7 +234,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -421,7 +422,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -494,7 +495,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -30,6 +29,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -30,6 +29,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -288,7 +289,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -31,6 +30,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -41,6 +41,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -178,7 +179,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -233,7 +234,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -421,7 +422,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -494,7 +495,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -30,6 +29,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -30,6 +29,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -288,7 +289,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -180,7 +181,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -235,7 +236,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -423,7 +424,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -496,7 +497,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -290,7 +291,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -180,7 +181,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -235,7 +236,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -423,7 +424,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -496,7 +497,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -290,7 +291,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -31,6 +30,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -41,6 +41,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -178,7 +179,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -233,7 +234,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -421,7 +422,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -494,7 +495,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -30,6 +29,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -30,6 +29,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -288,7 +289,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -31,6 +30,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -41,6 +41,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -178,7 +179,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -233,7 +234,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -421,7 +422,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -494,7 +495,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -30,6 +29,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -30,6 +29,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -40,6 +40,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -288,7 +289,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -180,7 +181,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -235,7 +236,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -423,7 +424,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -496,7 +497,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -290,7 +291,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { ApiResponse } from '../model/apiResponse';
@@ -33,6 +32,7 @@ export class PetService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -43,6 +43,7 @@ export class PetService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -180,7 +181,7 @@ export class PetService {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (status) {
             queryParameters = queryParameters.set('status', status.join(COLLECTION_FORMATS['csv']));
         }
@@ -235,7 +236,7 @@ export class PetService {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (tags) {
             queryParameters = queryParameters.set('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
@@ -423,7 +424,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (name !== undefined) {
@@ -496,7 +497,7 @@ export class PetService {
         if (useForm) {
             formParams = new FormData();
         } else {
-            formParams = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+            formParams = new HttpParams({encoder: this.encoder});
         }
 
         if (additionalMetadata !== undefined) {

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { Order } from '../model/order';
@@ -32,6 +31,7 @@ export class StoreService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class StoreService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -13,9 +13,8 @@
 
 import { Inject, Injectable, Optional }                      from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams,
-         HttpResponse, HttpEvent }                           from '@angular/common/http';
-import { CustomHttpUrlEncodingCodec }                        from '../encoder';
-
+         HttpResponse, HttpEvent, HttpParameterCodec }       from '@angular/common/http';
+import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
 import { User } from '../model/user';
@@ -32,6 +31,7 @@ export class UserService {
     protected basePath = 'http://petstore.swagger.io/v2';
     public defaultHeaders = new HttpHeaders();
     public configuration = new Configuration();
+    public encoder: HttpParameterCodec;
 
     constructor(protected httpClient: HttpClient, @Optional()@Inject(BASE_PATH) basePath: string, @Optional() configuration: Configuration) {
 
@@ -42,6 +42,7 @@ export class UserService {
         } else {
             this.configuration.basePath = basePath || this.basePath;
         }
+        this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
     /**
@@ -290,7 +291,7 @@ export class UserService {
             throw new Error('Required parameter password was null or undefined when calling loginUser.');
         }
 
-        let queryParameters = new HttpParams({encoder: new CustomHttpUrlEncodingCodec()});
+        let queryParameters = new HttpParams({encoder: this.encoder});
         if (username !== undefined && username !== null) {
             queryParameters = queryParameters.set('username', <any>username);
         }

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/configuration.ts
@@ -1,3 +1,5 @@
+import { HttpParameterCodec } from '@angular/common/http';
+
 export interface ConfigurationParameters {
     apiKeys?: {[ key: string ]: string};
     username?: string;

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/configuration.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/configuration.ts
@@ -5,6 +5,7 @@ export interface ConfigurationParameters {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 }
 
 export class Configuration {
@@ -14,6 +15,7 @@ export class Configuration {
     accessToken?: string | (() => string);
     basePath?: string;
     withCredentials?: boolean;
+    encoder?: HttpParameterCodec;
 
     constructor(configurationParameters: ConfigurationParameters = {}) {
         this.apiKeys = configurationParameters.apiKeys;
@@ -22,6 +24,7 @@ export class Configuration {
         this.accessToken = configurationParameters.accessToken;
         this.basePath = configurationParameters.basePath;
         this.withCredentials = configurationParameters.withCredentials;
+        this.encoder = configurationParameters.encoder;
     }
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
@@ -1,18 +1,15 @@
-    import { HttpUrlEncodingCodec } from '@angular/common/http';
+import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* CustomHttpUrlEncodingCodec
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+* Custom HttpParameterCodec
+* Workaround for https://github.com/angular/angular/issues/18261
 */
-export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
-        k = super.encodeKey(k);
-        return k.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        v = super.encodeValue(v);
-        return v.replace(/\+/gi, '%2B');
+        return encodeURIComponent(k);
     }
 }
 

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
@@ -9,7 +9,13 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
         return encodeURIComponent(k);
     }
     encodeValue(v: string): string {
-        return encodeURIComponent(k);
+        return encodeURIComponent(v);
+    }
+    decodeKey(k: string): string {
+        return decodeURIComponent(k);
+    }
+    decodeValue(v: string): string {
+        return decodeURIComponent(v);
     }
 }
 


### PR DESCRIPTION
* Add encoder to configuration
* Fix import indention
* Default encoder workaround for https://github.com/angular/angular/issues/18261

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

fixes https://github.com/OpenAPITools/openapi-generator/issues/3372