### PR TITLE
[Golang][Client] Fix collectionFormat=multi request bug

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -389,6 +389,11 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                     }
                 }
 
+                // import "reflect" package if the parameter is collectionFormat=multi
+                if (param.isCollectionFormatMulti) {
+                    imports.add(createMapping("import", "reflect"));
+                }
+
                 // import "optionals" package if the parameter is optional
                 if (!param.required) {
                     if (!addedOptionalImport) {

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -132,11 +132,37 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	{{#hasQueryParams}}
 	{{#queryParams}}
 	{{#required}}
+	{{#isCollectionFormatMulti}}
+        t:={{paramName}}
+        if reflect.TypeOf(t).Kind() == reflect.Slice {
+            s := reflect.ValueOf(t)
+            for i := 0; i < s.Len(); i++ {
+                localVarQueryParams.Add("{{baseName}}", parameterToString(s.Index(i), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+            }
+        } else {
+            localVarQueryParams.Add("{{baseName}}", parameterToString(t, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	    }
+	{{/isCollectionFormatMulti}}
+	{{^isCollectionFormatMulti}}
 	localVarQueryParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	{{/isCollectionFormatMulti}}
 	{{/required}}
 	{{^required}}
 	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
+	{{#isCollectionFormatMulti}}
+        t:=localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value()
+        if reflect.TypeOf(t).Kind() == reflect.Slice {
+            s := reflect.ValueOf(t)
+            for i := 0; i < s.Len(); i++ {
+                localVarQueryParams.Add("{{baseName}}", parameterToString(s.Index(i), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+            }
+        } else {
+            localVarQueryParams.Add("{{baseName}}", parameterToString(t, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	    }
+	{{/isCollectionFormatMulti}}
+	{{^isCollectionFormatMulti}}
 		localVarQueryParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	{{/isCollectionFormatMulti}}
 	}
 	{{/required}}
 	{{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -133,15 +133,15 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	{{#queryParams}}
 	{{#required}}
 	{{#isCollectionFormatMulti}}
-        t:={{paramName}}
-        if reflect.TypeOf(t).Kind() == reflect.Slice {
-            s := reflect.ValueOf(t)
-            for i := 0; i < s.Len(); i++ {
-                localVarQueryParams.Add("{{baseName}}", parameterToString(s.Index(i), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
-            }
-        } else {
-            localVarQueryParams.Add("{{baseName}}", parameterToString(t, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
-	    }
+	t:={{paramName}}
+	if reflect.TypeOf(t).Kind() == reflect.Slice {
+		s := reflect.ValueOf(t)
+		for i := 0; i < s.Len(); i++ {
+			localVarQueryParams.Add("{{baseName}}", parameterToString(s.Index(i), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+		}
+	} else {
+		localVarQueryParams.Add("{{baseName}}", parameterToString(t, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
 	localVarQueryParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
@@ -150,15 +150,15 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	{{^required}}
 	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
 	{{#isCollectionFormatMulti}}
-        t:=localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value()
-        if reflect.TypeOf(t).Kind() == reflect.Slice {
-            s := reflect.ValueOf(t)
-            for i := 0; i < s.Len(); i++ {
-                localVarQueryParams.Add("{{baseName}}", parameterToString(s.Index(i), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
-            }
-        } else {
-            localVarQueryParams.Add("{{baseName}}", parameterToString(t, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
-	    }
+		t:=localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value()
+		if reflect.TypeOf(t).Kind() == reflect.Slice {
+			s := reflect.ValueOf(t)
+			for i := 0; i < s.Len(); i++ {
+				localVarQueryParams.Add("{{baseName}}", parameterToString(s.Index(i), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+			}
+		} else {
+			localVarQueryParams.Add("{{baseName}}", parameterToString(t, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+		}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
 		localVarQueryParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@antihax @bvwells @kemokemo 

### Description of the PR

This PR fixes parameters which use `collectionFormat=multi` so that duplicate keys (but different values) are sent in the query string instead of a single key with a single CSV concatenated value.

See description of bug here:

https://github.com/OpenAPITools/openapi-generator/issues/3386

#### Notes

This PR doesn't introduce any breaking changes and is built on the existing `antihax/optional.Interface` type for an optional `[]string`.

For a breaking change, it would be nice to implement an `[]string` in the optional structs and only use if the array has one or more elements.

For example, the following is currently generated:

```go
type APIOpts struct {
	Name      optional.String
	UserIds   optional.Interface
}
```

It may be better to generate:

```go
type APIOpts struct {
	Name      optional.String
	UserIds   []string
}
```